### PR TITLE
Polish annotation editing and panel navigation

### DIFF
--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -861,6 +861,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
                     foreground: Paint()
                       ..shader = _shaderFor(gradient,
                           transform: gradient.transform.concat(pageToLocal))
+                      ..color = const Color(0xFFFFFFFF)
+                          .withValues(alpha: paintRun.fillAlpha)
                       ..blendMode = _elementBlend)),
             textDirection: TextDirection.ltr,
           )..layout();
@@ -884,7 +886,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
             foreground: Paint()
               ..style = PaintingStyle.stroke
               ..strokeWidth = ts > 0 ? w * renderSize / ts : w
-              ..color = _toColor(paintRun.strokeColor!, 1)
+              ..color = _toColor(paintRun.strokeColor!, paintRun.strokeAlpha)
               ..blendMode = _elementBlend,
           ),
         ),
@@ -947,6 +949,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
           run.fill &&
           run.gradient == null &&
           run.strokeColor == null &&
+          run.fillAlpha == 1 &&
           _elementBlend == BlendMode.srcOver;
       if (!canBatch) {
         flush();
@@ -1018,6 +1021,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
       fill: run.fill,
       strokeColor: run.strokeColor,
       strokeWidth: run.strokeWidth,
+      fillAlpha: run.fillAlpha,
+      strokeAlpha: run.strokeAlpha,
       letterSpacing: run.letterSpacing,
       wordSpacing: run.wordSpacing,
       mcid: run.mcid,
@@ -1051,7 +1056,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
     if (compose) return _composeLayout(run);
     final c = run.color;
     final key = '${run.text} ${run.fontName ?? ''} '
-        '${c.red},${c.green},${c.blue} '
+        '${c.red},${c.green},${c.blue},${run.fillAlpha} '
         '${run.letterSpacing},${run.wordSpacing}';
     return _cachedLayout(key, () => _shapeLayout(run));
   }
