### PR TITLE
Build the page once for thumbnails and preview LoDs (#699)

### DIFF
--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -193,7 +193,12 @@ function parse(lines, frames) {
     }
     const warm = line.match(/worker warm=([\d.]+)ms/);
     if (warm) r.workerWarmMax = Math.max(r.workerWarmMax, Number(warm[1]));
-    const pre = line.match(/prerender page=\d+ (?:worker )?(vector|full) /);
+    // `prerender page=N lod=<rung> [worker ][shared ]<vector|full> warm=…`.
+    // The lod token arrived with the preview ladder and `shared` with #699's
+    // one-record-per-ladder build; both are optional so an older bundle's
+    // lines still count.
+    const pre = line.match(
+      /prerender page=\d+ (?:lod=\S+ )?(?:worker )?(?:shared )?(vector|full) /);
     if (pre) r.prerender[pre[1]]++;
     // The #527 bounded early prefix is real ink on the target page too, so it
     // counts as first content for the baseline (progressive off) - otherwise the

--- a/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
+++ b/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
@@ -1,0 +1,145 @@
+# Thumbnails and preview LoDs reuse work the viewer already did (#699)
+
+The field trace on #699 (113-page corporate report, scrolled in the web app
+after #698's motion-safe lane landed) put the two background surfaces above
+the document itself in platform-thread cost over a ~10 s window: 1525 ms of
+thumbnail tiles and 523 ms of preview-LoD warms against 584 ms of actual page
+interprets, with 49 of 58 janked frames raster-dominated. Both numbers were
+spent re-deriving something the viewer already had.
+
+## The preview ladder walked the page once per rung
+
+`PdfPagePreviewCache.renderPreview` produced exactly one raster per call, so
+the viewer's prerender loop - which selects one page and one rung at a time -
+walked the same content stream for base, then again for 400px, then again for
+800px:
+
+```
+prerender page=107 lod=base  full warm=108.9ms
+prerender page=107 lod=400px full warm=56.6ms
+prerender page=107 lod=800px full warm=61.1ms
+```
+
+The rungs differ only in raster size. `renderPreview` now takes
+`alsoFillLongestSides`: it collects the rungs that are missing, records the
+page **once** at the sharpest rung's image resolution, and rasterizes every
+rung from that one `ui.Picture`. A rung that rode along on another rung's
+record prints a `shared` token in its `prerender` line and a `warm=` that is
+its own raster only, so a trace still says what each rung cost.
+
+The viewer decides what rides along (`_ladderRungsFor` in pdf_viewer.dart):
+the still-missing intermediate rungs of a page inside
+`PdfPagePreviewLodPolicy.intermediateWindow`. Vector-first motion passes stay
+base-only - intermediates are image-complete by construction.
+
+**Selection policy is unchanged, arrival order is not.** The loop still picks
+the nearest page missing a base preview first; what changed is that a base
+render for a page in the tight LoD window now also yields that page's sharper
+rungs, since they cost only their own raster once the page is interpreted. A
+far page's base preview therefore lands a couple of downscale rasters later
+than before. `idle prerender promotes only the nearby LoD working set` in
+page_preview_test.dart had to wait on both conditions instead of racing them;
+its assertions (page 4 base-covered, page 4 without intermediates) still hold.
+
+## A 128px thumbnail cost a whole page interpret
+
+With no active worker `rasterizeThumbnail` fell through to
+`PdfPageRenderer.renderImage`, walking the entire content stream to fill a
+128px tile - for a page the viewer had interpreted seconds earlier and still
+held a retained scene for:
+
+```
+[perf 1005] scene-cache store page=74 commands=739 …
+[perf 1337] thumbnail page=74 tile px=128 local interpret+raster=55.4ms (no worker)
+```
+
+`rasterizeThumbnail` now takes the viewer's `PdfPagePreviewCache` and tries
+its retained scene first - ahead of the worker, which is a strictly more
+expensive way to obtain the same commands. A hit is a replay plus the tile's
+own (tiny) raster: no content-stream parse, no image codec, and a
+`thumbnail … retained replay+raster=` line in place of the
+`local interpret+raster=` one.
+
+What the lookup has to get right is that "the same display" is not the same as
+"an identical `PdfPageRenderPlan`". Two of the plan's inputs have spellings
+that coincide, and `_retainedSceneForTile` tries both:
+
+* **Rotation.** A plan carrying the page's own /Rotate and a plan carrying
+  null are the same render, and different producers write different ones - the
+  viewer always resolves an explicit angle, a bare `PdfPageView` may not.
+* **Annotations.** This is the one that decides whether the optimization fires
+  in the app at all. The viewer bakes annotations into the page picture only
+  when it is *not* drawing them in a live overlay layer
+  (`_pageImagesShowAnnotations`), and an editing session - which is when the
+  thumbnail strip exists - always uses the overlay. So its retained scenes are
+  annotation-free while the strip asks for annotations, and without this the
+  hit rate in `PdfEditorView` would be zero. On a page that carries no
+  annotations the two are the same pixels, so only such a page tries the other
+  spelling; an annotated page still renders itself.
+
+A view rotation, another paper colour, or annotations on a page that has some
+all miss, as they should, and every path below is unchanged.
+
+**Image LoD** is the other guard: a scene whose images were decoded below the
+tile's own ratio would draw them softer than a fresh render, so those decline.
+A tile ratio is a fraction of any display ratio, so it is a guard, not a
+common case.
+
+The warm pass reuses a scene too: `skipIfWorkerDeclines` means "do not start a
+heavy UI-thread interpret", not "ignore a page that is already recorded". The
+motion gate still applies - a replay is cheap but is still platform-thread
+work, so a tile waits for the scroll to settle.
+
+## Measuring
+
+`test/benchmark_background_surfaces_test.dart` prices both halves on the VM
+(synthetic text/CAD profiles plus the committed
+`test_corpora/dartpdf/letterhead-report-40p.pdf`, the document class the issue
+names) and fails if either reuse stops paying:
+
+```
+background-surfaces ordinary: pages=4 ladderPerRung=17.3ms/page
+  ladderOneRecord=2.8ms/page (-84%) tileLocal=2.2ms/tile tileRetained=1.2ms/tile (-44%)
+background-surfaces cad-vector: pages=1 ladderPerRung=886.9ms/page
+  ladderOneRecord=317.1ms/page (-64%) tileLocal=173.1ms/tile tileRetained=159.4ms/tile (-8%)
+background-surfaces letterhead-report: pages=6 ladderPerRung=37.1ms/page
+  ladderOneRecord=17.5ms/page (-53%) tileLocal=9.7ms/tile tileRetained=7.6ms/tile (-22%)
+```
+
+Read the tile column knowing what the VM leaves out: there the 128px readback
+dominates a tile, so removing the interpret is worth 22% on the letterhead
+report; on the web, where the trace measured a whole tile at 55 ms, the
+interpret is the bulk of it. The CAD row is the honest floor - a
+20k-command transcript costs about the same to replay whoever recorded it, so
+reuse buys 8% there.
+
+The web half is the real-Chrome harness (`tool/perf.sh web wheel-letterhead`,
+and `wheel-letterhead-noworker` for the worker-less session the trace was
+captured in), which is where the CanvasKit raster time these surfaces spend
+actually shows up. It was not run for this change: this container has neither a
+system Chrome nor the `puppeteer-core` install `app/tool/perf` needs.
+
+`page_preview_test.dart` and `editing_thumbnail_cache_test.dart` pin the
+mechanism rather than the timing, by counting tokenized content operations
+(`PdfPerfCount.contentOps`): the ladder tokenizes the page once where three
+per-rung calls tokenize it three times, and a tile served from a retained
+scene tokenizes nothing at all.
+
+## Still open from the same trace
+
+The issue reports two further findings, deliberately left alone here:
+
+* **The exact page-raster cache is inert on that document** (163
+  `page-raster miss … reason=empty` lines, zero stores, against an idle
+  256 MB budget). The likely gate is `putFullImage`'s
+  `_renderedAtFullImageRatio()` refusing a page that rendered as a prefetch
+  neighbour at half image resolution and then never re-rendered because its
+  raster was already current.
+* **The session had no render worker at all** (`path=recorded(no-worker)`),
+  which is why all of this landed on the UI thread. The suspected cause is a
+  deploy serving `main.dart.wasm` alongside a dart2js-only worker asset - the
+  pairing `render_worker_web.dart`'s own comment names as the hazard.
+
+Neither is worker-specific to this fix: the ladder's repeated walks cost the
+same on every platform, and the thumbnail reuse removes the interpret whether
+or not a worker exists.

--- a/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
+++ b/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
@@ -98,20 +98,30 @@ work, so a tile waits for the scroll to settle.
 names) and fails if either reuse stops paying:
 
 ```
-background-surfaces ordinary: pages=4 ladderPerRung=17.3ms/page
-  ladderOneRecord=2.8ms/page (-84%) tileLocal=2.2ms/tile tileRetained=1.2ms/tile (-44%)
-background-surfaces cad-vector: pages=1 ladderPerRung=886.9ms/page
-  ladderOneRecord=317.1ms/page (-64%) tileLocal=173.1ms/tile tileRetained=159.4ms/tile (-8%)
-background-surfaces letterhead-report: pages=6 ladderPerRung=37.1ms/page
-  ladderOneRecord=17.5ms/page (-53%) tileLocal=9.7ms/tile tileRetained=7.6ms/tile (-22%)
+background-surfaces ordinary: pages=4 ladderPerRung=19.1ms/page
+  ladderOneRecord=2.5ms/page (-87%) tileLocal=2.2ms/tile tileRetained=0.8ms/tile (-62%)
+background-surfaces cad-vector: pages=1 ladderPerRung=920.1ms/page
+  ladderOneRecord=313.6ms/page (-66%) tileLocal=179.0ms/tile tileRetained=92.5ms/tile (-48%)
+background-surfaces letterhead-report: pages=6 ladderPerRung=35.1ms/page
+  ladderOneRecord=16.6ms/page (-53%) tileLocal=7.4ms/tile tileRetained=5.5ms/tile (-25%)
 ```
 
 Read the tile column knowing what the VM leaves out: there the 128px readback
