### PR TITLE
Fix Linux launch crashes and add GUI smoke tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ninja-build libgtk-3-dev libsecret-1-dev libjsoncpp-dev \
-            desktop-file-utils appstream xvfb
+            desktop-file-utils appstream xvfb x11-utils
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.47.0
@@ -237,28 +237,12 @@ jobs:
           for sz in 64 128 256 512; do
             test -f "$bundle/share/icons/hicolor/${sz}x${sz}/apps/dev.milanko.dartpdf.png"
           done
-      # Headless smoke launch: catch immediate startup crashes (plugin
-      # registration, a missing .so) that a compile can't. Non-blocking - a GUI
-      # under Xvfb can be flaky in CI, so a launch failure warns rather than
-      # fails the job. Surviving ~8s without exiting is treated as success.
-      - name: Smoke launch under Xvfb (non-blocking)
+      - name: Smoke launch GUI under Xvfb
         working-directory: app
-        continue-on-error: true
         run: |
-          set -uo pipefail
-          bin=build/linux/x64/release/bundle/dart_pdf_editor_app
-          xvfb-run -a "$bin" >/tmp/dartpdf-smoke.log 2>&1 &
-          pid=$!
-          sleep 8
-          if kill -0 "$pid" 2>/dev/null; then
-            echo "App still running after 8s - startup OK."
-            kill "$pid" 2>/dev/null || true
-            wait "$pid" 2>/dev/null || true
-          else
-            echo "::warning::App exited within 8s during headless smoke launch."
-            cat /tmp/dartpdf-smoke.log || true
-            exit 1
-          fi
+          ../tool/smoke_test_linux_gui.sh \
+            --cmd "build/linux/x64/release/bundle/dart_pdf_editor_app" \
+            --timeout 15
 
   # Static validation of the Microsoft Store packaging scripts. The real
   # submission needs a Windows runner and Partner Center credentials

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install Flatpak build tools and runtime
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder gnupg dbus-x11 xvfb
+          sudo apt-get install -y flatpak flatpak-builder gnupg dbus-x11 xvfb x11-utils
           flatpak remote-add --user --if-not-exists flathub \
             https://dl.flathub.org/repo/flathub.flatpakrepo
           flatpak install --user --noninteractive -y flathub \
@@ -128,17 +128,8 @@ jobs:
             dartpdf-local "$FLATPAK_ID//stable"
           flatpak info --user "$FLATPAK_ID"
           flatpak run --user --command=dartpdf-cli "$FLATPAK_ID" --version
-          set +e
-          timeout 12s dbus-run-session -- xvfb-run -a \
-            flatpak run --user "$FLATPAK_ID" \
-            >"$RUNNER_TEMP/dartpdf-flatpak-smoke.log" 2>&1
-          status=$?
-          set -e
-          if [[ "$status" -ne 124 ]]; then
-            cat "$RUNNER_TEMP/dartpdf-flatpak-smoke.log"
-            echo "Flatpak exited before the smoke-test window (status $status)" >&2
-            exit 1
-          fi
+          dbus-run-session -- \
+            tool/smoke_test_linux_gui.sh --cmd "flatpak run --user $FLATPAK_ID" --timeout 15
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           sudo apt-get update
-          sudo apt-get install -y dbus-x11 xvfb
+          sudo apt-get install -y dbus-x11 xvfb x11-utils
 
       - name: Build and lint snap
         run: |
@@ -92,24 +92,14 @@ jobs:
           sudo snap install --dangerous "$snap_file"
           snap info "$SNAP_NAME"
           sudo snap run "$SNAP_NAME.cli" --version
-          set +e
           # GitHub hosts the runner inside a non-interactive system service,
           # so its user has no PAM-created session cgroup for snap-confine.
           # Root still runs through the snap's strict AppArmor/seccomp/mount
           # sandbox and avoids that runner-only cgroup limitation.
           sudo install -d -m 700 /run/user/0 /root/snap/dartpdf/common
           sudo env XDG_RUNTIME_DIR=/run/user/0 \