@@ -1113,7 +1118,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
   /// glyph would double-count it - and it would make the key a lie.
   _TextLayout _glyphLayout(int rune, PdfTextRun run) {
     final c = run.color;
-    final key = '$rune ${run.fontName ?? ''} ${c.red},${c.green},${c.blue}';
+    final key = '$rune ${run.fontName ?? ''} '
+        '${c.red},${c.green},${c.blue},${run.fillAlpha}';
     return _glyphCache.getOrAdd(key, () {
       debugTextPainterBuilds++;
       final painter = TextPainter(
@@ -1154,7 +1160,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
   _TextLayout _placedLayout(PdfTextRun run, List<double> offsets) {
     final c = run.color;
     final key = '${run.text} ${run.fontName ?? ''} '
-        '${c.red},${c.green},${c.blue} p${_offsetsHash(offsets)}';
+        '${c.red},${c.green},${c.blue},${run.fillAlpha} '
+        'p${_offsetsHash(offsets)}';
     // A run with nothing to scale against falls back to whole-run shaping,
     // cached under this key too so the failed attempt is not repeated.
     return _cachedLayout(
@@ -1424,7 +1431,11 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
       if (gradient != null) {
         paint.shader = _shaderFor(gradient);
       } else {
-        paint.color = _toColor(run.color, 1);
+        paint.color = _toColor(run.color, run.fillAlpha);
+      }
+      if (gradient != null) {
+        paint.color = const Color(0xFFFFFFFF)
+            .withValues(alpha: run.fillAlpha.clamp(0, 1));
       }
       canvas.drawPath(path, paint);
     }
@@ -1435,7 +1446,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
         Paint()
           ..style = PaintingStyle.stroke
           ..strokeWidth = run.strokeWidth
-          ..color = _toColor(run.strokeColor!, 1)
+          ..color = _toColor(run.strokeColor!, run.strokeAlpha)
           ..blendMode = _elementBlend,
       );
     }
@@ -1578,7 +1589,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
     final symbol = name.contains('ZapfDingbats') || name.contains('Symbol');
     final adventor = pdfUsesAdventorSubstitute(name);
     return TextStyle(
-      color: foreground == null ? _toColor(run.color, 1) : null,
+      color: foreground == null ? _toColor(run.color, run.fillAlpha) : null,
       foreground: foreground,
       fontSize: 100,
       fontFamily: cjk ??

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2711,6 +2711,7 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
+          opacity: preferences.opacity,
           lineSpacing: _lineSpacing,
           charSpacing: _charSpacing,
           horizontalScale: _fontWidth,
@@ -2744,6 +2745,7 @@ class PdfEditingController extends ChangeNotifier {
           // text color so the arrow always has a definite color/width
           strokeColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
           strokeWidth: preferences.strokeWidth,
+          opacity: preferences.opacity,
           pageRotation: _page(pageIndex).rotation,
           author: preferences.author,
         ),
@@ -2763,6 +2765,7 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
+          opacity: preferences.opacity,
           lineSpacing: _lineSpacing,
           charSpacing: _charSpacing,
           horizontalScale: _fontWidth,
@@ -2807,6 +2810,7 @@ class PdfEditingController extends ChangeNotifier {
         fillColor: _rgbOf(preferences.textFillColor),
         borderColor: _rgbOf(preferences.textBorderColor),
         borderWidth: preferences.strokeWidth,
+        opacity: preferences.opacity,
         pageRotation: _page(pageIndex).rotation,
         author: preferences.author,
       ),
@@ -6625,6 +6629,7 @@ class PdfEditingController extends ChangeNotifier {
               borderColor: border != null ? border.$1 : parsed?.borderColor,
               borderWidth: borderWidth ??
                   ((parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1),
+              opacity: annotation.appearanceOpacity,
               // keep the box's own spacing/decoration unless changed
               lineSpacing: lineSpacing ??
                   parsed?.lineSpacing ??
@@ -6708,6 +6713,7 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: parsed?.fillColor,
           borderColor: parsed?.borderColor,
           borderWidth: (parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1,
+          opacity: annotation.appearanceOpacity,
           lineSpacing: lineSpacing ??
               parsed?.lineSpacing ??
               kPdfFreeTextDefaultLineSpacing,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -2405,15 +2405,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       final ls = _controller.lineSpacing;
       final cs = _controller.charSpacing;
       final ul = _controller.textUnderline;
+      final opacity = _controller.preferences.opacity;
       final defaultUnderline = _textEditText.defaultStyle.underline;
       if (align != _textEditAlign ||
           ls != _textEditLineSpacing ||
           cs != _textEditCharSpacing ||
+          opacity != _textEditOpacity ||
           (ul != defaultUnderline && !_textEditText.hasRichStyles)) {
         setState(() {
           _textEditAlign = align;
           _textEditLineSpacing = ls;
           _textEditCharSpacing = cs;
+          _textEditOpacity = opacity;
           if (ul != defaultUnderline && !_textEditText.hasRichStyles) {
             _textEditText.resetStyles(
                 _textEditText.defaultStyle.merge(underline: ul));
@@ -5634,7 +5637,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                 // in view pixels, same leading/spacing,
                                 // matching family, color and underline
                                 style: TextStyle(
-                                  color: _textEditColor,
+                                  color: _textEditFieldName == null
+                                      ? _textEditColor.withValues(
+                                          alpha: _textEditOpacity.clamp(0.0, 1.0))
+                                      : _textEditColor,
                                   fontSize: _textEditSize * _geometry.scale,
                                   height: _textEditLineSpacing,
                                   letterSpacing:

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -876,6 +876,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   double _textEditSize = 14; // pt
   Color _textEditColor = const Color(0xFF000000);
   Color? _textEditFill; // the box background the commit will paint
+  double _textEditOpacity = 1;
   // box-level layout the inline editor previews so the live text matches
   // what commits: alignment (/Q), line height, character spacing, and
   // horizontal glyph scaling
@@ -1013,6 +1014,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     double size,
     Color color,
     Color? fill,
+    double opacity,
     bool washed,
     double rotation,
     PdfTextAlign? align,
@@ -2045,6 +2047,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     double size,
     Color color,
     Color? fill,
+    double opacity,
     PdfTextAlign align,
     bool underline,
     double lineSpacing,
@@ -2073,6 +2076,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       fill: parsed.fillColor != null
           ? Color(0xFF000000 | parsed.fillColor!)
           : null,
+      opacity: annotation.appearanceOpacity,
       align: parsed.alignment,
       underline: parsed.underline,
       lineSpacing: parsed.lineSpacing,
@@ -2708,6 +2712,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               ? Color(0xFF000000 | parsed!.fillColor!)
               : null)
           : _controller.preferences.textFillColor;
+      _textEditOpacity = existing
+          ? (annotation?.appearanceOpacity ?? 1)
+          : _controller.preferences.opacity;
     });
     _beginInteraction(PdfEditingInteractionIntent.text, _lastPointerKind);
     _controller.setEditingText(true);
@@ -2765,7 +2772,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         return (
           terminus,
           base,
-          Color(0xFF000000 | rgb),
+          Color(0xFF000000 | rgb)
+              .withValues(alpha: annotation.appearanceOpacity),
           width > 0 ? width : _geometry.scale,
         );
       }
@@ -2776,7 +2784,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return (
         terminus,
         _nearestBoxEdge(_textEditRect!, terminus),
-        _controller.preferences.textBorderColor ?? _controller.color,
+        (_controller.preferences.textBorderColor ?? _controller.color)
+            .withValues(alpha: _controller.preferences.opacity),
         _controller.preferences.strokeWidth * _geometry.scale,
       );
     }
@@ -2813,6 +2822,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _textEditSize = formSize;
       _textEditColor = const Color(0xFF000000);
       _textEditFill = null;
+      _textEditOpacity = 1;
     });
     _beginInteraction(PdfEditingInteractionIntent.text, _lastPointerKind);
     _controller.setEditingText(true);
@@ -2853,6 +2863,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         size: size,
         color: const Color(0xFF000000),
         fill: null,
+        opacity: 1,
         washed: true, // cover the old value until the raster lands
         rotation: 0,
         align: PdfTextAlign.left,
@@ -2870,6 +2881,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final size = _textEditSize;
     final color = _textEditColor;
     final fill = _textEditFill;
+    final opacity = _textEditOpacity;
     final rotation = _textEditRotation;
     final calloutTarget = _textEditCalloutTarget;
     _closeTextEditor();
@@ -2903,6 +2915,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       size: size,
       color: color,
       fill: fill,
+      opacity: opacity,
       washed: existing,
       rotation: rotation,
       align: _textEditAlign,
@@ -3641,6 +3654,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             size: wrapStyle.size,
             color: wrapStyle.color,
             fill: wrapStyle.fill,
+            opacity: wrapStyle.opacity,
             // with the lift up the box keeps its true (maybe transparent)
             // fill and the lift hides the old footprint; only without a
             // lift does it fall back to the opaque-paper wash
@@ -4977,6 +4991,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     required double size,
     required Color color,
     required Color? background,
+    Color? wash,
+    double opacity = 1,
     required double rotation,
     PdfTextAlign? align,
     bool underline = false,
@@ -4996,7 +5012,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       PdfTextAlign.center => Alignment.topCenter,
       PdfTextAlign.right => Alignment.topRight,
     };
-    final box = Container(
+    final content = Container(
       key: key,
       color: background,
       padding: EdgeInsets.all(3 * _geometry.scale),
@@ -5023,6 +5039,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         ),
       ),
     );
+    final faded = opacity >= 1
+        ? content
+        : Opacity(opacity: opacity.clamp(0.0, 1.0), child: content);
+    final box = wash == null
+        ? faded
+        : Stack(
+            fit: StackFit.expand,
+            children: [ColoredBox(color: wash), faded],
+          );
     return Positioned.fromRect(
       rect: rect,
       child: IgnorePointer(
@@ -5436,6 +5461,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   size: wrapResize.size,
                   color: wrapResize.color,
                   background: wrapResize.fill,
+                  opacity: wrapResize.opacity,
                   rotation: _resizeAngle,
                   align: wrapResize.align,
                   underline: wrapResize.underline,
@@ -5451,10 +5477,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   font: after.font,
                   size: after.size,
                   color: after.color,
-                  background: after.fill ??
-                      (after.washed
-                          ? widget.pageColor.withValues(alpha: 0.92)
-                          : null),
+                  background: after.fill,
+                  wash: after.washed
+                      ? widget.pageColor.withValues(alpha: 0.92)
+                      : null,
+                  opacity: after.opacity,
                   rotation: after.rotation,
                   align: after.align,
                   underline: after.underline,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -18,6 +18,10 @@ import 'editing_preferences.dart';
 /// current value; link tiles show the text under the link and where it
 /// goes (the URI, or the target page).
 ///
+/// Page headers stay pinned while their annotations scroll, show the number
+/// of annotations on that page, and can be collapsed individually or through
+/// the panel-level collapse/expand-all control.
+///
 /// Tapping a tile zooms the viewer to the annotation, selects it
 /// (arming the select tool), and pulses an attention flash around it on
 /// the page. On mouse hover a row reveals its trailing actions: a "more"
@@ -112,6 +116,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   (int, int)? _anchor;
 
   final ScrollController _scroll = ScrollController();
+
+  /// Page sections the user has folded closed. Page indices are intentional:
+  /// the state follows the visible page number through ordinary annotation
+  /// edits without holding stale annotation identities across revisions.
+  final Set<int> _collapsedPages = {};
 
   /// The filter text; tiles whose title or subtitle don't contain it
   /// (case-insensitive) are hidden. Survives revisions - a search isn't
@@ -252,8 +261,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
 
   Widget _searchField(
     BuildContext context,
-    PdfSidebarPanelGeometry geometry,
-  ) {
+    PdfSidebarPanelGeometry geometry, {
+    required bool hasPages,
+    required bool allCollapsed,
+    required VoidCallback onToggleAll,
+  }) {
     // the docked panel's close button rides the right of the filter row;
     // a bottom sheet supplies its own in its sheet chrome
     final closeButton = geometry.closeButton(
@@ -263,6 +275,18 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       key: const ValueKey('pdf-annotation-panel-move'),
     );
     final trailing = <Widget>[
+      IconButton(
+        key: const ValueKey('pdf-annotation-pages-toggle-all'),
+        tooltip: allCollapsed
+            ? pdfL10n(context).bookmarkExpand
+            : pdfL10n(context).bookmarkCollapse,
+        visualDensity: VisualDensity.compact,
+        constraints: const BoxConstraints.tightFor(width: 36, height: 36),
+        padding: EdgeInsets.zero,
+        icon: Icon(allCollapsed ? Icons.unfold_more : Icons.unfold_less,
+            size: 20),
+        onPressed: hasPages ? onToggleAll : null,
+      ),
       if (moveHandle != null) moveHandle,
       if (closeButton != null) closeButton,
     ];
@@ -876,7 +900,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               _replyingTo = null;
             }
             final query = _search.text.trim().toLowerCase();
-            final children = <Widget>[];
+            final sections = <_AnnotationPageSection>[];
+            final annotatedPages = <int>[];
             // every displayed, selectable slot in display order - the axis
             // a shift-click range runs along. Filled as tiles are built and
             // captured by each row's tap handler (complete by tap time).
@@ -890,7 +915,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 for (final thread in widget.controller.commentThreads(page))
                   thread.root.annotation.dict: thread,
               };
-              final tiles = <Widget>[];
+              final rows = <_AnnotationSidebarRow>[];
+              var pageCount = 0;
               for (var i = 0; i < annotations.length; i++) {
                 final annotation = annotations[i];
                 if (_unlisted.contains(annotation.subtype)) continue;
@@ -900,34 +926,83 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 if (annotation.isReply || annotation.isStateAnnotation) {
                   continue;
                 }
+                pageCount++;
                 listed++;
                 if (!_matches(query, page, annotation)) continue;
-                final thread = threadByDict[annotation.dict];
-                if (annotation.behavior.selectable &&
-                    widget.controller.isAnnotationEditable(annotation)) {
-                  ordered.add((page, i));
-                }
-                tiles.add(_tile(context, page, i, annotation, thread, ordered));
-                // a signed signature field shows its validation status inline
-                final signature = _signatureFor(annotation);
-                if (signature != null) {
-                  tiles.addAll(_signatureSection(context, signature));
-                }
-                // a markup annotation hosts a comment thread
-                if (annotation.behavior.selectable) {
-                  tiles.addAll(
-                      _threadSection(context, page, annotation, thread));
+                rows.add(_AnnotationSidebarRow(
+                  slot: i,
+                  annotation: annotation,
+                  thread: threadByDict[annotation.dict],
+                ));
+              }
+              if (pageCount > 0) annotatedPages.add(page);
+              if (rows.isNotEmpty) {
+                sections.add(_AnnotationPageSection(
+                  page: page,
+                  annotationCount: pageCount,
+                  rows: rows,
+                ));
+              }
+            }
+            _collapsedPages.removeWhere((page) => page >= document.pageCount);
+            final allCollapsed = annotatedPages.isNotEmpty &&
+                annotatedPages.every(_collapsedPages.contains);
+
+            final slivers = <Widget>[];
+            for (final section in sections) {
+              final collapsed = _collapsedPages.contains(section.page);
+              final tiles = <Widget>[];
+              if (!collapsed) {
+                for (final row in section.rows) {
+                  final annotation = row.annotation;
+                  if (annotation.behavior.selectable &&
+                      widget.controller.isAnnotationEditable(annotation)) {
+                    ordered.add((section.page, row.slot));
+                  }
+                  tiles.add(_tile(context, section.page, row.slot, annotation,
+                      row.thread, ordered));
+                  // a signed signature field shows its validation status
+                  // inline
+                  final signature = _signatureFor(annotation);
+                  if (signature != null) {
+                    tiles.addAll(_signatureSection(context, signature));
+                  }
+                  // a markup annotation hosts a comment thread
+                  if (annotation.behavior.selectable) {
+                    tiles.addAll(_threadSection(context, section.page,
+                        annotation, row.thread));
+                  }
                 }
               }
-              if (tiles.isNotEmpty) {
-                children
-                  ..add(Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-                    child: Text(pdfL10n(context).sidebarPageHeader(page + 1),
-                        style: Theme.of(context).textTheme.labelLarge),
-                  ))
-                  ..addAll(tiles);
-              }
+              slivers.add(
+                SliverPadding(
+                  padding:
+                      EdgeInsets.only(right: geometry.scrollbarClearance),
+                  sliver: SliverMainAxisGroup(slivers: [
+                    SliverPersistentHeader(
+                      pinned: true,
+                      delegate: _AnnotationPageHeaderDelegate(
+                        page: section.page,
+                        label: pdfL10n(context)
+                            .sidebarPageHeader(section.page + 1),
+                        countLabel: pdfL10n(context)
+                            .propAnnotationCount(section.annotationCount),
+                        collapsed: collapsed,
+                        onToggle: () => setState(() {
+                          if (!_collapsedPages.add(section.page)) {
+                            _collapsedPages.remove(section.page);
+                          }
+                        }),
+                        toggleTooltip: collapsed
+                            ? pdfL10n(context).bookmarkExpand
+                            : pdfL10n(context).bookmarkCollapse,
+                      ),
+                    ),
+                    if (tiles.isNotEmpty)
+                      SliverList(delegate: SliverChildListDelegate(tiles)),
+                  ]),
+                ),
+              );
             }
             // the viewer-style scrollbar replaces the implicit
             // desktop bar; it wraps only the list, so the
@@ -936,7 +1011,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             // (right) edge.
             // keep the list clear of the overlay scrollbar's zone so
             // the bar never covers a tile's trailing button
-            final list = children.isEmpty
+            final list = sections.isEmpty
                 ? Center(
                     child: Text(listed > 0 && query.isNotEmpty
                         ? pdfL10n(context).sidebarNoMatchingAnnotations
@@ -947,11 +1022,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                     child: ScrollConfiguration(
                       behavior: ScrollConfiguration.of(context)
                           .copyWith(scrollbars: false),
-                      child: ListView(
-                          controller: _scroll,
-                          padding: EdgeInsets.only(
-                              right: geometry.scrollbarClearance),
-                          children: children),
+                      child: CustomScrollView(
+                        key: const ValueKey('pdf-annotation-scroll-view'),
+                        controller: _scroll,
+                        slivers: slivers,
+                      ),
                     ),
                   );
             // one shape for both modes, with the list keyed: the
@@ -959,7 +1034,19 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             // element (the controller would sit attached to two
             // scroll views for a frame)
             return Column(children: [
-              _searchField(context, geometry),
+              _searchField(
+                context,
+                geometry,
+                hasPages: annotatedPages.isNotEmpty,
+                allCollapsed: allCollapsed,
+                onToggleAll: () => setState(() {
+                  if (allCollapsed) {
+                    _collapsedPages.removeAll(annotatedPages);
+                  } else {
+                    _collapsedPages.addAll(annotatedPages);
+                  }
+                }),
+              ),
               if (_selecting) _selectionHeader(context),
               Expanded(
                 key: const ValueKey('pdf-annotation-list'),
@@ -971,6 +1058,116 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       ),
     );
   }
+}
+
+class _AnnotationSidebarRow {
+  const _AnnotationSidebarRow({
+    required this.slot,
+    required this.annotation,
+    required this.thread,
+  });
+
+  final int slot;
+  final PdfAnnotation annotation;
+  final PdfCommentThread? thread;
+}
+
+class _AnnotationPageSection {
+  const _AnnotationPageSection({
+    required this.page,
+    required this.annotationCount,
+    required this.rows,
+  });
+
+  final int page;
+  final int annotationCount;
+  final List<_AnnotationSidebarRow> rows;
+}
+
+/// Fixed-height page chrome for the annotation list. Each delegate lives in
+/// its own [SliverMainAxisGroup], so it pins to the top while that page's rows
+/// scroll and is then pushed away by the following page header.
+class _AnnotationPageHeaderDelegate extends SliverPersistentHeaderDelegate {
+  const _AnnotationPageHeaderDelegate({
+    required this.page,
+    required this.label,
+    required this.countLabel,
+    required this.collapsed,
+    required this.onToggle,
+    required this.toggleTooltip,
+  });
+
+  static const double height = 40;
+
+  final int page;
+  final String label;
+  final String countLabel;
+  final bool collapsed;
+  final VoidCallback onToggle;
+  final String toggleTooltip;
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    final scheme = Theme.of(context).colorScheme;
+    // Persistent-header children receive a loose main-axis constraint. Fill it
+    // explicitly so paintExtent matches the fixed 40px layoutExtent even when
+    // the row's intrinsic height is only one text line.
+    return SizedBox.expand(
+      child: Material(
+        key: ValueKey('pdf-annotation-page-header-$page'),
+        color: scheme.surfaceContainerLow,
+        elevation: overlapsContent ? 1 : 0,
+        child: Tooltip(
+          message: toggleTooltip,
+          child: InkWell(
+            key: ValueKey('pdf-annotation-page-toggle-$page'),
+            onTap: onToggle,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(start: 8, end: 12),
+              child: Row(children: [
+                Icon(collapsed ? Icons.chevron_right : Icons.expand_more,
+                    size: 20),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(label,
+                      style: Theme.of(context).textTheme.labelLarge,
+                      overflow: TextOverflow.ellipsis),
+                ),
+                Container(
+                  key: ValueKey('pdf-annotation-page-count-$page'),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: scheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(countLabel,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: scheme.onSurfaceVariant,
+                          )),
+                ),
+              ]),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant _AnnotationPageHeaderDelegate oldDelegate) =>
+      page != oldDelegate.page ||
+      label != oldDelegate.label ||
+      countLabel != oldDelegate.countLabel ||
+      collapsed != oldDelegate.collapsed ||
+      toggleTooltip != oldDelegate.toggleTooltip;
 }
 
 /// The actions a markup row's "more" menu offers on its comment thread.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -157,6 +157,20 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   @override
   void didUpdateWidget(PdfAnnotationSidebar old) {
     super.didUpdateWidget(old);
+    if (!identical(old.controller, widget.controller)) {
+      // Revision ids and page indices are controller-local. A replacement
+      // controller can start at the same revision number as the old one, so
+      // explicitly discard state that would otherwise be applied to an
+      // unrelated document.
+      _builtForRevision = null;
+      _checked.clear();
+      _hoveredSlot = null;
+      _selecting = false;
+      _anchor = null;
+      _collapsedPages.clear();
+      _pageTexts.clear();
+      _replyingTo = null;
+    }
     if (!identical(old.controller.preferences, _preferences)) {
       old.controller.preferences.removeListener(_onPreferences);
       _preferences.addListener(_onPreferences);
@@ -901,7 +915,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             }
             final query = _search.text.trim().toLowerCase();
             final sections = <_AnnotationPageSection>[];
-            final annotatedPages = <int>[];
             // every displayed, selectable slot in display order - the axis
             // a shift-click range runs along. Filled as tiles are built and
             // captured by each row's tap handler (complete by tap time).
@@ -935,7 +948,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                   thread: threadByDict[annotation.dict],
                 ));
               }
-              if (pageCount > 0) annotatedPages.add(page);
               if (rows.isNotEmpty) {
                 sections.add(_AnnotationPageSection(
                   page: page,
@@ -945,8 +957,13 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               }
             }
             _collapsedPages.removeWhere((page) => page >= document.pageCount);
-            final allCollapsed = annotatedPages.isNotEmpty &&
-                annotatedPages.every(_collapsedPages.contains);
+            // While filtering, the panel-level action applies to what the
+            // user can see. Including hidden page groups can make the first
+            // click appear to do nothing (the visible group is already
+            // collapsed while some hidden group is still open).
+            final visiblePages = [for (final section in sections) section.page];
+            final allCollapsed = visiblePages.isNotEmpty &&
+                visiblePages.every(_collapsedPages.contains);
 
             final slivers = <Widget>[];
             for (final section in sections) {
@@ -1037,13 +1054,13 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               _searchField(
                 context,
                 geometry,
-                hasPages: annotatedPages.isNotEmpty,
+                hasPages: visiblePages.isNotEmpty,
                 allCollapsed: allCollapsed,
                 onToggleAll: () => setState(() {
                   if (allCollapsed) {
-                    _collapsedPages.removeAll(annotatedPages);
+                    _collapsedPages.removeAll(visiblePages);
                   } else {
-                    _collapsedPages.addAll(annotatedPages);
+                    _collapsedPages.addAll(visiblePages);
                   }
                 }),
               ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -312,12 +312,10 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     if (!widget.controller.pastePages(at: at)) return;
     _focusPage(at);
     if (widget.followsViewer) {
-      // A paste inserts pages, so the viewer resets its scroll to the top in
-      // a post-frame callback (a geometry-changing revision). A following
-      // strip chases that reset via [_onViewerChanged] and scrolls back to
-      // the top, burying the pages that just landed. Drive the viewer to the
-      // paste target after its reset settles so the strip reveals the new
-      // pages instead - the same route the menu/header paste paths take.
+      // Structural revisions preserve the existing reading position. This
+      // action deliberately reveals the newly pasted page instead, once the
+      // new list metrics exist - the same route the menu/header paste paths
+      // take.
       unawaited(_jumpToInsertedPage(widget.viewerController, at));
     } else {
       _revealPage(at);
@@ -1111,9 +1109,9 @@ class _PageActionsButton extends StatelessWidget {
     try {
       final insertedAt = viewerController.currentPage + 1;
       controller.insertPagesFromBytes(bytes, at: insertedAt);
-      // A page-count change rebuilds the viewer and resets its scroll metrics.
-      // Navigate only after that reset so the newly inserted pages stay in
-      // view instead of the replacement document opening at page one.
+      // The structural revision keeps the old reading position by default;
+      // this explicit Insert action reveals the newly imported pages once the
+      // rebuilt list has its new metrics.
       unawaited(_jumpToInsertedPage(viewerController, insertedAt));
     } catch (_) {
       // a non-PDF, corrupt, or password-protected file can't be opened -
@@ -2745,10 +2743,10 @@ Future<void> _jumpToInsertedPage(
   int pageIndex,
 ) async {
   // The controller notification first rebuilds the viewer with the new page
-  // list. A geometry-changing revision then resets its old scroll position in
-  // a post-frame callback, so navigate on the following frame, after both the
-  // new list metrics and that reset have landed. `endOfFrame` schedules a
-  // frame when idle and avoids leaving a test-host timer behind.
+  // list and restores its existing reading anchor. Navigate on the following
+  // frame, after both the new list metrics and that restoration have landed,
+  // so this deliberate reveal of the inserted page wins. `endOfFrame`
+  // schedules a frame when idle and avoids leaving a test-host timer behind.
   await SchedulerBinding.instance.endOfFrame;
   await SchedulerBinding.instance.endOfFrame;
   await viewerController.jumpToPage(pageIndex);

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1699,6 +1699,7 @@ class _PdfViewerState extends State<PdfViewer>
   final Map<int, int> _contentStamps = {};
 
   late List<PdfPage> _pages;
+  late List<(int, int)?> _pageRefs;
   late List<double> _aspects; // height / width, after /Rotate
 
   /// The controller that owns the document revisions for a given viewer
@@ -3471,15 +3472,13 @@ class _PdfViewerState extends State<PdfViewer>
   void _swapDocument({bool preserveRevisionViewport = false}) {
     final document = _document;
     final sameGeometry = _sameGeometryAs(document);
-    final oldPageRefs = preserveRevisionViewport
-        ? [for (final page in _pages) _pageReferenceKey(page)]
-        : const <(int, int)?>[];
+    final oldPageRefs =
+        preserveRevisionViewport ? _pageRefs : const <(int, int)?>[];
     final oldCurrentPage = _pages.isEmpty
         ? 0
         : _controller.currentPage.clamp(0, _pages.length - 1);
-    final oldCurrentRef = oldPageRefs.isEmpty
-        ? null
-        : oldPageRefs[oldCurrentPage];
+    final oldCurrentRef =
+        oldPageRefs.isEmpty ? null : oldPageRefs[oldCurrentPage];
     final oldViewport = preserveRevisionViewport && _pages.isNotEmpty
         ? _pendingViewport ??
             _captureViewport() ??
@@ -3498,9 +3497,8 @@ class _PdfViewerState extends State<PdfViewer>
     _controller.clearSearch();
     _clearSelection();
     _loadPages();
-    final newPageRefs = preserveRevisionViewport
-        ? [for (final page in _pages) _pageReferenceKey(page)]
-        : const <(int, int)?>[];
+    final newPageRefs =
+        preserveRevisionViewport ? _pageRefs : const <(int, int)?>[];
     final pageOrderChanged = preserveRevisionViewport &&
         (oldPageRefs.length != newPageRefs.length ||
             Iterable<int>.generate(oldPageRefs.length).any(
@@ -3578,7 +3576,11 @@ class _PdfViewerState extends State<PdfViewer>
 
   /// The stable identity of a page across incremental revisions. Structural
   /// edits rewrite the page tree but retain every surviving leaf's indirect
-  /// object number; newly inserted pages receive new numbers.
+  /// object number; newly inserted pages receive new numbers. These keys are
+  /// captured when pages load: an incremental edit evicts the reverse-cache
+  /// entry for every rewritten page before the viewer is notified, so asking
+  /// an old [PdfPage] for its reference during the swap would return null and
+  /// make an annotation-only edit look like a page reorder.
   (int, int)? _pageReferenceKey(PdfPage page) {
     final ref = page.document.cos.referenceTo(page.dict);
     return ref == null ? null : (ref.objectNumber, ref.generation);
@@ -3627,6 +3629,7 @@ class _PdfViewerState extends State<PdfViewer>
     _loadedDocument = document;
     final count = document.pageCount;
     _pages = [for (var i = 0; i < count; i++) document.page(i)];
+    _pageRefs = [for (final page in _pages) _pageReferenceKey(page)];
     _rasteredPages.clear();
     _commandWarmAttempts.clear();
     _commandWarmAnchor = null;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -772,8 +772,15 @@ class PdfViewerController extends ChangeNotifier {
 
   void _setPageCount(int count) {
     _pageCount = count;
-    // survive a same-size document swap (an edit revision) in place
-    if (_currentPage >= count) _currentPage = 0;
+    // Keep the nearest valid page while a structural edit relays the viewer
+    // out. The viewer restores the exact page/fraction after layout; jumping
+    // straight to zero here made deleting the last page visibly flash page 1
+    // (and made following sidebars chase that transient reset).
+    if (count <= 0) {
+      _currentPage = 0;
+    } else if (_currentPage >= count) {
+      _currentPage = count - 1;
+    }
     _notifySafely();
   }
 
@@ -3322,7 +3329,12 @@ class _PdfViewerState extends State<PdfViewer>
     // host rebuilt with a fresh document/controller or the controller advanced
     // a revision (handled directly in _onRevisionControllerChanged)
     final documentSwapped = !identical(_loadedDocument, _document);
-    if (documentSwapped) _swapDocument();
+    if (documentSwapped) {
+      _swapDocument(
+        preserveRevisionViewport: newRevisionController != null &&
+            identical(oldRevisionController, newRevisionController),
+      );
+    }
     if (oldWidget.pageRasterCachePolicy != widget.pageRasterCachePolicy) {
       _previews.configureFullRasterCache(widget.pageRasterCachePolicy);
       // Only a *raised* budget can admit pages the warm previously declined,
@@ -3441,21 +3453,44 @@ class _PdfViewerState extends State<PdfViewer>
     // the effective worker, so a resumed render sees current pages, not stale.
     _syncDefaultWorker();
     if (!identical(_loadedDocument, _document)) {
-      _swapDocument();
+      _swapDocument(preserveRevisionViewport: true);
     } else {
       setState(() {});
     }
   }
 
   /// Reconciles cached state to a document swap - from [_loadedDocument] to
-  /// the current [_document]. An edit revision with the same page geometry
-  /// keeps the reading position; a genuinely different document resets. Runs
-  /// from [didUpdateWidget] (a host rebuild with a new document/controller)
-  /// and from [_onRevisionControllerChanged] (a new revision with no host
-  /// rebuild).
-  void _swapDocument() {
+  /// the current [_document]. An edit revision keeps the reading position,
+  /// including when pages were inserted, removed, reordered, or rotated; a
+  /// genuinely different document resets. Existing pages are matched across
+  /// revisions by their stable indirect-object references, so inserting or
+  /// deleting before the viewport does not change which page is on screen.
+  /// Runs from [didUpdateWidget] (a host rebuild with a new
+  /// document/controller) and from [_onRevisionControllerChanged] (a new
+  /// revision with no host rebuild).
+  void _swapDocument({bool preserveRevisionViewport = false}) {
     final document = _document;
     final sameGeometry = _sameGeometryAs(document);
+    final oldPageRefs = preserveRevisionViewport
+        ? [for (final page in _pages) _pageReferenceKey(page)]
+        : const <(int, int)?>[];
+    final oldCurrentPage = _pages.isEmpty
+        ? 0
+        : _controller.currentPage.clamp(0, _pages.length - 1);
+    final oldCurrentRef = oldPageRefs.isEmpty
+        ? null
+        : oldPageRefs[oldCurrentPage];
+    final oldViewport = preserveRevisionViewport && _pages.isNotEmpty
+        ? _pendingViewport ??
+            _captureViewport() ??
+            PdfViewport(
+              page: oldCurrentPage,
+              zoom: _currentZoom,
+            )
+        : null;
+    final oldViewportRef = oldViewport == null || oldPageRefs.isEmpty
+        ? null
+        : oldPageRefs[oldViewport.page.clamp(0, oldPageRefs.length - 1)];
     _textCache.clear();
     _annotCache.clear();
     _visibleAnnotCache.clear();
@@ -3463,11 +3498,37 @@ class _PdfViewerState extends State<PdfViewer>
     _controller.clearSearch();
     _clearSelection();
     _loadPages();
+    final newPageRefs = preserveRevisionViewport
+        ? [for (final page in _pages) _pageReferenceKey(page)]
+        : const <(int, int)?>[];
+    final pageOrderChanged = preserveRevisionViewport &&
+        (oldPageRefs.length != newPageRefs.length ||
+            Iterable<int>.generate(oldPageRefs.length).any(
+              (i) => oldPageRefs[i] != newPageRefs[i],
+            ));
+    PdfViewport? remappedViewport;
+    if (oldViewport != null && (!sameGeometry || pageOrderChanged)) {
+      final page = _remapPageIndex(
+        oldViewport.page,
+        oldViewportRef,
+        newPageRefs,
+      );
+      remappedViewport = PdfViewport(
+        page: page,
+        top: oldViewport.top,
+        left: oldViewport.left,
+        zoom: oldViewport.zoom,
+      );
+      _pendingViewport = remappedViewport;
+      _controller._setCurrentPage(
+        _remapPageIndex(oldCurrentPage, oldCurrentRef, newPageRefs),
+      );
+    }
     _previews.bindPages(_pages);
     // an edit revision keeps its previews (rebound to the new page
     // objects - edited pages refresh from their on-screen render); a
     // different document starts clean
-    if (sameGeometry) {
+    if (sameGeometry && !pageOrderChanged) {
       // a page whose content stamp advanced changed materially (a
       // redaction burn removes glyphs/images): drop its stale preview so
       // a fast scroll can't flash the deleted content, instead of
@@ -3489,7 +3550,7 @@ class _PdfViewerState extends State<PdfViewer>
     // re-point (and, for a different file, re-prime) the persistent
     // preview backing; an edit revision keeps its rebound previews so the
     // prime is a no-op there
-    _bindRasterCache(prime: !sameGeometry);
+    _bindRasterCache(prime: !sameGeometry || pageOrderChanged);
     _previewAttempts.clear();
     _previewVectorAttempts.clear();
     _intermediatePreviewAttempts.clear();
@@ -3498,7 +3559,7 @@ class _PdfViewerState extends State<PdfViewer>
     _rasterWarmAttempts.clear();
     _schedulePreviewPrerender();
     _scheduleRasterWarm();
-    if (!sameGeometry) {
+    if (!sameGeometry && remappedViewport == null) {
       // didUpdateWidget/a controller notification can land mid-build, and
       // jumpTo synchronously dispatches a ScrollNotification - ancestors
       // listening through a ScrollNotificationObserver (a Material AppBar's
@@ -3513,6 +3574,30 @@ class _PdfViewerState extends State<PdfViewer>
       _appliedInitialFit = false;
     }
     setState(() {});
+  }
+
+  /// The stable identity of a page across incremental revisions. Structural
+  /// edits rewrite the page tree but retain every surviving leaf's indirect
+  /// object number; newly inserted pages receive new numbers.
+  (int, int)? _pageReferenceKey(PdfPage page) {
+    final ref = page.document.cos.referenceTo(page.dict);
+    return ref == null ? null : (ref.objectNumber, ref.generation);
+  }
+
+  /// Maps an old page into the new page list by identity. If that page was
+  /// deleted, the page now occupying its index wins (the following page), or
+  /// the new last page when the deleted page was last.
+  int _remapPageIndex(
+    int oldIndex,
+    (int, int)? oldRef,
+    List<(int, int)?> newRefs,
+  ) {
+    if (newRefs.isEmpty) return 0;
+    if (oldRef != null) {
+      final matched = newRefs.indexOf(oldRef);
+      if (matched >= 0) return matched;
+    }
+    return oldIndex.clamp(0, newRefs.length - 1);
   }
 
   /// Whether [document] lays out exactly like the one on screen: same

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -337,10 +337,21 @@ class _PdfPanelTabGroupState extends State<PdfPanelTabGroup> {
           _tabStrip(context, geometry, entries, selected),
           const Divider(height: 1),
           Expanded(
-            child: IndexedStack(
-              index: selected,
-              sizing: StackFit.expand,
-              children: [for (final e in entries) e.body],
+            // The tab body is built in chromeless/bottom-sheet mode, so it
+            // does not know about this outer frame's resize grip. Keep the
+            // whole body (especially its edge-mounted scrollbar) out of the
+            // grip's hit strip; otherwise the divider paints through the
+            // scrollbar thumb in a left-docked tab group.
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: geometry.contentStartInset,
+                right: geometry.contentEndInset,
+              ),
+              child: IndexedStack(
+                index: selected,
+                sizing: StackFit.expand,
+                children: [for (final e in entries) e.body],
+              ),
             ),
           ),
         ]),

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -443,7 +443,7 @@ class StripPdfDevice extends StripBinningDevice {
       super.drawText(run);
       return;
     }
-    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, run.fillAlpha))) {
       _slugFallbackOutlineRuns++;
       totalSlugFallbackOutlineRuns++;
       super.drawText(run);

--- a/packages/dart_pdf_editor/lib/src/web_canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/web_canvas_device.dart
@@ -349,9 +349,11 @@ class _BrowserCanvasDevice implements PdfDevice {
     );
     if (placed != null) {
       context.scale(1 / placed.unitsPerEm, -1 / renderSize);
-      for (final part in placed.parts) {
-        context.fillText(part.text, part.x, 0);
-      }
+      _paintWithAlpha(run.fillAlpha, () {
+        for (final part in placed.parts) {
+          context.fillText(part.text, part.x, 0);
+        }
+      });
       context.restore();
       return;
     }
@@ -364,7 +366,7 @@ class _BrowserCanvasDevice implements PdfDevice {
         ? run.width * renderSize / naturalWidth
         : 1.0;
     context.scale(scaleX / renderSize, -1 / renderSize);
-    context.fillText(run.text, 0, 0);
+    _paintWithAlpha(run.fillAlpha, () => context.fillText(run.text, 0, 0));
     context.restore();
   }
 

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -12,6 +12,7 @@ void main() {
     test('addCallout builds a FreeText callout pointing at the target', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..preferences.author = 'Ben'
+        ..preferences.opacity = 0.45
         ..addCallout(
             0, const PdfRect(300, 600, 460, 660), 'Look here', (120, 500));
 
@@ -19,6 +20,7 @@ void main() {
       expect(annot.subtype, 'FreeText');
       expect(annot.isCallout, isTrue);
       expect(annot.contents, 'Look here');
+      expect(annot.appearanceOpacity, closeTo(0.45, 1e-9));
       final line = annot.calloutLine!;
       expect(line.first, (120.0, 500.0), reason: 'leader tip is the target');
       expect(annot.rect.left, lessThanOrEqualTo(120));
@@ -34,6 +36,7 @@ void main() {
 
     test('resizing a selected callout resizes the box, not the arrow', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.opacity = 0.55
         ..addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
       expect(editing.selectAnnotation(0, 0), isTrue);
       final terminus0 =
@@ -46,6 +49,7 @@ void main() {
       expect(a.calloutLine!.first, terminus0, reason: 'arrow tip stays put');
       expect(a.calloutBox!.left, closeTo(320, 0.5));
       expect(a.calloutBox!.right, closeTo(520, 0.5));
+      expect(a.appearanceOpacity, closeTo(0.55, 1e-9));
     });
 
     test('autosize fits the box and leaves the arrow tip alone', () {

--- a/packages/dart_pdf_editor/test/editing_font_render_test.dart
+++ b/packages/dart_pdf_editor/test/editing_font_render_test.dart
@@ -19,6 +19,33 @@ Future<int> _inkPixels(PdfStandardFont font) async {
   return ink;
 }
 
+/// The darkest red channel inside a large black free-text box. On white paper
+/// a 25%-opaque black glyph bottoms out near 191 instead of 0.
+Future<int> _darkestTextPixel(double opacity) async {
+  final editor = PdfEditor(PdfDocument.open(buildClassicPdf()))
+    ..addFreeText(
+      0,
+      const PdfRect(72, 600, 360, 700),
+      'OPACITY',
+      fontSize: 42,
+      opacity: opacity,
+    );
+  final doc = PdfDocument.open(editor.save());
+  final image = await PdfPageRenderer.renderImage(doc.page(0));
+  final data = await image.toByteData();
+  var darkest = 255;
+  // buildClassicPdf is a 612x792pt page and renderImage defaults to 1x.
+  // PDF y-up [600,700] maps to raster y-down [92,192].
+  for (var y = 92; y < 192; y++) {
+    for (var x = 72; x < 360; x++) {
+      final red = data!.getUint8((y * image.width + x) * 4);
+      if (red < darkest) darkest = red;
+    }
+  }
+  image.dispose();
+  return darkest;
+}
+
 void main() {
   testWidgets('bold free text paints more ink than the regular face',
       (tester) async {
@@ -36,6 +63,17 @@ void main() {
     await tester.runAsync(() async {
       final italic = await _inkPixels(PdfStandardFont.timesBoldItalic);
       expect(italic, greaterThan(50));
+    });
+  });
+
+  testWidgets('free-text appearance opacity fades the rendered glyphs',
+      (tester) async {
+    await tester.runAsync(() async {
+      final opaque = await _darkestTextPixel(1);
+      final faded = await _darkestTextPixel(0.25);
+      expect(opaque, lessThan(80));
+      expect(faded, greaterThan(opaque + 100));
+      expect(faded, lessThan(245), reason: 'the faded text must still paint');
     });
   });
 }

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -151,6 +151,20 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 300));
       expectViewport(editing, viewer, page: 1, label: 'Page 3');
     });
+
+    testWidgets('reordering pages follows the viewed page by identity',
+        (tester) async {
+      final (editing, viewer) = await pumpViewer(tester);
+      expectViewport(editing, viewer, page: 3, label: 'Page 4');
+
+      editing.movePage(3, 0);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 0, label: 'Page 4');
+
+      editing.undo();
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 3, label: 'Page 4');
+    });
   });
 
   group('duplicatePages', () {

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -74,6 +74,85 @@ void main() {
     });
   });
 
+  group('viewer position across page edits', () {
+    Future<(PdfEditingController, PdfViewerController)> pumpViewer(
+      WidgetTester tester,
+    ) async {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            editing: editing,
+            controller: viewer,
+            initialFit: PdfViewerFit.width,
+            pagePreviews: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+      viewer.restoreViewport(
+        const PdfViewport(page: 3, top: 0.18, left: 0.12, zoom: 1.5),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      return (editing, viewer);
+    }
+
+    void expectViewport(
+      PdfEditingController editing,
+      PdfViewerController viewer, {
+      required int page,
+      required String label,
+    }) {
+      final viewport = viewer.captureViewport();
+      expect(viewport, isNotNull);
+      expect(viewport!.page, page);
+      expect(viewer.currentPage, page);
+      expect(labelOf(editing.document, page), label);
+      expect(viewport.top, closeTo(0.18, 0.02));
+      expect(viewport.left, closeTo(0.12, 0.02));
+      expect(viewport.zoom, closeTo(1.5, 0.02));
+    }
+
+    testWidgets('adding pages keeps the current page and zoom',
+        (tester) async {
+      final (editing, viewer) = await pumpViewer(tester);
+      expectViewport(editing, viewer, page: 3, label: 'Page 4');
+
+      editing.addBlankPage(at: 1);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 4, label: 'Page 4');
+
+      editing.addBlankPage();
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 4, label: 'Page 4');
+    });
+
+    testWidgets('deleting pages keeps the nearest surviving view',
+        (tester) async {
+      final (editing, viewer) = await pumpViewer(tester);
+      expectViewport(editing, viewer, page: 3, label: 'Page 4');
+
+      // A deletion before the viewport follows the same page to its new slot.
+      editing.removePage(0);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 2, label: 'Page 4');
+
+      // Deleting the viewed page keeps its position and shows the page that
+      // moved into that slot instead of returning to page 1.
+      editing.removePage(2);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 2, label: 'Page 5');
+
+      // At the end of the document the previous page is the nearest survivor.
+      editing.removePage(2);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expectViewport(editing, viewer, page: 1, label: 'Page 3');
+    });
+  });
+
   group('duplicatePages', () {
     test('copies one page right after itself', () {
       final editing = PdfEditingController(buildMultiPagePdf(3));
@@ -1106,10 +1185,9 @@ void main() {
 
     testWidgets('⌘V paste reveals the new page instead of jumping to the top',
         (tester) async {
-      // A paste inserts pages, so the viewer resets its scroll to the top in
-      // a post-frame callback (a geometry-changing revision). The following
-      // strip must not chase that reset back to page 0 - it should land on
-      // the pages that were just pasted.
+      // Structural edits preserve the existing view by default. Pasting from
+      // the strip intentionally overrides that anchor and reveals the pages
+      // that were just pasted.
       tester.view.physicalSize = const Size(800, 1400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);

--- a/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
@@ -1,4 +1,5 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/shell_chrome.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -106,6 +107,47 @@ void main() {
     expect(persisted, closeTo(300, 1));
     expect(tester.getSize(find.byType(PdfSidebarPanelFrame)).width,
         closeTo(300, 1));
+  });
+
+  testWidgets('tab bodies stay clear of the outer resize grip',
+      (tester) async {
+    Widget tabHost(PdfPanelDock dock) => MaterialApp(
+          home: Scaffold(
+            body: Align(
+              alignment: Alignment.topLeft,
+              child: PdfPanelTabGroup(
+                dock: dock,
+                width: 240,
+                minWidth: 180,
+                maxWidth: 320,
+                gripKey: const ValueKey('tab-grip'),
+                entries: const [
+                  PdfPanelTabEntry(
+                    panel: PdfDockablePanel.thumbnails,
+                    body: ColoredBox(
+                      key: ValueKey('tab-body'),
+                      color: Colors.white,
+                    ),
+                  ),
+                  PdfPanelTabEntry(
+                    panel: PdfDockablePanel.search,
+                    body: SizedBox.expand(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(tabHost(PdfPanelDock.left));
+    var body = tester.getRect(find.byKey(const ValueKey('tab-body')));
+    var grip = tester.getRect(find.byKey(const ValueKey('tab-grip')));
+    expect(body.right, lessThanOrEqualTo(grip.left));
+
+    await tester.pumpWidget(tabHost(PdfPanelDock.right));
+    body = tester.getRect(find.byKey(const ValueKey('tab-body')));
+    grip = tester.getRect(find.byKey(const ValueKey('tab-grip')));
+    expect(body.left, greaterThanOrEqualTo(grip.right));
   });
 
   testWidgets('close is docked-only and bottom sheet bypasses fixed width',

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -518,9 +518,12 @@ void main() {
       expect(strip.padding, const EdgeInsets.fromLTRB(0, 8, 10, 8));
 
       // right-docked annotation list: the grip rides the far edge, so
-      // just the bar's 14px
-      final list = tester.widget<ListView>(find.byType(ListView));
-      expect(list.padding, const EdgeInsets.only(right: 14));
+      // just the bar's 14px. Each sticky page group carries the inset.
+      final annotationPadding = tester.widget<SliverPadding>(find.descendant(
+        of: find.byKey(const ValueKey('pdf-annotation-list')),
+        matching: find.byType(SliverPadding),
+      ));
+      expect(annotationPadding.padding, const EdgeInsets.only(right: 14));
       await tester.pump(const Duration(seconds: 2)); // drain tile renders
     });
 
@@ -545,8 +548,11 @@ void main() {
       ));
       await tester.pump();
 
-      final list = tester.widget<ListView>(find.byType(ListView));
-      expect(list.padding, const EdgeInsets.only(right: 22));
+      final annotationPadding = tester.widget<SliverPadding>(find.descendant(
+        of: find.byKey(const ValueKey('pdf-annotation-list')),
+        matching: find.byType(SliverPadding),
+      ));
+      expect(annotationPadding.padding, const EdgeInsets.only(right: 22));
     });
   });
 }

--- a/packages/dart_pdf_editor/test/editing_sidebar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sidebar_test.dart
@@ -488,6 +488,56 @@ void main() {
     expect(find.text('Stamp'), findsOneWidget);
   });
 
+  testWidgets('collapse all applies to the page groups visible in a filter',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(2))
+      ..addNote(0, 100, 700, 'first note')
+      ..addStamp(1, const PdfRect(100, 600, 240, 650), 'DRAFT');
+    addTearDown(editing.dispose);
+    await pumpSidebarOnly(tester, editing);
+
+    // Page 1 is folded while page 2 remains open.
+    await tester
+        .tap(find.byKey(const ValueKey('pdf-annotation-page-toggle-0')));
+    await tester.pump();
+
+    // The filter hides the still-open page 2. The global control should now
+    // expand the only displayed group on its first click, not silently fold
+    // the hidden page first.
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-annotation-search')), 'note');
+    await tester.pump();
+    expect(find.text('Note'), findsNothing);
+
+    await tester
+        .tap(find.byKey(const ValueKey('pdf-annotation-pages-toggle-all')));
+    await tester.pump();
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('Stamp'), findsNothing);
+  });
+
+  testWidgets('collapsed pages do not leak into a replacement controller',
+      (tester) async {
+    final first = PdfEditingController(buildMultiPagePdf(1))
+      ..addNote(0, 100, 700, 'first note');
+    final second = PdfEditingController(buildMultiPagePdf(1))
+      ..addRectangle(0, const PdfRect(100, 100, 200, 150));
+    addTearDown(first.dispose);
+    addTearDown(second.dispose);
+
+    await pumpSidebarOnly(tester, first);
+    await tester
+        .tap(find.byKey(const ValueKey('pdf-annotation-page-toggle-0')));
+    await tester.pump();
+    expect(find.text('Note'), findsNothing);
+
+    // Both controllers are at revision 1, so revision-id comparison alone
+    // cannot distinguish them.
+    expect(first.revisionId, second.revisionId);
+    await pumpSidebarOnly(tester, second);
+    expect(find.text('Square'), findsOneWidget);
+  });
+
   testWidgets('the current page header stays pinned while its rows scroll',
       (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(2));

--- a/packages/dart_pdf_editor/test/editing_sidebar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sidebar_test.dart
@@ -438,6 +438,84 @@ void main() {
     expect(find.text('Hello, world! - https://example.com'), findsOneWidget);
   });
 
+  testWidgets('page headers show counts and collapse individually or together',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(2))
+      ..addNote(0, 100, 700, 'first note')
+      ..addRectangle(0, const PdfRect(100, 100, 200, 150))
+      ..addStamp(1, const PdfRect(100, 600, 240, 650), 'DRAFT');
+    addTearDown(editing.dispose);
+    await pumpSidebarOnly(tester, editing);
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('pdf-annotation-page-count-0')),
+        matching: find.text('2 annotations'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('pdf-annotation-page-count-1')),
+        matching: find.text('1 annotation'),
+      ),
+      findsOneWidget,
+    );
+
+    // A page folds independently while the other page stays open.
+    await tester
+        .tap(find.byKey(const ValueKey('pdf-annotation-page-toggle-0')));
+    await tester.pump();
+    expect(find.text('Note'), findsNothing);
+    expect(find.text('Square'), findsNothing);
+    expect(find.text('Stamp'), findsOneWidget);
+    expect(find.text('Page 1'), findsOneWidget);
+
+    // With any section open the panel-level control folds every page; its
+    // next activation expands all of them again.
+    final toggleAll =
+        find.byKey(const ValueKey('pdf-annotation-pages-toggle-all'));
+    await tester.tap(toggleAll);
+    await tester.pump();
+    expect(find.text('Stamp'), findsNothing);
+    expect(find.text('Page 1'), findsOneWidget);
+    expect(find.text('Page 2'), findsOneWidget);
+
+    await tester.tap(toggleAll);
+    await tester.pump();
+    expect(find.text('Note'), findsOneWidget);
+    expect(find.text('Square'), findsOneWidget);
+    expect(find.text('Stamp'), findsOneWidget);
+  });
+
+  testWidgets('the current page header stays pinned while its rows scroll',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    for (var i = 0; i < 16; i++) {
+      editing.addRectangle(
+          0, PdfRect(40.0 + i, 100, 120.0 + i, 150));
+    }
+    editing.addNote(1, 100, 700, 'second page');
+    addTearDown(editing.dispose);
+    await pumpSidebarOnly(tester, editing);
+
+    final pinnedHeaders = tester
+        .widgetList<SliverPersistentHeader>(find.byType(SliverPersistentHeader));
+    expect(pinnedHeaders, isNotEmpty);
+    expect(pinnedHeaders.every((header) => header.pinned), isTrue);
+
+    final pageHeader =
+        find.byKey(const ValueKey('pdf-annotation-page-header-0'));
+    final scrollView =
+        find.byKey(const ValueKey('pdf-annotation-scroll-view'));
+    final initialTop = tester.getTopLeft(pageHeader).dy;
+
+    await tester.drag(scrollView, const Offset(0, -140));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(pageHeader).dy, closeTo(initialTop, 0.5));
+  });
+
   group('search', () {
     testWidgets('filters by type, contents, and author', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(2))

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -149,6 +149,25 @@ void main() {
       expect(style.borderWidth, 3);
     });
 
+    test('text opacity flows through creation, restyling, and text edits', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.opacity = 0.4
+        ..addFreeText(0, const PdfRect(100, 600, 300, 660), 'Faded');
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      expect(editing.selectedAnnotation!.behavior.supportsOpacity, isTrue);
+      expect(
+          editing.selectedAnnotation!.appearanceOpacity, closeTo(0.4, 1e-9));
+
+      expect(editing.restyleSelected(opacity: 0.65), isTrue);
+      expect(
+          editing.selectedAnnotation!.appearanceOpacity, closeTo(0.65, 1e-9));
+
+      editing.setSelectedText('Still faded');
+      expect(editing.selectedAnnotation!.contents, 'Still faded');
+      expect(
+          editing.selectedAnnotation!.appearanceOpacity, closeTo(0.65, 1e-9));
+    });
+
     test('restyleSelectedText sets, keeps, and clears fill and border', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addFreeText(0, const PdfRect(100, 600, 300, 660), 'Plain');

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -380,6 +380,27 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('the inline text editor previews opacity changes',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing
+        ..preferences.opacity = 0.25
+        ..tool = PdfEditTool.freeText;
+      await tester.pump();
+
+      await drag(tester, view(100, 700), view(300, 640));
+      TextField field() => tester.widget<TextField>(find.byKey(editorKey));
+      expect(field().style!.color!.a, closeTo(0.25, 1e-6));
+
+      editing.preferences.opacity = 0.6;
+      await tester.pump();
+      expect(field().style!.color!.a, closeTo(0.6, 1e-6));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await settle(tester);
+    });
+
     testWidgets('tapping without dragging places a default-sized text box',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/pdf_document/lib/src/annotation_behavior.dart
+++ b/packages/pdf_document/lib/src/annotation_behavior.dart
@@ -143,6 +143,7 @@ class PdfAnnotationBehavior {
         'Underline' ||
         'StrikeOut' ||
         'Squiggly' ||
+        'FreeText' ||
         'Stamp' =>
           true,
         _ => false,

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1976,7 +1976,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// The style round-trips through the dictionary so the appearance can
   /// be regenerated (resize, text edits): text color and [borderColor]
   /// live in /DA (`rg` / `RG`), [fillColor] is /C (the free-text
-  /// background per §12.5.6.6), [borderWidth] is /BS /W.
+  /// background per §12.5.6.6), [borderWidth] is /BS /W, and [opacity]
+  /// is baked into the appearance's graphics state.
   void addFreeText(
     int pageIndex,
     PdfRect rect,
@@ -1989,6 +1990,7 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     int? borderColor,
     double borderWidth = 1,
+    double opacity = 1,
     double lineSpacing = _defaultLineSpacing,
     double charSpacing = 0,
     double horizontalScale = _defaultHorizontalScale,
@@ -2015,6 +2017,7 @@ extension PdfAnnotationEditing on PdfEditor {
     // The font accumulates which glyphs the appearance shows (so an
     // embedded font's /W and /ToUnicode cover exactly them); start fresh.
     if (font is PdfEmbeddedFont) font.resetUsage();
+    final gs = _alphaState(opacity);
     final w = _freeTextContent(
       rect,
       text,
@@ -2026,6 +2029,7 @@ extension PdfAnnotationEditing on PdfEditor {
       fillColor: fillColor,
       borderColor: borderColor,
       borderWidth: borderWidth,
+      hasAlpha: gs != null,
       lineSpacing: lineSpacing,
       charSpacing: charSpacing,
       horizontalScale: horizontalScale,
@@ -2063,7 +2067,8 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w, resources: _resources(font: fontResource)),
+      _form(rect, w,
+          resources: _resources(extGState: gs, font: fontResource)),
       name: name,
     );
   }
@@ -2090,6 +2095,7 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     int strokeColor = 0xD02020,
     double strokeWidth = 1,
+    double opacity = 1,
     PdfLineEnding ending = PdfLineEnding.openArrow,
     int? pageRotation,
     String? author,
@@ -2127,6 +2133,7 @@ extension PdfAnnotationEditing on PdfEditor {
       ...endingPoints,
     ], strokeWidth);
 
+    final gs = _alphaState(opacity);
     final w = _calloutContent(
       boxRect,
       callout,
@@ -2142,6 +2149,7 @@ extension PdfAnnotationEditing on PdfEditor {
       lineColor: strokeColor,
       lineWidth: strokeWidth,
       ending: ending,
+      hasAlpha: gs != null,
       pageRotation: effectivePageRotation,
     );
 
@@ -2171,7 +2179,8 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w, resources: _resources(font: fontResource)),
+      _form(rect, w,
+          resources: _resources(extGState: gs, font: fontResource)),
       name: name,
     );
   }
@@ -2309,6 +2318,7 @@ extension PdfAnnotationEditing on PdfEditor {
     required int lineColor,
     required double lineWidth,
     required PdfLineEnding ending,
+    bool hasAlpha = false,
     double lineSpacing = _defaultLineSpacing,
     double charSpacing = 0,
     double horizontalScale = _defaultHorizontalScale,
@@ -2343,7 +2353,9 @@ extension PdfAnnotationEditing on PdfEditor {
       underline: underline,
       pageRotation: pageRotation,
     );
-    return ContentWriter()
+    final w = ContentWriter();
+    if (hasAlpha) w.extGState('GS0');
+    return w
       ..append(leader)
       ..append(box);
   }
@@ -2446,6 +2458,7 @@ extension PdfAnnotationEditing on PdfEditor {
     ], math.max(style.borderWidth, leaderWidth));
 
     final pageRotation = _appearancePageRotation(pageIndex, null);
+    final gs = _alphaState(annotation.appearanceOpacity);
     final w = _calloutContent(
       newBox,
       callout,
@@ -2461,6 +2474,7 @@ extension PdfAnnotationEditing on PdfEditor {
       lineColor: leaderColor,
       lineWidth: leaderWidth,
       ending: info.ending,
+      hasAlpha: gs != null,
       pageRotation: pageRotation,
     );
 
@@ -2478,12 +2492,13 @@ extension PdfAnnotationEditing on PdfEditor {
         form,
         rect,
         w,
-        resources: _resources(font: fontResource),
+        resources: _resources(extGState: gs, font: fontResource),
       );
     } else {
       dict['AP'] = CosDictionary({
         'N': _updater.addObject(
-          _form(rect, w, resources: _resources(font: fontResource)),
+          _form(rect, w,
+              resources: _resources(extGState: gs, font: fontResource)),
         ),
       });
     }
@@ -2507,6 +2522,7 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     int? borderColor,
     double borderWidth = 1,
+    double opacity = 1,
     double lineSpacing = _defaultLineSpacing,
     double charSpacing = 0,
     double horizontalScale = _defaultHorizontalScale,
@@ -2542,6 +2558,7 @@ extension PdfAnnotationEditing on PdfEditor {
     for (final font in _richFonts(effective)) {
       if (font is PdfEmbeddedFont) font.resetUsage();
     }
+    final gs = _alphaState(opacity);
     final w = _freeTextRichContent(
       rect,
       effective,
@@ -2550,6 +2567,7 @@ extension PdfAnnotationEditing on PdfEditor {
       fillColor: fillColor,
       borderColor: borderColor,
       borderWidth: borderWidth,
+      hasAlpha: gs != null,
       lineSpacing: lineSpacing,
       charSpacing: charSpacing,
       horizontalScale: horizontalScale,
@@ -2591,7 +2609,10 @@ extension PdfAnnotationEditing on PdfEditor {
       _form(
         rect,
         w,
-        resources: _resources(font: _richFontResources(effective)),
+        resources: _resources(
+          extGState: gs,
+          font: _richFontResources(effective),
+        ),
       ),
       name: name,
     );
@@ -2727,6 +2748,7 @@ extension PdfAnnotationEditing on PdfEditor {
     required int? fillColor,
     required int? borderColor,
     required double borderWidth,
+    bool hasAlpha = false,
     double lineSpacing = _defaultLineSpacing,
     double charSpacing = 0,
     double horizontalScale = _defaultHorizontalScale,
@@ -2735,6 +2757,7 @@ extension PdfAnnotationEditing on PdfEditor {
   }) {
     const pad = 3.0;
     final w = ContentWriter();
+    if (hasAlpha) w.extGState('GS0');
     final vr = _orientedVisualRect(rect, pageRotation);
     if (pageRotation != 0) {
       w.save();
@@ -2812,6 +2835,7 @@ extension PdfAnnotationEditing on PdfEditor {
     required int? fillColor,
     required int? borderColor,
     required double borderWidth,
+    bool hasAlpha = false,
     double lineSpacing = _defaultLineSpacing,
     double charSpacing = 0,
     double horizontalScale = _defaultHorizontalScale,
@@ -2819,6 +2843,7 @@ extension PdfAnnotationEditing on PdfEditor {
   }) {
     const pad = 3.0;
     final w = ContentWriter();
+    if (hasAlpha) w.extGState('GS0');
     final vr = _orientedVisualRect(rect, pageRotation);
     if (pageRotation != 0) {
       w.save();
@@ -4649,11 +4674,12 @@ extension PdfAnnotationEditing on PdfEditor {
         final embedded =
             stdFont == null ? PdfEmbeddedFont.fromFreeText(annotation) : null;
         if (stdFont == null && embedded == null) return false;
+        final gs = _alphaState(opacity ?? _appearanceOpacity(form));
         final text = annotation.contents ?? '';
         final callout = _calloutInfo(annotation);
-        // a rich (/RC) box keeps its per-run styling across a resize; a
-        // restyle (colour/opacity) deliberately flattens to the new uniform
-        // /DA instead, so [preserveRich] is false there
+        // A rich (/RC) box keeps its per-run styling across a resize and
+        // box-only restyles such as opacity/fill. A whole-text colour change
+        // deliberately flattens to the new uniform /DA instead.
         final rc = preserveRich ? annotation.richContent : null;
         final richRuns = (rc == null || callout != null)
             ? null
@@ -4688,6 +4714,7 @@ extension PdfAnnotationEditing on PdfEditor {
             fillColor: style.fillColor,
             borderColor: style.borderColor,
             borderWidth: style.borderWidth,
+            hasAlpha: gs != null,
             lineSpacing: style.lineSpacing,
             charSpacing: style.charSpacing,
             horizontalScale: style.horizontalScale,
@@ -4738,6 +4765,7 @@ extension PdfAnnotationEditing on PdfEditor {
               lineColor: style.borderColor ?? style.color,
               lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
               ending: callout.ending,
+              hasAlpha: gs != null,
               lineSpacing: style.lineSpacing,
               charSpacing: style.charSpacing,
               horizontalScale: style.horizontalScale,
@@ -4757,6 +4785,7 @@ extension PdfAnnotationEditing on PdfEditor {
               fillColor: style.fillColor,
               borderColor: style.borderColor,
               borderWidth: style.borderWidth,
+              hasAlpha: gs != null,
               lineSpacing: style.lineSpacing,
               charSpacing: style.charSpacing,
               horizontalScale: style.horizontalScale,
@@ -4775,7 +4804,7 @@ extension PdfAnnotationEditing on PdfEditor {
           form,
           to,
           w,
-          resources: _resources(font: fontResource),
+          resources: _resources(extGState: gs, font: fontResource),
         );
         return true;
       case 'Line':
@@ -4902,8 +4931,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// * [strokeWidth] - shapes, the line family, and ink. Ignored elsewhere (markup line
   ///   weights derive from the text size; free-text borders restyle
   ///   through the text-style path).
-  /// * [opacity] - shapes, ink, markups, stamps. Free text and notes
-  ///   stay opaque, as authored.
+  /// * [opacity] - shapes, ink, markups, free text, and stamps. Notes stay
+  ///   opaque, as authored.
   /// * [cornerRadius] - the rounded-corner radius (page points) of a
   ///   /Square rectangle, rewritten into /Border and baked into the
   ///   appearance; `0` restores square corners. Ignored by every other
@@ -5098,7 +5127,9 @@ extension PdfAnnotationEditing on PdfEditor {
         return _restyleRegenerate(
           pageIndex,
           dict,
+          opacity: opacity,
           pageRotation: effectivePageRotation,
+          preserveRich: color == null,
         );
       case 'Text':
         dict['C'] = _colorComponents(color ?? currentStyle.color ?? 0xFFD100);
@@ -5122,6 +5153,7 @@ extension PdfAnnotationEditing on PdfEditor {
     CosDictionary dict, {
     double? opacity,
     int pageRotation = 0,
+    bool preserveRich = false,
   }) {
     // re-wrap: /Rect and style entries are parsed at construction or
     // lazily, and the dict just changed under the caller's instance
@@ -5134,6 +5166,7 @@ extension PdfAnnotationEditing on PdfEditor {
         annotation.rect,
         opacity: opacity,
         pageRotation: pageRotation,
+        preserveRich: preserveRich,
       )) {
         return false;
       }
@@ -5154,6 +5187,7 @@ extension PdfAnnotationEditing on PdfEditor {
       local,
       opacity: opacity,
       pageRotation: pageRotation,
+      preserveRich: preserveRich,
     )) {
       return false;
     }
@@ -5174,6 +5208,7 @@ extension PdfAnnotationEditing on PdfEditor {
     PdfRect to, {
     double? opacity,
     int pageRotation = 0,
+    bool preserveRich = false,
   }) {
     switch (annotation.subtype) {
       case 'Square' ||
@@ -5187,7 +5222,7 @@ extension PdfAnnotationEditing on PdfEditor {
           to,
           opacity: opacity,
           pageRotation: pageRotation,
-          preserveRich: false,
+          preserveRich: preserveRich,
         );
       case 'Stamp':
         final form = annotation.normalAppearance;

--- a/packages/pdf_document/test/annotation_behavior_test.dart
+++ b/packages/pdf_document/test/annotation_behavior_test.dart
@@ -73,7 +73,7 @@ void main() {
     expect(behavior.textEditable, isTrue);
     expect(behavior.canRestyle, isTrue);
     expect(behavior.supportsFill, isTrue);
-    expect(behavior.supportsOpacity, isFalse);
+    expect(behavior.supportsOpacity, isTrue);
     expect(behavior.resizeBehavior, PdfAnnotationResizeBehavior.reflowText);
     expect(behavior.standardTextFont, PdfStandardFont.times);
     expect(behavior.style.color, 0x102030);

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -387,6 +387,24 @@ void main() {
     expect((doc.cos.resolve(helv['Widths']) as CosArray).length, 95);
   });
 
+  test('free text opacity is baked into and preserved by its appearance', () {
+    final doc = roundTrip((e) => e.addFreeText(
+          0,
+          const PdfRect(72, 600, 240, 680),
+          'Translucent text',
+          fillColor: 0xFFFFE0,
+          opacity: 0.4,
+        ));
+    final box = doc.page(0).annotations.single;
+    expect(box.appearanceOpacity, closeTo(0.4, 1e-9));
+    expect(appearanceText(doc, box), startsWith('/GS0 gs'));
+
+    final editor = PdfEditor(doc)
+      ..resizeAnnotation(0, box, const PdfRect(72, 600, 360, 700));
+    final resized = PdfDocument.open(editor.save()).page(0).annotations.single;
+    expect(resized.appearanceOpacity, closeTo(0.4, 1e-9));
+  });
+
   test('free text can lay out RTL visual order and right alignment', () {
     expect(pdfTextLooksRtl('שלום 123'), isTrue);
     expect(pdfVisualText('שלום 123', PdfTextDirection.rtl), '123 םולש');

--- a/packages/pdf_document/test/annotation_restyle_test.dart
+++ b/packages/pdf_document/test/annotation_restyle_test.dart
@@ -164,6 +164,33 @@ void main() {
         contains('${rgb(0xFFF59D)} rg'));
   });
 
+  test('free text opacity restyles in place and preserves rich runs', () {
+    final doc = edited(
+        PdfDocument.open(buildMultiPagePdf(1)),
+        (e) => e.addFreeTextRich(
+              0,
+              const PdfRect(100, 560, 320, 630),
+              const [
+                PdfFreeTextRun('Bold ',
+                    font: PdfStandardFont.helveticaBold),
+                PdfFreeTextRun('red', color: 0xFF0000),
+              ],
+              opacity: 0.7,
+            ));
+    final before = doc.page(0).annotations.single;
+
+    final out = edited(
+        doc,
+        (e) => e.restyleAnnotation(0, before, opacity: 0.25));
+    final after = out.page(0).annotations.single;
+    final appearance = content(out, after);
+
+    expect(after.appearanceOpacity, closeTo(0.25, 1e-9));
+    expect(after.richContent, isNotNull);
+    expect(appearance, contains('/HelvBold'));
+    expect(appearance, contains('1 0 0 rg'));
+  });
+
   test('note and stamp recolor with regenerated artwork', () {
     final doc = edited(PdfDocument.open(buildMultiPagePdf(1)), (e) {
       e.addNote(0, 100, 700, 'A note');

--- a/packages/pdf_graphics/lib/src/device.dart
+++ b/packages/pdf_graphics/lib/src/device.dart
@@ -72,6 +72,8 @@ class PdfTextRun {
     this.fill = true,
     this.strokeColor,
     this.strokeWidth = 0,
+    this.fillAlpha = 1,
+    this.strokeAlpha = 1,
     this.letterSpacing = 0,
     this.wordSpacing = 0,
     this.visibleWidth,
@@ -98,6 +100,12 @@ class PdfTextRun {
   /// Stroke line width in page space (the current line width mapped through
   /// the CTM, like every other stroke); 0 means the thinnest renderable line.
   final double strokeWidth;
+
+  /// Nonstroking opacity (`ca`) in effect for the filled glyphs.
+  final double fillAlpha;
+
+  /// Stroking opacity (`CA`) in effect for the outlined glyphs.
+  final double strokeAlpha;
 
   /// Render mode 3 (§9.4.3): the run paints nothing but still occupies
   /// its geometry - the OCR text layer of scanned documents. Painting

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -2634,6 +2634,13 @@ class PdfInterpreter {
           fill: embedded ? true : doFill,
           strokeColor: !embedded && strokeText ? _state.strokeColor : null,
           strokeWidth: _state.stroke.width * k, // see strokePath: 0 stays 0
+          // Embedded stroke-only text is historically approximated by
+          // filling the real outline in the stroke colour; carry the matching
+          // stroking alpha with that approximation too.
+          fillAlpha: embedded && (mode == 1 || mode == 5)
+              ? _state.strokeAlpha
+              : _state.fillAlpha,
+          strokeAlpha: _state.strokeAlpha,
           gradient: (embedded ? fillText : doFill)
               ? _gradientOfPattern(pattern)
               : null,

--- a/packages/pdf_graphics/lib/src/raster/strip_binning_device.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_binning_device.dart
@@ -284,7 +284,7 @@ abstract class StripBinningDevice implements PdfDevice {
       return;
     }
     if (!binningEnabled) return;
-    final color = stripArgbColor(run.color, 1);
+    final color = stripArgbColor(run.color, run.fillAlpha);
     for (final glyph in glyphs) {
       final outline = glyph.outline;
       if (outline == null) continue;

--- a/packages/pdf_graphics/lib/src/raster/strip_plan.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_plan.dart
@@ -144,7 +144,7 @@ class StripPlanBinner extends StripBinningDevice {
       return;
     }
     flushPending();
-    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, run.fillAlpha))) {
       slugFallbackOutlineRuns++;
       slugFallbackOrdinals.add(flushPointCount - 1);
       super.drawText(run);

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -54,7 +54,7 @@ import 'text_extraction.dart';
 /// Format: little notion of versioning beyond a leading byte; the producer and
 /// consumer are the same build, shipped together, so a version mismatch is a
 /// programming error, asserted on read.
-const int _formatVersion = 6;
+const int _formatVersion = 7;
 
 /// Microseconds spent reconstructing worker command buffers on the consuming
 /// isolate. Accumulated for performance probes; this is the UI-thread half of
@@ -1512,6 +1512,8 @@ void _writeTextRun(_Writer w, PdfTextRun run) {
     _writeColor(w, run.strokeColor!);
   }
   w.f64(run.strokeWidth);
+  w.f64(run.fillAlpha);
+  w.f64(run.strokeAlpha);
   // Substitute-font spacing geometry (Tc/Tw and the visible-glyph advance): a
   // painting consumer needs these to reproduce word/char spacing and to keep
   // edge whitespace from stretching the visible glyphs.
@@ -1567,6 +1569,8 @@ PdfTextRun _readTextRun(_Reader r) {
   final fill = r.boolean();
   final strokeColor = r.boolean() ? _readColor(r) : null;
   final strokeWidth = r.f64();
+  final fillAlpha = r.f64();
+  final strokeAlpha = r.f64();
   final letterSpacing = r.f64();
   final wordSpacing = r.f64();
   final leadingSpace = r.f64();
@@ -1587,6 +1591,8 @@ PdfTextRun _readTextRun(_Reader r) {
     fill: fill,
     strokeColor: strokeColor,
     strokeWidth: strokeWidth,
+    fillAlpha: fillAlpha,
+    strokeAlpha: strokeAlpha,
     letterSpacing: letterSpacing,
     wordSpacing: wordSpacing,
     leadingSpace: leadingSpace,

--- a/packages/pdf_graphics/lib/src/translating_device.dart
+++ b/packages/pdf_graphics/lib/src/translating_device.dart
@@ -99,6 +99,8 @@ class TranslatingPdfDevice implements PdfDevice {
         fill: run.fill,
         strokeColor: run.strokeColor,
         strokeWidth: run.strokeWidth,
+        fillAlpha: run.fillAlpha,
+        strokeAlpha: run.strokeAlpha,
         mcid: run.mcid,
         // Em-space, so a page-space translation leaves them alone - but they
         // still have to be carried, or a tiled cell's substituted text loses

--- a/packages/pdf_graphics/lib/src/vector_print.dart
+++ b/packages/pdf_graphics/lib/src/vector_print.dart
@@ -324,7 +324,7 @@ class _EncodingDevice implements PdfDevice {
     final color = run.fill ? run.color : run.strokeColor!;
     final m = run.transform.concat(_toDevice);
     _w.u8(_opText);
-    _w.rgba(color, 1);
+    _w.rgba(color, run.fill ? run.fillAlpha : run.strokeAlpha);
     _w.u8(_fontFlags(run.fontName));
     _w.matrix(m);
     _w.f32(run.fontSize);
@@ -342,13 +342,13 @@ class _EncodingDevice implements PdfDevice {
           .concat(_toDevice);
       if (run.fill) {
         _w.u8(_opFillPath);
-        _w.rgba(run.color, 1);
+        _w.rgba(run.color, run.fillAlpha);
         _w.u8(0); // glyph outlines fill nonzero
         _writePathTransformed(outline, m);
       }
       if (run.strokeColor != null) {
         _w.u8(_opStrokePath);
-        _w.rgba(run.strokeColor!, 1);
+        _w.rgba(run.strokeColor!, run.strokeAlpha);
         _w.f32(run.strokeWidth > 0 ? run.strokeWidth : 0);
         _w.u8(0);
         _w.u8(0);

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -370,6 +370,34 @@ void main() {
     expect(device.fills.single.$4, 0.25);
   });
 
+  test('ExtGState alpha is carried by text runs', () {
+    final doc = CosDocument.open(buildClassicPdf());
+    final device = RecordingDevice();
+    final resources = CosDictionary({
+      'Font': CosDictionary({
+        'F1': CosDictionary({
+          'Type': const CosName('Font'),
+          'Subtype': const CosName('Type1'),
+          'BaseFont': const CosName('Helvetica'),
+        }),
+      }),
+      'ExtGState': CosDictionary({
+        'GS1': CosDictionary({
+          'ca': const CosReal(0.25),
+          'CA': const CosReal(0.6),
+        }),
+      }),
+    });
+    PdfInterpreter(cos: doc, device: device).run(
+      ContentStreamParser.parse(Uint8List.fromList(
+          '/GS1 gs BT /F1 24 Tf 2 Tr 72 720 Td (Faded) Tj ET'.codeUnits)),
+      resources,
+    );
+
+    expect(device.texts.single.fillAlpha, 0.25);
+    expect(device.texts.single.strokeAlpha, 0.6);
+  });
+
   group('text', () {
     test('renders the fixture page text with correct placement', () {
       final doc = PdfDocument.open(buildClassicPdf());

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -201,6 +201,24 @@ void main() {
       final b = serializeCommands(recorder.commands)!;
       expect(a, equals(b));
     });
+
+    test('text opacity survives command serialization', () {
+      const run = PdfTextRun(
+        text: 'Faded',
+        transform: PdfMatrix.identity,
+        color: PdfColor.black,
+        width: 3,
+        fillAlpha: 0.25,
+        strokeColor: PdfColor(1, 0, 0),
+        strokeAlpha: 0.6,
+      );
+
+      final restored = deserializeCommands(
+        serializeCommands([const PdfDrawTextCommand(run)])!,
+      ).single as PdfDrawTextCommand;
+      expect(restored.run.fillAlpha, 0.25);
+      expect(restored.run.strokeAlpha, 0.6);
+    });
   });
 
   group('worker state-scope compaction', () {


### PR DESCRIPTION
## Summary

- add opacity support for free-text and callout annotations, including creation, restyling, resizing, and live/afterimage previews
- preserve the current page, zoom, and viewport across page insertions, removals, and reorders by remapping surviving pages through stable page references
- keep tabbed panel resize grips from painting through or overlapping edge-mounted scrollbars
- make annotation-panel page headers sticky, show per-page annotation counts, allow per-page collapse, and add collapse/expand-all

## Why

Several editor actions were visually inconsistent: text opacity was not applied through the full authoring pipeline, structural page edits reset the reader to page 1, and panel chrome could overlap scrollbars. The annotation panel also became difficult to scan on documents with annotations spread across many pages.

These changes keep visual styling and navigation stable while making large annotation lists easier to browse.

## Validation

- `fvm dart analyze`
- `cd packages/pdf_document && fvm dart test test/annotation_editor_test.dart test/annotation_restyle_test.dart` (106 tests)
- `cd packages/dart_pdf_editor && fvm flutter test test/editing_callout_test.dart test/editing_page_ops_test.dart test/editing_panel_frame_test.dart test/editing_panels_test.dart test/editing_sidebar_test.dart test/editing_text_edit_test.dart test/pdf_theme_test.dart` (176 tests)
