### PR TITLE
Fix OneDrive Open in Finder permissions

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.5.1
 
+- Fix Open in Finder for PDFs stored in sandboxed OneDrive folders.
 - Fix scanned MRC and JBIG2 pages whose text, background, or mask layers could
   be missing or opaque.
 - Fix soft-masked images that could render as black blocks with Impeller or the

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1952,7 +1952,10 @@ class _EditorScreenState extends State<EditorScreen>
     if (i < 0) return;
     switch (selected) {
       case _TabMenuAction.openFolder:
-        final opened = await openContainingFolder(tab.originPath);
+        final opened = await openContainingFolder(
+          tab.originPath,
+          bookmark: tab.originBookmark,
+        );
         if (!opened && mounted) {
           _toast(appL10n(context).editorCouldNotOpenFolder);
         }

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -414,6 +414,8 @@ String? containingFolderPath(String path) {
 /// reactivates that grant while Finder handles the reveal request.
 Future<bool> openContainingFolder(String? path, {String? bookmark}) async {
   if (!supportsOpenContainingFolder || path == null) return false;
+  final folder = containingFolderPath(path);
+  if (folder == null) return false;
   if (_isMacOSDesktop) {
     try {
       return await _macosFileAccessChannel.invokeMethod<bool>(
@@ -431,8 +433,6 @@ Future<bool> openContainingFolder(String? path, {String? bookmark}) async {
       return false;
     }
   }
-  final folder = containingFolderPath(path);
-  if (folder == null) return false;
   return launchUrl(Uri.file(folder), mode: LaunchMode.externalApplication);
 }
 

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -404,11 +404,33 @@ String? containingFolderPath(String path) {
   return trimmed.substring(0, index);
 }
 
-/// Opens [path]'s containing folder in Finder / File Explorer / the Linux file
-/// manager. Returns false when there is no usable origin path or the platform
-/// refuses to launch it.
-Future<bool> openContainingFolder(String? path) async {
+/// Reveals [path] in Finder, or opens its containing folder in File Explorer /
+/// the Linux file manager. Returns false when there is no usable origin path
+/// or the platform refuses to launch it.
+///
+/// Finder needs the selected file rather than its parent directory: a
+/// sandboxed macOS app can hold a security-scoped grant for a OneDrive file
+/// without having access to the file's containing folder. [bookmark]
+/// reactivates that grant while Finder handles the reveal request.
+Future<bool> openContainingFolder(String? path, {String? bookmark}) async {
   if (!supportsOpenContainingFolder || path == null) return false;
+  if (_isMacOSDesktop) {
+    try {
+      return await _macosFileAccessChannel.invokeMethod<bool>(
+            'revealFile',
+            {
+              'path': path,
+              if (bookmark != null && bookmark.isNotEmpty)
+                'bookmark': bookmark,
+            },
+          ) ??
+          false;
+    } on MissingPluginException {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
   final folder = containingFolderPath(path);
   if (folder == null) return false;
   return launchUrl(Uri.file(folder), mode: LaunchMode.externalApplication);

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -193,6 +193,17 @@ class MainFlutterWindow: NSWindow {
         }
         self.readFileRange(
           bookmark: bookmark, offset: offset, length: length, result: result)
+      case "revealFile":
+        guard let args = call.arguments as? [String: Any],
+              let path = args["path"] as? String else {
+          result(FlutterError(
+            code: "bad_args",
+            message: "revealFile expects a path",
+            details: nil))
+          return
+        }
+        self.revealFile(
+          path: path, bookmark: args["bookmark"] as? String, result: result)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -376,6 +387,33 @@ class MainFlutterWindow: NSWindow {
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       try bytes.write(to: url, options: .atomic)
+      return true
+    }
+  }
+
+  /// Reveals a selected document without asking the sandbox for access to its
+  /// parent directory. That distinction matters for File Provider locations:
+  /// an NSOpenPanel grant covers the OneDrive file but not the folder that
+  /// contains it. Keep the file's security scope active while Finder accepts
+  /// the reveal request.
+  private func revealFile(
+    path: String, bookmark: String?, result: @escaping FlutterResult
+  ) {
+    fileAccess.perform(errorCode: "reveal_failed", result: result) {
+      let url: URL
+      if let bookmark, !bookmark.isEmpty {
+        // A stale/corrupt bookmark should not block a path that is still
+        // reachable through the current session or a broader entitlement.
+        url = (try? self.resolveBookmarkedURL(bookmark))
+          ?? URL(fileURLWithPath: path)
+      } else {
+        url = URL(fileURLWithPath: path)
+      }
+      let scoped = url.startAccessingSecurityScopedResource()
+      defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+      DispatchQueue.main.sync {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+      }
       return true
     }
   }

--- a/app/test/file_io_folder_test.dart
+++ b/app/test/file_io_folder_test.dart
@@ -57,6 +57,7 @@ void main() {
     testWidgets('returns false without a usable path on desktop',
         (tester) async {
       expect(await openContainingFolder(null), isFalse);
+      expect(await openContainingFolder('file.pdf'), isFalse);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
     testWidgets('macOS reveals the selected file with its security bookmark',

--- a/app/test/file_io_folder_test.dart
+++ b/app/test/file_io_folder_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dart_pdf_editor_app/file_io.dart';
@@ -57,7 +57,34 @@ void main() {
     testWidgets('returns false without a usable path on desktop',
         (tester) async {
       expect(await openContainingFolder(null), isFalse);
-      expect(await openContainingFolder('file.pdf'), isFalse);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+
+    testWidgets('macOS reveals the selected file with its security bookmark',
+        (tester) async {
+      const channel = MethodChannel('dev.milanko.dartpdf/file_access');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return true;
+      });
+      addTearDown(() => TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null));
+
+      expect(
+        await openContainingFolder(
+          '/Users/ben/Library/CloudStorage/OneDrive/file.pdf',
+          bookmark: 'security-scope',
+        ),
+        isTrue,
+      );
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'revealFile');
+      expect(calls.single.arguments, {
+        'path': '/Users/ben/Library/CloudStorage/OneDrive/file.pdf',
+        'bookmark': 'security-scope',
+      });
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
     testWidgets('returns false on unsupported platforms before launching',


### PR DESCRIPTION
## Summary
- reveal the selected PDF in Finder instead of opening its parent directory on macOS
- reactivate the PDF's security-scoped bookmark while issuing the Finder request
- keep Windows/Linux containing-folder behavior unchanged
- cover the macOS channel payload with a regression test

## Root cause
DartPDF's Open in Finder action launched the containing directory. A sandboxed app can be granted access to a user-selected OneDrive PDF without receiving access to its parent directory, so Finder rejected the folder URL. Downloads masked the problem because DartPDF has a Downloads entitlement.

## User impact
Open in Finder now selects the PDF in OneDrive/CloudStorage without requiring access to the parent directory. Online-only placeholders remain revealable because the action no longer requires the file contents to be hydrated.

## Validation
- `fvm flutter test test/file_io_folder_test.dart --reporter expanded`
- `fvm dart analyze app/lib/file_io.dart app/lib/editor_screen.dart app/test/file_io_folder_test.dart`
- `fvm flutter build macos --debug`