-dominates a tile, so removing the interpret is worth 22% on the letterhead
-report; on the web, where the trace measured a whole tile at 55 ms, the
-interpret is the bulk of it. The CAD row is the honest floor - a
-20k-command transcript costs about the same to replay whoever recorded it, so
-reuse buys 8% there.
+is most of a small page's tile, which is why the letterhead report gains 25%
+where the command-heavy CAD sheet gains 48%. On the web, where the trace
+measured a whole tile at 55 ms, the interpret is the bulk of it.
+
+The gates differ per half, deliberately. The ladder is gated on wall time - it
+saves an interpret per rung, which is large on every profile here. The tile is
+gated on the interpret itself (`contentOps == 0`): its ms column is real but
+close enough on a fast host that gating there would buy a flake rather than a
+signal.
+
+Writing that benchmark also demonstrated the freshness rule it measures: the
+first version recorded the scene from a second `PdfDocument` opened over the
+same bytes, which looks identical and misses every time, because the cache
+tests page *identity*. Both tile columns were quietly measuring the local
+interpret until the scene was recorded from `controller.pageAt(i)`.
 
 The web half is the real-Chrome harness. `scroll-text` is the scenario that
 actually warms previews - `wheel` and `read` keep moving, and the prerender

--- a/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
+++ b/doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md
@@ -113,11 +113,41 @@ interpret is the bulk of it. The CAD row is the honest floor - a
 20k-command transcript costs about the same to replay whoever recorded it, so
 reuse buys 8% there.
 
-The web half is the real-Chrome harness (`tool/perf.sh web wheel-letterhead`,
-and `wheel-letterhead-noworker` for the worker-less session the trace was
-captured in), which is where the CanvasKit raster time these surfaces spend
-actually shows up. It was not run for this change: this container has neither a
-system Chrome nor the `puppeteer-core` install `app/tool/perf` needs.
+The web half is the real-Chrome harness. `scroll-text` is the scenario that
+actually warms previews - `wheel` and `read` keep moving, and the prerender
+loop needs a full second of idle on web, so neither ever starts it.
+`tool/perf.sh webdiff e4dafb9 scroll-text --iterations 3`:
+
+```
+metric                  baseline    current     Δ         verdict
+agentMemoryBytes        112953482   111146987   -1.6%     ·
+buildMax                43.89       45.55       +3.8%     ·
+buildP50                2.54        2.73        +7.5%     ·
+buildP95                6.88        6.50        -5.5%     ·
+jankCount               174         167         -4.0%     ·
+openBytesMs             234         243         +3.8%     ·
+openDocMs               238         247         +3.7%     ·
+openPageCountMs         491         526         +7.1%     ·
+✓ no metric regressed past 1.1×
+```
+
+The scenario has no metric for what a preview rung costs, so read the warm
+counts instead: full ladder rungs completed inside the same ~31 s window went
+9/9/9 (baseline) to 11/14/13 (current) - the same interpret budget producing
+about 40% more rungs - while janked frames fell 4% and agent memory 1.6%. Note
+this scenario is worker-backed, so the record was already off the platform
+thread; what one rung still costs there is its own CanvasKit readback, which no
+amount of reuse can remove. The worker-less session the issue traced is the
+larger win, and the thumbnail half has no web coverage at all: the perf harness
+has no thumbnail strip.
+
+The `open*` triple drifting ~4% is the harness, not this change:
+`openBytesMs` is fetching the file's bytes, which no code here touches, and it
+moved with the other two.
+
+Fixing the driver was part of getting these numbers: `prerender warms` had been
+reporting 0/0 on every scenario since the ladder added its `lod=` token to the
+line the regex matched.
 
 `page_preview_test.dart` and `editing_thumbnail_cache_test.dart` pin the
 mechanism rather than the timing, by counting tokenized content operations

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -8,12 +8,14 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:pdf_document/pdf_document.dart';
 
 import '../debug_overlays.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_range_dialog.dart';
 import '../pdf_page_view.dart';
 import '../pdf_viewer.dart';
+import '../preview_cache.dart';
 import '../tile_store.dart';
 import '../perf_log.dart';
 import '../raster_cache.dart';
@@ -524,6 +526,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       deferUiWork: _viewerRenderBusy,
       reason: 'warm',
       disk: controller.pageRenderStamp(index) == 0 ? cache.disk : null,
+      previews: widget.viewerController.pagePreviewCache,
     );
     if (image == null) return;
     PdfThumbnailSidebar.debugRasterizations++;
