### PR TITLE
Fix Bluebeam free text editing compatibility

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -6199,7 +6199,13 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// The selected annotation's text, for pre-filling an edit prompt.
-  String? get selectedText => selectedAnnotation?.contents;
+  String? get selectedText {
+    final annotation = selectedAnnotation;
+    final text = annotation?.contents;
+    return annotation?.subtype == 'FreeText' && text != null
+        ? pdfNormalizeLineEndings(text)
+        : text;
+  }
 
   /// Parses a free-text annotation's /DA: the font it was written with
   /// and its size, falling back to the current preferences.
@@ -6595,6 +6601,9 @@ class PdfEditingController extends ChangeNotifier {
     bool? underline,
   }) {
     if (_selected.isEmpty) return;
+    final rewrittenText = annotation.subtype == 'FreeText'
+        ? pdfNormalizeLineEndings(text)
+        : text;
     final page = _selected.last.$1;
     // a rotated text box flattens to horizontal under plain remove +
     // re-add (addFreeText/addStamp/addNote bake a horizontal matrix), so
@@ -6619,7 +6628,7 @@ class PdfEditingController extends ChangeNotifier {
             e.addFreeText(
               page,
               rect,
-              text,
+              rewrittenText,
               fontSize: size ?? style.size,
               font: font ?? style.font,
               // keep the box's own alignment unless this edit changes it
@@ -6647,7 +6656,7 @@ class PdfEditingController extends ChangeNotifier {
             e.addStamp(
               page,
               rect,
-              text,
+              rewrittenText,
               color: color ?? 0xC03030,
               pageRotation: _page(page).rotation,
               author: by,
@@ -6658,7 +6667,7 @@ class PdfEditingController extends ChangeNotifier {
               page,
               rect.left,
               rect.top,
-              text,
+              rewrittenText,
               color: color ?? 0xFFD100,
               pageRotation: _page(page).rotation,
               author: by,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1072,6 +1072,26 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     return zoom.isFinite && zoom > 0 ? 1 / zoom : 1.0;
   }
 
+  /// Keeps Flutter's Apple-platform two-device-pixel cursor nudge constant in
+  /// screen space. The editor lives inside the viewer transform, so the stock
+  /// `-2 / devicePixelRatio` local offset otherwise grows with deep zoom and
+  /// leaves the caret visibly detached from both ends of centred text.
+  Widget _zoomAwareCursor(BuildContext context, Widget child) {
+    final media = MediaQuery.of(context);
+    final platform = Theme.of(context).platform;
+    if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
+      return child;
+    }
+    final scale = _chromeScale;
+    if (!scale.isFinite || scale <= 0) return child;
+    return MediaQuery(
+      data: media.copyWith(
+        devicePixelRatio: media.devicePixelRatio / scale,
+      ),
+      child: child,
+    );
+  }
+
   /// Null while the eyedropper is armed without a tool, or while a
   /// default-mode (mouse click) selection exists without one.
   PdfEditTool? get _tool => _controller.tool;
@@ -5601,7 +5621,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                             final direction = _flutterTextDirection(value.text);
                             return Directionality(
                               textDirection: direction,
-                              child: TextField(
+                              child: _zoomAwareCursor(context, TextField(
                                 key: ValueKey(_textEditFieldName == null
                                     ? 'pdf-freetext-editor'
                                     : 'pdf-form-text-editor'),
@@ -5703,7 +5723,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                     3 * _geometry.scale,
                                   ),
                                 ),
-                              ),
+                              )),
                             );
                           },
                         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -861,6 +861,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   // refreshes _textEditRect from this through the live geometry
   PdfRect? _textEditPageRect;
   bool _textEditExisting = false;
+  (int, int)? _textEditAnnotationSlot;
   PdfEditTool? _textEditTool;
   // when non-null the open editor is a callout: this is the page-space point
   // (the terminus) the committed box's leader line will point at
@@ -2380,6 +2381,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         });
       }
     }
