### PR TITLE
Fix Windows open/save dialog crashes under the multi-window runner

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -14,6 +14,7 @@ import 'l10n/app_localizations.dart';
 import 'app.dart' deferred as app;
 import 'app_info.dart' deferred as app_info;
 import 'window_support.dart';
+import 'windows_file_dialogs.dart';
 
 /// The git commit this build was compiled from, or `unknown` for a build that
 /// did not pass one. Supplied by the build scripts as
@@ -31,6 +32,11 @@ Future<void> main(List<String> args) async {
 
   // PackageInfo (loaded below) needs the binding; ensure it before awaiting.
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Windows only, and after the Dart plugin registrant has run so this wins:
+  // the stock file_selector plugin dereferences a Flutter view the runner
+  // never creates, so opening or saving a document would crash the process.
+  WindowsFileDialogs.installIfNeeded();
 
   // Diagnostics: turn on the in-app performance trace (interpret times,
   // render-hold/scheduler transitions, prerender warms, and frame JANK,

--- a/app/lib/windows_file_dialogs.dart
+++ b/app/lib/windows_file_dialogs.dart
@@ -1,0 +1,216 @@
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The runner channel that shows Windows' common-item dialogs.
+///
+/// `file_selector_windows` cannot show them here: it takes the dialog's owner
+/// window from the plugin registrar's implicit `FlutterView`, and DartPDF's
+/// desktop runners start the engine without one so Dart owns every native
+/// window (see window_support.dart). `registrar->GetView()` is then null and
+/// the plugin dereferences it, taking the process down the first time the user
+/// opens a document or picks a save location. The runner knows its active
+/// window without a view, so it drives the dialogs itself
+/// (windows/runner/file_dialogs.cpp).
+@visibleForTesting
+const windowsFileDialogChannel =
+    MethodChannel('dev.milanko.dartpdf/file_dialogs');
+
+/// Routes `file_selector` through DartPDF's own Windows dialogs.
+///
+/// Installed process-wide on Windows so both runner bootstraps take one code
+/// path. Every method falls back to the implementation it replaced when the
+/// runner carries no dialog channel, which keeps a Dart build running against
+/// an older runner working.
+class WindowsFileDialogs extends FileSelectorPlatform {
+  WindowsFileDialogs({
+    MethodChannel channel = windowsFileDialogChannel,
+    FileSelectorPlatform? fallback,
+  })  : _channel = channel,
+        _fallback = fallback;
+
+  final MethodChannel _channel;
+  final FileSelectorPlatform? _fallback;
+
+  /// Replaces [FileSelectorPlatform.instance] on Windows, and reports whether
+  /// it did. A no-op elsewhere: macOS and Linux dialogs need no Flutter view,
+  /// and the web/mobile implementations are unrelated.
+  static bool installIfNeeded() {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.windows) return false;
+    final previous = FileSelectorPlatform.instance;
+    if (previous is WindowsFileDialogs) return true;
+    FileSelectorPlatform.instance = WindowsFileDialogs(fallback: previous);
+    return true;
+  }
+
+  @override
+  Future<XFile?> openFile({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    final result = await _show(
+      'openFile',
+      acceptedTypeGroups: acceptedTypeGroups,
+      initialDirectory: initialDirectory,
+      confirmButtonText: confirmButtonText,
+    );
+    if (result == null) {
+      return _fallback?.openFile(
+        acceptedTypeGroups: acceptedTypeGroups,
+        initialDirectory: initialDirectory,
+        confirmButtonText: confirmButtonText,
+      );
+    }
+    return result.paths.isEmpty ? null : XFile(result.paths.first);
+  }
+
+  @override
+  Future<List<XFile>> openFiles({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    final result = await _show(
+      'openFiles',
+      acceptedTypeGroups: acceptedTypeGroups,
+      initialDirectory: initialDirectory,
+      confirmButtonText: confirmButtonText,
+    );
+    if (result == null) {
+      return await _fallback?.openFiles(
+            acceptedTypeGroups: acceptedTypeGroups,
+            initialDirectory: initialDirectory,
+            confirmButtonText: confirmButtonText,
+          ) ??
+          const <XFile>[];
+    }
+    return [for (final path in result.paths) XFile(path)];
+  }
+
+  @override
+  Future<FileSaveLocation?> getSaveLocation({
+    List<XTypeGroup>? acceptedTypeGroups,
+    SaveDialogOptions options = const SaveDialogOptions(),
+  }) async {
+    final result = await _show(
+      'getSaveLocation',
+      acceptedTypeGroups: acceptedTypeGroups,
+      initialDirectory: options.initialDirectory,
+      confirmButtonText: options.confirmButtonText,
+      suggestedName: options.suggestedName,
+    );
+    if (result == null) {
+      return _fallback?.getSaveLocation(
+        acceptedTypeGroups: acceptedTypeGroups,
+        options: options,
+      );
+    }
+    if (result.paths.isEmpty) return null;
+    return FileSaveLocation(
+      result.paths.first,
+      activeFilter: result.activeFilter(acceptedTypeGroups),
+    );
+  }
+
+  @override
+  Future<String?> getDirectoryPathWithOptions(FileDialogOptions options) async {
+    final result = await _show(
+      'getDirectoryPath',
+      acceptedTypeGroups: null,
+      initialDirectory: options.initialDirectory,
+      confirmButtonText: options.confirmButtonText,
+    );
+    if (result == null) {
+      return _fallback?.getDirectoryPathWithOptions(options);
+    }
+    return result.paths.isEmpty ? null : result.paths.first;
+  }
+
+  @override
+  Future<List<String>> getDirectoryPathsWithOptions(
+      FileDialogOptions options) async {
+    final result = await _show(
+      'getDirectoryPaths',
+      acceptedTypeGroups: null,
+      initialDirectory: options.initialDirectory,
+      confirmButtonText: options.confirmButtonText,
+    );
+    if (result == null) {
+      return await _fallback?.getDirectoryPathsWithOptions(options) ??
+          const <String>[];
+    }
+    return result.paths;
+  }
+
+  /// Invokes [method] on the runner, or returns null when this runner has no
+  /// dialog channel so the caller can fall back.
+  Future<_DialogResult?> _show(
+    String method, {
+    required List<XTypeGroup>? acceptedTypeGroups,
+    required String? initialDirectory,
+    required String? confirmButtonText,
+    String? suggestedName,
+  }) async {
+    final groups = [
+      for (final group in acceptedTypeGroups ?? const <XTypeGroup>[])
+        _encodeTypeGroup(group),
+    ];
+    try {
+      final reply = await _channel.invokeMapMethod<String, Object?>(method, {
+        'acceptedTypeGroups': groups,
+        if (initialDirectory != null) 'initialDirectory': initialDirectory,
+        if (confirmButtonText != null) 'confirmButtonText': confirmButtonText,
+        if (suggestedName != null) 'suggestedName': suggestedName,
+      });
+      return _DialogResult.fromReply(reply);
+    } on MissingPluginException {
+      return null;
+    }
+  }
+}
+
+/// Encodes one filter entry, rejecting a group Windows cannot express - the
+/// same contract (and error) as `file_selector_windows`, so a mis-declared
+/// group fails loudly here rather than silently widening the dialog.
+Map<String, Object?> _encodeTypeGroup(XTypeGroup group) {
+  if (!group.allowsAny && (group.extensions?.isEmpty ?? true)) {
+    throw ArgumentError(
+      'Provided type group $group does not allow all files, but does not set '
+      'any of the Windows-supported filter categories. "extensions" must be '
+      'non-empty for Windows if anything is non-empty.',
+    );
+  }
+  return {
+    'label': group.label ?? '',
+    'extensions': [...?group.extensions],
+  };
+}
+
+/// The runner's reply: the chosen paths, plus the one-based index of the type
+/// filter that was active (0 when the dialog reported none).
+@immutable
+class _DialogResult {
+  const _DialogResult(this.paths, this.filterIndex);
+
+  factory _DialogResult.fromReply(Map<String, Object?>? reply) {
+    if (reply == null) return const _DialogResult([], 0);
+    final paths = <String>[
+      for (final path in (reply['paths'] as List<Object?>?) ?? const [])
+        if (path is String && path.isNotEmpty) path,
+    ];
+    return _DialogResult(paths, (reply['filterIndex'] as int?) ?? 0);
+  }
+
+  final List<String> paths;
+  final int filterIndex;
+
+  /// The group [filterIndex] points at, or null when the dialog reported no
+  /// filter (or one outside the list we sent).
+  XTypeGroup? activeFilter(List<XTypeGroup>? groups) {
+    if (groups == null || filterIndex < 1 || filterIndex > groups.length) {
+      return null;
+    }
+    return groups[filterIndex - 1];
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -39,6 +39,10 @@ dependencies:
 
   # Cross-platform file I/O and OS integration.
   file_selector: ^1.0.3
+  # Depended on directly, not just through file_selector: DartPDF swaps in its
+  # own Windows dialog implementation (lib/windows_file_dialogs.dart) because
+  # the plugin needs a Flutter view the multi-window runner never creates.
+  file_selector_platform_interface: ^2.7.0
   share_plus: ^13.3.0
   url_launcher: ^6.3.0
   # Printing has no third-party PDF engine. Where the OS can print a PDF
@@ -99,7 +103,6 @@ dev_dependencies:
   # Text extraction, used by the on-device OCR integration test to assert
   # the recognized layer is selectable (pdf_ocr_ondevice is a runtime dep).
   pdf_graphics: ^3.6.0
-  file_selector_platform_interface: ^2.7.0
   # Points the crash-recovery store at a temp directory so its append/truncate
   # behaviour can be tested against a real filesystem (see
   # test/unsaved_changes_store_io_test.dart).

--- a/app/test/windows_file_dialogs_test.dart
+++ b/app/test/windows_file_dialogs_test.dart
@@ -36,6 +36,8 @@ class _FallbackSelector extends FileSelectorPlatform {
   bool openedFile = false;
   bool openedFiles = false;
   bool savedLocation = false;
+  bool pickedDirectory = false;
+  bool pickedDirectories = false;
 
   @override
   Future<XFile?> openFile({
@@ -64,6 +66,20 @@ class _FallbackSelector extends FileSelectorPlatform {
   }) async {
     savedLocation = true;
     return const FileSaveLocation(r'C:\fallback.pdf');
+  }
+
+  @override
+  Future<String?> getDirectoryPathWithOptions(FileDialogOptions options) async {
+    pickedDirectory = true;
+    return r'C:\fallback';
+  }
+
+  @override
+  Future<List<String>> getDirectoryPathsWithOptions(
+    FileDialogOptions options,
+  ) async {
+    pickedDirectories = true;
+    return [r'C:\fallback'];
   }
 }
 
@@ -183,9 +199,19 @@ void main() {
     expect((await dialogs.openFile())?.path, r'C:\fallback.pdf');
     expect((await dialogs.openFiles()).single.path, r'C:\fallback.pdf');
     expect((await dialogs.getSaveLocation())?.path, r'C:\fallback.pdf');
+    expect(
+      await dialogs.getDirectoryPathWithOptions(const FileDialogOptions()),
+      r'C:\fallback',
+    );
+    expect(
+      await dialogs.getDirectoryPathsWithOptions(const FileDialogOptions()),
+      [r'C:\fallback'],
+    );
     expect(fallback.openedFile, isTrue);
     expect(fallback.openedFiles, isTrue);
     expect(fallback.savedLocation, isTrue);
+    expect(fallback.pickedDirectory, isTrue);
+    expect(fallback.pickedDirectories, isTrue);
   });
 
   test('a channel-less runner with no fallback cancels instead of throwing',
@@ -197,8 +223,14 @@ void main() {
     expect(await dialogs.openFile(), isNull);
     expect(await dialogs.openFiles(), isEmpty);
     expect(await dialogs.getSaveLocation(), isNull);
-    expect(await dialogs.getDirectoryPathWithOptions(const FileDialogOptions()),
-        isNull);
+    expect(
+      await dialogs.getDirectoryPathWithOptions(const FileDialogOptions()),
+      isNull,
+    );
+    expect(
+      await dialogs.getDirectoryPathsWithOptions(const FileDialogOptions()),
+      isEmpty,
+    );
   });
 
   test('a type group Windows cannot express is rejected up front', () async {

--- a/app/test/windows_file_dialogs_test.dart
+++ b/app/test/windows_file_dialogs_test.dart
@@ -1,0 +1,273 @@
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/windows_file_dialogs.dart';
+
+/// Records the calls the runner would receive and replies with [reply], or
+/// throws [MissingPluginException] when [reply] is null - the shape of a
+/// runner that predates the dialog channel.
+class _FakeRunner {
+  _FakeRunner({this.reply});
+
+  Map<String, Object?>? reply;
+  final calls = <MethodCall>[];
+
+  void install() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(windowsFileDialogChannel, (call) async {
+      calls.add(call);
+      if (reply == null) throw MissingPluginException(call.method);
+      return reply;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(windowsFileDialogChannel, null);
+    });
+  }
+
+  Map<String, Object?> get lastArguments =>
+      (calls.last.arguments as Map).cast<String, Object?>();
+}
+
+/// Stands in for the implementation [WindowsFileDialogs] displaces.
+class _FallbackSelector extends FileSelectorPlatform {
+  bool openedFile = false;
+  bool openedFiles = false;
+  bool savedLocation = false;
+
+  @override
+  Future<XFile?> openFile({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    openedFile = true;
+    return XFile(r'C:\fallback.pdf');
+  }
+
+  @override
+  Future<List<XFile>> openFiles({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    openedFiles = true;
+    return [XFile(r'C:\fallback.pdf')];
+  }
+
+  @override
+  Future<FileSaveLocation?> getSaveLocation({
+    List<XTypeGroup>? acceptedTypeGroups,
+    SaveDialogOptions options = const SaveDialogOptions(),
+  }) async {
+    savedLocation = true;
+    return const FileSaveLocation(r'C:\fallback.pdf');
+  }
+}
+
+const _pdf = XTypeGroup(label: 'PDF', extensions: ['pdf']);
+const _images = XTypeGroup(label: 'Images', extensions: ['png', 'jpg']);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('openFile forwards the type filters and returns the pick', () async {
+    final runner = _FakeRunner(reply: {
+      'paths': [r'C:\docs\report.pdf'],
+      'filterIndex': 1,
+    });
+    runner.install();
+    final dialogs = WindowsFileDialogs();
+
+    final file = await dialogs.openFile(
+      acceptedTypeGroups: [_pdf, _images],
+      initialDirectory: r'C:\docs',
+      confirmButtonText: 'Open',
+    );
+
+    // Only the path is asserted: XFile derives `name` with the *host*
+    // separator, so a Windows path only splits correctly on a Windows host.
+    expect(file?.path, r'C:\docs\report.pdf');
+    expect(runner.calls.single.method, 'openFile');
+    expect(runner.lastArguments['initialDirectory'], r'C:\docs');
+    expect(runner.lastArguments['confirmButtonText'], 'Open');
+    expect(runner.lastArguments['acceptedTypeGroups'], [
+      {
+        'label': 'PDF',
+        'extensions': ['pdf'],
+      },
+      {
+        'label': 'Images',
+        'extensions': ['png', 'jpg'],
+      },
+    ]);
+  });
+
+  test('a dismissed open dialog reads as a cancellation, not a failure',
+      () async {
+    final runner = _FakeRunner(reply: {'paths': <String>[], 'filterIndex': 0});
+    runner.install();
+
+    expect(
+      await WindowsFileDialogs().openFile(acceptedTypeGroups: [_pdf]),
+      isNull,
+    );
+    expect(
+      await WindowsFileDialogs().openFiles(acceptedTypeGroups: [_pdf]),
+      isEmpty,
+    );
+    expect(
+      await WindowsFileDialogs().getSaveLocation(acceptedTypeGroups: [_pdf]),
+      isNull,
+    );
+  });
+
+  test('openFiles returns every pick in order', () async {
+    final runner = _FakeRunner(reply: {
+      'paths': [r'C:\a.pdf', r'C:\b.pdf'],
+      'filterIndex': 1,
+    });
+    runner.install();
+
+    final files = await WindowsFileDialogs().openFiles(
+      acceptedTypeGroups: [_pdf],
+    );
+
+    expect(files.map((f) => f.path), [r'C:\a.pdf', r'C:\b.pdf']);
+    expect(runner.calls.single.method, 'openFiles');
+  });
+
+  test('getSaveLocation passes the suggested name and reports the filter',
+      () async {
+    final runner = _FakeRunner(reply: {
+      'paths': [r'C:\docs\out.pdf'],
+      'filterIndex': 2,
+    });
+    runner.install();
+
+    final location = await WindowsFileDialogs().getSaveLocation(
+      acceptedTypeGroups: [_pdf, _images],
+      options: const SaveDialogOptions(suggestedName: 'out.pdf'),
+    );
+
+    expect(location?.path, r'C:\docs\out.pdf');
+    expect(location?.activeFilter, _images);
+    expect(runner.calls.single.method, 'getSaveLocation');
+    expect(runner.lastArguments['suggestedName'], 'out.pdf');
+  });
+
+  test('a filter index outside the groups we sent reports no active filter',
+      () async {
+    final runner = _FakeRunner(reply: {
+      'paths': [r'C:\docs\out.pdf'],
+      'filterIndex': 7,
+    });
+    runner.install();
+
+    final location = await WindowsFileDialogs().getSaveLocation(
+      acceptedTypeGroups: [_pdf],
+    );
+
+    expect(location?.activeFilter, isNull);
+  });
+
+  test('a runner without the channel falls back to the old implementation',
+      () async {
+    final runner = _FakeRunner();
+    runner.install();
+    final fallback = _FallbackSelector();
+    final dialogs = WindowsFileDialogs(fallback: fallback);
+
+    expect((await dialogs.openFile())?.path, r'C:\fallback.pdf');
+    expect((await dialogs.openFiles()).single.path, r'C:\fallback.pdf');
+    expect((await dialogs.getSaveLocation())?.path, r'C:\fallback.pdf');
+    expect(fallback.openedFile, isTrue);
+    expect(fallback.openedFiles, isTrue);
+    expect(fallback.savedLocation, isTrue);
+  });
+
+  test('a channel-less runner with no fallback cancels instead of throwing',
+      () async {
+    final runner = _FakeRunner();
+    runner.install();
+    final dialogs = WindowsFileDialogs();
+
+    expect(await dialogs.openFile(), isNull);
+    expect(await dialogs.openFiles(), isEmpty);
+    expect(await dialogs.getSaveLocation(), isNull);
+    expect(await dialogs.getDirectoryPathWithOptions(const FileDialogOptions()),
+        isNull);
+  });
+
+  test('a type group Windows cannot express is rejected up front', () async {
+    final runner = _FakeRunner(reply: {'paths': <String>[], 'filterIndex': 0});
+    runner.install();
+
+    await expectLater(
+      WindowsFileDialogs().openFile(
+        acceptedTypeGroups: [
+          const XTypeGroup(label: 'Bad', mimeTypes: ['x/y'])
+        ],
+      ),
+      throwsArgumentError,
+    );
+    expect(runner.calls, isEmpty);
+  });
+
+  test('directory picks route to the runner too', () async {
+    final runner = _FakeRunner(reply: {
+      'paths': [r'C:\docs'],
+      'filterIndex': 0,
+    });
+    runner.install();
+    final dialogs = WindowsFileDialogs();
+
+    expect(
+      await dialogs.getDirectoryPathWithOptions(const FileDialogOptions()),
+      r'C:\docs',
+    );
+    expect(
+      await dialogs.getDirectoryPathsWithOptions(const FileDialogOptions()),
+      [r'C:\docs'],
+    );
+    expect(runner.calls.map((c) => c.method),
+        ['getDirectoryPath', 'getDirectoryPaths']);
+  });
+
+  group('installIfNeeded', () {
+    late FileSelectorPlatform original;
+
+    setUp(() {
+      original = FileSelectorPlatform.instance;
+      addTearDown(() => FileSelectorPlatform.instance = original);
+    });
+
+    test('takes over the platform instance on Windows', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      expect(WindowsFileDialogs.installIfNeeded(), isTrue);
+      expect(FileSelectorPlatform.instance, isA<WindowsFileDialogs>());
+
+      // Idempotent: a second call must not wrap the instance in itself.
+      final installed = FileSelectorPlatform.instance;
+      expect(WindowsFileDialogs.installIfNeeded(), isTrue);
+      expect(FileSelectorPlatform.instance, same(installed));
+    });
+
+    test('leaves every other platform alone', () {
+      for (final platform in [
+        TargetPlatform.macOS,
+        TargetPlatform.linux,
+        TargetPlatform.android,
+      ]) {
+        debugDefaultTargetPlatformOverride = platform;
+        expect(WindowsFileDialogs.installIfNeeded(), isFalse);
+        expect(FileSelectorPlatform.instance, same(original));
+      }
+      debugDefaultTargetPlatformOverride = null;
+    });
+  });
+}

--- a/app/windows/runner/CMakeLists.txt
+++ b/app/windows/runner/CMakeLists.txt
@@ -7,6 +7,7 @@ project(runner LANGUAGES CXX)
 #
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
+  "file_dialogs.cpp"
   "flutter_window.cpp"
   "image_clipboard.cpp"
   "main.cpp"
@@ -42,6 +43,9 @@ target_link_libraries(${BINARY_NAME} PRIVATE "windowscodecs.lib" "ole32.lib")
 # native_print.cpp: the print dialog (comdlg32), persisted settings (advapi32),
 # and GDI blitting (gdi32).
 target_link_libraries(${BINARY_NAME} PRIVATE "comdlg32.lib" "advapi32.lib" "gdi32.lib")
+# file_dialogs.cpp: the common-item open/save dialogs (IFileDialog lives in
+# shell32; ole32 is already linked above for COM itself).
+target_link_libraries(${BINARY_NAME} PRIVATE "shell32.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/app/windows/runner/file_dialogs.cpp
+++ b/app/windows/runner/file_dialogs.cpp
@@ -1,0 +1,177 @@
+#include "file_dialogs.h"
+
+#include <shobjidl.h>
+#include <windows.h>
+
+#include <utility>
+
+namespace dart_pdf {
+
+namespace {
+
+// Minimal scoped COM pointer. The runner deliberately avoids pulling in ATL or
+// WRL for six call sites; this covers exactly the shape used below.
+template <typename T>
+class ComPtr {
+ public:
+  ComPtr() = default;
+  ~ComPtr() { Reset(); }
+
+  ComPtr(const ComPtr&) = delete;
+  ComPtr& operator=(const ComPtr&) = delete;
+
+  // Address of the (released) slot, for IID_PPV_ARGS.
+  T** Put() {
+    Reset();
+    return &ptr_;
+  }
+
+  T* Get() const { return ptr_; }
+  T* operator->() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+  void Reset() {
+    if (ptr_ != nullptr) {
+      ptr_->Release();
+      ptr_ = nullptr;
+    }
+  }
+
+ private:
+  T* ptr_ = nullptr;
+};
+
+// "*.png;*.jpg" for a filter's extensions, or "*.*" when it names none.
+std::wstring FilterSpec(const FileTypeFilter& filter) {
+  if (filter.extensions.empty()) return L"*.*";
+  std::wstring spec;
+  for (const std::wstring& extension : filter.extensions) {
+    if (!spec.empty()) spec += L";";
+    spec += L"*." + extension;
+  }
+  return spec;
+}
+
+// The filesystem path behind |item|, or an empty string when it has none
+// (a shell item that is not a file, or a failed query).
+std::wstring PathForShellItem(IShellItem* item) {
+  if (item == nullptr) return std::wstring();
+  wchar_t* wide_path = nullptr;
+  if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &wide_path))) {
+    return std::wstring();
+  }
+  std::wstring path(wide_path);
+  ::CoTaskMemFree(wide_path);
+  return path;
+}
+
+void CollectOpenResults(IFileDialog* dialog, FileDialogResult* out) {
+  ComPtr<IFileOpenDialog> open_dialog;
+  if (FAILED(dialog->QueryInterface(IID_PPV_ARGS(open_dialog.Put())))) return;
+  ComPtr<IShellItemArray> items;
+  if (FAILED(open_dialog->GetResults(items.Put())) || !items) return;
+  DWORD count = 0;
+  if (FAILED(items->GetCount(&count))) return;
+  for (DWORD index = 0; index < count; index++) {
+    ComPtr<IShellItem> item;
+    if (FAILED(items->GetItemAt(index, item.Put()))) continue;
+    std::wstring path = PathForShellItem(item.Get());
+    if (!path.empty()) out->paths.push_back(std::move(path));
+  }
+}
+
+void CollectSaveResult(IFileDialog* dialog, FileDialogResult* out) {
+  ComPtr<IShellItem> item;
+  if (FAILED(dialog->GetResult(item.Put()))) return;
+  std::wstring path = PathForShellItem(item.Get());
+  if (!path.empty()) out->paths.push_back(std::move(path));
+}
+
+FileDialogResult ShowDialog(HWND owner, const FileDialogRequest& request,
+                            bool save) {
+  FileDialogResult result;
+  ComPtr<IFileDialog> dialog;
+  HRESULT hr = ::CoCreateInstance(
+      save ? CLSID_FileSaveDialog : CLSID_FileOpenDialog, nullptr,
+      CLSCTX_INPROC_SERVER, IID_PPV_ARGS(dialog.Put()));
+  if (FAILED(hr) || !dialog) {
+    result.error = FAILED(hr) ? hr : E_FAIL;
+    return result;
+  }
+
+  FILEOPENDIALOGOPTIONS options = 0;
+  if (SUCCEEDED(dialog->GetOptions(&options))) {
+    // FORCEFILESYSTEM keeps every result addressable as a real path, which is
+    // the only kind this app can read or write.
+    options |= FOS_FORCEFILESYSTEM;
+    if (!save && request.allow_multiple) options |= FOS_ALLOWMULTISELECT;
+    if (!save && request.select_folders) options |= FOS_PICKFOLDERS;
+    dialog->SetOptions(options);
+  }
+
+  // The COMDLG_FILTERSPEC entries borrow these strings, so both vectors have
+  // to outlive the SetFileTypes call - and `specs` must never reallocate.
+  std::vector<std::wstring> spec_strings;
+  std::vector<COMDLG_FILTERSPEC> specs;
+  spec_strings.reserve(request.filters.size());
+  specs.reserve(request.filters.size());
+  for (const FileTypeFilter& filter : request.filters) {
+    spec_strings.push_back(FilterSpec(filter));
+    specs.push_back({filter.label.c_str(), spec_strings.back().c_str()});
+  }
+  if (!specs.empty()) {
+    dialog->SetFileTypes(static_cast<UINT>(specs.size()), specs.data());
+  }
+
+  if (!request.initial_directory.empty()) {
+    ComPtr<IShellItem> folder;
+    if (SUCCEEDED(::SHCreateItemFromParsingName(
+            request.initial_directory.c_str(), nullptr,
+            IID_PPV_ARGS(folder.Put())))) {
+      dialog->SetFolder(folder.Get());
+    }
+  }
+  if (!request.suggested_name.empty()) {
+    dialog->SetFileName(request.suggested_name.c_str());
+  }
+  if (!request.confirm_button_text.empty()) {
+    dialog->SetOkButtonLabel(request.confirm_button_text.c_str());
+  }
+
+  hr = dialog->Show(owner);
+  if (hr == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
+    // Dismissed. An empty selection is the answer, not an error.
+    result.shown = true;
+    return result;
+  }
+  if (FAILED(hr)) {
+    result.error = hr;
+    return result;
+  }
+
+  if (save) {
+    CollectSaveResult(dialog.Get(), &result);
+  } else {
+    CollectOpenResults(dialog.Get(), &result);
+  }
+  UINT filter_index = 0;
+  if (SUCCEEDED(dialog->GetFileTypeIndex(&filter_index))) {
+    result.filter_index = filter_index;
+  }
+  result.shown = true;
+  return result;
+}
+
+}  // namespace
+
+FileDialogResult ShowOpenFileDialog(HWND owner,
+                                    const FileDialogRequest& request) {
+  return ShowDialog(owner, request, /*save=*/false);
+}
+
+FileDialogResult ShowSaveFileDialog(HWND owner,
+                                    const FileDialogRequest& request) {
+  return ShowDialog(owner, request, /*save=*/true);
+}
+
+}  // namespace dart_pdf

--- a/app/windows/runner/file_dialogs.h
+++ b/app/windows/runner/file_dialogs.h
@@ -1,0 +1,56 @@
+#ifndef RUNNER_FILE_DIALOGS_H_
+#define RUNNER_FILE_DIALOGS_H_
+
+#include <windows.h>
+
+#include <string>
+#include <vector>
+
+namespace dart_pdf {
+
+// One entry of the dialog's file-type dropdown. |extensions| carries bare
+// extensions ("pdf"), not patterns - the dialog builds "*.pdf" itself.
+struct FileTypeFilter {
+  std::wstring label;
+  std::vector<std::wstring> extensions;
+};
+
+// Everything the Dart side can configure on a dialog. Empty strings mean
+// "leave the platform default alone".
+struct FileDialogRequest {
+  std::vector<FileTypeFilter> filters;
+  std::wstring initial_directory;
+  std::wstring suggested_name;
+  std::wstring confirm_button_text;
+  bool allow_multiple = false;
+  bool select_folders = false;
+};
+
+// The outcome of one dialog. |shown| distinguishes a dialog the user
+// dismissed (shown, empty paths) from one that could not run at all (not
+// shown, |error| carries the HRESULT).
+struct FileDialogResult {
+  bool shown = false;
+  HRESULT error = S_OK;
+  std::vector<std::wstring> paths;
+
+  // One-based index of the type filter the user had selected, or 0 when the
+  // dialog did not report one.
+  unsigned int filter_index = 0;
+};
+
+// Shows the common-item open dialog owned by |owner|, blocking until the user
+// dismisses it. Picks folders instead of files when |request.select_folders|
+// is set, and allows several only when |request.allow_multiple| is.
+FileDialogResult ShowOpenFileDialog(HWND owner,
+                                    const FileDialogRequest& request);
+
+// Shows the common-item save dialog owned by |owner|, blocking until the user
+// dismisses it. The returned path is whatever the user typed - the caller is
+// responsible for forcing an extension.
+FileDialogResult ShowSaveFileDialog(HWND owner,
+                                    const FileDialogRequest& request);
+
+}  // namespace dart_pdf
+
+#endif  // RUNNER_FILE_DIALOGS_H_

--- a/app/windows/runner/platform_channels.cpp
+++ b/app/windows/runner/platform_channels.cpp
@@ -9,6 +9,7 @@
 #include <variant>
 #include <vector>
 
+#include "file_dialogs.h"
 #include "image_clipboard.h"
 #include "utils.h"
 
@@ -22,6 +23,8 @@ constexpr char kNativePrintChannelName[] =
 constexpr char kMemoryChannelName[] = "dev.milanko.dartpdf/memory";
 constexpr char kWindowGeometryChannelName[] =
     "dev.milanko.dartpdf/window_geometry";
+constexpr char kFileDialogChannelName[] =
+    "dev.milanko.dartpdf/file_dialogs";
 
 const flutter::EncodableValue* Lookup(const flutter::EncodableMap& map,
                                       const char* key) {
@@ -44,6 +47,78 @@ std::optional<int64_t> Integer(const flutter::EncodableValue& value) {
   if (const auto* number = std::get_if<int64_t>(&value)) return *number;
   if (const auto* number = std::get_if<int32_t>(&value)) return *number;
   return std::nullopt;
+}
+
+std::wstring OptionalString(const flutter::EncodableMap* args, const char* key) {
+  if (args == nullptr) return std::wstring();
+  const auto* value = Lookup(*args, key);
+  if (value == nullptr) return std::wstring();
+  const auto* text = std::get_if<std::string>(value);
+  return text == nullptr ? std::wstring() : Utf16FromUtf8(*text);
+}
+
+// Decodes the `acceptedTypeGroups` argument: a list of
+// `{label: String, extensions: [String]}` maps. Unusable entries are skipped
+// rather than failing the call - a dialog with one filter missing is far
+// better than no dialog.
+std::vector<dart_pdf::FileTypeFilter> DecodeFilters(
+    const flutter::EncodableMap* args) {
+  std::vector<dart_pdf::FileTypeFilter> filters;
+  if (args == nullptr) return filters;
+  const auto* groups_value = Lookup(*args, "acceptedTypeGroups");
+  const auto* groups =
+      groups_value == nullptr
+          ? nullptr
+          : std::get_if<flutter::EncodableList>(groups_value);
+  if (groups == nullptr) return filters;
+  for (const auto& group_value : *groups) {
+    const auto* group = std::get_if<flutter::EncodableMap>(&group_value);
+    if (group == nullptr) continue;
+    dart_pdf::FileTypeFilter filter;
+    if (const auto* label = Lookup(*group, "label")) {
+      if (const auto* text = std::get_if<std::string>(label)) {
+        filter.label = Utf16FromUtf8(*text);
+      }
+    }
+    if (const auto* extensions = Lookup(*group, "extensions")) {
+      if (const auto* list = std::get_if<flutter::EncodableList>(extensions)) {
+        for (const auto& extension : *list) {
+          const auto* text = std::get_if<std::string>(&extension);
+          if (text != nullptr && !text->empty()) {
+            filter.extensions.push_back(Utf16FromUtf8(*text));
+          }
+        }
+      }
+    }
+    if (filter.label.empty()) continue;
+    filters.push_back(std::move(filter));
+  }
+  return filters;
+}
+
+dart_pdf::FileDialogRequest DecodeDialogRequest(
+    const flutter::EncodableMap* args) {
+  dart_pdf::FileDialogRequest request;
+  request.filters = DecodeFilters(args);
+  request.initial_directory = OptionalString(args, "initialDirectory");
+  request.suggested_name = OptionalString(args, "suggestedName");
+  request.confirm_button_text = OptionalString(args, "confirmButtonText");
+  return request;
+}
+
+// The reply shape shared by all three dialog methods: the chosen paths (empty
+// when the user cancelled) plus the one-based index of the active type filter.
+flutter::EncodableValue DialogPayload(const dart_pdf::FileDialogResult& result) {
+  flutter::EncodableList paths;
+  paths.reserve(result.paths.size());
+  for (const std::wstring& path : result.paths) {
+    paths.push_back(flutter::EncodableValue(Utf8FromUtf16(path.c_str())));
+  }
+  return flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("paths"), flutter::EncodableValue(paths)},
+      {flutter::EncodableValue("filterIndex"),
+       flutter::EncodableValue(static_cast<int64_t>(result.filter_index))},
+  });
 }
 
 flutter::EncodableValue FilePayload(const std::wstring& path) {
@@ -272,6 +347,51 @@ void DartPdfPlatformChannels::Register(flutter::BinaryMessenger* messenger) {
         } else {
           result->NotImplemented();
         }
+      });
+
+  // Native common-item dialogs. `file_selector_windows` derives the dialog
+  // owner from the registrar's implicit FlutterView, which the engine-owned
+  // multi-window bootstrap deliberately does not create - the plugin then
+  // dereferences a null view and takes the process down the first time the
+  // user opens or saves a file. The runner already knows the active window,
+  // so DartPDF drives the dialogs itself (see lib/windows_file_dialogs.dart).
+  file_dialog_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          messenger, kFileDialogChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  file_dialog_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        const std::string& method = call.method_name();
+        const bool save = method == "getSaveLocation";
+        const bool folders = method == "getDirectoryPath" ||
+                             method == "getDirectoryPaths";
+        const bool multiple =
+            method == "openFiles" || method == "getDirectoryPaths";
+        if (!save && !folders && method != "openFile" &&
+            method != "openFiles") {
+          result->NotImplemented();
+          return;
+        }
+
+        const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+        dart_pdf::FileDialogRequest request = DecodeDialogRequest(args);
+        request.allow_multiple = multiple;
+        request.select_folders = folders;
+
+        const HWND owner = owner_window_ ? owner_window_() : nullptr;
+        const dart_pdf::FileDialogResult dialog =
+            save ? dart_pdf::ShowSaveFileDialog(owner, request)
+                 : dart_pdf::ShowOpenFileDialog(owner, request);
+        if (!dialog.shown) {
+          result->Error(
+              "file_dialog_failed", "Could not show the file dialog",
+              flutter::EncodableValue(std::in_place_type<int32_t>,
+                                      static_cast<int32_t>(dialog.error)));
+          return;
+        }
+        result->Success(DialogPayload(dialog));
       });
 }
 

