### PR TITLE
Fix stale macOS page rendering after edits

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Build Linux
         working-directory: app
         run: |
-          flutter build linux --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+          flutter build linux --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }} --dart-define=PDF_BUILD_COMMIT=${{ github.sha }}
           build/linux/x64/release/bundle/dartpdf-cli --version
       - name: Tar bundle (portable folder)
         working-directory: app
@@ -438,7 +438,7 @@ jobs:
             macos/Runner.xcodeproj/project.pbxproj
       - name: Build macOS
         working-directory: app
-        run: flutter build macos --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+        run: flutter build macos --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }} --dart-define=PDF_BUILD_COMMIT=${{ github.sha }}
       - uses: actions/download-artifact@v8
         with:
           pattern: macos-cli-*

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -142,12 +142,12 @@ class AppDevTools extends ChangeNotifier {
   /// it rebuilds the mounted viewer in place; [PdfPageView] then retires its
   /// old scene sessions without reopening the PDF; the base raster stays
   /// visible while the selected backend repopulates the invalidated LoD.
+  ///
+  /// The custom flutter_gpu backend is experimental. Keep Canvas as the safe
+  /// default even on supported platforms; developers can opt into flutter_gpu
+  /// from the panel when they are deliberately testing it.
   late final ValueNotifier<TileRasterBackendMode> tileRasterBackendMode =
-      ValueNotifier(
-    flutterGpuTileRasterBackend.isPlatformSupported
-        ? TileRasterBackendMode.flutterGpu
-        : TileRasterBackendMode.canvas,
-  );
+      ValueNotifier(TileRasterBackendMode.canvas);
 
   /// Changes when the selected backend instance is replaced without changing
   /// its mode (for example after editing a GPU byte ceiling).
@@ -159,6 +159,7 @@ class AppDevTools extends ChangeNotifier {
   int _gpuTextureBytes = 256 << 20;
   int _gpuGeometryBytes = 256 << 20;
   bool _gpuOverprintApproximation = false;
+  bool _flutterGpuOptIn = false;
 
   bool get gpuOverprintApproximation => _gpuOverprintApproximation;
 
@@ -177,7 +178,13 @@ class AppDevTools extends ChangeNotifier {
           ? flutterGpuTileRasterBackend
           : _canvasTileRasterBackend;
 
-  void setTileRasterBackendMode(TileRasterBackendMode mode) {
+  void setTileRasterBackendMode(
+    TileRasterBackendMode mode, {
+    bool recordOptIn = true,
+  }) {
+    if (recordOptIn) {
+      _flutterGpuOptIn = mode == TileRasterBackendMode.flutterGpu;
+    }
     if (tileRasterBackendMode.value == mode) return;
     tileRasterBackendMode.value = mode;
     // A backend A/B switch must not keep serving already-rendered slabs from
@@ -635,10 +642,22 @@ class AppDevTools extends ChangeNotifier {
         final restored = TileRasterBackendMode.values
             .where((value) => value.name == mode)
             .firstOrNull;
-        if (restored != null &&
-            (restored != TileRasterBackendMode.flutterGpu ||
-                flutterGpuTileRasterBackend.isPlatformSupported)) {
-          setTileRasterBackendMode(restored);
+        if (restored != null) {
+          // Older releases selected flutter_gpu automatically on supported
+          // Macs and then persisted that choice. Requiring this new marker
+          // migrates those installs back to Canvas while preserving a
+          // deliberate Developer Tools opt-in made after this change.
+          final restoreFlutterGpu =
+              restored == TileRasterBackendMode.flutterGpu &&
+                  map['flutterGpuOptIn'] == true &&
+                  flutterGpuTileRasterBackend.isPlatformSupported;
+          _flutterGpuOptIn = restoreFlutterGpu;
+          setTileRasterBackendMode(
+            restoreFlutterGpu
+                ? TileRasterBackendMode.flutterGpu
+                : TileRasterBackendMode.canvas,
+            recordOptIn: false,
+          );
         }
       }
       if (map['tileBorders'] case final bool v) {
@@ -701,6 +720,7 @@ class AppDevTools extends ChangeNotifier {
         jsonEncode({
           'deepZoomMode': deepZoomMode,
           'tileRasterBackend': tileRasterBackendMode.value.name,
+          'flutterGpuOptIn': _flutterGpuOptIn,
           'gpuTextureBytes': flutterGpuTileRasterBackend.maxTextureBytes,
           'gpuGeometryBytes': flutterGpuTileRasterBackend.maxGeometryBytes,
           'gpuOverprintApproximation': _gpuOverprintApproximation,

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -52,6 +52,8 @@ class DevToolsPanel extends StatefulWidget {
     super.key,
     required this.onClose,
     this.session,
+    this.viewerController,
+    this.documentTitle,
     this.bottomSheet = false,
     this.gpuPreviewDownloads = _defaultGpuPreviewDownloads,
   });
@@ -60,6 +62,13 @@ class DevToolsPanel extends StatefulWidget {
 
   /// The active tab's edit session, when one is open.
   final PdfEditingController? session;
+
+  /// The active tab's viewer, used to tie page/backend diagnostics to what the
+  /// user was actually looking at when the snapshot was exported.
+  final PdfViewerController? viewerController;
+
+  /// Human-readable active tab title. This is diagnostic metadata only.
+  final String? documentTitle;
 
   /// Render as a bottom sheet (phones) rather than a right-docked side panel:
   /// a rounded, height-capped card with a drag-handle affordance and its own
@@ -301,9 +310,11 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         'overprintApproximation': _tools.gpuOverprintApproximation,
         'stats': _tools.flutterGpuTileRasterBackend.stats.toJson(),
       },
+      'tileRasterPages': PdfTileRasterDiagnostics.instance.snapshot(),
       if (store != null)
         'tileStore': {
           'tiles': store.tileCount,
+          'namespaces': store.debugNamespaceCount,
           'retainedBytes': store.retainedBytes,
           'inFlight': store.inFlightCount,
           'scheduled': store.debugTilesScheduled,
@@ -312,12 +323,52 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           'batches': store.debugBatchesDispatched,
         },
       'pdfPerf': PdfPerf.snapshot().toJson(),
+      if (widget.viewerController != null)
+        'activeView': {
+          'documentTitle': widget.documentTitle,
+          'currentPage': widget.viewerController!.currentPage + 1,
+          'pagePresentationEpoch':
+              widget.viewerController!.pagePresentationEpoch,
+          'tileCacheNamespace':
+              widget.viewerController!.tileCacheNamespaceIdentity,
+        },
       if (session != null)
         'session': {
+          'documentTitle': widget.documentTitle,
+          'sessionIdentity': identityHashCode(session),
+          'documentIdentity': identityHashCode(session.document),
+          'tileCacheNamespace':
+              widget.viewerController?.tileCacheNamespaceIdentity,
           'pages': session.document.pageCount,
+          'currentPage': widget.viewerController == null
+              ? null
+              : widget.viewerController!.currentPage + 1,
+          'pageColor':
+              '#${session.preferences.pageColor.toARGB32().toRadixString(16).padLeft(8, '0').toUpperCase()}',
+          'showAnnotations': session.preferences.showAnnotations,
+          'highlightFormFields': session.preferences.highlightFormFields,
           'currentRevisionBytes': session.bytes.length,
           'sessionBufferBytes': session.sessionBufferBytes,
           'revisions': session.revisionCount,
+          'revisionId': session.revisionId,
+          'lastWorkerRevisionIncremental': session.lastRevisionDelta != null,
+          'pagePresentationEpoch':
+              widget.viewerController?.pagePresentationEpoch,
+          'currentPageRenderStamp': widget.viewerController == null
+              ? null
+              : session.pageRenderStamp(
+                  widget.viewerController!.currentPage,
+                ),
+          'currentPageContentStamp': widget.viewerController == null
+              ? null
+              : session.pageContentRenderStamp(
+                  widget.viewerController!.currentPage,
+                ),
+          'currentPageDestructiveStamp': widget.viewerController == null
+              ? null
+              : session.pageDestructiveStamp(
+                  widget.viewerController!.currentPage,
+                ),
         },
       'log': [
         for (final entry in _tools.log)
@@ -1430,6 +1481,15 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
     return _section(theme, 'Session', [
       _kv(theme, 'Pages', '${session.document.pageCount}',
           help: 'Page count of the active document.'),
+      if (widget.viewerController != null)
+        _kv(
+          theme,
+          'Page presentation epoch',
+          '${widget.viewerController!.pagePresentationEpoch ?? '-'}',
+          help: 'Advances after page insert, remove, or reorder. A rendering '
+              'artifact report should show the current epoch and a new tile '
+              'namespace after a structural edit.',
+        ),
       _kv(theme, 'Current revision', _mb(session.bytes.length),
           help: 'Byte size of the document as it stands now - what Save '
               'writes. Every edit appends an incremental revision, so this '

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2775,6 +2775,8 @@ class _EditorScreenState extends State<EditorScreen>
                         DevToolsPanel(
                           onClose: _toggleDevTools,
                           session: tab?.session,
+                          viewerController: tab?.viewer,
+                          documentTitle: tab?.title,
                         ),
                     ],
                   ),
@@ -2801,6 +2803,8 @@ class _EditorScreenState extends State<EditorScreen>
                       child: DevToolsPanel(
                         onClose: _toggleDevTools,
                         session: tab?.session,
+                        viewerController: tab?.viewer,
+                        documentTitle: tab?.title,
                         bottomSheet: true,
                       ),
                     ),

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -1,6 +1,8 @@
 // Devtools options persist across app restarts: every panel change writes
 // the whole option set to SharedPreferences, and restoreOptions applies it
 // over the platform defaults at startup.
+import 'dart:convert';
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -31,11 +33,17 @@ void main() {
       maxGeometryBytes: 256 << 20,
     );
     AppDevTools.instance.setGpuOverprintApproximation(false);
-    AppDevTools.instance
-        .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
+    AppDevTools.instance.setTileRasterBackendMode(TileRasterBackendMode.canvas);
     AppDevTools.instance.flutterGpuTileRasterBackend.stats.reset();
     PdfPerfLog.enabled = false;
     pdfRenderWorkerPoolSize = defaultPdfRenderWorkerPoolSize;
+  });
+
+  test('Canvas is the default tile raster backend', () {
+    expect(
+      AppDevTools.instance.tileRasterBackendMode.value,
+      TileRasterBackendMode.canvas,
+    );
   });
 
   test('options round-trip through SharedPreferences', () async {
@@ -148,6 +156,7 @@ void main() {
   test('restore with nothing persisted leaves the defaults alone', () async {
     SharedPreferences.setMockInitialValues({});
     pdfRenderWorkerPoolSize = 3;
+    AppDevTools.instance.setTileRasterBackendMode(TileRasterBackendMode.canvas);
     AppDevTools.instance.setPageRasterCachePolicy(
       const PdfPageRasterCachePolicy(),
     );
@@ -158,12 +167,35 @@ void main() {
     AppDevTools.instance.useAutoPageRasterCache();
     await AppDevTools.instance.restoreOptions();
     expect(AppDevTools.instance.deepZoomMode, AppDevTools.modePatch);
+    expect(
+      AppDevTools.instance.tileRasterBackendMode.value,
+      TileRasterBackendMode.canvas,
+    );
     expect(pdfRenderWorkerPoolSize, 3);
     expect(
       AppDevTools.instance.pageRasterCachePolicy.value,
       const PdfPageRasterCachePolicy(),
     );
     expect(AppDevTools.instance.pageRasterWarmPolicy.value.enabled, isFalse);
+  });
+
+  test('legacy automatic flutter_gpu selection migrates to Canvas', () async {
+    SharedPreferences.setMockInitialValues({
+      'flutter.devtools.options': jsonEncode({
+        'tileRasterBackend': TileRasterBackendMode.flutterGpu.name,
+      }),
+    });
+    final tools = AppDevTools.instance;
+    tools.setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
+
+    await tools.restoreOptions();
+
+    expect(tools.tileRasterBackendMode.value, TileRasterBackendMode.canvas);
+
+    await tools.persistOptions();
+    final stored =
+        (await SharedPreferences.getInstance()).getString('devtools.options');
+    expect(jsonDecode(stored!)['flutterGpuOptIn'], isFalse);
   });
 
   test('a corrupt payload is logged, not thrown', () async {

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -75,9 +75,17 @@ class PdfPageView extends StatefulWidget {
     this.transformScale,
     this.transformChanges,
     this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
+    this.tileCacheNamespace,
   }) : assert(qualityPageCount >= 1);
 
   final PdfPage page;
+
+  /// Stable owner identity for entries in the process-wide tile cache.
+  ///
+  /// Viewers supply a token that survives incremental document revisions but
+  /// differs across tabs/windows. A standalone page view falls back to its
+  /// current [PdfDocument] identity.
+  final Object? tileCacheNamespace;
 
   /// Display rotation override. When set, the page renders at this
   /// rotation instead of its own /Rotate - the view rotation feature
@@ -882,6 +890,9 @@ class _PdfPageViewState extends State<PdfPageView>
         rotation: widget.rotation,
       );
 
+  Object get _effectiveTileCacheNamespace =>
+      widget.tileCacheNamespace ?? widget.page.document;
+
   PdfPageRenderIntent _renderIntent(PdfPageView source) => PdfPageRenderIntent(
         page: source.page,
         pageIndex: source.previewIndex,
@@ -1612,8 +1623,10 @@ class _PdfPageViewState extends State<PdfPageView>
   /// any in-flight raster from the superseded scene (issue #308's model).
   void _invalidateTiles() {
     if (!PdfPageView.tileStoreDetail) return;
-    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
-        .invalidate(pages: {widget.previewIndex});
+    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance).invalidate(
+      pages: {widget.previewIndex},
+      cacheNamespace: _effectiveTileCacheNamespace,
+    );
   }
 
   void _dropDetail() {
@@ -4539,19 +4552,23 @@ class _PdfPageViewState extends State<PdfPageView>
     final previousRegion = _tileDetailRegion;
     final previousRatio = _tileDetailRatio;
     final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
-    store.invalidatePageTilesWhere(widget.previewIndex, (tile) {
-      final retainedTileRatio = store.ladder.ratioFor(tile.rung);
-      final slack = 0.5 / retainedTileRatio;
-      final requiredImageRatio = _tileImageRatio(retainedTileRatio);
-      if (requiredImageRatio > imageRatio * 1.01 ||
-          !_rectCovers(region, tile.region, slack)) {
-        return false;
-      }
-      return previousRegion == null ||
-          previousRatio == null ||
-          previousRatio < requiredImageRatio * 0.99 ||
-          !_rectCovers(previousRegion, tile.region, slack);
-    });
+    store.invalidatePageTilesWhere(
+      widget.previewIndex,
+      (tile) {
+        final retainedTileRatio = store.ladder.ratioFor(tile.rung);
+        final slack = 0.5 / retainedTileRatio;
+        final requiredImageRatio = _tileImageRatio(retainedTileRatio);
+        if (requiredImageRatio > imageRatio * 1.01 ||
+            !_rectCovers(region, tile.region, slack)) {
+          return false;
+        }
+        return previousRegion == null ||
+            previousRatio == null ||
+            previousRatio < requiredImageRatio * 0.99 ||
+            !_rectCovers(previousRegion, tile.region, slack);
+      },
+      cacheNamespace: _effectiveTileCacheNamespace,
+    );
     if (previous != null) {
       _disposeTileRasterSession(previous);
       previous.dispose();
@@ -4671,6 +4688,7 @@ class _PdfPageViewState extends State<PdfPageView>
       child: PdfTileLayer(
         store: store,
         identity: PdfTilePageIdentity(
+          cacheNamespace: _effectiveTileCacheNamespace,
           pageIndex: widget.previewIndex,
           pageEpoch: widget.pageEpoch,
           contentStamp: widget.contentStamp,
@@ -4843,21 +4861,46 @@ class _PdfPageViewState extends State<PdfPageView>
     PdfRetainedScene scene,
     Rect region,
     double pixelRatio,
-  ) =>
-      _tileRasterSessionFor(scene).rasterizeRegion(
+  ) async {
+    try {
+      final image = await _tileRasterSessionFor(scene).rasterizeRegion(
         region,
         pixelRatio: pixelRatio,
         tracePage: widget.previewIndex,
       );
+      PdfTileRasterDiagnostics.instance.reportTile(
+        cacheNamespace: _effectiveTileCacheNamespace,
+        pageIndex: widget.previewIndex,
+        region: region,
+        pixelRatio: pixelRatio,
+        width: image.width,
+        height: image.height,
+      );
+      return image;
+    } catch (error) {
+      PdfTileRasterDiagnostics.instance.reportTile(
+        cacheNamespace: _effectiveTileCacheNamespace,
+        pageIndex: widget.previewIndex,
+        region: region,
+        pixelRatio: pixelRatio,
+        width: 0,
+        height: 0,
+        error: error,
+      );
+      rethrow;
+    }
+  }
 
   PdfTileRasterSession _tileRasterSessionFor(PdfRetainedScene scene) =>
       _tileRasterSessions.putIfAbsent(scene, () {
         final backend = widget.tileRasterBackend;
         String label() => _tileBackendLabel(backend);
         PdfTileRasterSession? preferred;
+        Object? initializationError;
         try {
           preferred = backend.createSession(scene);
         } catch (error) {
+          initializationError = error;
           PdfPerfLog.log(
             'tile backend init fallback page=${widget.previewIndex} '
             'backend=${label()} error=$error',
@@ -4867,14 +4910,41 @@ class _PdfPageViewState extends State<PdfPageView>
             const PdfCanvasTileRasterBackend().createSession(scene);
         if (preferred == null) {
           scene.releaseDecodedImagePixels();
+          PdfTileRasterDiagnostics.instance.reportSession(
+            cacheNamespace: _effectiveTileCacheNamespace,
+            document: widget.page.document,
+            scene: scene,
+            pageIndex: widget.previewIndex,
+            requestedBackend: label(),
+            effectiveBackend: 'canvas',
+            fallbackReason: backend.lastSessionRejection ??
+                initializationError?.toString() ??
+                'backend declined',
+            commandCount: scene.commands.length,
+            pageColor: scene.plan.pageColor.toARGB32(),
+            annotations: scene.plan.annotations,
+            rotation: scene.plan.rotation,
+          );
           PdfPerfLog.log(
             'tile backend session page=${widget.previewIndex} '
             'requested=${label()} route=canvas '
-            'reason=${backend.lastSessionRejection ?? 'backend declined'} '
+            'reason=${backend.lastSessionRejection ?? initializationError ?? 'backend declined'} '
             'commands=${scene.commands.length}',
           );
           return fallback;
         }
+        PdfTileRasterDiagnostics.instance.reportSession(
+          cacheNamespace: _effectiveTileCacheNamespace,
+          document: widget.page.document,
+          scene: scene,
+          pageIndex: widget.previewIndex,
+          requestedBackend: label(),
+          effectiveBackend: label(),
+          commandCount: scene.commands.length,
+          pageColor: scene.plan.pageColor.toARGB32(),
+          annotations: scene.plan.annotations,
+          rotation: scene.plan.rotation,
+        );
         PdfPerfLog.log(
           'tile backend session page=${widget.previewIndex} '
           'requested=${label()} route=${preferred == fallback ? 'canvas' : label()} '
@@ -4890,10 +4960,17 @@ class _PdfPageViewState extends State<PdfPageView>
         return _FallbackTileRasterSession(
           primary: preferred,
           fallback: fallback,
-          onFallback: (error) => PdfPerfLog.log(
-            'tile backend raster fallback page=${widget.previewIndex} '
-            'backend=${label()} error=$error',
-          ),
+          onFallback: (error) {
+            PdfTileRasterDiagnostics.instance.reportFallback(
+              cacheNamespace: _effectiveTileCacheNamespace,
+              pageIndex: widget.previewIndex,
+              error: error,
+            );
+            PdfPerfLog.log(
+              'tile backend raster fallback page=${widget.previewIndex} '
+              'backend=${label()} error=$error',
+            );
+          },
         );
       });
 

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -46,6 +46,7 @@ import 'retained_scene.dart';
 import 'scrollbar.dart';
 import 'theme.dart';
 import 'tile_raster_backend.dart';
+import 'tile_store.dart';
 import 'toast.dart';
 import 'viewport.dart';
 
@@ -427,6 +428,26 @@ class PdfViewerController extends ChangeNotifier {
   /// [PdfViewer.pagePreviews]); null when no viewer is attached.
   @visibleForTesting
   PdfPagePreviewCache? get debugPreviewCache => _state?._previews;
+
+  /// Test hook: the namespace isolating this viewer's process-wide LoD tiles.
+  @visibleForTesting
+  Object? get debugTileCacheNamespace => _state?._tileCacheNamespace;
+
+  /// Opaque identity matching this viewer to [PdfTileRasterDiagnostics].
+  ///
+  /// Intended for support snapshots only. It is process-local and must not be
+  /// persisted or used as a document identifier.
+  int? get tileCacheNamespaceIdentity {
+    final namespace = _state?._tileCacheNamespace;
+    return namespace == null ? null : identityHashCode(namespace);
+  }
+
+  /// Generation of the attached viewer's page-presentation state.
+  ///
+  /// It advances when pages are inserted, removed, or reordered. Support
+  /// snapshots include it so a report can distinguish a raster produced for
+  /// the current page slots from one that belonged to the pre-edit structure.
+  int? get pagePresentationEpoch => _state?._pageEpoch;
 
   /// The attached viewer's low-res page previews (see [PdfViewer.pagePreviews]),
   /// or null when no viewer is attached or previews are off. The page
@@ -1653,6 +1674,12 @@ class _PdfViewerState extends State<PdfViewer>
   /// what keeps fast-scrolled pages from being blank (see
   /// [PdfViewer.pagePreviews]).
   final _previews = PdfPagePreviewCache();
+
+  /// Process-wide tile-cache boundary for this viewer's document lineage.
+  /// Incremental revisions retain it; replacing the document/controller does
+  /// not. Without this boundary, two tabs at the same page/revision coordinates
+  /// can paint each other's cached tiles.
+  Object _tileCacheNamespace = Object();
 
   /// Pages the background prerender already tried (by page object
   /// identity), so a page whose render throws can't be retried forever.
@@ -3472,6 +3499,15 @@ class _PdfViewerState extends State<PdfViewer>
   void _swapDocument({bool preserveRevisionViewport = false}) {
     final document = _document;
     final sameGeometry = _sameGeometryAs(document);
+    if (!preserveRevisionViewport) {
+      // The old namespace cannot be reached after an unrelated document swap.
+      // Evict it now and fence its asynchronous completions; otherwise dead
+      // tiles consume the global LRU until pressure happens to remove them,
+      // and per-page invalidation epochs retain the old viewer token forever.
+      (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+          .invalidateNamespace(_tileCacheNamespace);
+      _tileCacheNamespace = Object();
+    }
     final oldPageRefs =
         preserveRevisionViewport ? _pageRefs : const <(int, int)?>[];
     final oldCurrentPage = _pages.isEmpty
@@ -3504,6 +3540,18 @@ class _PdfViewerState extends State<PdfViewer>
             Iterable<int>.generate(oldPageRefs.length).any(
               (i) => oldPageRefs[i] != newPageRefs[i],
             ));
+    if (pageOrderChanged) {
+      // A structural revision is a new page-slot lineage. pageEpoch is part of
+      // every tile key, but the store is process-wide and old raster requests
+      // may still be completing while the new revision is built. Give the new
+      // slots their own namespace as well: old completions then remain
+      // unreachable even if a backend or persistence layer mishandles an
+      // invalidation edge. Ordinary content/annotation revisions retain the
+      // namespace and keep their unaffected tile reuse.
+      (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+          .invalidateNamespace(_tileCacheNamespace);
+      _tileCacheNamespace = Object();
+    }
     PdfViewport? remappedViewport;
     if (oldViewport != null && (!sameGeometry || pageOrderChanged)) {
       final page = _remapPageIndex(
@@ -3523,10 +3571,13 @@ class _PdfViewerState extends State<PdfViewer>
       );
     }
     _previews.bindPages(_pages);
-    // an edit revision keeps its previews (rebound to the new page
-    // objects - edited pages refresh from their on-screen render); a
-    // different document starts clean
-    if (sameGeometry && !pageOrderChanged) {
+    // Only an edit revision keeps its previews (rebound to the new page
+    // objects - edited pages refresh from their on-screen render). Geometry
+    // alone is not identity: swapping two unrelated same-sized documents in
+    // one viewer must not briefly paint the previous file's previews.
+    final canRebindPreviews =
+        preserveRevisionViewport && sameGeometry && !pageOrderChanged;
+    if (canRebindPreviews) {
       // a page whose content stamp advanced changed materially (a
       // redaction burn removes glyphs/images): drop its stale preview so
       // a fast scroll can't flash the deleted content, instead of
@@ -3548,7 +3599,7 @@ class _PdfViewerState extends State<PdfViewer>
     // re-point (and, for a different file, re-prime) the persistent
     // preview backing; an edit revision keeps its rebound previews so the
     // prime is a no-op there
-    _bindRasterCache(prime: !sameGeometry || pageOrderChanged);
+    _bindRasterCache(prime: !canRebindPreviews);
     _previewAttempts.clear();
     _previewVectorAttempts.clear();
     _intermediatePreviewAttempts.clear();
@@ -3880,6 +3931,11 @@ class _PdfViewerState extends State<PdfViewer>
   @override
   void dispose() {
     _commandWarmGeneration++;
+    // A namespace is private to this State and cannot be reused after dispose.
+    // Retire it explicitly so the process-wide store neither lands an old
+    // asynchronous raster nor retains an unreachable viewer token.
+    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        .invalidateNamespace(_tileCacheNamespace);
     WidgetsBinding.instance.removeObserver(this);
     _defaultWorkerHost?.dispose();
     _revisionController?.removeListener(_onRevisionControllerChanged);
@@ -7109,81 +7165,95 @@ class _PdfViewerState extends State<PdfViewer>
                 right: widget.pageSpacing + widget.trailingPadding)
             : EdgeInsets.only(
                 bottom: widget.pageSpacing + widget.trailingPadding),
-        itemBuilder: (context, index) => Padding(
-          padding: _horizontal
-              ? EdgeInsets.only(left: index == 0 ? 0 : widget.pageSpacing)
-              : EdgeInsets.only(top: index == 0 ? 0 : widget.pageSpacing),
-          // each page lays out at its real size relative to the reference
-          // page (times the layout zoom), centred on the cross axis - so
-          // pages keep their true sizes instead of stretching to the viewport
-          child: Center(
-            child: FractionallySizedBox(
-              widthFactor: _horizontal ? null : _crossFactor(index),
-              heightFactor: _horizontal ? _crossFactor(index) : null,
-              child: _PdfViewerPage(
-                page: _pages[index],
-                effectiveRotation: _effectiveRotation(index),
-                index: index,
-                pageColor: widget.pageColor,
-                showAnnotations: widget.showAnnotations,
-                pageImagesShowAnnotations: _pageImagesShowAnnotations,
-                trustContentStamp: _annotationLayerController != null ||
-                    widget.editing != null ||
-                    (widget.interactiveForms && widget.formController != null),
-                formFields: widget.highlightFormFields && widget.showAnnotations
-                    ? _formFieldRects(index)
-                    : const [],
-                interactiveForms:
-                    widget.interactiveForms && widget.showAnnotations,
-                scale: _renderScale,
-                settleGeneration: _settleGeneration,
-                pageEpoch: _pageEpoch,
-                contentStamp: _contentStamp(index),
-                destructiveStamp: _destructiveStamp(index),
-                renderPriority: _renderPriority(index),
-                focusDistance:
-                    (index - (_jumpFocusPage ?? _controller.currentPage)).abs(),
-                forceForeground: _jumpFocusPage == index,
-                onScreenSpan: _onScreenSpan,
-                matches: _controller._matchesOn(index),
-                currentMatch: _controller._currentMatch >= 0
-                    ? _controller._matches[_controller._currentMatch]
-                    : null,
-                selection: _selectionQuadsOn(index),
-                textSelection: _textSelectionOn(index),
-                overlayBuilder: widget.pageOverlayBuilder,
-                editing: editing,
-                formController: editing ?? widget.formController,
-                editingTextPrompt:
-                    widget.editingTextPrompt ?? showPdfTextPrompt,
-                formImagePicker: widget.formImagePicker,
-                imagePicker: widget.imagePicker,
-                onSnapshot: widget.onSnapshot,
-                onPlaceSignature: widget.onPlaceSignature,
-                onAnnotationTap: widget.onAnnotationTap,
-                contextMenuEnabled: widget.contextMenuEnabled,
-                interactionHost: PdfEditingInteractionHost(
-                  panViewport: _touchGrabPanBy,
-                  endViewportPan: _flingViewport,
-                  edgeAutoScroll: _edgeAutoScrollDelta,
-                  showAnnotationMenu: _showSelectionMenu,
-                  showFormFieldMenu: _showFormFieldMenu,
-                  requestContextMenu: _requestContextMenu,
-                  resolvePagePoint: _resolvePagePointGlobal,
-                  moveDragPreview: _onMoveDragPreview,
-                  textEditClosed: _reclaimFocusAfterTextEdit,
+        itemBuilder: (context, index) => KeyedSubtree(
+          // Insert/remove/reorder used to update a slot's existing page State
+          // in place. Its generation guards rejected stale Futures, but native
+          // compositor resources already submitted by the old State could
+          // outlive that Dart Future and paint into a later frame. A structure
+          // epoch therefore owns the complete presentation subtree: changing
+          // it disposes the old raster/scene/tile/annotation layers and mounts
+          // a clean State for the page now occupying this slot.
+          key: ValueKey((_tileCacheNamespace, _pageEpoch, index)),
+          child: Padding(
+            padding: _horizontal
+                ? EdgeInsets.only(left: index == 0 ? 0 : widget.pageSpacing)
+                : EdgeInsets.only(top: index == 0 ? 0 : widget.pageSpacing),
+            // each page lays out at its real size relative to the reference
+            // page (times the layout zoom), centred on the cross axis - so
+            // pages keep their true sizes instead of stretching to the viewport
+            child: Center(
+              child: FractionallySizedBox(
+                widthFactor: _horizontal ? null : _crossFactor(index),
+                heightFactor: _horizontal ? _crossFactor(index) : null,
+                child: _PdfViewerPage(
+                  page: _pages[index],
+                  tileCacheNamespace: _tileCacheNamespace,
+                  effectiveRotation: _effectiveRotation(index),
+                  index: index,
+                  pageColor: widget.pageColor,
+                  showAnnotations: widget.showAnnotations,
+                  pageImagesShowAnnotations: _pageImagesShowAnnotations,
+                  trustContentStamp: _annotationLayerController != null ||
+                      widget.editing != null ||
+                      (widget.interactiveForms &&
+                          widget.formController != null),
+                  formFields:
+                      widget.highlightFormFields && widget.showAnnotations
+                          ? _formFieldRects(index)
+                          : const [],
+                  interactiveForms:
+                      widget.interactiveForms && widget.showAnnotations,
+                  scale: _renderScale,
+                  settleGeneration: _settleGeneration,
+                  pageEpoch: _pageEpoch,
+                  contentStamp: _contentStamp(index),
+                  destructiveStamp: _destructiveStamp(index),
+                  renderPriority: _renderPriority(index),
+                  focusDistance:
+                      (index - (_jumpFocusPage ?? _controller.currentPage))
+                          .abs(),
+                  forceForeground: _jumpFocusPage == index,
+                  onScreenSpan: _onScreenSpan,
+                  matches: _controller._matchesOn(index),
+                  currentMatch: _controller._currentMatch >= 0
+                      ? _controller._matches[_controller._currentMatch]
+                      : null,
+                  selection: _selectionQuadsOn(index),
+                  textSelection: _textSelectionOn(index),
+                  overlayBuilder: widget.pageOverlayBuilder,
+                  editing: editing,
+                  formController: editing ?? widget.formController,
+                  editingTextPrompt:
+                      widget.editingTextPrompt ?? showPdfTextPrompt,
+                  formImagePicker: widget.formImagePicker,
+                  imagePicker: widget.imagePicker,
+                  onSnapshot: widget.onSnapshot,
+                  onPlaceSignature: widget.onPlaceSignature,
+                  onAnnotationTap: widget.onAnnotationTap,
+                  contextMenuEnabled: widget.contextMenuEnabled,
+                  interactionHost: PdfEditingInteractionHost(
+                    panViewport: _touchGrabPanBy,
+                    endViewportPan: _flingViewport,
+                    edgeAutoScroll: _edgeAutoScrollDelta,
+                    showAnnotationMenu: _showSelectionMenu,
+                    showFormFieldMenu: _showFormFieldMenu,
+                    requestContextMenu: _requestContextMenu,
+                    resolvePagePoint: _resolvePagePointGlobal,
+                    moveDragPreview: _onMoveDragPreview,
+                    textEditClosed: _reclaimFocusAfterTextEdit,
+                  ),
+                  interactionSession: widget.interactionSession,
+                  crossPageGhost: _crossPageGhostFor(index),
+                  transformScale: _transformScale,
+                  transformChanges: _transform,
+                  renderScheduler: _renderScheduler,
+                  previewCache: widget.pagePreviews ? _previews : null,
+                  renderWorker: _effectiveRenderWorker,
+                  performance: widget.performance,
+                  tileRasterBackend: widget.tileRasterBackend,
+                  predictStrokes: widget.predictStrokes,
+                  onRasterStateChanged: _setPageRasterReady,
                 ),
-                interactionSession: widget.interactionSession,
-                crossPageGhost: _crossPageGhostFor(index),
-                transformScale: _transformScale,
-                transformChanges: _transform,
-                renderScheduler: _renderScheduler,
-                previewCache: widget.pagePreviews ? _previews : null,
-                renderWorker: _effectiveRenderWorker,
-                performance: widget.performance,
-                tileRasterBackend: widget.tileRasterBackend,
-                predictStrokes: widget.predictStrokes,
-                onRasterStateChanged: _setPageRasterReady,
               ),
             ),
           ),
@@ -7903,6 +7973,7 @@ class _AnnotationAppearancePainter extends CustomPainter {
 class _PdfViewerPage extends StatefulWidget {
   const _PdfViewerPage({
     required this.page,
+    required this.tileCacheNamespace,
     required this.effectiveRotation,
     required this.index,
     required this.pageColor,
@@ -7949,6 +8020,7 @@ class _PdfViewerPage extends StatefulWidget {
   });
 
   final PdfPage page;
+  final Object tileCacheNamespace;
 
   /// The combined document + view rotation for this page.
   final int effectiveRotation;
@@ -8197,6 +8269,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
     return Stack(children: [
       PdfPageView(
         page: widget.page,
+        tileCacheNamespace: widget.tileCacheNamespace,
         rotation: widget.effectiveRotation,
         scale: widget.scale,
         // Keep one fit-size backing image and sharpen only the visible slice

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:ui' as ui;
 
 import 'package:flutter/painting.dart';
@@ -103,6 +104,168 @@ abstract interface class PdfTileRasterScheduling {
   /// to keep command submission and texture allocation within a frame budget
   /// while the base/coarser image remains visible underneath.
   int? get maxNewTilesPerPaint;
+}
+
+/// Bounded, always-on page/tile routing diagnostics for support exports.
+///
+/// Aggregate backend counters can say that a GPU submission completed, but
+/// they cannot identify which document/page produced a corrupt texture—or
+/// whether that page had already fallen back to Canvas. This registry records
+/// the latest route and raster for up to [maxEntries] page namespaces without
+/// retaining documents, scenes, or viewer objects.
+class PdfTileRasterDiagnostics {
+  PdfTileRasterDiagnostics._();
+
+  static final PdfTileRasterDiagnostics instance = PdfTileRasterDiagnostics._();
+
+  static const int maxEntries = 128;
+
+  final LinkedHashMap<(int, int), _PdfTileRasterDiagnosticEntry> _entries =
+      LinkedHashMap<(int, int), _PdfTileRasterDiagnosticEntry>();
+
+  void reportSession({
+    required Object cacheNamespace,
+    required Object document,
+    required Object scene,
+    required int pageIndex,
+    required String requestedBackend,
+    required String effectiveBackend,
+    required int commandCount,
+    required int pageColor,
+    required bool annotations,
+    required int? rotation,
+    String? fallbackReason,
+  }) {
+    final key = (identityHashCode(cacheNamespace), pageIndex);
+    _entries.remove(key);
+    _entries[key] = _PdfTileRasterDiagnosticEntry(
+      namespaceIdentity: key.$1,
+      documentIdentity: identityHashCode(document),
+      sceneIdentity: identityHashCode(scene),
+      pageIndex: pageIndex,
+      requestedBackend: requestedBackend,
+      effectiveBackend: effectiveBackend,
+      fallbackReason: fallbackReason,
+      commandCount: commandCount,
+      pageColor: pageColor,
+      annotations: annotations,
+      rotation: rotation,
+      updatedAt: DateTime.now(),
+    );
+    while (_entries.length > maxEntries) {
+      _entries.remove(_entries.keys.first);
+    }
+  }
+
+  void reportFallback({
+    required Object cacheNamespace,
+    required int pageIndex,
+    required Object error,
+  }) {
+    final entry =
+        _entries.remove((identityHashCode(cacheNamespace), pageIndex));
+    if (entry == null) return;
+    entry
+      ..effectiveBackend = 'canvas'
+      ..fallbackReason = error.toString()
+      ..updatedAt = DateTime.now();
+    _entries[(entry.namespaceIdentity, pageIndex)] = entry;
+  }
+
+  void reportTile({
+    required Object cacheNamespace,
+    required int pageIndex,
+    required Rect region,
+    required double pixelRatio,
+    required int width,
+    required int height,
+    Object? error,
+  }) {
+    final entry =
+        _entries.remove((identityHashCode(cacheNamespace), pageIndex));
+    if (entry == null) return;
+    if (error == null) {
+      entry.tileRasters++;
+    } else {
+      entry.tileFailures++;
+    }
+    entry
+      ..lastTileError = error?.toString()
+      ..lastTile = <String, Object?>{
+        'left': region.left,
+        'top': region.top,
+        'width': region.width,
+        'height': region.height,
+        'pixelRatio': pixelRatio,
+        'imageWidth': width,
+        'imageHeight': height,
+      }
+      ..updatedAt = DateTime.now();
+    _entries[(entry.namespaceIdentity, pageIndex)] = entry;
+  }
+
+  /// A JSON-safe, least-recently-updated-first snapshot.
+  List<Map<String, Object?>> snapshot() => <Map<String, Object?>>[
+        for (final entry in _entries.values) entry.toJson(),
+      ];
+
+  /// Clears support history without changing any renderer or cache state.
+  void clear() => _entries.clear();
+}
+
+class _PdfTileRasterDiagnosticEntry {
+  _PdfTileRasterDiagnosticEntry({
+    required this.namespaceIdentity,
+    required this.documentIdentity,
+    required this.sceneIdentity,
+    required this.pageIndex,
+    required this.requestedBackend,
+    required this.effectiveBackend,
+    required this.fallbackReason,
+    required this.commandCount,
+    required this.pageColor,
+    required this.annotations,
+    required this.rotation,
+    required this.updatedAt,
+  });
+
+  final int namespaceIdentity;
+  final int documentIdentity;
+  final int sceneIdentity;
+  final int pageIndex;
+  final String requestedBackend;
+  String effectiveBackend;
+  String? fallbackReason;
+  final int commandCount;
+  final int pageColor;
+  final bool annotations;
+  final int? rotation;
+  DateTime updatedAt;
+  int tileRasters = 0;
+  int tileFailures = 0;
+  String? lastTileError;
+  Map<String, Object?>? lastTile;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'updatedAt': updatedAt.toIso8601String(),
+        'namespaceIdentity': namespaceIdentity,
+        'documentIdentity': documentIdentity,
+        'sceneIdentity': sceneIdentity,
+        'pageIndex': pageIndex,
+        'pageNumber': pageIndex + 1,
+        'requestedBackend': requestedBackend,
+        'effectiveBackend': effectiveBackend,
+        'fallbackReason': fallbackReason,
+        'commands': commandCount,
+        'pageColor':
+            '#${pageColor.toRadixString(16).padLeft(8, '0').toUpperCase()}',
+        'annotations': annotations,
+        'rotation': rotation,
+        'tileRasters': tileRasters,
+        'tileFailures': tileFailures,
+        'lastTileError': lastTileError,
+        'lastTile': lastTile,
+      };
 }
 
 /// The universal retained-scene renderer used today and as a fallback for

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -121,12 +121,24 @@ class PdfTileZoomLadder {
 @immutable
 class PdfTilePageIdentity {
   const PdfTilePageIdentity({
+    this.cacheNamespace,
     required this.pageIndex,
     required this.pageEpoch,
     required this.contentStamp,
     required this.destructiveStamp,
     required this.plan,
   });
+
+  /// Stable identity of the viewer/document lineage that owns this tile.
+  ///
+  /// [PdfTileStore.instance] is process-wide, including across tabs and native
+  /// windows. Page index and revision stamps are only unique inside one
+  /// document, so omitting this boundary lets page 58 in one tab consume page
+  /// 58's pixels from another. Keep the same value across incremental
+  /// revisions to preserve unchanged-page reuse, and replace it when a viewer
+  /// opens an unrelated document. Null remains useful for isolated stores and
+  /// backwards-compatible tests.
+  final Object? cacheNamespace;
 
   final int pageIndex;
   final int pageEpoch;
@@ -137,6 +149,7 @@ class PdfTilePageIdentity {
   @override
   bool operator ==(Object other) =>
       other is PdfTilePageIdentity &&
+      identical(cacheNamespace, other.cacheNamespace) &&
       pageIndex == other.pageIndex &&
       pageEpoch == other.pageEpoch &&
       contentStamp == other.contentStamp &&
@@ -144,8 +157,24 @@ class PdfTilePageIdentity {
       plan == other.plan;
 
   @override
-  int get hashCode =>
-      Object.hash(pageIndex, pageEpoch, contentStamp, destructiveStamp, plan);
+  int get hashCode => Object.hash(identityHashCode(cacheNamespace), pageIndex,
+      pageEpoch, contentStamp, destructiveStamp, plan);
+}
+
+class _PdfTilePageSlot {
+  const _PdfTilePageSlot(this.cacheNamespace, this.pageIndex);
+
+  final Object? cacheNamespace;
+  final int pageIndex;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _PdfTilePageSlot &&
+      identical(cacheNamespace, other.cacheNamespace) &&
+      pageIndex == other.pageIndex;
+
+  @override
+  int get hashCode => Object.hash(identityHashCode(cacheNamespace), pageIndex);
 }
 
 /// The full cache key of a single tile.
@@ -361,7 +390,8 @@ class PdfTileStore extends ChangeNotifier {
   /// measured at a 55% discard rate in issue #427).
   int _epochCounter = 0;
   int _allPagesEpoch = -1;
-  final Map<int, int> _pageEpoch = {};
+  final Map<Object?, int> _namespaceEpoch = Map<Object?, int>.identity();
+  final Map<_PdfTilePageSlot, int> _pageEpoch = {};
 
   bool _tickScheduled = false;
   bool _disposed = false;
@@ -384,6 +414,23 @@ class PdfTileStore extends ChangeNotifier {
 
   /// Tiles whose raster is currently in flight.
   int get inFlightCount => _inFlight.length;
+
+  /// Distinct viewer/document namespaces currently represented by retained
+  /// or in-flight tiles. Exported support snapshots use this to make
+  /// cross-tab cache isolation directly auditable.
+  int get debugNamespaceCount {
+    final namespaces = Set<Object?>.identity();
+    for (final key in _cache.keys) {
+      namespaces.add(key.id.cacheNamespace);
+    }
+    for (final key in _inFlight) {
+      namespaces.add(key.id.cacheNamespace);
+    }
+    for (final key in _persistentInFlight) {
+      namespaces.add(key.id.cacheNamespace);
+    }
+    return namespaces.length;
+  }
 
   /// The weight budget, live-adjustable (a device-memory tier could lower it).
   int get maxBytes => _cache.maxWeight;
@@ -834,7 +881,7 @@ class PdfTileStore extends ChangeNotifier {
     final dispatchEpoch = _epochCounter;
     rasterize(region, ratio).then((image) {
       _inFlight.remove(key);
-      if (_disposed || _isStale(id.pageIndex, dispatchEpoch)) {
+      if (_disposed || _isStale(id, dispatchEpoch)) {
         image.dispose();
         debugTilesDiscarded++;
         // Invalidation can race a visible raster. Its completion releases the
@@ -842,12 +889,14 @@ class PdfTileStore extends ChangeNotifier {
         // the tile; otherwise the stale result disappears with no event to
         // replace it.
         if (notifyOnLand) _scheduleTick();
+        _dropNamespaceFenceIfIdle(id.cacheNamespace);
         return;
       }
       if (_cache.containsKey(key)) {
         // A persistent hit won the race. Keep its already-visible pixels and
         // release the duplicate raster without replacing/promoting the entry.
         image.dispose();
+        _dropNamespaceFenceIfIdle(id.cacheNamespace);
         return;
       }
       _cache.put(
@@ -855,9 +904,11 @@ class PdfTileStore extends ChangeNotifier {
       debugTilesLanded++;
       _storePersistentTile(key, image, region, ratio, persistence);
       if (notifyOnLand) _scheduleTick();
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     }, onError: (Object _, StackTrace __) {
       _inFlight.remove(key);
       debugTilesDiscarded++;
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     });
     return true;
   }
@@ -938,10 +989,11 @@ class PdfTileStore extends ChangeNotifier {
       for (final key in batch) {
         _inFlight.remove(key);
       }
-      if (_disposed || _isStale(id.pageIndex, dispatchEpoch)) {
+      if (_disposed || _isStale(id, dispatchEpoch)) {
         slab.dispose();
         debugTilesDiscarded += batch.length;
         if (notifyOnLand) _scheduleTick();
+        _dropNamespaceFenceIfIdle(id.cacheNamespace);
         return;
       }
       final sliceClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
@@ -968,11 +1020,13 @@ class PdfTileStore extends ChangeNotifier {
         '${PdfPerfLog.rssSuffix()}',
       );
       if (notifyOnLand) _scheduleTick();
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     }, onError: (Object _, StackTrace __) {
       for (final key in batch) {
         _inFlight.remove(key);
       }
       debugTilesDiscarded += batch.length;
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     });
   }
 
@@ -1027,11 +1081,13 @@ class PdfTileStore extends ChangeNotifier {
             region: region, pixelRatio: ratio, width: width, height: height)
         .then((image) {
       _persistentInFlight.remove(key);
-      if (image == null) return;
-      if (_disposed ||
-          _isStale(id.pageIndex, dispatchEpoch) ||
-          _cache.containsKey(key)) {
+      if (image == null) {
+        _dropNamespaceFenceIfIdle(id.cacheNamespace);
+        return;
+      }
+      if (_disposed || _isStale(id, dispatchEpoch) || _cache.containsKey(key)) {
         image.dispose();
+        _dropNamespaceFenceIfIdle(id.cacheNamespace);
         return;
       }
       _cache.put(
@@ -1039,8 +1095,10 @@ class PdfTileStore extends ChangeNotifier {
       debugPersistentHits++;
       debugTilesLanded++;
       if (notifyOnLand) _scheduleTick();
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     }, onError: (Object _, StackTrace __) {
       _persistentInFlight.remove(key);
+      _dropNamespaceFenceIfIdle(id.cacheNamespace);
     });
   }
 
@@ -1054,15 +1112,52 @@ class PdfTileStore extends ChangeNotifier {
         region: region, pixelRatio: pixelRatio));
   }
 
-  bool _isStale(int pageIndex, int dispatchEpoch) =>
+  bool _isStale(PdfTilePageIdentity id, int dispatchEpoch) =>
       _allPagesEpoch > dispatchEpoch ||
-      (_pageEpoch[pageIndex] ?? -1) > dispatchEpoch;
+      (_namespaceEpoch[id.cacheNamespace] ?? -1) > dispatchEpoch ||
+      (_pageEpoch[_PdfTilePageSlot(id.cacheNamespace, id.pageIndex)] ?? -1) >
+          dispatchEpoch;
+
+  /// Drops every retained and in-flight tile belonging to one viewer/document
+  /// lineage, without disturbing the other tabs sharing this process store.
+  ///
+  /// Structural page edits call this before replacing their namespace. The
+  /// epoch check makes any raster or persistent load already in flight for the
+  /// old page slots dispose its result instead of repopulating dead cache
+  /// entries after the edit.
+  void invalidateNamespace(Object? cacheNamespace) {
+    if (_disposed) return;
+    _namespaceEpoch[cacheNamespace] = ++_epochCounter;
+    _cache.evictWhere(
+      (key) => identical(key.id.cacheNamespace, cacheNamespace),
+    );
+    _pageEpoch.removeWhere(
+      (slot, _) => identical(slot.cacheNamespace, cacheNamespace),
+    );
+    _dropNamespaceFenceIfIdle(cacheNamespace);
+  }
+
+  /// An invalidated namespace needs a strong epoch fence only while one of its
+  /// old asynchronous requests can still complete. Drop it afterward so a
+  /// long editing session with many page operations does not retain every
+  /// superseded namespace object forever.
+  void _dropNamespaceFenceIfIdle(Object? cacheNamespace) {
+    if (!_namespaceEpoch.containsKey(cacheNamespace)) return;
+    final active = _inFlight.any(
+          (key) => identical(key.id.cacheNamespace, cacheNamespace),
+        ) ||
+        _persistentInFlight.any(
+          (key) => identical(key.id.cacheNamespace, cacheNamespace),
+        );
+    if (!active) _namespaceEpoch.remove(cacheNamespace);
+  }
 
   /// Drops retained (and in-flight) tiles. With [pages] null every tile is
-  /// dropped; otherwise only tiles for those page slots - the model
+  /// dropped; otherwise only tiles for those page slots inside
+  /// [cacheNamespace] - the model
   /// [PdfCachingRenderWorker.updateRevision]'s `changedPages` feeds. In-flight
   /// rasters for the affected pages are discarded on completion.
-  void invalidate({Set<int>? pages}) {
+  void invalidate({Set<int>? pages, Object? cacheNamespace}) {
     if (_disposed) return;
     final epoch = ++_epochCounter;
     if (pages == null) {
@@ -1070,9 +1165,11 @@ class PdfTileStore extends ChangeNotifier {
       _cache.clear();
     } else {
       for (final page in pages) {
-        _pageEpoch[page] = epoch;
+        _pageEpoch[_PdfTilePageSlot(cacheNamespace, page)] = epoch;
       }
-      _cache.evictWhere((key) => pages.contains(key.id.pageIndex));
+      _cache.evictWhere((key) =>
+          identical(key.id.cacheNamespace, cacheNamespace) &&
+          pages.contains(key.id.pageIndex));
     }
   }
 
@@ -1082,14 +1179,15 @@ class PdfTileStore extends ChangeNotifier {
   /// The selective retained eviction lets a newly expanded image-detail scene
   /// replace tiles that could only have come from the capped base decode while
   /// preserving already-sharp tiles in the scene's previous coverage.
-  void invalidatePageTilesWhere(
-    int pageIndex,
-    bool Function(PdfTile tile) test,
-  ) {
+  void invalidatePageTilesWhere(int pageIndex, bool Function(PdfTile tile) test,
+      {Object? cacheNamespace}) {
     if (_disposed) return;
-    _pageEpoch[pageIndex] = ++_epochCounter;
+    _pageEpoch[_PdfTilePageSlot(cacheNamespace, pageIndex)] = ++_epochCounter;
     _cache.evictWhere((key) {
-      if (key.id.pageIndex != pageIndex) return false;
+      if (!identical(key.id.cacheNamespace, cacheNamespace) ||
+          key.id.pageIndex != pageIndex) {
+        return false;
+      }
       final tile = _cache.peek(key);
       return tile != null && test(tile);
     });

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -1182,6 +1182,42 @@ void main() {
     expect(fullRaster, findsWidgets);
   });
 
+  testWidgets('same-geometry document swap clears previews and tile identity',
+      (tester) async {
+    final first = PdfDocument.open(buildClassicPdf());
+    final second = PdfDocument.open(buildMultiPagePdf(1));
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    Widget viewer(PdfDocument document, {required bool active}) => MaterialApp(
+          home: Scaffold(
+            body: PdfViewer(
+              document: document,
+              controller: controller,
+              initialFit: PdfViewerFit.width,
+              previewWindow: 1,
+              active: active,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(viewer(first, active: true));
+    final cache = controller.debugPreviewCache!;
+    for (var i = 0; i < 100 && !cache.has(0); i++) {
+      await settle(tester);
+    }
+    expect(cache.has(0), isTrue);
+    final firstNamespace = controller.debugTileCacheNamespace;
+
+    // Keep the replacement parked so it cannot refill the cache before the
+    // assertion. The documents deliberately have identical page geometry:
+    // geometry is not proof that their pixels share an identity.
+    await tester.pumpWidget(viewer(second, active: false));
+    expect(controller.debugTileCacheNamespace, isNot(same(firstNamespace)));
+    expect(cache.has(0), isFalse,
+        reason: 'the first document\'s preview must not survive the swap');
+  });
+
   testWidgets('proactive previews wait for the configured idle delay',
       (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(8));

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1466,6 +1466,40 @@ void main() {
           reason: 'the viewer tracks the controller revision by itself');
     });
 
+    testWidgets('page deletion starts a fresh presentation generation',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            editing: editing,
+            controller: controller,
+          ),
+        ),
+      ));
+      await tester.pump();
+      final oldNamespace = controller.debugTileCacheNamespace;
+      final oldEpoch = controller.pagePresentationEpoch;
+      final oldPageState = tester.state(find.byType(PdfPageView).first);
+
+      editing.removePage(0);
+      await tester.pump();
+
+      expect(controller.pageCount, 2);
+      expect(controller.pagePresentationEpoch, oldEpoch! + 1);
+      expect(controller.debugTileCacheNamespace, isNot(same(oldNamespace)),
+          reason: 'pre-delete tile completions must be unreachable');
+      expect(tester.state(find.byType(PdfPageView).first),
+          isNot(same(oldPageState)),
+          reason: 'a shifted page slot must not inherit native render state');
+    });
+
     testWidgets('a stale standalone document never desyncs the viewer',
         (tester) async {
       SharedPreferences.setMockInitialValues({});

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -186,6 +186,7 @@ void main() {
 
   testWidgets('an unavailable tile backend falls back during initialization',
       (tester) async {
+    PdfTileRasterDiagnostics.instance.clear();
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
 
@@ -203,6 +204,7 @@ void main() {
       store.dispose();
       PdfPerfLog.enabled = false;
       PdfPerfLog.sink = null;
+      PdfTileRasterDiagnostics.instance.clear();
     });
 
     final doc = PdfDocument.open(buildClassicPdf());
@@ -239,6 +241,14 @@ void main() {
           'requested=recording route=canvas reason=test unsupported clip')),
       reason: 'field traces must explain why the requested backend declined',
     );
+    final pageDiagnostic = PdfTileRasterDiagnostics.instance.snapshot().last;
+    expect(pageDiagnostic['pageNumber'], 1);
+    expect(pageDiagnostic['requestedBackend'], 'recording');
+    expect(pageDiagnostic['effectiveBackend'], 'canvas');
+    expect(pageDiagnostic['fallbackReason'], 'test unsupported clip');
+    expect(pageDiagnostic['pageColor'], '#FFFFFFFF');
+    expect(pageDiagnostic['tileRasters'], greaterThan(0));
+    expect(pageDiagnostic['lastTile'], isA<Map<String, Object?>>());
   });
 
   testWidgets('tile path composites deep-zoom tiles instead of the patch',

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -103,8 +103,14 @@ class _Persistence implements PdfTilePersistence {
 
 const _plan = PdfPageRenderPlan();
 
-PdfTilePageIdentity _id(int page, {int epoch = 0, int content = 0}) =>
+PdfTilePageIdentity _id(
+  int page, {
+  int epoch = 0,
+  int content = 0,
+  Object? namespace,
+}) =>
     PdfTilePageIdentity(
+      cacheNamespace: namespace,
       pageIndex: page,
       pageEpoch: epoch,
       contentStamp: content,
@@ -646,6 +652,104 @@ void main() {
   });
 
   group('PdfTileStore.invalidate', () {
+    testWidgets('isolates equal page coordinates between document namespaces',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final firstRaster = _Rasterizer();
+        final secondRaster = _Rasterizer();
+        final first = Object();
+        final second = Object();
+        const region = Rect.fromLTWH(0, 0, 16, 16);
+
+        store.viewFor(
+          id: _id(0, namespace: first),
+          pageSize: const Size(16, 16),
+          desiredRatio: 1,
+          visiblePageRect: region,
+          rasterize: firstRaster.call,
+        );
+        await firstRaster.flush();
+        expect(store.tileCount, 1);
+
+        final secondView = store.viewFor(
+          id: _id(0, namespace: second),
+          pageSize: const Size(16, 16),
+          desiredRatio: 1,
+          visiblePageRect: region,
+          rasterize: secondRaster.call,
+        );
+        expect(secondView.complete, isFalse,
+            reason: 'a second document must not consume the first tile');
+        await secondRaster.flush();
+        expect(store.tileCount, 2);
+
+        store.invalidate(pages: {0}, cacheNamespace: first);
+        expect(
+          store.containsTile(PdfTileKey(_id(0, namespace: first), 0, 0, 0)),
+          isFalse,
+        );
+        expect(
+          store.containsTile(PdfTileKey(_id(0, namespace: second), 0, 0, 0)),
+          isTrue,
+          reason: 'page invalidation must remain inside its document',
+        );
+        store.dispose();
+      });
+    });
+
+    testWidgets('namespace invalidation evicts and fences only that lineage',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final oldNamespace = Object();
+        final otherNamespace = Object();
+        final oldRaster = _Rasterizer();
+        final otherRaster = _Rasterizer();
+
+        // Keep the old lineage in flight while another tab lands a tile.
+        store.viewFor(
+          id: _id(0, namespace: oldNamespace),
+          pageSize: const Size(32, 16),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 16),
+          rasterize: oldRaster.call,
+        );
+        store.viewFor(
+          id: _id(0, namespace: otherNamespace),
+          pageSize: const Size(16, 16),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 16, 16),
+          rasterize: otherRaster.call,
+        );
+        await otherRaster.flush();
+        expect(store.tileCount, 1);
+
+        store.invalidateNamespace(oldNamespace);
+        await oldRaster.flush();
+
+        expect(store.debugTilesDiscarded, 2,
+            reason: 'pre-edit completions cannot revive the old lineage');
+        expect(
+          store.containsTile(
+              PdfTileKey(_id(0, namespace: otherNamespace), 0, 0, 0)),
+          isTrue,
+          reason: 'another tab shares the store but not the invalidation',
+        );
+        store.dispose();
+      });
+    });
+
     testWidgets('selective invalidation preserves unrelated sharp tiles',
         (tester) async {
       await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -72,6 +72,11 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache _imageCache;
   final _GpuGeometryPool _geometryPool;
+  // Contexts belong to Flutter views and can disappear when a native window
+  // closes. Keep only weak membership so diagnostics do not turn every view
+  // ever opened into a process-lifetime root.
+  final Expando<bool> _seenContexts = Expando<bool>('pdf-gpu-context');
+  gpu.GpuContext? _lastContext;
   String? _lastSessionRejection;
 
   @override
@@ -100,6 +105,16 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     _lastSessionRejection = null;
     try {
       final context = gpu.gpuContext;
+      if (_seenContexts[context] != true) {
+        _seenContexts[context] = true;
+        stats.contextsSeen++;
+      }
+      final previousContext = _lastContext;
+      if (previousContext != null && !identical(previousContext, context)) {
+        stats.contextSwitches++;
+      }
+      _lastContext = context;
+      stats.lastContextIdentity = identityHashCode(context);
       final unitBuild = _buildGpuUnits(scene.commands);
       final units = unitBuild.units;
       if (units == null) {
@@ -900,20 +915,35 @@ class _CompiledScene {
   final _GpuGeometryPool geometryPool;
   final List<_GpuGeometryResource> geometryLeases;
   bool _disposed = false;
+  bool _texturesReleased = false;
   bool _geometryReleased = false;
   int _inFlight = 0;
 
   void dispose() {
     if (_disposed) return;
     _disposed = true;
-    imageCache.releaseAll(textureLeases, stats);
-    _releaseGeometryIfReady();
+    _releaseResourcesIfReady();
   }
 
-  void _releaseGeometryIfReady() {
-    if (!_disposed || _inFlight != 0 || _geometryReleased) return;
-    _geometryReleased = true;
-    geometryPool.releaseAll(geometryLeases, stats);
+  void _releaseResourcesIfReady() {
+    if (!_disposed || _inFlight != 0) return;
+    // The render pass references both the scene's geometry buffers and image
+    // textures until its completion callback fires. A structural document
+    // edit disposes the old page scene immediately; releasing the texture
+    // leases here used to make them eviction-eligible while that scene's last
+    // command buffer was still executing. Under Impeller/Metal the evicted
+    // texture could then disappear underneath the submitted pass, producing
+    // solid-colour rectangles or unrelated image fragments after page
+    // insert/remove/reorder. Geometry already observed the completion fence;
+    // image leases must share that exact lifetime.
+    if (!_texturesReleased) {
+      _texturesReleased = true;
+      imageCache.releaseAll(textureLeases, stats);
+    }
+    if (!_geometryReleased) {
+      _geometryReleased = true;
+      geometryPool.releaseAll(geometryLeases, stats);
+    }
   }
 
   void _completeSubmission(
@@ -938,7 +968,7 @@ class _CompiledScene {
       'queue=${(elapsed / 1000).toStringAsFixed(1)}ms '
       'success=$success inFlight=${stats.inFlightSubmissions}',
     );
-    _releaseGeometryIfReady();
+    _releaseResourcesIfReady();
   }
 
   ui.Image render(
@@ -1072,7 +1102,7 @@ class _CompiledScene {
       stats
         ..inFlightSubmissions = math.max(0, stats.inFlightSubmissions - 1)
         ..failedSubmissions += 1;
-      _releaseGeometryIfReady();
+      _releaseResourcesIfReady();
       rethrow;
     }
     stats
@@ -1243,7 +1273,8 @@ class _GpuImageTexture {
 }
 
 class _GpuTextureKey {
-  const _GpuTextureKey(this.content, this.width, this.height);
+  const _GpuTextureKey(this.context, this.content, this.width, this.height);
+  final gpu.GpuContext context;
   final Object content;
   final int width;
   final int height;
@@ -1251,12 +1282,14 @@ class _GpuTextureKey {
   @override
   bool operator ==(Object other) =>
       other is _GpuTextureKey &&
+      identical(other.context, context) &&
       other.content == content &&
       other.width == width &&
       other.height == height;
 
   @override
-  int get hashCode => Object.hash(content, width, height);
+  int get hashCode =>
+      Object.hash(identityHashCode(context), content, width, height);
 }
 
 class _GpuImageCache {
@@ -1274,8 +1307,8 @@ class _GpuImageCache {
     ui.Image image,
     FlutterGpuTileBackendStats stats,
   ) async {
-    final key =
-        _GpuTextureKey(pdfImageContentKey(request), image.width, image.height);
+    final key = _GpuTextureKey(
+        context, pdfImageContentKey(request), image.width, image.height);
     final hit = _entries.remove(key);
     if (hit != null) {
       _entries[key] = hit;
@@ -1683,7 +1716,11 @@ class _GpuGeometryPool {
         ((data.lengthInBytes + chunkBytes - 1) ~/ chunkBytes) * chunkBytes;
     _GpuGeometryResource? resource;
     for (final candidate in _resources) {
-      if (candidate.leased || candidate.capacity < capacity) continue;
+      if (!identical(candidate.context, context) ||
+          candidate.leased ||
+          candidate.capacity < capacity) {
+        continue;
+      }
       if (resource == null || candidate.capacity < resource.capacity) {
         resource = candidate;
       }
@@ -1697,6 +1734,7 @@ class _GpuGeometryPool {
         );
       }
       resource = _GpuGeometryResource(
+        context,
         context.createDeviceBuffer(gpu.StorageMode.hostVisible, capacity),
         capacity,
       );
@@ -1730,7 +1768,8 @@ class _GpuGeometryPool {
 }
 
 class _GpuGeometryResource {
-  _GpuGeometryResource(this.buffer, this.capacity);
+  _GpuGeometryResource(this.context, this.buffer, this.capacity);
+  final gpu.GpuContext context;
   final gpu.DeviceBuffer buffer;
   final int capacity;
   bool leased = false;
@@ -2133,12 +2172,23 @@ class _GpuPipelines {
         softMaskMaskSampler =
             library['PdfTileSoftMaskFragment']!.getUniformSlot('mask_tex');
 
-  static Future<_GpuPipelines>? _instance;
+  // Native multi-window builds can expose a distinct Impeller context per
+  // Flutter view. Pipelines are context-owned; reusing the first window's
+  // pipeline objects in another context produces undefined output rather than
+  // a reliable submission error.
+  // Expando gives this cache weak, identity-based context keys. A regular
+  // static map would keep a closed Flutter window and all of its native
+  // pipelines alive for the rest of the process.
+  static final Expando<Future<_GpuPipelines>> _instances =
+      Expando<Future<_GpuPipelines>>('pdf-gpu-pipelines');
 
-  static Future<_GpuPipelines> instance(gpu.GpuContext context) =>
-      _instance ??= _loadLibrary().then(
-        (library) => _GpuPipelines._(context, library),
-      );
+  static Future<_GpuPipelines> instance(gpu.GpuContext context) {
+    final existing = _instances[context];
+    if (existing != null) return existing;
+    return _instances[context] = _loadLibrary().then(
+      (library) => _GpuPipelines._(context, library),
+    );
+  }
 
   static Future<gpu.ShaderLibrary> _loadLibrary() async {
     for (final asset in const [

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -2,6 +2,9 @@
 class FlutterGpuTileBackendStats {
   String? lastRejection;
   String? lastTileRoute;
+  int? lastContextIdentity;
+  int contextsSeen = 0;
+  int contextSwitches = 0;
   int sessionsCreated = 0;
   int sessionsRejected = 0;
   int sessionsDisposed = 0;
@@ -44,6 +47,9 @@ class FlutterGpuTileBackendStats {
   Map<String, Object?> toJson() => {
         'lastRejection': lastRejection,
         'lastTileRoute': lastTileRoute,
+        'lastContextIdentity': lastContextIdentity,
+        'contextsSeen': contextsSeen,
+        'contextSwitches': contextSwitches,
         'sessionsCreated': sessionsCreated,
         'sessionsRejected': sessionsRejected,
         'sessionsDisposed': sessionsDisposed,
@@ -93,6 +99,7 @@ class FlutterGpuTileBackendStats {
     sessionsRejected = 0;
     sessionsDisposed = 0;
     rasterFallbacks = 0;
+    contextSwitches = 0;
     peakActiveSessions = activeSessions;
     overprintApproximationSessions = 0;
     scenesCompiled = 0;
@@ -126,6 +133,8 @@ class FlutterGpuTileBackendStats {
   @override
   String toString() => 'sessions=$sessionsCreated rejected=$sessionsRejected '
       'disposed=$sessionsDisposed rasterFallbacks=$rasterFallbacks '
+      'contexts=$contextsSeen contextSwitches=$contextSwitches '
+      'lastContext=$lastContextIdentity '
       'activeSessions=$activeSessions peakActiveSessions=$peakActiveSessions '
       'overprintApprox=$overprintApproximationSessions '
       'compiled=$scenesCompiled compileUs=$compileMicros '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -8,6 +8,9 @@ void main() {
       ..sessionsRejected = 2
       ..sessionsDisposed = 1
       ..rasterFallbacks = 1
+      ..lastContextIdentity = 1234
+      ..contextsSeen = 2
+      ..contextSwitches = 3
       ..activeSessions = 3
       ..peakActiveSessions = 4
       ..activeTextureLeases = 5
@@ -31,10 +34,16 @@ void main() {
     expect(stats.toJson(), containsPair('lastTileRoute', 'canvas-fallback'));
     expect(stats.toJson(), containsPair('completedSubmissions', 8));
     expect(stats.toJson(), containsPair('maxCompletionMicros', 9000));
+    expect(stats.toJson(), containsPair('lastContextIdentity', 1234));
+    expect(stats.toJson(), containsPair('contextsSeen', 2));
+    expect(stats.toJson(), containsPair('contextSwitches', 3));
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
     expect(stats.rasterFallbacks, 0);
+    expect(stats.lastContextIdentity, 1234);
+    expect(stats.contextsSeen, 2);
+    expect(stats.contextSwitches, 0);
     expect(stats.lastRejection, isNull);
     expect(stats.lastTileRoute, isNull);
     expect(stats.activeSessions, 3);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -258,13 +258,18 @@ void main() {
       final region = Offset.zero & scene.pageSize;
 
       final first = backend.createSession(scene)!;
-      (await first.rasterizeRegion(region, pixelRatio: 0.25)).dispose();
+      final firstImage = await first.rasterizeRegion(region, pixelRatio: 0.25);
+      await _pixels(firstImage);
+      firstImage.dispose();
       first.dispose();
       expect(backend.stats.texturesUploaded, 1);
       expect(backend.stats.textureBytes, greaterThan(0));
 
       final second = backend.createSession(scene)!;
-      (await second.rasterizeRegion(region, pixelRatio: 0.25)).dispose();
+      final secondImage =
+          await second.rasterizeRegion(region, pixelRatio: 0.25);
+      await _pixels(secondImage);
+      secondImage.dispose();
       second.dispose();
       expect(backend.stats.texturesUploaded, 1);
       expect(backend.stats.textureCacheHits, 1);
@@ -272,11 +277,51 @@ void main() {
       backend.clearImageCache();
       expect(backend.stats.textureBytes, 0);
       final third = backend.createSession(scene)!;
-      (await third.rasterizeRegion(region, pixelRatio: 0.25)).dispose();
+      final thirdImage = await third.rasterizeRegion(region, pixelRatio: 0.25);
+      await _pixels(thirdImage);
+      thirdImage.dispose();
       third.dispose();
       expect(backend.stats.texturesUploaded, 2);
     });
   });
+
+  testWidgets('disposing an in-flight scene keeps its image texture leased',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final scene = await PdfRetainedScene.record(
+          PdfDocument.open(buildEmbeddedFontImagePdf()).page(0));
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend(maxTextureBytes: 1 << 20);
+      final session = backend.createSession(scene)!;
+
+      // rasterizeRegion returns the resolve image as soon as the Metal command
+      // buffer is submitted; the readback below is what waits for completion.
+      // A page-tree edit can dispose the session in precisely this window.
+      final image = await session.rasterizeRegion(
+        Offset.zero & scene.pageSize,
+        pixelRatio: 2,
+      );
+      expect(backend.stats.inFlightSubmissions, 1);
+      expect(backend.stats.activeTextureLeases, 1);
+
+      session.dispose();
+      expect(backend.stats.activeTextureLeases, 1,
+          reason: 'the submitted render pass still references the texture');
+
+      await _pixels(image);
+      image.dispose();
+      for (var i = 0; i < 100 && backend.stats.activeTextureLeases != 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+      expect(backend.stats.inFlightSubmissions, 0);
+      expect(backend.stats.activeTextureLeases, 0,
+          reason: 'the completion fence releases the retired scene');
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
 
   testWidgets('content identity survives worker-reconstructed scenes',
       (tester) async {
@@ -376,6 +421,9 @@ void main() {
           reason: 'a refused scene must not overshoot the byte ceiling');
 
       pinned.dispose();
+      for (var i = 0; i < 100 && backend.stats.activeTextureLeases != 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
       expect(backend.stats.activeTextureLeases, 0);
       final admitted = backend.createSession(secondScene)!;
       (await admitted.rasterizeRegion(region, pixelRatio: 1)).dispose();


### PR DESCRIPTION
## Summary

- isolate the process-wide LoD tile cache by viewer/document lineage so equal page coordinates in different tabs cannot share pixels
- retire page presentation state after insert/remove/reorder operations and fence stale asynchronous tile completions
- keep flutter_gpu textures and geometry leased until the submitted Impeller command buffer completes, and scope native resources to their GPU context
- make Canvas the safe app default while retaining an explicit, persisted flutter_gpu developer opt-in
- export page-level backend, tile, document, revision, and build diagnostics for future field reports

## Root cause

The corruption had multiple state/lifetime paths that converged after document edits:

1. The global tile store keyed entries by page/revision coordinates, which are not unique across open documents.
2. Structural page edits could reuse the existing widget State for a different page slot while older asynchronous raster/native work was still retiring.
3. A disposed flutter_gpu scene released image texture leases immediately even when its last Metal/Impeller command buffer was still in flight.
4. Pipelines, textures, and geometry could be reused across distinct GPU contexts in multi-window native builds.

These paths explain the observed unrelated fragments, solid-color fills, and post-deletion artifacts while the saved PDF itself continues to parse and render cleanly.

## Adversarial review

The follow-up review found and addressed additional edge cases before publication:

- changed GPU context tracking and pipeline caches to weak identity ownership so closed windows are not retained forever
- explicitly invalidate abandoned namespaces on unrelated document swaps and viewer disposal
- preserve backend initialization exceptions in the exported per-page diagnostics
- clear same-geometry previews on unrelated document swaps instead of treating geometry as document identity

## Impact

- Existing Canvas rendering remains the compatibility path and is now the app default.
- flutter_gpu remains available as an explicit Developer Tools opt-in.
- Incremental non-structural revisions keep their unaffected cache reuse.
- Structural revisions trade the affected page subtree/cache lineage for correctness and deterministic resource retirement.
- Release builds now stamp the Git commit on Linux and macOS as well as Windows, making exported diagnostics attributable to exact source.

## Checks

- `fvm dart analyze`
- `cd packages/dart_pdf_editor && fvm flutter test test/tile_store_test.dart test/tile_store_page_view_test.dart test/page_preview_test.dart test/pdf_viewer_test.dart`
- `cd packages/dart_pdf_editor_flutter_gpu && fvm flutter test --enable-impeller --enable-flutter-gpu test/backend_stats_test.dart test/flutter_gpu_tile_backend_test.dart`
- `cd app && fvm flutter test test/devtools_options_test.dart test/devtools_panel_test.dart`
- real-world 207 MB, 85-page edited PDF parse and page-54 render smoke