+    if (_textEditExisting && _textEditFieldName == null) {
+      // The opacity control restyles the selected annotation in place while
+      // its inline editor stays open. Follow the new appearance alpha so the
+      // live glyphs do not remain opaque and make the control look inert.
+      final opacity = _controller.selectedAnnotationSlot ==
+              _textEditAnnotationSlot
+          ? _controller.selectedAnnotation?.appearanceOpacity
+          : null;
+      if (opacity != null && opacity != _textEditOpacity) {
+        setState(() => _textEditOpacity = opacity);
+      }
+    }
     if (_controller.shouldKeepEditingTextFocused &&
         _textEditRect != null &&
         !_textEditFocus.hasFocus) {
@@ -2657,6 +2670,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final style = existing ? _controller.selectedTextStyle : null;
     // /DA carries the text color; /C is the box background for free text
     final annotation = existing ? _controller.selectedAnnotation : null;
+    final annotationSlot =
+        existing ? _controller.selectedAnnotationSlot : null;
     final parsed = annotation?.behavior.style.freeText;
     final annotationColor = annotation?.behavior.style.color;
     // an already-rotated box edits in its rotated frame: take the chrome's
@@ -2694,11 +2709,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _textEditText.resetStyles(fallbackStyle);
       _textEditText.text = existing ? (_controller.selectedText ?? '') : '';
     }