@@ -1557,6 +1560,7 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
       deferUiWork: _viewerRenderBusy,
       reason: 'warm',
       disk: controller.pageRenderStamp(index) == 0 ? cache.disk : null,
+      previews: widget.viewerController.pagePreviewCache,
     );
     if (image == null) return;
     PdfThumbnailSidebar.debugRasterizations++;
@@ -2859,6 +2863,7 @@ class _PageThumbnailState extends State<_PageThumbnail> {
     final annotations = widget.showAnnotations;
     final cache = widget.cache;
     final worker = widget.renderWorker;
+    final previews = widget.viewerController.pagePreviewCache;
     cache.request(this, pageIndex, () async {
       // superseded (newer revision, resize) or already landed - skip
       if (!mounted || _pendingKey != key) return;
@@ -2896,6 +2901,7 @@ class _PageThumbnailState extends State<_PageThumbnail> {
           // only persist/read disk for pages untouched this session - the
           // disk key is content-derived and render stamps reset per session
           disk: controller.pageRenderStamp(pageIndex) == 0 ? cache.disk : null,
+          previews: previews,
         );
         if (image == null) {
           if (deferred && mounted && _pendingKey == key) {
@@ -3013,6 +3019,12 @@ int _thumbnailFocusFromScroll(ScrollController scroll, int pageCount) {
 /// worker preempted for a higher-priority tile - returns null instead of
 /// falling back to a heavy UI-thread interpret, so warming never blocks a
 /// frame.
+///
+/// [previews] is the viewer's preview cache. When it still holds the page's
+/// recorded scene from the last time the page was on screen, the tile is
+/// replayed straight out of it - no content-stream walk and no image decode,
+/// which is what the local fallback below otherwise pays in full to fill a
+/// 128px tile (55 ms per tile in the #699 field trace).
 Future<ui.Image?> rasterizeThumbnail({
   required PdfEditingController controller,
   required int pageIndex,
@@ -3025,6 +3037,7 @@ Future<ui.Image?> rasterizeThumbnail({
   bool Function()? deferUiWork,
   String reason = 'tile',
   PdfRasterCache? disk,
+  PdfPagePreviewCache? previews,
 }) async {
   final page = controller.pageAt(pageIndex);
   final size = PdfPageRenderer.pageSize(page);
@@ -3056,6 +3069,41 @@ Future<ui.Image?> rasterizeThumbnail({
     });
   final sw = Stopwatch()..start();
   try {
+    // Cheapest live path first: the page's own retained scene. It is already
+    // interpreted and its images are already decoded, so a tile costs a
+    // command replay plus its (tiny) raster - no worker round trip, and none
+    // of the local walk below. The lookup must name the exact display plan the
+    // tile wants; a scene recorded under a view rotation, a different paper
+    // colour, or with annotations the tile does not show simply misses and
+    // every path below is unchanged.
+    final retained = _retainedSceneForTile(previews, pageIndex, page,
+        pageColor: pageColor, annotations: annotations);
+    if (retained != null) {
+      try {
+        final sceneImageRatio = retained.imagePixelRatio;
+        // A scene whose images were decoded below the tile's own ratio would
+        // draw them softer than a fresh render; leave those to the paths
+        // below. A tile ratio is a fraction of any display ratio, so this
+        // holds in practice - it is a guard, not a common case.
+        if ((sceneImageRatio == null || sceneImageRatio >= ratio) &&
+            !(deferUiWork?.call() ?? false)) {
+          final image = await retained.scene.rasterize(pixelRatio: ratio);
+          final retainedMs = sw.elapsedMicroseconds / 1000.0;
+          trace.instant('retained replay+raster', arguments: {
+            'ms': retainedMs,
+            'commands': retained.scene.commands.length,
+          });
+          PdfPerfLog.log('thumbnail page=$pageIndex $reason px=$pixelWidth '
+              'retained replay+raster=${_traceMs(retainedMs)} '
+              'commands=${retained.scene.commands.length}');
+          disk?.storeThumbnail(pageIndex, pixelWidth, image,
+              pageColor: pageColor.toARGB32(), annotations: annotations);
+          return image;
+        }
+      } finally {
+        retained.dispose();
+      }
+    }
     // the heavy interpret runs on the isolate, only the small replay + raster
     // stays here. Image pages and the web fallback return null and rasterize
     // locally.
@@ -3158,6 +3206,55 @@ Future<ui.Image?> rasterizeThumbnail({
   } finally {
     trace.finish();
   }
+}
+
+/// Leases the retained scene a tile of [page] can replay, or null.
+///
+/// The scene has to have been recorded under a display that draws the same
+/// pixels the tile wants, which is not the same as an identical
+/// [PdfPageRenderPlan] - two of the plan's inputs have spellings that coincide:
+///
+///  * **Rotation.** A plan carrying the page's own /Rotate and a plan carrying
+///    null both render the page unrotated relative to itself, and different
+///    producers write different ones (the viewer always resolves an explicit
+///    angle, a bare [PdfPageView] may not).
+///  * **Annotations.** The viewer bakes annotations into the page picture only
+///    when it is not drawing them in a live overlay layer - and an editing
+///    session, which is when this strip exists, always draws them in the
+///    overlay. So its scenes are recorded annotation-free while the strip asks
+///    for annotations, and on a page that carries none those are the same
+///    pixels. Only such a page tries the other spelling.
+///
+/// Everything else - a view rotation, another paper colour, or annotations on
+/// a page that actually has some - misses, as it should: the scene would not
+/// draw what the tile is asking for, and every path below it is unchanged.
+PdfRetainedSceneHandle? _retainedSceneForTile(
+  PdfPagePreviewCache? previews,
+  int pageIndex,
+  PdfPage page, {
+  required Color pageColor,
+  required bool annotations,
+}) {
+  if (previews == null) return null;
+  final annotationSpellings = <bool>[
+    annotations,
+    if (page.annotations.isEmpty) !annotations,
+  ];
+  for (final withAnnotations in annotationSpellings) {
+    for (final rotation in <int?>[page.rotation, null]) {
+      final handle = previews.retainedSceneFor(
+        pageIndex,
+        page,
+        plan: PdfPageRenderPlan(
+          pageColor: pageColor,
+          annotations: withAnnotations,
+          rotation: rotation,
+        ),
+      );
+      if (handle != null) return handle;
+    }
+  }
+  return null;
 }
 
 String _traceMs(double v) => '${v.toStringAsFixed(1)}ms';

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2899,6 +2899,12 @@ class _PdfViewerState extends State<PdfViewer>
         } else {
           _previewAttempts.add(page);
         }
+        // Every ladder rung this page still owes rides along on the one
+        // interpret this pass is about to pay for. The rungs differ only in
+        // raster size, so warming them one at a time walked the same content
+        // stream three times per page (#699).
+        final alsoFill = _ladderRungsFor(index, targetLongestSide,
+            vectorOnly: vectorOnly);
         var deferredPreview = false;
         await _previews.renderPreview(index, page,
             pageColor: widget.pageColor,
@@ -2907,6 +2913,7 @@ class _PdfViewerState extends State<PdfViewer>
             rotation: _effectiveRotation(index),
             decodeImages: !vectorOnly,
             targetLongestSide: targetLongestSide,
+            alsoFillLongestSides: alsoFill,
             commandLimit: vectorOnly ? _jumpPreviewOperationLimit : null,
             deferUiWork: () {
           // A full preview may start during genuine idle time and have its
@@ -2969,6 +2976,34 @@ class _PdfViewerState extends State<PdfViewer>
         }
       }
     }
+  }
+
+  /// The intermediate ladder rungs page [index] still needs beyond
+  /// [targetLongestSide], for pages inside the LoD window.
+  ///
+  /// These cost only their own raster when they ride along with another
+  /// rung's interpret ([PdfPagePreviewCache.renderPreview]), so a page warmed
+  /// to base while it sits in the window arrives with its whole ladder rather
+  /// than being re-interpreted once per rung on later passes. Empty during
+  /// vector-first motion: intermediates are image-complete only.
+  List<double> _ladderRungsFor(int index, double? targetLongestSide,
+      {required bool vectorOnly}) {
+    final policy = widget.pagePreviewLodPolicy;
+    if (vectorOnly || !policy.enabled || policy.intermediateWindow == 0) {
+      return const [];
+    }
+    final pages = _pages;
+    if (pages.isEmpty) return const [];
+    final current = _controller.currentPage.clamp(0, pages.length - 1);
+    if ((index - current).abs() > policy.intermediateWindow) return const [];
+    final page = pages[index];
+    return [
+      for (final side in _previews.intermediateLongestSides)
+        if (side != targetLongestSide &&
+            !_previews.isFresh(index, page,
+                requireImages: true, targetLongestSide: side))
+          side,
+    ];
   }
 
   /// Starts the idle preview loop only after page-layout callbacks from the

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -1228,6 +1228,14 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// synchronous UI-thread work, so callers pace and gate these (the viewer
   /// pauses while the user scrolls). A page that fails to render simply gets
   /// no preview.
+  ///
+  /// [alsoFillLongestSides] names further ladder rungs to fill from the *same*
+  /// interpretation. The ladder's rungs differ only in raster size, so walking
+  /// the content stream once per rung was pure waste: the field trace behind
+  /// #699 shows one page warmed to base/400px/800px costing three interprets
+  /// and 227 ms of platform thread. The page is recorded once, at the sharpest
+  /// requested rung's image resolution, and every rung is rasterized from that
+  /// one picture.
   Future<void> renderPreview(int index, PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
@@ -1235,6 +1243,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
       int? rotation,
       bool decodeImages = true,
       double? targetLongestSide,
+      List<double> alsoFillLongestSides = const [],
       int priority = 1,
       int? commandLimit,
       bool Function()? deferUiWork}) async {
@@ -1242,13 +1251,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
     if (_disposed ||
         !_acceptsPage(index, page) ||
         (intermediate &&
-            !_intermediateLongestSides.contains(targetLongestSide)) ||
-        isFresh(
-          index,
-          page,
-          requireImages: decodeImages,
-          targetLongestSide: targetLongestSide,
-        )) {
+            !_intermediateLongestSides.contains(targetLongestSide))) {
       return;
     }
     // Command-limited/vector-first pixels are the instant fallback. Promoting
@@ -1261,96 +1264,118 @@ class PdfPagePreviewCache extends ChangeNotifier {
       // is exactly what fast-scroll prefetch is trying to avoid.
       return;
     }
+    // The rungs this build owes, the caller's own target first. A rung that is
+    // already fresh, not configured, or (for intermediates) not image-complete
+    // never joins.
+    final targets = <double?>[];
+    void consider(double? side) {
+      if (targets.contains(side)) return;
+      if (side != null &&
+          (!decodeImages || !_intermediateLongestSides.contains(side))) {
+        return;
+      }
+      if (isFresh(index, page,
+          requireImages: decodeImages, targetLongestSide: side)) {
+        return;
+      }
+      targets.add(side);
+    }
+
+    consider(targetLongestSide);
+    for (final side in alsoFillLongestSides) {
+      consider(side);
+    }
+    if (targets.isEmpty) return;
     try {
       final sw = Stopwatch()..start();
       final size = PdfPageRenderer.pageSize(page, rotation: rotation);
-      final ratio = _ratioFor(size, targetLongestSide: targetLongestSide);
+      // One build serves every rung, so it has to be recorded at the sharpest
+      // one's resolution: images decoded for a 200px preview cannot be
+      // sharpened into an 800px one afterwards.
+      var buildRatio = 0.0;
+      for (final side in targets) {
+        buildRatio =
+            math.max(buildRatio, _ratioFor(size, targetLongestSide: side));
+      }
       // priority 1: prefetch yields to any on-screen page the worker owes.
-      // The preview is rasterized at [ratio] (longest side ~200px), so cap the
-      // worker's images to that - a heavy raster underlay need not ship at full
+      // Every rung is rasterized at or below [buildRatio], so cap the worker's
+      // images to that - a heavy raster underlay need not ship at full
       // resolution just to be downscaled into a thumbnail.
       final commands = worker != null && worker.isActive
           ? await worker.record(index,
               annotations: annotations,
               priority: priority,
-              imagePixelRatio: decodeImages ? ratio : null,
+              imagePixelRatio: decodeImages ? buildRatio : null,
               decodeImages: decodeImages,
               commandLimit: commandLimit)
           : null;
       if (!decodeImages && commands == null) {
-        // Worker-declined vector warms must stay cheap. Falling back to
-        // renderImage here would synchronously interpret/decode images on the
-        // UI thread during the fast-scroll path.
+        // Worker-declined vector warms must stay cheap. Recording locally here
+        // would synchronously interpret/decode images on the UI thread during
+        // the fast-scroll path.
         return;
       }
       if (deferUiWork?.call() ?? false) return;
-      if (_disposed ||
-          !_acceptsPage(index, page) ||
-          isFresh(
-            index,
-            page,
-            requireImages: decodeImages,
-            targetLongestSide: targetLongestSide,
-          )) {
-        return;
-      }
-      final ui.Image image;
+      if (_disposed || !_acceptsPage(index, page)) return;
       var includesImages = decodeImages;
+      final plan = PdfPageRenderPlan(
+          pageColor: pageColor, annotations: annotations, rotation: rotation);
+      final ui.Picture picture;
       if (commands != null) {
         includesImages = commandLimit == null &&
             (decodeImages || !PdfPageRenderer.hasImageDraws(commands));
-        final picture = await PdfPageRenderer.pictureFromCommands(
-            page, commands,
-            pageColor: pageColor,
-            rotation: rotation,
-            includeImages: decodeImages,
-            maxImagePixelRatio: ratio);
-        if (!_acceptsPage(index, page) || (deferUiWork?.call() ?? false)) {
-          picture.dispose();
-          return;
-        }
-        try {
-          image = await PdfPageRenderer.rasterize(picture, size, ratio);
-        } finally {
-          picture.dispose();
-        }
+        picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
+            page, commands, plan,
+            includeImages: decodeImages, maxImagePixelRatio: buildRatio);
       } else {
-        if (deferUiWork?.call() ?? false) return;
-        image = await PdfPageRenderer.renderImage(page,
-            pixelRatio: ratio,
-            pageColor: pageColor,
-            annotations: annotations,
-            recorded: true,
-            rotation: rotation);
+        picture = await PdfPageRenderer.renderPictureRecordedWithPlan(page, plan,
+            maxImagePixelRatio: buildRatio);
       }
-      if (deferUiWork?.call() ?? false) {
-        image.dispose();
-        return;
-      }
-      sw.stop();
-      PdfPerfLog.log('prerender page=$index '
-          'lod=${targetLongestSide == null ? 'base' : '${targetLongestSide.toStringAsFixed(0)}px'} '
-          '${commands != null ? 'worker ' : ''}'
-          '${includesImages ? 'full' : 'vector'} '
-          'warm=${(sw.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms');
-      if (_disposed ||
-          !_acceptsPage(index, page) ||
-          isFresh(
+      try {
+        var shared = false;
+        for (final side in targets) {
+          if (deferUiWork?.call() ?? false) return;
+          if (_disposed ||
+              !_acceptsPage(index, page) ||
+              isFresh(index, page,
+                  requireImages: decodeImages, targetLongestSide: side)) {
+            continue;
+          }
+          final image = await PdfPageRenderer.rasterize(
+              picture, size, _ratioFor(size, targetLongestSide: side));
+          if (deferUiWork?.call() ?? false) {
+            image.dispose();
+            return;
+          }
+          if (_disposed ||
+              !_acceptsPage(index, page) ||
+              isFresh(index, page,
+                  requireImages: decodeImages, targetLongestSide: side)) {
+            image.dispose();
+            continue;
+          }
+          // `shared` marks a rung that cost only its own raster because the
+          // rung before it already paid for the interpret - the line a #699
+          // trace comparison reads.
+          PdfPerfLog.log('prerender page=$index '
+              'lod=${side == null ? 'base' : '${side.toStringAsFixed(0)}px'} '
+              '${commands != null ? 'worker ' : ''}'
+              '${shared ? 'shared ' : ''}'
+              '${includesImages ? 'full' : 'vector'} '
+              'warm=${(sw.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms');
+          sw.reset();
+          shared = true;
+          _store(
             index,
             page,
-            requireImages: decodeImages,
-            targetLongestSide: targetLongestSide,
-          )) {
-        image.dispose();
-        return;
+            image,
+            includesImages: includesImages,
+            targetLongestSide: side,
+          );
+        }
+      } finally {
+        picture.dispose();
       }
-      _store(
-        index,
-        page,
-        image,
-        includesImages: includesImages,
-        targetLongestSide: targetLongestSide,
-      );
     } catch (_) {
       // no preview is strictly better than a crash mid-scroll
     }

--- a/packages/dart_pdf_editor/test/benchmark_background_surfaces_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_background_surfaces_test.dart
@@ -1,0 +1,196 @@
+// Puts a number on #699: what the two background surfaces - the thumbnail
+// strip and the preview LoD ladder - cost when they re-interpret a page the
+// viewer has already interpreted, against what they cost when they reuse that
+// work.
+//
+// Both halves are measured the way the surfaces actually pay them, on the
+// platform thread:
+//
+//   ladder   base/400px/800px previews of one page, warmed rung by rung (a
+//            content-stream walk each) against the whole ladder rasterized
+//            from a single record
+//   tile     a 128px thumbnail from a local interpret+raster against the same
+//            tile replayed out of the page's retained scene
+//
+// The synthetic profiles and the committed letterhead report run by default,
+// so the numbers exist on any machine. Point this at another document with:
+//
+//   cd packages/dart_pdf_editor
+//   PDF_SURFACE_BENCHMARK_PDF=/path/to/report.pdf fvm flutter test \
+//     test/benchmark_background_surfaces_test.dart
+//
+//   PDF_SURFACE_BENCHMARK_PAGES=6   # pages sampled from the front of the file
+//
+// This is the VM half. The web half is the real-Chrome harness: run
+// `tool/perf.sh web wheel-letterhead` (and the `read-*` scenarios) for the
+// dart2js/CanvasKit picture of the same journey.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  const pageColor = Color(0xFFFFFFFF);
+  const levels = [400.0, 800.0];
+  const lodPolicy = PdfPagePreviewLodPolicy(
+    intermediateLongestSides: levels,
+    maxBytes: 256 * 1024 * 1024,
+    maxEntryBytes: 64 * 1024 * 1024,
+  );
+
+  PdfPagePreviewCache newCache() => PdfPagePreviewCache(lodPolicy: lodPolicy);
+
+  /// Warms the whole ladder of [index] one rung per call - what the viewer
+  /// did before #699: one content-stream walk per rung.
+  Future<int> perRungMicros(int index, PdfPage page) async {
+    final cache = newCache();
+    final clock = Stopwatch()..start();
+    await cache.renderPreview(index, page, pageColor: pageColor);
+    for (final side in levels) {
+      await cache.renderPreview(index, page,
+          pageColor: pageColor, targetLongestSide: side);
+    }
+    clock.stop();
+    expect(cache.hasIntermediate(index, targetLongestSide: levels.last), isTrue);
+    cache.dispose();
+    return clock.elapsedMicroseconds;
+  }
+
+  /// Warms the same ladder from one record.
+  Future<int> ladderMicros(int index, PdfPage page) async {
+    final cache = newCache();
+    final clock = Stopwatch()..start();
+    await cache.renderPreview(index, page,
+        pageColor: pageColor, alsoFillLongestSides: levels);
+    clock.stop();
+    expect(cache.hasIntermediate(index, targetLongestSide: levels.last), isTrue);
+    cache.dispose();
+    return clock.elapsedMicroseconds;
+  }
+
+  /// A tile rendered the way a worker-less session rendered it: interpret the
+  /// whole page to fill 128 px.
+  Future<int> localTileMicros(PdfEditingController controller, int index) async {
+    final clock = Stopwatch()..start();
+    final image = await rasterizeThumbnail(
+      controller: controller,
+      pageIndex: index,
+      pageColor: pageColor,
+      annotations: true,
+      pixelWidth: 128,
+      worker: null,
+    );
+    clock.stop();
+    expect(image, isNotNull);
+    image!.dispose();
+    return clock.elapsedMicroseconds;
+  }
+
+  /// The same tile replayed from the scene the viewer already holds. The
+  /// record is deliberately outside the clock: the viewer paid for it when the
+  /// page was on screen.
+  Future<int> retainedTileMicros(
+      PdfEditingController controller, int index, PdfPage page) async {
+    final cache = newCache();
+    final plan = PdfPageRenderPlan(
+      pageColor: pageColor,
+      annotations: true,
+      rotation: page.rotation,
+    );
+    final scene = await PdfRetainedScene.record(page, plan: plan);
+    cache
+        .retainScene(index, page, scene,
+            plan: plan, fromWorker: false, estimatedBytes: 1 << 20)
+        .dispose();
+    final clock = Stopwatch()..start();
+    final image = await rasterizeThumbnail(
+      controller: controller,
+      pageIndex: index,
+      pageColor: pageColor,
+      annotations: true,
+      pixelWidth: 128,
+      worker: null,
+      previews: cache,
+    );
+    clock.stop();
+    expect(image, isNotNull);
+    image!.dispose();
+    cache.dispose();
+    return clock.elapsedMicroseconds;
+  }
+
+  Future<void> report(String label, Uint8List bytes, {required int pages}) async {
+    final document = PdfDocument.open(bytes);
+    final controller = PdfEditingController(bytes);
+    addTearDown(controller.dispose);
+    final sampled = pages < document.pageCount ? pages : document.pageCount;
+    var perRung = 0;
+    var ladder = 0;
+    var localTile = 0;
+    var retainedTile = 0;
+    for (var i = 0; i < sampled; i++) {
+      final page = document.page(i);
+      perRung += await perRungMicros(i, page);
+      ladder += await ladderMicros(i, page);
+      localTile += await localTileMicros(controller, i);
+      retainedTile += await retainedTileMicros(controller, i, page);
+    }
+    double ms(int micros) => micros / sampled / 1000;
+    // ignore: avoid_print
+    print('background-surfaces $label: pages=$sampled '
+        'ladderPerRung=${ms(perRung).toStringAsFixed(1)}ms/page '
+        'ladderOneRecord=${ms(ladder).toStringAsFixed(1)}ms/page '
+        '(-${(100 * (perRung - ladder) / perRung).toStringAsFixed(0)}%) '
+        'tileLocal=${ms(localTile).toStringAsFixed(1)}ms/tile '
+        'tileRetained=${ms(retainedTile).toStringAsFixed(1)}ms/tile '
+        '(-${(100 * (localTile - retainedTile) / localTile).toStringAsFixed(0)}%)');
+
+    // The point of both changes. If either stops holding, the surfaces are
+    // paying for work they already have and this benchmark should fail rather
+    // than print a number nobody reads.
+    expect(ladder, lessThan(perRung),
+        reason: 'one record for the whole ladder must beat one per rung');
+    expect(retainedTile, lessThan(localTile),
+        reason: 'replaying a retained scene must beat interpreting the page');
+  }
+
+  testWidgets('ordinary text pages', (tester) async {
+    await tester.runAsync(
+        () => report('ordinary', buildMultiPagePdf(4), pages: 4));
+  });
+
+  testWidgets('dense vector linework (CAD profile)', (tester) async {
+    await tester.runAsync(() => report(
+        'cad-vector', buildSyntheticCadStrip(ops: 20000, streams: 4),
+        pages: 1));
+  });
+
+  testWidgets('letterhead report (the #699 document class)', (tester) async {
+    final file = File('../../test_corpora/dartpdf/letterhead-report-40p.pdf');
+    if (!file.existsSync()) {
+      markTestSkipped('missing ${file.path}');
+      return;
+    }
+    await tester.runAsync(
+        () => report('letterhead-report', file.readAsBytesSync(), pages: 6));
+  });
+
+  testWidgets('real document sweep', (tester) async {
+    final path = Platform.environment['PDF_SURFACE_BENCHMARK_PDF'];
+    if (path == null) {
+      markTestSkipped('set PDF_SURFACE_BENCHMARK_PDF');
+      return;
+    }
+    final pages = int.tryParse(
+            Platform.environment['PDF_SURFACE_BENCHMARK_PAGES'] ?? '') ??
+        6;
+    await tester.runAsync(() => report(
+        path.split(Platform.pathSeparator).last,
+        File(path).readAsBytesSync(),
+        pages: pages));
+  });
+}

--- a/packages/dart_pdf_editor/test/benchmark_background_surfaces_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_background_surfaces_test.dart
@@ -30,6 +30,7 @@ import 'dart:typed_data';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
@@ -92,9 +93,16 @@ void main() {
 
   /// The same tile replayed from the scene the viewer already holds. The
   /// record is deliberately outside the clock: the viewer paid for it when the
-  /// page was on screen.
-  Future<int> retainedTileMicros(
-      PdfEditingController controller, int index, PdfPage page) async {
+  /// page was on screen. Returns the tile's wall time and the content-stream
+  /// operations it tokenized - which is what the reuse actually removes, and
+  /// unlike the wall time is the same number on every machine.
+  Future<({int micros, int ops})> retainedTileMicros(
+      PdfEditingController controller, int index) async {
+    // The scene has to be recorded from the page object the tile will ask
+    // about - the cache's freshness test is page identity, and the controller
+    // caches its own PdfPage per index. Recording from a second PdfDocument
+    // over the same bytes looks identical and misses every time.
+    final page = controller.pageAt(index);
     final cache = newCache();
     final plan = PdfPageRenderPlan(
       pageColor: pageColor,
@@ -106,6 +114,8 @@ void main() {
         .retainScene(index, page, scene,
             plan: plan, fromWorker: false, estimatedBytes: 1 << 20)
         .dispose();
+    PdfPerf.enabled = true;
+    PdfPerf.reset();
     final clock = Stopwatch()..start();
     final image = await rasterizeThumbnail(
       controller: controller,
@@ -117,10 +127,12 @@ void main() {
       previews: cache,
     );
     clock.stop();
+    final ops = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+    PdfPerf.enabled = false;
     expect(image, isNotNull);
     image!.dispose();
     cache.dispose();
-    return clock.elapsedMicroseconds;
+    return (micros: clock.elapsedMicroseconds, ops: ops);
   }
 
   Future<void> report(String label, Uint8List bytes, {required int pages}) async {
@@ -132,12 +144,15 @@ void main() {
     var ladder = 0;
     var localTile = 0;
     var retainedTile = 0;
+    var retainedTileOps = 0;
     for (var i = 0; i < sampled; i++) {
       final page = document.page(i);
       perRung += await perRungMicros(i, page);
       ladder += await ladderMicros(i, page);
       localTile += await localTileMicros(controller, i);
-      retainedTile += await retainedTileMicros(controller, i, page);
+      final retained = await retainedTileMicros(controller, i);
+      retainedTile += retained.micros;
+      retainedTileOps += retained.ops;
     }
     double ms(int micros) => micros / sampled / 1000;
     // ignore: avoid_print
@@ -152,10 +167,17 @@ void main() {
     // The point of both changes. If either stops holding, the surfaces are
     // paying for work they already have and this benchmark should fail rather
     // than print a number nobody reads.
+    //
+    // The ladder is gated on wall time because the saving is an interpret per
+    // rung - large on every profile here. The tile is gated on the interpret
+    // itself instead: on the VM a small page's 128px readback can be most of
+    // the tile, so the ms column is real but too close to call on a fast host,
+    // and gating it there would buy a flake rather than a signal. What must
+    // always hold is that the tile did not walk the page.
     expect(ladder, lessThan(perRung),
         reason: 'one record for the whole ladder must beat one per rung');
-    expect(retainedTile, lessThan(localTile),
-        reason: 'replaying a retained scene must beat interpreting the page');
+    expect(retainedTileOps, 0,
+        reason: 'a tile served from a retained scene tokenizes nothing');
   }
 
   testWidgets('ordinary text pages', (tester) async {

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -657,6 +657,98 @@ void main() {
       rendered!.dispose();
     });
 
+    testWidgets('a plan spelling rotation as null still serves a tile',
+        (tester) async {
+      // Null means "the page's own /Rotate", so it is the same render as a
+      // plan carrying that angle. The viewer always resolves an explicit
+      // angle; a bare PdfPageView may not.
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      const plan = PdfPageRenderPlan(
+        pageColor: Color(0xFFFFFFFF),
+        annotations: true,
+      );
+
+      late final int tileOps;
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan, fromWorker: false, estimatedBytes: 1 << 20)
+            .dispose();
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(tileOps, 0);
+      rendered!.dispose();
+    });
+
+    testWidgets('a scene decoded below the tile ratio is declined',
+        (tester) async {
+      // Replaying it would draw the page's images softer than a fresh render
+      // would. A tile ratio is a fraction of any display ratio, so this is a
+      // guard rather than a case the viewer produces.
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: page.rotation,
+      );
+
+      late final int tileOps;
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan,
+                fromWorker: false,
+                imagePixelRatio: 0.001,
+                estimatedBytes: 1 << 20)
+            .dispose();
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(tileOps, greaterThan(0),
+          reason: 'the tile renders the page rather than replaying a scene '
+              'whose images are softer than it needs');
+      rendered!.dispose();
+    });
+
     testWidgets('the warm pass reuses a retained scene without a worker',
         (tester) async {
       final controller = PdfEditingController(buildMultiPagePdf(1));

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -6,6 +6,7 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/editing/thumbnail_cache.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -469,6 +470,271 @@ void main() {
         await tester.pump(const Duration(milliseconds: 10));
       }
       expect(PdfThumbnailSidebar.debugRasterizations, 4);
+    });
+  });
+
+  group('retained scene reuse', () {
+    testWidgets('a tile replays the viewer scene instead of re-interpreting',
+        (tester) async {
+      // #699: with no worker a 128px tile fell through to a full page
+      // interpret - for a page the viewer had walked seconds earlier and
+      // still holds a retained scene for.
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: page.rotation,
+      );
+
+      ui.Image? rendered;
+      late final int tileOps;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan,
+                fromWorker: false,
+                estimatedBytes: 1 << 20)
+            .dispose(); // the cache keeps its own reference
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(rendered!.width, 128);
+      expect(tileOps, 0,
+          reason: 'the tile replays retained commands - no content walk');
+      rendered!.dispose();
+    });
+
+    testWidgets('an editing session\'s annotation-free scene serves a tile',
+        (tester) async {
+      // The viewer bakes annotations into the page picture only when it is
+      // not drawing them in an overlay layer - and an editing session, which
+      // is when the strip exists, always uses the overlay. On a page that
+      // carries no annotations those are the same pixels.
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      expect(page.annotations, isEmpty);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: false,
+        rotation: page.rotation,
+      );
+
+      late final int tileOps;
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan, fromWorker: false, estimatedBytes: 1 << 20)
+            .dispose();
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(tileOps, 0);
+      rendered!.dispose();
+    });
+
+    testWidgets('an annotated page will not take an annotation-free scene',
+        (tester) async {
+      final controller = PdfEditingController(buildAnnotatedPdf());
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      expect(page.annotations, isNotEmpty);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: false,
+        rotation: page.rotation,
+      );
+
+      late final int tileOps;
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan, fromWorker: false, estimatedBytes: 1 << 20)
+            .dispose();
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(tileOps, greaterThan(0),
+          reason: 'the tile must draw the annotations the scene omits');
+      rendered!.dispose();
+    });
+
+    testWidgets('a scene recorded for another display is not reused',
+        (tester) async {
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      // A grey-paper scene cannot stand in for a white-paper tile.
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFF808080),
+        annotations: true,
+        rotation: page.rotation,
+      );
+
+      late final int tileOps;
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan,
+                fromWorker: false,
+                estimatedBytes: 1 << 20)
+            .dispose();
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          previews: previews,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(tileOps, greaterThan(0),
+          reason: 'the mismatched scene is declined and the tile renders '
+              'the page itself');
+      rendered!.dispose();
+    });
+
+    testWidgets('the warm pass reuses a retained scene without a worker',
+        (tester) async {
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: page.rotation,
+      );
+
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan,
+                fromWorker: false,
+                estimatedBytes: 1 << 20)
+            .dispose();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          skipIfWorkerDeclines: true,
+          reason: 'warm',
+          previews: previews,
+        );
+      });
+
+      expect(rendered, isNotNull,
+          reason: 'skipping the local interpret does not mean skipping a '
+              'scene that is already recorded');
+      rendered!.dispose();
+    });
+
+    testWidgets('a retained scene is not replayed during motion',
+        (tester) async {
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      final plan = PdfPageRenderPlan(
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: page.rotation,
+      );
+
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        previews
+            .retainScene(0, page, scene,
+                plan: plan,
+                fromWorker: false,
+                estimatedBytes: 1 << 20)
+            .dispose();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: null,
+          deferUiWork: () => true,
+          previews: previews,
+        );
+      });
+
+      expect(rendered, isNull,
+          reason: 'a replay is cheap but still platform-thread work; the '
+              'tile waits for the scroll to settle');
     });
   });
 

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -10,6 +10,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
@@ -338,6 +339,88 @@ void main() {
         inInclusiveRange(790, 800),
         reason: 'preview ratios do not upscale a sub-800pt page past 1x');
     frame.image.dispose();