-            timeout 12s dbus-run-session -- \
-            xvfb-run -a -f /root/snap/dartpdf/common/.Xauthority \
-            snap run "$SNAP_NAME" \
-            >"$RUNNER_TEMP/dartpdf-snap-smoke.log" 2>&1
-          task_status=$?
-          set -e
-          if [[ "$task_status" -ne 124 ]]; then
-            cat "$RUNNER_TEMP/dartpdf-snap-smoke.log"
-            echo "Snap exited before the smoke-test window (status $task_status)" >&2
-            exit 1
-          fi
+            dbus-run-session -- \
+            tool/smoke_test_linux_gui.sh --cmd "snap run $SNAP_NAME" --timeout 15
 
       - uses: actions/upload-artifact@v7
         with:
@@ -138,14 +128,5 @@ jobs:
           set +e
           sudo install -d -m 700 /run/user/0 /root/snap/dartpdf/common
           sudo env XDG_RUNTIME_DIR=/run/user/0 \
-            timeout 12s dbus-run-session -- \
-            xvfb-run -a -f /root/snap/dartpdf/common/.Xauthority \
-            snap run "$SNAP_NAME" \
-            >"$RUNNER_TEMP/dartpdf-snap-store-smoke.log" 2>&1
-          task_status=$?
-          set -e
-          if [[ "$task_status" -ne 124 ]]; then
-            cat "$RUNNER_TEMP/dartpdf-snap-store-smoke.log"
-            echo "Store snap exited before the smoke-test window (status $task_status)" >&2
-            exit 1
-          fi
+            dbus-run-session -- \
+            tool/smoke_test_linux_gui.sh --cmd "snap run $SNAP_NAME" --timeout 15

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - run: sudo apt-get update && sudo apt-get install -y ninja-build libgtk-3-dev libsecret-1-dev libjsoncpp-dev
+      - run: sudo apt-get update && sudo apt-get install -y ninja-build libgtk-3-dev libsecret-1-dev libjsoncpp-dev xvfb x11-utils
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -218,6 +218,19 @@ jobs:
           echo "$APPIMAGETOOL_SHA256  appimagetool-x86_64.AppImage" | sha256sum -c -
           chmod +x appimagetool-x86_64.AppImage
           ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run "$APPDIR" dartpdf-linux-x86_64.AppImage
+
+      - name: Smoke-test Linux GUI bundle
+        run: |
+          tool/smoke_test_linux_gui.sh \
+            --cmd "app/build/linux/x64/release/bundle/dart_pdf_editor_app" \
+            --timeout 15
+
+      - name: Smoke-test Linux AppImage GUI
+        working-directory: app
+        run: |
+          ../tool/smoke_test_linux_gui.sh \
+            --cmd "./dartpdf-linux-x86_64.AppImage --appimage-extract-and-run" \
+            --timeout 15
       - uses: actions/upload-artifact@v7
         with:
           name: linux
@@ -246,6 +259,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed ($LASTEXITCODE)" }
           & build/windows/x64/runner/Release/dartpdf.exe --version
           if ($LASTEXITCODE -ne 0) { throw "dartpdf.exe smoke check failed ($LASTEXITCODE)" }
+      - name: Smoke-test Windows GUI launch
+        working-directory: app
+        shell: pwsh
+        # Launch the GUI executable and require it to survive the window: a
+        # startup crash (plugin registration, missing DLL) exits immediately.
+        run: |
+          $exe = "build/windows/x64/runner/Release/dart_pdf_editor_app.exe"
+          $p = Start-Process $exe -PassThru
+          Start-Sleep -Seconds 12
+          $p.Refresh()
+          if ($p.HasExited) {
+            throw "dart_pdf_editor_app.exe exited during smoke launch (code $($p.ExitCode))"
+          }
+          Stop-Process -Id $p.Id -Force
+          echo "App still running after 12s - startup OK."
       - name: Bundle MSVC runtime (makes the folder portable on clean PCs)
         working-directory: app
         shell: pwsh
@@ -459,6 +487,27 @@ jobs:
         env:
           CODESIGN_ENTITLEMENTS: macos/Runner/AdHoc.entitlements
         run: bash macos/resign_embedded_code.sh build/macos/Build/Products/Release/DartPDF.app