--- a/app/windows/runner/platform_channels.h
+++ b/app/windows/runner/platform_channels.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "file_dialogs.h"
 #include "native_print.h"
 
 // Engine-scoped DartPDF services shared by the normal single-view runner and
@@ -41,6 +42,8 @@ class DartPdfPlatformChannels {
       image_clipboard_channel_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       native_print_channel_;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      file_dialog_channel_;
   NativePrinter native_printer_;
 };
 

--- a/doc/dev-log/2026-08-19-windows-file-dialog-crash.md
+++ b/doc/dev-log/2026-08-19-windows-file-dialog-crash.md
@@ -1,0 +1,96 @@
+# Windows: open/save dialogs crashed the multi-window runner
+
+"Open PDF in new tab" and "Save as" both took the Windows app down. Same
+single cause, and it is a consequence of the engine-owned bootstrap that
+desktop multi-windowing needs (#687, doc/dev-log/2026-08-14-flutter-347-multi-window.md).
+
+## Root cause
+
+`file_selector_windows` captures the dialog's owner window at registration
+time, straight off the registrar's implicit view:
+
+```cpp
+// file_selector_windows/windows/file_selector_plugin.cpp
+HWND GetRootWindow(flutter::FlutterView* view) {
+  return ::GetAncestor(view->GetNativeWindow(), GA_ROOT);   // view is null
+}
+...
+  [registrar] { return GetRootWindow(registrar->GetView()); }
+```
+
+The pinned Flutter 3.47 client wrapper is explicit that this can be null:
+
+```cpp
+// plugin_registrar_windows.h
+// Returns the implicit view, or nullptr if there is no implicit view.
+FlutterView* GetView() { return implicit_view_.get(); }
+```
+
+DartPDF's Windows runner deliberately has no implicit view - it runs a bare
+`flutter::FlutterEngine` so Dart can create every native window itself. So
+`GetView()` is null, the plugin dereferences it, and the process dies at the
+first `openFile`/`openFiles`/`getSaveLocation`. Nothing recovers from it:
+it's an access violation inside the method-call handler, not a Dart
+exception, so no toast and no fallback.
+
+Auditing the rest of the Windows plugin set for the same shape:
+
+| plugin | uses the implicit view | effect here |
+| --- | --- | --- |
+| `file_selector_windows` | unguarded deref | **crash** (this fix) |
+| `desktop_drop` | guarded, bails out | drag-and-drop silently inert |
+| `share_plus` | unguarded deref | unreachable - only called on Android/iOS |
+| `url_launcher_windows`, `flutter_secure_storage_windows`, `flutter_doc_scanner` | no | fine |
+
+## Fix
+
+The runner already knows its active window without a view - it hands one to
+the print dialog and the image clipboard - so DartPDF drives the common-item
+dialogs itself.
+
+- `windows/runner/file_dialogs.{h,cpp}`: `IFileOpenDialog`/`IFileSaveDialog`
+  behind a small struct API (filters, initial folder, suggested name, OK
+  label, multi-select, folder mode). A dismissed dialog is an empty
+  selection, not an error; only a dialog that could not run reports its
+  HRESULT.
+- `windows/runner/platform_channels.cpp`: a `dev.milanko.dartpdf/file_dialogs`
+  channel over it, owned by the same `OwnerWindow` provider the print and
+  clipboard channels use. Registered by both bootstraps, so the single-view
+  runner gets it too.
+- `lib/windows_file_dialogs.dart`: `WindowsFileDialogs`, a
+  `FileSelectorPlatform` that routes to that channel.
+  `installIfNeeded()` swaps it in from `main()` on Windows only, after
+  `ensureInitialized()` so it wins over the Dart plugin registrant. Every
+  `file_selector` call site is unchanged.
+
+Two things kept deliberately faithful to the plugin it displaces, so the
+swap is invisible to callers: a type group that names neither "any" nor any
+extension throws the same `ArgumentError` up front, and the save dialog
+reports its active filter by the same one-based index.
+
+`getDirectoryPath`/`getDirectoryPaths` route through the channel as well.
+The app doesn't call them today, but they were the plugin's other two
+crash sites and leaving them out would just bank a future one.
+
+## Verification
+
+- `app/test/windows_file_dialogs_test.dart` (11 tests): argument encoding,
+  cancellation, multi-pick, active-filter mapping, out-of-range filter
+  index, the `ArgumentError` contract, folder picks, the
+  MissingPluginException fallback, and `installIfNeeded` being
+  Windows-only and idempotent.
+- The native sources were cross-compiled against the pinned SDK's real
+  `cpp_client_wrapper` headers (`flutter precache --windows`, then
+  `x86_64-w64-mingw32-g++ -std=c++17 -fsyntax-only -Wall -Wextra
+  -Wconversion`); all eight runner translation units are clean. `/W4 /WX`
+  patterns to keep in mind if this file grows: every narrowing conversion
+  is an explicit cast, and the `COMDLG_FILTERSPEC` array borrows strings
+  from two vectors that are `reserve`d up front so they never reallocate.
+- `flutter test` in `app/`: 463 passing.
+
+## Still open
+
+Drag-and-drop onto a Windows window is inert for the same reason -
+`desktop_drop` returns early when the registrar has no view ("no window, no
+drop"). Fixing it needs a per-window `IDropTarget` in the runner rather than
+a channel, so it is not in this change.


### PR DESCRIPTION
## Summary

"Open PDF in new tab" and "Save as" both crash the Windows app. One cause for both, and it is a consequence of the engine-owned bootstrap that desktop multi-windowing needs (#687).

`file_selector_windows` captures the dialog's owner window from the plugin registrar's implicit `FlutterView`:

```cpp
// file_selector_windows/windows/file_selector_plugin.cpp
HWND GetRootWindow(flutter::FlutterView* view) {
  return ::GetAncestor(view->GetNativeWindow(), GA_ROOT);   // view is null
}
...
  [registrar] { return GetRootWindow(registrar->GetView()); }
```

The pinned Flutter 3.47 client wrapper is explicit that this can be null — *"Returns the implicit view, or nullptr if there is no implicit view"* — and DartPDF's Windows runner deliberately has none: it runs a bare `flutter::FlutterEngine` so Dart creates every native window itself. The plugin dereferences null on the first `openFile`/`openFiles`/`getSaveLocation`. It is an access violation inside the method-call handler, not a Dart exception, so nothing on the Dart side can catch, toast, or fall back.

Auditing the rest of the Windows plugin set for the same shape:

| plugin | uses the implicit view | effect here |
| --- | --- | --- |
| `file_selector_windows` | unguarded deref | **crash** (fixed here) |
| `desktop_drop` | guarded, bails out | drag-and-drop silently inert |
| `share_plus` | unguarded deref | unreachable — only called on Android/iOS |
| `url_launcher_windows`, `flutter_secure_storage_windows`, `flutter_doc_scanner` | no | fine |

**The fix.** The runner already knows its active window without a view — it supplies one to the print dialog and the image clipboard — so DartPDF drives the common-item dialogs itself.

- `app/windows/runner/file_dialogs.{h,cpp}` — `IFileOpenDialog`/`IFileSaveDialog` behind a small struct API (filters, initial folder, suggested name, OK label, multi-select, folder mode). A dismissed dialog is an empty selection, not an error; only a dialog that could not run reports its HRESULT.
- `app/windows/runner/platform_channels.cpp` — a `dev.milanko.dartpdf/file_dialogs` channel over it, owned by the same `OwnerWindow` provider the print and clipboard channels use. Registered by both bootstraps, so the single-view runner gets it too.
- `app/lib/windows_file_dialogs.dart` — `WindowsFileDialogs`, a `FileSelectorPlatform` routing to that channel. `installIfNeeded()` swaps it in from `main()` on Windows only, after `ensureInitialized()` so it wins over the Dart plugin registrant. **Every `file_selector` call site is unchanged.** A runner without the channel falls back to the implementation it replaced.

Two behaviours kept deliberately faithful to the plugin it displaces, so the swap is invisible to callers: a type group naming neither "any" nor any extension throws the same `ArgumentError` up front, and the save dialog reports its active filter by the same one-based index.

`getDirectoryPath`/`getDirectoryPaths` route through the channel as well. The app does not call them today, but they were the plugin's other two null-view crash sites and leaving them out would just bank a future one.

No behaviour change on macOS, Linux, web, or mobile — `installIfNeeded()` returns false there.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app — the DartPDF app (`app/`): Dart, Windows runner, and a dev-log note

## Change type

- [x] Bug fix

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean across the workspace
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

The change touches only `app/` and the Windows runner; no engine package is modified, so the corpus, Ghent, and per-package suites have nothing to exercise here. What was run instead:

- `cd app && fvm flutter test` — **463 passing**, including the new `app/test/windows_file_dialogs_test.dart` (11 tests): argument encoding, cancellation, multi-pick, active-filter mapping, an out-of-range filter index, the `ArgumentError` contract, folder picks, the `MissingPluginException` fallback, and `installIfNeeded` being Windows-only and idempotent.
- The native sources were cross-compiled against the pinned SDK's real `cpp_client_wrapper` headers (`flutter precache --windows`, then `x86_64-w64-mingw32-g++ -std=c++17 -fsyntax-only -Wall -Wextra -Wconversion`). All eight runner translation units are clean; the only warnings emitted come from Flutter's own `method_codec.h`.

I could not run the app on a Windows host from this environment, so the end-to-end dialog interaction is unverified on-device — the crash mechanism, the null-view contract, and the replacement's compile-correctness are all verified above, but a manual open/save on Windows before merge is worth it.

## PDF fixtures and screenshots

None — no rendering or document behaviour changes.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `file_selector_platform_interface` moves from a dev-dependency to a runtime dependency of `app/`, since `lib/` now implements the interface directly.
- **Still open, deliberately out of scope:** drag-and-drop onto a Windows window is inert for the same underlying reason — `desktop_drop` returns early when the registrar has no view (*"no window, no drop"*). Fixing it needs a per-window `IDropTarget` in the runner rather than a method channel, so it is not in this change. Worth a follow-up issue.
- `/W4 /WX` is on for the runner. If `file_dialogs.cpp` grows: every narrowing conversion is an explicit cast, and the `COMDLG_FILTERSPEC` array borrows string data from two vectors that are `reserve`d up front so they can never reallocate out from under it.
- Background and the full audit are in `doc/dev-log/2026-08-19-windows-file-dialog-crash.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pif2PSbZYWmho5beuSEu9

---
_Generated by [Claude Code](https://claude.ai/code/session_019pif2PSbZYWmho5beuSEu9)_