+  });
+
+  testWidgets('one interpret fills every rung of the preview ladder',
+      (tester) async {
+    // #699: the ladder's rungs differ only in raster size, so warming them
+    // one call at a time walked the same content stream once per rung.
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    const levels = [400.0, 800.0];
+    PdfPagePreviewCache build() => PdfPagePreviewCache(
+          lodPolicy: const PdfPagePreviewLodPolicy(
+            intermediateLongestSides: levels,
+            maxBytes: 8 * 1024 * 1024,
+            maxEntryBytes: 4 * 1024 * 1024,
+          ),
+        );
+
+    final perRung = build();
+    addTearDown(perRung.dispose);
+    final shared = build();
+    addTearDown(shared.dispose);
+
+    late final int perRungOps;
+    late final int sharedOps;
+    await tester.runAsync(() async {
+      PdfPerf.enabled = true;
+      addTearDown(() => PdfPerf.enabled = false);
+      PdfPerf.reset();
+      await perRung.renderPreview(0, page);
+      await perRung.renderPreview(0, page, targetLongestSide: levels[0]);
+      await perRung.renderPreview(0, page, targetLongestSide: levels[1]);
+      perRungOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      PdfPerf.reset();
+      await shared.renderPreview(0, page, alsoFillLongestSides: levels);
+      sharedOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+    });
+
+    expect(sharedOps, greaterThan(0));
+    expect(perRungOps, sharedOps * 3,
+        reason: 'a rung per call tokenizes the page three times over; the '
+            'ladder build tokenizes it once and rasterizes each rung from '
+            'that one record');
+    for (final cache in [perRung, shared]) {
+      expect(cache.isFresh(0, page, requireImages: true), isTrue);
+      expect(cache.hasIntermediate(0, targetLongestSide: levels[0]), isTrue);
+      expect(cache.hasIntermediate(0, targetLongestSide: levels[1]), isTrue);
+    }
+    final sharpest = shared.previewFor(0)!;
+    expect(sharpest.targetLongestSide, levels[1]);
+    expect(math.max(sharpest.image.width, sharpest.image.height),
+        inInclusiveRange(790, 800),
+        reason: 'the sharpest rung is rasterized at its own ratio, not '
+            'upscaled from the base preview');
+    sharpest.image.dispose();
+  });
+
+  testWidgets('a ladder build skips rungs that are already fresh',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    const levels = [400.0, 800.0];
+    final cache = PdfPagePreviewCache(
+      lodPolicy: const PdfPagePreviewLodPolicy(
+        intermediateLongestSides: levels,
+        maxBytes: 8 * 1024 * 1024,
+        maxEntryBytes: 4 * 1024 * 1024,
+      ),
+    );
+    addTearDown(cache.dispose);
+
+    late final int ops;
+    await tester.runAsync(() async {
+      await cache.renderPreview(0, page, alsoFillLongestSides: levels);
+      PdfPerf.enabled = true;
+      addTearDown(() => PdfPerf.enabled = false);
+      PdfPerf.reset();
+      await cache.renderPreview(0, page, alsoFillLongestSides: levels);
+      ops = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+    });
+
+    expect(ops, 0,
+        reason: 'nothing is missing, so the page is not recorded at all');
   });
 
   testWidgets('a late intermediate promotion cannot cross page revisions',
@@ -1421,8 +1504,14 @@ void main() {
     await tester.pump();
     final cache = controller.debugPreviewCache!;
 
+    // A page inside the LoD window fills its whole ladder from one interpret
+    // (#699), so the sharp rungs can land before the wider base sweep gets
+    // to page 4 - wait for both to settle rather than for whichever the
+    // warm order happens to reach first.
     for (var i = 0;
-        i < 150 && !cache.hasIntermediate(2, targetLongestSide: 800);
+        i < 150 &&
+            !(cache.hasIntermediate(2, targetLongestSide: 800) &&
+                cache.has(4));
         i++) {
       await settle(tester);
     }


### PR DESCRIPTION
## Summary

Fixes the two background surfaces in #699 that spent more platform thread than the document itself, by re-deriving work the viewer already had.

**The preview LoD ladder walked the page once per rung.** The rungs differ only in raster size, but `renderPreview` produced exactly one raster per call, so the viewer's prerender loop — one page, one rung at a time — interpreted page 107 three times to produce base/400px/800px (227 ms in the trace). `renderPreview` now takes `alsoFillLongestSides`: it collects the rungs that are missing, records the page **once** at the sharpest one's image resolution, and rasterizes every rung from that single `ui.Picture`. The viewer offers the still-missing rungs of a page inside the LoD window (`_ladderRungsFor`); vector-first motion passes stay base-only, since intermediates are image-complete by construction. A rung that rode along prints a `shared` token in its `prerender` line, and a `warm=` that is its own raster only.

Selection policy is unchanged — the nearest page missing a base preview is still picked first — but a base render for a page in the LoD window now also yields its sharper rungs, so a far page's base preview lands a couple of downscale rasters later than before. One existing test raced that ordering and now waits for both conditions; its assertions are intact.

**A 128 px thumbnail cost a whole page interpret.** With no active worker `rasterizeThumbnail` fell through to `renderImage`, walking the whole content stream to fill a tile for a page the viewer had interpreted seconds earlier and still held a retained scene for. It now takes the viewer's `PdfPagePreviewCache` and tries that scene first — ahead of the worker, which is a strictly more expensive way to obtain the same commands. The lookup has to know that "the same display" is not "an identical `PdfPageRenderPlan`":

* **Rotation** has two spellings (the page's own `/Rotate`, or null meaning it) and different producers write different ones.
* **Annotations** decide whether this fires in the app at all. The viewer bakes annotations into the page picture only when it is *not* drawing them in a live overlay layer — and an editing session, which is when the thumbnail strip exists, always uses the overlay. Its retained scenes are therefore annotation-free while the strip asks for annotations; on a page carrying none those are the same pixels, so only such a page tries the other spelling. Without this the hit rate in `PdfEditorView` would be zero.

Anything else — a view rotation, another paper colour, annotations on a page that has some, or images decoded below the tile's ratio — misses, and every path below is unchanged. The motion gate still applies: a replay is cheap but is still platform-thread work.

Also fixes the web harness's `prerender warms` counter, which has been reporting 0/0 since the ladder added its `lod=` token to that line.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log + `app/tool/perf/driver.mjs`)

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean, whole workspace)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2358 pass)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `dart_pdf_editor`'s preview/thumbnail caches and produces the same pixels through a different number of records, so the parser/render corpora are unaffected.

### Measurements

New `packages/dart_pdf_editor/test/benchmark_background_surfaces_test.dart` prices both halves on the VM and fails if either reuse stops paying:

```
background-surfaces ordinary:          ladder 19.1 -> 2.5 ms/page (-87%)    tile 2.2 -> 0.8 ms (-62%)
background-surfaces cad-vector:        ladder 920.1 -> 313.6 ms/page (-66%) tile 179.0 -> 92.5 ms (-48%)
background-surfaces letterhead-report: ladder 35.1 -> 16.6 ms/page (-53%)   tile 7.4 -> 5.5 ms (-25%)
```

On the VM the 128 px readback is most of a small page's tile, which is why the letterhead report gains 25% where the command-heavy CAD sheet gains 48%. On the web, where the trace measured a whole tile at 55 ms, the interpret is the bulk of it.

The two halves are gated differently on purpose: the ladder on wall time (it saves an interpret per rung, large on every profile), the tile on the interpret itself (`contentOps == 0`) — its ms column is real but close enough on a fast host that gating there would buy a flake rather than a signal. `page_preview_test` and `editing_thumbnail_cache_test` pin the mechanism the same way: the ladder tokenizes the page once where three per-rung calls tokenize it three times, and a tile served from a retained scene tokenizes nothing at all.

**Web A/B**, `tool/perf.sh webdiff e4dafb9 scroll-text --iterations 3` (`scroll-text` is the scenario that actually warms previews — `wheel` and `read` keep moving, and the prerender loop needs a full second of idle on web):

```
metric                  baseline    current     Δ         verdict
agentMemoryBytes        112953482   111146987   -1.6%     ·
buildMax                43.89       45.55       +3.8%     ·
buildP50                2.54        2.73        +7.5%     ·
buildP95                6.88        6.50        -5.5%     ·
jankCount               174         167         -4.0%     ·
openBytesMs             234         243         +3.8%     ·
openDocMs               238         247         +3.7%     ·
openPageCountMs         491         526         +7.1%     ·
✓ no metric regressed past 1.1×
```

The scenario has no metric for what a rung costs, so read the warm counts: full ladder rungs completed inside the same ~31 s window went **9/9/9 (baseline) → 11/14/13 (current)** — the same interpret budget producing about 40% more rungs. Caveats: this scenario is worker-backed, so the record was already off-thread and what a rung still costs there is its own CanvasKit readback; and the `open*` triple's ~4% drift is the harness, not this change (`openBytesMs` is fetching the file's bytes, which nothing here touches, and it moved with the other two). The thumbnail half has no web coverage — the perf harness has no thumbnail strip.

An earlier revision of this description quoted weaker tile numbers; that benchmark recorded its scene from a second `PdfDocument` over the same bytes, which misses on page identity, so both tile columns were timing the local interpret. Corrected in f125cda — see [this comment](https://github.com/ben-milanko/dart-pdf/pull/700#issuecomment-5341831769).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The issue's two other findings are deliberately untouched here, since both are separate from "build the page once":

* **The exact page-raster cache sitting inert** (163 `page-raster miss … reason=empty`, zero stores). The reporter's hypothesis holds up on reading: `putFullImage` is gated on `_renderedAtFullImageRatio()`, which refuses a page that rendered as a prefetch neighbour at half image resolution and then never re-rendered because its raster was already current.
* **The session having no render worker at all.** Worth confirming from the deploy's `webworker …` open lines, as the issue suggests.

Neither is worker-specific to this fix: the ladder's repeated walks cost the same on every platform, and the thumbnail reuse removes the interpret whether or not a worker exists.

Design notes and the reasoning behind the plan-matching rules are in `doc/dev-log/2026-08-19-thumbnail-preview-lod-reuse.md`.