+      - name: Smoke-test macOS app launch
+        working-directory: app
+        # Launch the signed .app directly and require it to survive the window:
+        # a startup crash (plugin registration, missing dylib) exits the process
+        # immediately. The runner's GUI session lets the app create its window.
+        run: |
+          set -euo pipefail
+          bin="build/macos/Build/Products/Release/DartPDF.app/Contents/MacOS/DartPDF"
+          "$bin" >"$RUNNER_TEMP/dartpdf-macos-smoke.log" 2>&1 &
+          pid=$!
+          sleep 12
+          if kill -0 "$pid" 2>/dev/null; then
+            echo "App still running after 12s - startup OK."
+            kill "$pid" 2>/dev/null || true
+          else
+            status=0
+            wait "$pid" || status=$?
+            cat "$RUNNER_TEMP/dartpdf-macos-smoke.log" || true
+            echo "macOS app exited during smoke launch (status $status)" >&2
+            exit 1
+          fi
       - name: Package DMG (unsigned)
         working-directory: app
         run: |

--- a/app/lib/window_support.dart
+++ b/app/lib/window_support.dart
@@ -33,7 +33,11 @@ bool get _desktopPlatform => switch (defaultTargetPlatform) {
 /// feature after that point is too late even though Flutter currently exposes
 /// the feature gate as mutable internal state.
 void enableDartPdfWindowing() {
-  if (!kIsWeb && _desktopPlatform) isWindowingEnabled = true;
+  if (!kIsWeb &&
+      _desktopPlatform &&
+      defaultTargetPlatform != TargetPlatform.linux) {
+    isWindowingEnabled = true;
+  }
 }
 
 /// Whether this process can expose DartPDF's experimental multi-window UI.

--- a/app/native/windowing_bootstrap.h
+++ b/app/native/windowing_bootstrap.h
@@ -4,10 +4,17 @@
 namespace dart_pdf {
 
 inline bool FlutterWindowingEnabled() {
+#if defined(__linux__)
+  // Linux GTK plugins (such as desktop_drop) assume a non-null FlView during
+  // fl_register_plugins. Headless engine bootstrap causes desktop_drop's
+  // gtk_drag_dest_set to fail on a null widget and prevents window creation.
+  return false;
+#else
   // DartPDF enables Flutter's matching framework feature before binding
   // initialization. Desktop runners must therefore start headless every time;
   // attaching an implicit view here would make later dialogs crash.
   return true;
+#endif
 }
 
 }  // namespace dart_pdf

--- a/app/packaging/snap/snap/snapcraft.yaml
+++ b/app/packaging/snap/snap/snapcraft.yaml
@@ -30,6 +30,14 @@ apps:
       - removable-media
       - password-manager-service
       - cups
+    slots:
+      - dartpdf-dbus
+
+slots:
+  dartpdf-dbus:
+    interface: dbus
+    bus: session
+    name: dev.milanko.dartpdf
 # Ask snapd to install the CUPS proxy on systems that do not already provide a
 # compatible print service. The app only needs the non-administrative `cups`
 # interface above; it never requests `cups-control`.

--- a/app/packaging/snap/snapcraft.yaml
+++ b/app/packaging/snap/snapcraft.yaml
@@ -1,0 +1,201 @@
+# Snap recipe for DartPDF (https://snapcraft.io/dartpdf).
+#
+# Mirrors the layout of the published snap (rev 6): core24 base, the
+# gnome-46-2404 platform runtime (SNAP_DESKTOP_RUNTIME), mesa-2404 GPU
+# passthrough wrapper, desktop-launch command chain, and the cups printing
+# content interface. Reconstructed from the installed snap's meta/snap.yaml
+# because the original recipe was never checked in.
+#
+# NEW vs rev 6: the `dartpdf-dbus` slot below. The Flutter Linux runner
+# registers its GApplication ID as a D-Bus well-known name at startup; strict
+# confinement denied that ownership and the app exited at launch ("not allowed
+# to own the service dev.milanko.dartpdf due to AppArmor policy"). The slot
+# generates the AppArmor `dbus (own) bus=session name=dev.milanko.dartpdf`
+# rule, so launch works AND a second `dartpdf file.pdf` invocation still
+# routes into the running instance via GApplication's primary-instance
+# machinery (the app's my_application_open warm-start path).
+#
+# Build:  sudo snapcraft
+# Verify: sudo snap install --dangerous dartpdf_<version>_amd64.snap
+# Run:    snap run dartpdf ; snap run dartpdf ~/some/file.pdf
+# Publish (needs `snapcraft login` once):
+#         snapcraft upload --release=stable dartpdf_<version>_amd64.snap
+
+name: dartpdf
+title: DartPDF
+summary: Edit, annotate, sign, and fill in PDFs
+description: |-
+  DartPDF is a PDF editor that runs entirely on your device. Open any PDF
+  to mark it up, fill in forms, sign it, redact content, rearrange pages,
+  or edit the text and images on the page. Changes save back to the
+  original file.
+
+
+
+  Nothing is uploaded. There is no account, no sync, and no ads. It is a
+  full, native PDF editor that keeps your documents on your own machine
+  rather than routing them through a proprietary incumbent's cloud.
+
+
+  Features:
+
+  - Highlight, underline, strikethrough, and freehand ink
+  - Shapes, arrows, text boxes, notes, and stamps
+  - Edit existing text and add images
+  - Redaction that removes the covered text and images from the file, not just from view
+  - Fill form fields (text, checkboxes, radio buttons, dropdowns), or add your own
+  - Drawn signatures placed anywhere, plus certificate-backed PAdES digital signatures
+  - OCR scanned PDFs so text can be selected and searched
+  - Reorder, delete, and export pages to a new file
+  - Full-text search, text selection, and links
+  - Compare two versions side by side
+  - Open password-protected files
+
+
+  Opens PDFs from your file manager, via drag-and-drop, or as a launch
+  argument. Light and dark themes.
+license: Apache-2.0
+base: core24
+confinement: strict
+grade: stable
+architectures:
+  - amd64
+
+# Version is adopted from app/pubspec.yaml by the dart-pdf-editor part's
+# override-pull; keep this key UNSET so adopt-info owns it.
+adopt-info: dart-pdf-editor
+
+apps:
+  dartpdf:
+    command: dart_pdf_editor_app
+    common-id: dev.milanko.dartpdf
+    command-chain:
+      - snap/command-chain/gpu-2404-wrapper
+      - snap/command-chain/desktop-launch
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - opengl
+      - wayland
+      - x11
+      - home
+      - network
+      - removable-media
+      - password-manager-service
+      - cups
+    slots:
+      - dartpdf-dbus
+  # cli: the dartpdf-cli binary's source lives outside this repository.
+  # Restore this app (and the matching `cli` part below) once the source is
+  # shared; until then, `snap run dartpdf.cli` is absent from the build.
+  # cli:
+  #   command: dartpdf-cli
+  #   plugs:
+  #     - home
+  #     - removable-media
+
+plugs:
+  dartpdf-install-cups:
+    interface: content
+    content: dartpdf-cups
+    target: $SNAP_DATA/cups
+    default-provider: cups
+  gpu-2404:
+    interface: content
+    target: $SNAP/gpu-2404
+    default-provider: mesa-2404
+  desktop:
+    mount-host-font-cache: false
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+  gnome-46-2404:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-46-2404
+
+slots:
+  dartpdf-dbus:
+    interface: dbus
+    bus: session
+    name: dev.milanko.dartpdf
+
+hooks:
+  configure:
+    command-chain:
+      - snap/command-chain/hooks-configure-fonts
+    plugs:
+      - desktop
+
+environment:
+  SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform
+  GTK_USE_PORTAL: '1'
+  LD_LIBRARY_PATH: ${SNAP_LIBRARY_PATH}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:$SNAP/lib
+  PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
+
+layout:
+  /usr/share/libdrm:
+    bind: $SNAP/gpu-2404/libdrm
+  /usr/share/drirc.d:
+    symlink: $SNAP/gpu-2404/drirc.d
+  /usr/share/X11/XErrorDB:
+    symlink: $SNAP/gpu-2404/X11/XErrorDB
+  /usr/lib/x86_64-linux-gnu/webkit2gtk-4.0:
+    bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0
+  /usr/lib/x86_64-linux-gnu/webkit2gtk-4.1:
+    bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1
+  /usr/lib/x86_64-linux-gnu/libproxy:
+    bind: $SNAP/gnome-platform/usr/lib/x86_64-linux-gnu/libproxy
+  /usr/share/xml/iso-codes:
+    bind: $SNAP/gnome-platform/usr/share/xml/iso-codes
+
+parts:
+  dart-pdf-editor:
+    # Repo root: `app` is a pub-workspace member of the root pubspec, so pub
+    # must resolve from the root (CI does the same: flutter pub get at the
+    # root, then flutter build linux inside app/).
+    source: ../../..
+    plugin: nil
+    adopt-info: dart-pdf-editor
+    build-snaps:
+      - flutter
+    build-packages:
+      - clang
+      - cmake
+      - ninja-build
+      - pkg-config
+      - libgtk-3-dev
+      - libsecret-1-dev
+      - libjsoncpp-dev
+    override-pull: |
+      snapcraftctl set-version \
+        "$(sed -n 's/^version: *\([0-9][0-9.]*\)[^0-9].*/\1/p' "$SNAPCRAFT_PART_SRC/app/pubspec.yaml" | head -1)"
+    override-build: |
+      set -eux
+      cd "$SNAPCRAFT_PART_SRC"
+      flutter config --no-analytics
+      flutter pub get
+      cd app
+      flutter build linux --release \
+        --build-name="$SNAPCRAFT_PROJECT_VERSION" --build-number=1
+      # The bundle carries the desktop integration already: app/linux's
+      # CMakeLists installs the .desktop, AppStream metainfo and hicolor
+      # icons under share/ (same files the flatpak recipe stages).
+      cp -r build/linux/x64/release/bundle/* "$SNAPCRAFT_PART_INSTALL/"
+
+  # cli:
+  #   source: <path to the dartpdf-cli source once shared>
+  #   plugin: nil
+  #   override-build: |
+  #     set -eux
+  #     ... dart compile exe ... -o "$SNAPCRAFT_PART_INSTALL/dartpdf-cli"

--- a/tool/smoke_test_linux_gui.sh
+++ b/tool/smoke_test_linux_gui.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: smoke_test_linux_gui.sh --cmd "<command>" [--timeout <seconds>]
+
+Smoke-tests a Linux GUI application launch (Snap, Flatpak, AppImage, or standalone bundle).
+Verifies that:
+1. The process starts up without GTK-CRITICAL assertions or D-Bus AccessDenied errors.
+2. A GTK window titled "DartPDF" or matching class "dev.milanko.dartpdf" is mapped and created.
+EOF
+}
+
+cmd=""
+timeout_secs=15
+is_xvfb_child=0
+
+while (($#)); do
+  case "$1" in
+    --cmd) cmd="${2:?missing --cmd value}"; shift 2 ;;
+    --timeout) timeout_secs="${2:?missing --timeout value}"; shift 2 ;;
+    --xvfb-child) is_xvfb_child=1; shift 1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$cmd" ]]; then
+  echo "Missing required argument: --cmd" >&2
+  exit 2
+fi
+
+# Force isolated Xvfb server execution unless already inside the child wrapper
+if (( is_xvfb_child == 0 )); then
+  exec env -u DISPLAY xvfb-run -a -s "-screen 0 1280x1024x24" "$0" --cmd "$cmd" --timeout "$timeout_secs" --xvfb-child
+fi
+
+log_file="$(mktemp /tmp/dartpdf-gui-smoke-XXXXXX.log)"
+cleanup() {
+  rm -f "$log_file"
+}
+trap cleanup EXIT
+
+echo "Starting GUI smoke test on DISPLAY=${DISPLAY:-none}: $cmd"
+
+bash -c "$cmd" >"$log_file" 2>&1 &
+app_pid=$!
+
+pass=0
+start_time=$(date +%s)
+
+while true; do
+  current_time=$(date +%s)
+  elapsed=$((current_time - start_time))
+
+  # 1. Check for fatal GTK / GLib / D-Bus error logs
+  if grep -qE "Gtk-CRITICAL|GLib-GObject-CRITICAL|AccessDenied|GTK_IS_WIDGET" "$log_file" 2>/dev/null; then
+    echo "ERROR: Critical GTK / D-Bus error detected during launch:" >&2
+    cat "$log_file" >&2
+    kill -9 "$app_pid" 2>/dev/null || true
+    exit 1
+  fi
+
+  # 2. Check for X11 window creation on isolated DISPLAY
+  if command -v xwininfo >/dev/null 2>&1 && [[ -n "${DISPLAY:-}" ]]; then
+    if xwininfo -display "$DISPLAY" -root -tree 2>/dev/null | grep -iE "DartPDF|dev\.milanko\.dartpdf" >/dev/null 2>&1; then
+      echo "SUCCESS: GTK window detected after ${elapsed}s."
+      pass=1
+      break
+    fi
+  fi
+
+  # 3. Check if process exited prematurely
+  if ! kill -0 "$app_pid" 2>/dev/null; then
+    wait "$app_pid" || status=$?
+    status=${status:-0}
+    if [[ "$status" -ne 0 ]]; then
+      echo "ERROR: App process exited prematurely with status $status:" >&2
+      cat "$log_file" >&2
+      exit 1
+    fi
+  fi
+
+  if (( elapsed >= timeout_secs )); then
+    break
+  fi
+
+  sleep 1
+done
+
+kill -9 "$app_pid" 2>/dev/null || true
+
+if (( pass != 1 )); then
+  echo "ERROR: GUI smoke test timed out after ${timeout_secs}s without detecting GTK window." >&2
+  cat "$log_file" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two launch-blocking bugs made the Linux app (snap, and any strict-confined/headless-adjacent launch) exit at startup, plus a CI gap that let them ship:

1. **Experimental windowing vs GTK plugins** — the headless engine bootstrap required by Flutter 3.47's experimental multi-window API leaves plugins like `desktop_drop` registering against a null `FlView`; `gtk_drag_dest_set` fails and no window is ever created. Fix (Linux-only): `window_support.dart` skips `isWindowingEnabled` and `windowing_bootstrap.h` returns `false` on `__linux__`, so Linux uses the classic single-window bootstrap. Windows/macOS multi-window is unchanged. Upstream issue: https://github.com/flutter/flutter/issues/191166
2. **Snap AppArmor D-Bus denial** — strict confinement blocked the GApplication from owning `dev.milanko.dartpdf` on the session bus. The new `dartpdf-dbus` slot in `snap/snapcraft.yaml` generates the `dbus (own)` rule; primary-instance routing (warm-start `my_application_open`) still works. The from-source `snapcraft.yaml` is also checked in next to the release repack recipe.

## CI: real launch smoke tests on every platform

`tool/smoke_test_linux_gui.sh` replaces the old non-blocking "survive 8s" checks: it runs the app under an isolated Xvfb display and **fails the job** on `Gtk-CRITICAL`/`GLib-GObject-CRITICAL`/D-Bus `AccessDenied` output, on premature exit, or if no `DartPDF`/`dev.milanko.dartpdf` window maps within the timeout. Wired into:

- `ci.yml` — Linux bundle smoke launch (now blocking; was `continue-on-error`)
- `release-app.yml` — Linux bundle + AppImage, **new macOS .app and Windows .exe launch checks**
- `publish-snap.yml` — both the dangerous-install and clean Store-install smoke tests
- `publish-flatpak.yml` — signed flatpak smoke test

## Verified locally

- Release build (`fvm flutter build linux --release`, Flutter 3.47.0) launches on a real X display; window maps as `DartPDF`/`dev.milanko.dartpdf`.
- `smoke_test_linux_gui.sh` passes against the built bundle and correctly fails on an instantly-exiting command and on `Gtk-CRITICAL` log spam.
- All touched workflow/recipe YAML parses clean.

The PR run itself proves the fix: the `linux` job's smoke launch exercises the rebuilt bootstrap path.