+    // TextEditingController.text invalidates the selection. Focus normally
+    // repairs it, but at the extreme zoom used for large CAD sheets Flutter
+    // can briefly paint the caret at the field origin. Seed the intended
+    // insertion point explicitly so it is always after the last glyph.
+    _textEditText.selection =
+        TextSelection.collapsed(offset: _textEditText.text.length);
     setState(() {
       _textEditRect = rect;
       _textEditPageRect = _geometry.toPageRect(rect);
       _textEditRotation = rotation;
       _textEditExisting = existing;
+      _textEditAnnotationSlot = annotationSlot;
       _textEditTool = _tool;
       _textEditFont =
           defaultFont is PdfStandardFont ? defaultFont : _controller.fontFamily;
@@ -2816,6 +2838,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _textEditPageRect = rect;
       _textEditRotation = 0;
       _textEditExisting = false;
+      _textEditAnnotationSlot = null;
       _textEditTool = _tool;
       _textEditFieldName = field.name;
       _textEditMultiline = field.isMultiline;
@@ -2981,11 +3004,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _textEditRect = null;
         _textEditPageRect = null;
         _textEditFieldName = null;
+        _textEditAnnotationSlot = null;
       });
     } else {
       _textEditRect = null;
       _textEditPageRect = null;
       _textEditFieldName = null;
+      _textEditAnnotationSlot = null;
     }
     _controller.setEditingText(false);
     // hand the keyboard back so the viewer's shortcuts work again right away

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -301,11 +301,12 @@ void main() {
     }
 
     Future<(PdfEditingController, PdfViewerController)> pumpEditor(
-        WidgetTester tester) async {
+        WidgetTester tester,
+        {Uint8List? bytes}) async {
       // the preference tests above seed the global mock store - these
       // tests assert on default styles, so start from an empty one
       SharedPreferences.setMockInitialValues({});
-      final editing = PdfEditingController(buildMultiPagePdf(2));
+      final editing = PdfEditingController(bytes ?? buildMultiPagePdf(2));
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);
@@ -398,6 +399,42 @@ void main() {
 
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();
+      await settle(tester);
+    });
+
+    testWidgets(
+        'Bluebeam text keeps its CSS layout, line breaks, caret, and opacity',
+        (tester) async {
+      final (editing, _) =
+          await pumpEditor(tester, bytes: buildBluebeamFreeTextPdf());
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+      expect(editing.requestEditSelectedTextInline(), isTrue);
+      await tester.pump();
+
+      final finder = find.byKey(editorKey);
+      final field = tester.widget<TextField>(finder);
+      expect(field.controller!.text, 'PJ\n202/7');
+      expect(field.controller!.selection,
+          const TextSelection.collapsed(offset: 8));
+      expect(field.textAlign, TextAlign.center);
+      expect(field.strutStyle!.height, closeTo(1.15, 1e-9));
+
+      // Opacity changes while the existing box is still being edited must be
+      // visible immediately, then survive the text rewrite on commit.
+      expect(editing.restyleSelected(opacity: 0.35), isTrue);
+      await tester.pump();
+      expect(tester.widget<TextField>(finder).style!.color!.a,
+          closeTo(0.35, 1e-6));
+
+      await tester.enterText(finder, 'PJ\n202/19');
+      await tap(tester, view(450, 400));
+
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.contents, 'PJ\n202/19');
+      expect(annotation.freeTextStyle!.alignment, PdfTextAlign.center);
+      expect(annotation.freeTextStyle!.lineSpacing, closeTo(1.15, 1e-9));
+      expect(annotation.appearanceOpacity, closeTo(0.35, 1e-9));
       await settle(tester);
     });
 

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -438,6 +438,65 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets(
+        'macOS caret stays attached to centered text at deep zoom',
+        (tester) async {
+      final (editing, viewer) = await pumpEditor(tester);
+      const rect = PdfRect(270, 550, 343.221, 567.7585);
+      editing.preferences
+        ..fontSize = 8
+        ..textAlign = PdfTextAlign.center;
+      editing
+        ..addFreeText(0, rect, 'UBX/UNX')
+        ..selectAnnotation(0, 0);
+      await tester.pump();
+
+      // Keep this box at the viewport centre while the outer viewer transform
+      // magnifies it. Flutter's stock macOS caret nudge is in local pixels;
+      // without compensation the zoom turns its 2px adjustment into a large
+      // visible gap at both the start and end of the centred line.
+      viewer.setZoom(4);
+      await tester.pump();
+      expect(editing.requestEditSelectedTextInline(), isTrue);
+      await tester.pump();
+
+      final finder = find.byKey(editorKey);
+      final field = tester.widget<TextField>(finder);
+      final editable = find.descendant(
+          of: finder, matching: find.byType(EditableText));
+      final render = tester.state<EditableTextState>(editable).renderEditable;
+      final chromeScale = field.cursorWidth / 2;
+      expect(chromeScale, lessThan(0.5));
+      expect(
+        render.cursorOffset.dx,
+        closeTo(
+          -2 / tester.view.devicePixelRatio * chromeScale,
+          1e-6,
+        ),
+      );
+
+      final textBox = render
+          .getBoxesForSelection(
+              const TextSelection(baseOffset: 0, extentOffset: 7))
+          .single;
+      final start = render
+          .getLocalRectForCaret(const TextPosition(offset: 0));
+      final end = render
+          .getLocalRectForCaret(const TextPosition(offset: 7));
+      expect(
+        (start.left - textBox.left) / chromeScale,
+        closeTo(-2 / tester.view.devicePixelRatio, 0.5),
+      );
+      expect(
+        (end.left - textBox.right) / chromeScale,
+        closeTo(-2 / tester.view.devicePixelRatio, 0.5),
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await settle(tester);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+
     testWidgets('tapping without dragging places a default-sized text box',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -677,6 +677,32 @@ class PdfAnnotation {
     final width = borderWidth ?? 0;
     final q = document.cos.resolve(dict['Q']);
     final cos = document.cos;
+
+    // Bluebeam writes the visual paragraph style to /DS and /RC but often
+    // omits /Q entirely. Keep the standard PDF entries authoritative, then
+    // fall back to those CSS declarations so the live editor and a regenerated
+    // appearance retain the original alignment and leading.
+    final cssSources = <String>[];
+    final ds = cos.resolve(dict['DS']);
+    if (ds is CosString) cssSources.add(ds.text);
+    final rc = cos.resolve(dict['RC']);
+    if (rc is CosString) {
+      for (final match in _htmlStyleRe.allMatches(rc.text)) {
+        cssSources.add(match.group(1)!);
+      }
+    }
+    String? cssValue(String property) {
+      final re = RegExp(
+        '(?:^|;)\\s*${RegExp.escape(property)}\\s*:\\s*([^;]+)',
+        caseSensitive: false,
+      );
+      for (final source in cssSources) {
+        final value = re.firstMatch(source)?.group(1)?.trim();
+        if (value != null && value.isNotEmpty) return value;
+      }
+      return null;
+    }
+
     double? number(String key) {
       final v = cos.resolve(dict[key]);
       if (v is CosInteger) return v.value.toDouble();
@@ -685,6 +711,17 @@ class PdfAnnotation {
     }
 
     final underlineFlag = cos.resolve(dict[kPdfFreeTextUnderlineKey]);
+    final cssAlign = switch (cssValue('text-align')?.toLowerCase()) {
+      'center' => PdfTextAlign.center,
+      'right' || 'end' => PdfTextAlign.right,
+      'left' || 'start' => PdfTextAlign.left,
+      _ => null,
+    };
+    final cssLineSpacing =
+        _cssLineSpacing(cssValue('line-height'), fontSize: size);
+    final cssCharSpacing = _cssPoints(cssValue('letter-spacing'));
+    final cssHorizontalScale = _cssPercent(cssValue('font-stretch'));
+    final cssDecoration = cssValue('text-decoration')?.toLowerCase();
     return PdfFreeTextStyle(
       fontName: tf.group(1)!,
       fontSize: size,
@@ -692,13 +729,19 @@ class PdfAnnotation {
       fillColor: background != null && background != text ? background : null,
       borderColor: lastColor('RG') ?? (width > 0 ? text : null),
       borderWidth: width,
-      alignment: PdfTextAlign.fromQuadding(q is CosInteger ? q.value : null),
-      lineSpacing:
-          number(kPdfFreeTextLineSpacingKey) ?? kPdfFreeTextDefaultLineSpacing,
-      charSpacing: number(kPdfFreeTextCharSpacingKey) ?? 0,
-      horizontalScale:
-          number(kPdfFreeTextHScaleKey) ?? kPdfFreeTextDefaultHorizontalScale,
-      underline: underlineFlag is CosBoolean && underlineFlag.value,
+      alignment: q is CosInteger
+          ? PdfTextAlign.fromQuadding(q.value)
+          : cssAlign ?? PdfTextAlign.left,
+      lineSpacing: number(kPdfFreeTextLineSpacingKey) ??
+          cssLineSpacing ??
+          kPdfFreeTextDefaultLineSpacing,
+      charSpacing: number(kPdfFreeTextCharSpacingKey) ?? cssCharSpacing ?? 0,
+      horizontalScale: number(kPdfFreeTextHScaleKey) ??
+          cssHorizontalScale ??
+          kPdfFreeTextDefaultHorizontalScale,
+      underline: underlineFlag is CosBoolean
+          ? underlineFlag.value
+          : (cssDecoration?.contains('underline') ?? false),
     );
   }
 
@@ -841,6 +884,49 @@ final RegExp _daTfRe = RegExp(r'/(\S+)\s+([\d.]+)\s+Tf');
 final RegExp _daRgRe = RegExp(r'([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+rg\b');
 final RegExp _daUpperRgRe = RegExp(r'([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+RG\b');
 final RegExp _daGrayRe = RegExp(r'([\d.]+)\s+g\b');
+final RegExp _htmlStyleRe = RegExp(
+  r'''style\s*=\s*["']([^"']*)["']''',
+  caseSensitive: false,
+);
+final RegExp _cssLengthRe = RegExp(
+  r'^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*(pt|%|em)?\s*$',
+  caseSensitive: false,
+);
+
+double? _cssLineSpacing(String? value, {required double fontSize}) {
+  if (value == null || fontSize <= 0) return null;
+  final match = _cssLengthRe.firstMatch(value);
+  final number = double.tryParse(match?.group(1) ?? '');
+  if (match == null || number == null || !number.isFinite || number <= 0) {
+    return null;
+  }
+  final spacing = switch (match.group(2)?.toLowerCase()) {
+    'pt' => number / fontSize,
+    '%' => number / 100,
+    'em' || null => number,
+    _ => null,
+  };
+  return spacing != null && spacing.isFinite && spacing > 0 ? spacing : null;
+}
+
+double? _cssPoints(String? value) {
+  if (value == null || value.toLowerCase() == 'normal') return null;
+  final match = _cssLengthRe.firstMatch(value);
+  final number = double.tryParse(match?.group(1) ?? '');
+  final unit = match?.group(2)?.toLowerCase();
+  if (number == null || !number.isFinite || (unit != null && unit != 'pt')) {
+    return null;
+  }
+  return number;
+}
+
+double? _cssPercent(String? value) {
+  final match = value == null ? null : _cssLengthRe.firstMatch(value);
+  if (match?.group(2) != '%') return null;
+  final number = double.tryParse(match?.group(1) ?? '');
+  return number != null && number.isFinite && number > 0 ? number : null;
+}
+
 final RegExp _pdfDateRe = RegExp(
     r"D:(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?(?:([+\-Z])(\d{2})?'?(\d{2})?)?");
 

--- a/packages/pdf_document/lib/src/text_box_appearance.dart
+++ b/packages/pdf_document/lib/src/text_box_appearance.dart
@@ -86,10 +86,19 @@ double pdfTextBoxLineX(
   }
 }
 
+/// Normalizes the three line-ending forms found in PDF strings to `\n`.
+///
+/// Bluebeam commonly stores FreeText paragraphs with bare carriage returns,
+/// while Flutter edits with line feeds. Treating a retained `\r` as a glyph
+/// changes line measurement and makes centred text jump horizontally after an
+/// edit.
+String pdfNormalizeLineEndings(String text) =>
+    text.replaceAll(RegExp(r'\r\n?'), '\n');
+
 /// Greedy word-wrap of [text] to [maxWidth] using [measure] to size a
-/// candidate line. Paragraphs (split on `\n`) always contribute at least one
-/// line; a single word wider than [maxWidth] overflows onto its own line (and
-/// is clipped by the appearance).
+/// candidate line. Paragraphs (with CR, LF, or CRLF separators) always
+/// contribute at least one line; a single word wider than [maxWidth] overflows
+/// onto its own line (and is clipped by the appearance).
 ///
 /// [tolerance] is the slack allowed before a line breaks. A box auto-sized to
 /// its content sets its width to `lineWidth + 2*pad` and wraps at
@@ -103,7 +112,7 @@ List<String> pdfWrapText(
   double tolerance = 0,
 }) {
   final lines = <String>[];
-  for (final paragraph in text.split('\n')) {
+  for (final paragraph in pdfNormalizeLineEndings(text).split('\n')) {
     var line = '';
     for (final word in paragraph.split(' ')) {
       final candidate = line.isEmpty ? word : '$line $word';

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -434,6 +434,27 @@ void main() {
     expect(style.underline, isFalse);
   });
 
+  test('Bluebeam CSS units and underline map to free text layout', () {
+    final doc = PdfDocument.open(buildBluebeamFreeTextPdf());
+    final dict = doc.page(0).annotations.single.dict;
+    dict
+      ..entries.remove('RC')
+      ..['DS'] = CosString.fromText('text-align:center; line-height:150%; '
+          'letter-spacing:2pt; font-stretch:80%; '
+          'text-decoration:underline');
+
+    final percent = PdfAnnotation.fromDict(doc, dict).freeTextStyle!;
+    expect(percent.alignment, PdfTextAlign.center);
+    expect(percent.lineSpacing, 1.5);
+    expect(percent.charSpacing, 2);
+    expect(percent.horizontalScale, 80);
+    expect(percent.underline, isTrue);
+
+    dict['DS'] = CosString.fromText('line-height:1.25em');
+    final em = PdfAnnotation.fromDict(doc, dict).freeTextStyle!;
+    expect(em.lineSpacing, 1.25);
+  });
+
   test('free text opacity is baked into and preserved by its appearance', () {
     final doc = roundTrip((e) => e.addFreeText(
           0,

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -387,6 +387,53 @@ void main() {
     expect((doc.cos.resolve(helv['Widths']) as CosArray).length, 95);
   });
 
+  test('Bluebeam free text recovers CSS alignment and CR line breaks', () {
+    final doc = PdfDocument.open(buildBluebeamFreeTextPdf());
+    final box = doc.page(0).annotations.single;
+    final style = box.freeTextStyle!;
+
+    expect(style.alignment, PdfTextAlign.center);
+    expect(style.lineSpacing, closeTo(1.15, 1e-9));
+    expect(box.contents, 'PJ\r202/7');
+    expect(pdfNormalizeLineEndings(box.contents!), 'PJ\n202/7');
+
+    // /RC is a second Bluebeam style source when /DS is missing.
+    box.dict.entries.remove('DS');
+    final fromRichContent = PdfAnnotation.fromDict(doc, box.dict);
+    expect(fromRichContent.freeTextStyle!.alignment, PdfTextAlign.center);
+    expect(fromRichContent.freeTextStyle!.lineSpacing, closeTo(1.15, 1e-9));
+
+    // Regeneration must measure the CR as a paragraph break, not as a glyph.
+    final editor = PdfEditor(doc)
+      ..restyleAnnotation(0, fromRichContent, opacity: 0.4);
+    final regenerated = PdfDocument.open(editor.save());
+    final after = regenerated.page(0).annotations.single;
+    final content = appearanceText(regenerated, after);
+    expect(' Tj'.allMatches(content), hasLength(2));
+    expect(content, isNot(contains('\\r')));
+    expect(after.appearanceOpacity, closeTo(0.4, 1e-9));
+  });
+
+  test('standard free text layout entries override Bluebeam CSS fallbacks', () {
+    final doc = PdfDocument.open(buildBluebeamFreeTextPdf());
+    final dict = doc.page(0).annotations.single.dict;
+    final ds = doc.cos.resolve(dict['DS']) as CosString;
+    dict
+      ..['DS'] = CosString.fromText('${ds.text}; text-decoration:underline')
+      ..['Q'] = const CosInteger(2)
+      ..[kPdfFreeTextLineSpacingKey] = const CosReal(1.4)
+      ..[kPdfFreeTextCharSpacingKey] = const CosReal(2)
+      ..[kPdfFreeTextHScaleKey] = const CosReal(80)
+      ..[kPdfFreeTextUnderlineKey] = const CosBoolean(false);
+
+    final style = PdfAnnotation.fromDict(doc, dict).freeTextStyle!;
+    expect(style.alignment, PdfTextAlign.right);
+    expect(style.lineSpacing, 1.4);
+    expect(style.charSpacing, 2);
+    expect(style.horizontalScale, 80);
+    expect(style.underline, isFalse);
+  });
+
   test('free text opacity is baked into and preserved by its appearance', () {
     final doc = roundTrip((e) => e.addFreeText(
           0,

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -399,6 +399,60 @@ Uint8List buildAppearanceAnnotationsPdf() {
   return ascii(buffer.toString());
 }
 
+/// Builds a minimal Bluebeam-style FreeText annotation.
+///
+/// Bluebeam stores centre alignment and 13.8pt leading in `/DS`/`/RC`, omits
+/// `/Q`, and uses a bare carriage return between the two `/Contents` lines.
+/// Its appearance also uses page-space coordinates with a translating form
+/// matrix. This combination is a compatibility fixture for inline editing and
+/// appearance regeneration.
+Uint8List buildBluebeamFreeTextPdf() {
+  const appearance = 'q BT 1 0 0 rg /Helv 12 Tf '
+      '1 0 0 1 190 632 Tm (PJ) Tj '
+      '1 0 0 1 176 618.2 Tm (202/7) Tj ET Q';
+  const ds = 'font: Helvetica 12pt; text-align:center; margin:3pt; '
+      'line-height:13.8pt; color:#FF0000';
+  const rc = '<body style="font:Helvetica 12pt; text-align:center; '
+      'margin:3pt; line-height:13.8pt; color:#FF0000">'
+      '<p style="text-align:center; line-height:13.8pt">PJ</p>'
+      '<p style="text-align:center; line-height:13.8pt">202/7</p></body>';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Annots [5 0 R] >>',
+    '<< /Length 0 >>\nstream\n\nendstream',
+    '<< /Type /Annot /Subtype /FreeText /P 3 0 R '
+        '/Rect [100 600 300 660] /F 4 /C [] '
+        '/Contents (PJ\\r202/7) /DA (1 0 0 rg /Helv 12 Tf) '
+        '/DS ($ds) /RC ($rc) /BS << /W 0 >> /AP << /N 6 0 R >> >>',
+    '<< /Type /XObject /Subtype /Form /FormType 1 '
+        '/BBox [100 600 300 660] /Matrix [1 0 0 1 -100 -600] '
+        '/Resources << /Font << /Helv 7 0 R >> >> '
+        '/Length ${appearance.length} >>\nstream\n$appearance\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica '
+        '/Encoding /WinAnsiEncoding >>',
+  ];
+
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
 /// Builds a one-page PDF with an interactive AcroForm:
 ///
 /// - text field "name" (merged widget) at [72 700 300 724], own


### PR DESCRIPTION
## Summary

- recover Bluebeam FreeText alignment and leading from `/DS` and `/RC` CSS when standard PDF entries are absent
- normalize CR, LF, and CRLF paragraph separators before editing, measurement, and appearance regeneration
- place the inline caret at the true end of the text and keep live opacity synchronized with the exact annotation being edited
- add a Bluebeam-style fixture plus document and Flutter regressions

## Root cause

Bluebeam commonly omits `/Q`, stores paragraph layout in CSS, and separates `/Contents` lines with bare carriage returns. The editor previously defaulted these annotations to left alignment and measured the retained CR as a glyph. This made the caret appear mid-text and caused text to shift or stretch when regenerated. Opacity restyling updated the annotation appearance, but the open inline editor retained its original alpha.

## Adversarial review

The review found and fixed two additional edge cases:

- an explicit PDF underline flag set to `false` could be overridden by a CSS underline declaration
- an open editor could theoretically pick up opacity from a different selected annotation on the same page

Standard PDF entries now remain authoritative in both boolean states, and live opacity synchronization is pinned to the exact page/slot selection.

## Validation

- `fvm dart analyze`
- `cd packages/pdf_document && fvm dart test test/annotation_editor_test.dart --reporter expanded`
- `cd packages/dart_pdf_editor && fvm flutter test test/editing_text_edit_test.dart --reporter expanded`
- full `pdf_document` suite: 816 passed, 1 skipped
- supplied Bluebeam PDF parse smoke: 1 page, 0 failures
