### PR TITLE
Fix free-text caret drift at deep zoom on macOS (#692)

### DIFF
--- a/doc/dev-log/2026-08-19-freetext-caret-gutter-zoom.md
+++ b/doc/dev-log/2026-08-19-freetext-caret-gutter-zoom.md
@@ -1,0 +1,79 @@
+# The inline free-text caret at deep zoom: Flutter's caret gutter (#692)
+
+#691 fixed one half of the macOS caret detachment - Flutter's Apple
+`-2 / devicePixelRatio` cursor nudge, which is a *screen*-space constant
+applied in the editor's local pixels and therefore multiplied by the viewer's
+transform. The app still reproduced the defect afterwards, and its regression
+(asserting `RenderEditable.cursorOffset` and `getLocalRectForCaret`) still
+passed. Both facts have the same explanation: **the caret was never wrong
+relative to the editor's own text.** Within one `RenderEditable`, the caret
+and the glyphs come out of the same `TextPainter`, so the only thing that can
+separate them is `cursorOffset` or `_snapToPhysicalPixel` - which is exactly
+what #691 measured, and exactly what it had already fixed.
+
+What was still moving is the whole live line, off the box.
+
+## The gutter
+
+`RenderEditable` reserves a gutter at the end of every editable line for the
+caret - `_kCaretGap` (a hard-coded `1.0`) plus `cursorWidth` - and lays the
+text out inside what is *left* of the field:
+
+```dart
+double get _caretMargin => _kCaretGap + cursorWidth;      // rendering/editable.dart
+final double availableMaxWidth = math.max(0.0, maxWidth - _caretMargin);
+```
+
+The paragraph is then painted at the field's origin, so a centred line sits
+half a gutter, and a right-aligned line a whole one, left of where the box
+centres it. Left-aligned text never notices - which is why the report was
+about a *centred* Bluebeam box, and why nobody had seen it on ordinary
+left-aligned notes.
+
+The gutter is a constant in **layout** pixels, and the inline editor lives
+under the viewer's zoom transform, so on screen it is `zoom x` that constant.
+Measured off the composited frame, centred free text drifted:
+
+| zoom | live text vs box centre |
+| --- | --- |
+| 4 px/pt | -2.75 logical px |
+| 40 px/pt (transform 24x) | -13.25 logical px |
+
+and right-aligned text twice that (-5.5 / -26.5). On a CAD sheet the fit
+scale is small, so an 8pt em is only two or three layout pixels wide and half
+a gutter is ~20% of a glyph: the caret at offset 0 stands off the first glyph
+and the caret at `text.length` lands *inside* the last one - the two symptoms
+in the issue, both growing with zoom.
+
+## The fix
+
+Hand the gutter back, out of the field's trailing content padding, so the
+band the text aligns inside is the appearance's own text area at any zoom
+(`_textEditRightPad` in `editing_overlay.dart`). A box on a big sheet can
+have a 3pt inset under a layout pixel, i.e. smaller than the gutter; the
+remainder comes out of the 2px chrome gutter instead
+(`_textEditGutterOverflow`), which the border paints over either way, so
+nothing visible moves. `pdfZoomAwareCaret` / `pdfCaretGutter` moved into
+`editing_text_menu.dart` (already the shared home for in-page text-field
+fixes) and the form-field inline editor now uses both - it had neither, so
+its caret carried the full uncompensated nudge at zoom.
+
+## Testing this class of bug
+
+`editing_caret_zoom_test.dart` measures the **composited frame**, in physical
+pixels, with the editor inside the transform: `RepaintBoundary.toImage` under
+`tester.runAsync` (the byte conversion never completes in the fake async
+zone), the box wash taken as the modal colour over the whole box interior
+(a band tight around one line can be more glyph than background), and glyph
+rows told from caret rows by run width - the Apple caret is drawn taller than
+the text, so it owns rows above and below the line. It asserts, for left,
+centred and right free text at 4 and 40 px/pt, that the painted caret hugs
+the glyph it marks *and* that the painted line sits on the appearance's text
+area. Reverting either half of the fix fails it; reverting #691's
+compensation fails it too.
+
+Gotchas for anyone extending it: `pumpAndSettle` never returns with an editor
+open (the caret blinks), `setZoom` zooms about the viewport centre so the box
+has to be placed there rather than scrolled to afterwards, and the viewer
+clamps the transform at 24x - `setZoom(40)` on a fit-width page is 24x, not
+31x.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -427,50 +428,62 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
           bindings: {
             const SingleActivator(LogicalKeyboardKey.escape): _cancelText,
           },
-          child: TextField(
-            key: const ValueKey('pdf-form-text-editor'),
-            controller: _text,
-            focusNode: _focus,
-            autofocus: true,
-            // single-line fields commit on Enter, not a newline
-            maxLines: _editMultiline ? null : 1,
-            expands: _editMultiline,
-            onSubmitted: (_) => _commitText(),
-            // tapping off the field commits it - the viewer suppresses its
-            // own focus steal while editing, so the field keeps focus
-            // until this fires
-            onTapOutside: (_) => _commitText(),
-            // the zoom transform would otherwise scale AND displace the
-            // long-press selection menu off-screen
-            contextMenuBuilder: (context, editableTextState) =>
-                pdfPlacedTextSelectionMenu(
-                  editableTextState,
-                  AdaptiveTextSelectionToolbar.editableText(
-                      editableTextState: editableTextState),
+          // the same zoom-space caret treatment the free-text editor gets:
+          // Apple's device-pixel nudge cancelled, and the caret gutter
+          // handed back below so right-aligned (RTL) values stay put
+          child: pdfZoomAwareCaret(
+            context,
+            chromeScale: chromeScale,
+            child: TextField(
+              key: const ValueKey('pdf-form-text-editor'),
+              controller: _text,
+              focusNode: _focus,
+              autofocus: true,
+              // single-line fields commit on Enter, not a newline
+              maxLines: _editMultiline ? null : 1,
+              expands: _editMultiline,
+              onSubmitted: (_) => _commitText(),
+              // tapping off the field commits it - the viewer suppresses its
+              // own focus steal while editing, so the field keeps focus
+              // until this fires
+              onTapOutside: (_) => _commitText(),
+              // the zoom transform would otherwise scale AND displace the
+              // long-press selection menu off-screen
+              contextMenuBuilder: (context, editableTextState) =>
+                  pdfPlacedTextSelectionMenu(
+                    editableTextState,
+                    AdaptiveTextSelectionToolbar.editableText(
+                        editableTextState: editableTextState),
+                  ),
+              textDirection: _flutterTextDirection(_text.text),
+              textAlign: _flutterTextDirection(_text.text) == TextDirection.rtl
+                  ? TextAlign.right
+                  : TextAlign.left,
+              textAlignVertical: _editMultiline
+                  ? TextAlignVertical.top
+                  : TextAlignVertical.center,
+              cursorColor: const Color(0xFF000000),
+              cursorWidth: 2 * chromeScale,
+              style: TextStyle(
+                color: const Color(0xFF000000),
+                fontSize: _editSize * scale,
+                height: 1.2,
+                fontFamily: _uiFamily(_editFont),
+                fontWeight:
+                    _editFont.isBold ? FontWeight.bold : FontWeight.normal,
+                fontStyle:
+                    _editFont.isItalic ? FontStyle.italic : FontStyle.normal,
+              ),
+              decoration: InputDecoration(
+                isCollapsed: true,
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.fromLTRB(
+                  2 * scale,
+                  2 * scale,
+                  math.max(0.0, 2 * scale - pdfCaretGutter(chromeScale)),
+                  2 * scale,
                 ),
-            textDirection: _flutterTextDirection(_text.text),
-            textAlign: _flutterTextDirection(_text.text) == TextDirection.rtl
-                ? TextAlign.right
-                : TextAlign.left,
-            textAlignVertical: _editMultiline
-                ? TextAlignVertical.top
-                : TextAlignVertical.center,
-            cursorColor: const Color(0xFF000000),
-            cursorWidth: 2 * chromeScale,
-            style: TextStyle(
-              color: const Color(0xFF000000),
-              fontSize: _editSize * scale,
-              height: 1.2,
-              fontFamily: _uiFamily(_editFont),
-              fontWeight:
-                  _editFont.isBold ? FontWeight.bold : FontWeight.normal,
-              fontStyle:
-                  _editFont.isItalic ? FontStyle.italic : FontStyle.normal,
-            ),
-            decoration: InputDecoration(
-              isCollapsed: true,
-              border: InputBorder.none,
-              contentPadding: EdgeInsets.all(2 * scale),
+              ),
             ),
           ),
         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1076,21 +1076,30 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// screen space. The editor lives inside the viewer transform, so the stock
   /// `-2 / devicePixelRatio` local offset otherwise grows with deep zoom and
   /// leaves the caret visibly detached from both ends of centred text.
-  Widget _zoomAwareCursor(BuildContext context, Widget child) {
-    final media = MediaQuery.of(context);
-    final platform = Theme.of(context).platform;
-    if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
-      return child;
-    }
-    final scale = _chromeScale;
-    if (!scale.isFinite || scale <= 0) return child;
-    return MediaQuery(
-      data: media.copyWith(
-        devicePixelRatio: media.devicePixelRatio / scale,
-      ),
-      child: child,
-    );
-  }
+  Widget _zoomAwareCursor(BuildContext context, Widget child) =>
+      pdfZoomAwareCaret(context, chromeScale: _chromeScale, child: child);
+
+  /// The appearance's own text inset, in overlay pixels - free text lays its
+  /// glyphs out 3 points inside the box.
+  double get _textEditPad => 3 * _geometry.scale;
+
+  /// The caret gutter Flutter reserves out of the width the text aligns in
+  /// (see [pdfCaretGutter]). [_textEditRightPad] and
+  /// [_textEditGutterOverflow] hand it back, so centred and right-aligned
+  /// glyphs land on the appearance's text area at any zoom (#692).
+  double get _textEditCaretGutter => pdfCaretGutter(_chromeScale);
+
+  /// Right content padding: the appearance inset less the caret gutter, so
+  /// the field is exactly one gutter wider than the text area it aligns in.
+  double get _textEditRightPad =>
+      math.max(0.0, _textEditPad - _textEditCaretGutter);
+
+  /// What of the gutter the content padding could not absorb (a box on a
+  /// large sheet has an inset under a pixel). The chrome gutter gives it up
+  /// instead: the border paints on the box edge either way, so the widened
+  /// content box moves nothing visible.
+  double get _textEditGutterOverflow =>
+      math.min(2.0, math.max(0.0, _textEditCaretGutter - _textEditPad));
 
   /// Null while the eyedropper is armed without a tool, or while a
   /// default-mode (mouse click) selection exists without one.
@@ -5599,7 +5608,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                         // decoration border adds itself to the padding, and
                         // any net inset shifts the text when the editor
                         // opens - content must sit exactly on the box
-                        padding: const EdgeInsets.all(2),
+                        padding: EdgeInsets.fromLTRB(
+                            2, 2, 2 - _textEditGutterOverflow, 2),
                         // the box's own fill when it has one; otherwise wash
                         // the paper color over what's underneath: faint for a
                         // fresh box, fully opaque when editing existing text
@@ -5713,14 +5723,17 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                   // from the top padding to avoid a small
                                   // edit-time layout jump.
                                   contentPadding: EdgeInsets.fromLTRB(
-                                    3 * _geometry.scale,
+                                    _textEditPad,
                                     math.max(
                                       0,
-                                      3 * _geometry.scale -
+                                      _textEditPad -
                                           0.1 * _textEditSize * _geometry.scale,
                                     ),
-                                    3 * _geometry.scale,
-                                    3 * _geometry.scale,
+                                    // the caret gutter, handed back so
+                                    // centred and right-aligned glyphs land
+                                    // on the appearance's text area
+                                    _textEditRightPad,
+                                    _textEditPad,
                                   ),
                                 ),
                               )),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
@@ -44,6 +44,47 @@ Widget pdfPlacedTextSelectionMenu(
   return Transform(transform: correction, child: menu);
 }
 
+/// Wraps an in-page [TextField] so Flutter's Apple-platform caret nudge
+/// stays constant in *screen* space.
+///
+/// Material and Cupertino text fields shift the caret two device pixels
+/// left on iOS and macOS (`-2 / devicePixelRatio`), and [RenderEditable]
+/// snaps the caret to the device pixel grid with the same ratio. Both are
+/// measured against the untransformed screen, so an editor living inside
+/// the viewer's zoom transform has them multiplied by the zoom: the caret
+/// drifts off the glyphs, by more the deeper you go. Feeding the subtree a
+/// device pixel ratio scaled by the same zoom ([chromeScale] is its
+/// inverse) cancels both, leaving the two physical pixels Flutter intends.
+///
+/// The identity off Apple platforms, and whenever the zoom is unusable.
+Widget pdfZoomAwareCaret(BuildContext context,
+    {required double chromeScale, required Widget child}) {
+  final platform = Theme.of(context).platform;
+  if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
+    return child;
+  }
+  if (!chromeScale.isFinite || chromeScale <= 0) return child;
+  final media = MediaQuery.of(context);
+  return MediaQuery(
+    data: media.copyWith(devicePixelRatio: media.devicePixelRatio / chromeScale),
+    child: child,
+  );
+}
+
+/// The gutter [RenderEditable] reserves at the end of every editable line
+/// for the caret: its one-pixel `_kCaretGap` plus the cursor width.
+///
+/// It comes out of the width the text is laid out and aligned in, so
+/// centred text sits half a gutter - and right-aligned text a whole one -
+/// to the left of the field. That is a constant in *layout* pixels, which
+/// the viewer transform magnifies into a visible gap: at 24x it drags a
+/// centred line about 13 screen pixels off the glyphs the page shows,
+/// which is what leaves an inline caret looking detached from both ends of
+/// centred free text at deep zoom (#692). In-page editors hand it back out
+/// of their trailing content padding, so the band the text aligns inside
+/// is the appearance's own text area at any zoom.
+double pdfCaretGutter(double chromeScale) => 1.0 + 2 * chromeScale;
+
 /// [Matrix4.isIdentity] is exact; the correction is a product of two
 /// float matrices, so an unscaled field lands a hair off it.
 bool _isIdentity(Matrix4 matrix) {

--- a/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
@@ -1,0 +1,262 @@
+// Where the inline free-text editor actually *paints* at deep zoom.
+//
+// The macOS caret defect (#692) survived a regression that asserted
+// `RenderEditable.cursorOffset` and the local caret rectangles, because the
+// caret was never wrong relative to the editor's own text - the whole live
+// line was drifting off the box. Everything here is therefore measured from
+// the composited frame, in physical pixels, with the editor inside the
+// viewer's zoom transform.
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One run of ink in a captured row: first and last inked column.
+typedef Ink = (int lo, int hi);
+
+const _noInk = (1 << 30, -1);
+
+void main() {
+  const editorKey = ValueKey('pdf-freetext-editor');
+  const boundaryKey = ValueKey('pdf-caret-zoom-frame');
+
+  // A box centred in the viewport at fit-width, so it stays on screen when
+  // the transform magnifies about the viewport centre: an 800x800 logical
+  // viewport over a 612x792 page shows the top 612pt, centred on (306, 486).
+  const rect = PdfRect(291, 477, 321, 494.7585);
+  const rectWidth = 321 - 291.0;
+  const fontSize = 8.0;
+  const text = 'UB';
+
+  Future<(PdfEditingController, PdfViewerController)> pumpEditor(
+      WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RepaintBoundary(
+          key: boundaryKey,
+          child: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return (editing, viewer);
+  }
+
+  /// Splits the ink inside [region] of the composited frame into the glyph
+  /// run and the caret, in physical pixels.
+  ///
+  /// The two are told apart by width: the caret is a hairline a couple of
+  /// logical pixels across at any zoom, the glyphs are a whole line of text,
+  /// and (on Apple platforms) the caret is drawn taller than the text, so it
+  /// owns rows of its own above and below the run.
+  Future<(Ink glyphs, Ink caret)> paintedInk(
+      WidgetTester tester, Rect region, Rect wash) async {
+    final boundary =
+        tester.renderObject<RenderRepaintBoundary>(find.byKey(boundaryKey));
+    final dpr = tester.view.devicePixelRatio;
+    final (image, data) = (await tester.runAsync(() async {
+      final image = await boundary.toImage(pixelRatio: dpr);
+      final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      return (image, data);
+    }))!;
+    final width = image.width;
+    final height = image.height;
+    final bytes = data!.buffer.asUint8List();
+    final x0 = (region.left * dpr).floor().clamp(0, width - 1);
+    final x1 = (region.right * dpr).ceil().clamp(0, width - 1);
+    final y0 = (region.top * dpr).floor().clamp(0, height - 1);
+    final y1 = (region.bottom * dpr).ceil().clamp(0, height - 1);
+    // The box wash is the modal colour over the whole box interior - a band
+    // tight around one line of text can be more glyph than background.
+    final counts = <int, int>{};
+    final wx0 = (wash.left * dpr).floor().clamp(0, width - 1);
+    final wx1 = (wash.right * dpr).ceil().clamp(0, width - 1);
+    final wy0 = (wash.top * dpr).floor().clamp(0, height - 1);
+    final wy1 = (wash.bottom * dpr).ceil().clamp(0, height - 1);
+    for (var x = wx0; x <= wx1; x++) {
+      for (var y = wy0; y <= wy1; y++) {
+        final i = (y * width + x) * 4;
+        final key = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+        counts[key] = (counts[key] ?? 0) + 1;
+      }
+    }
+    var background = 0, seen = -1;
+    counts.forEach((colour, count) {
+      if (count > seen) {
+        seen = count;
+        background = colour;
+      }
+    });
+    final bgR = (background >> 16) & 0xff;
+    final bgG = (background >> 8) & 0xff;
+    final bgB = background & 0xff;
+    var glyphs = _noInk, caret = _noInk;
+    for (var y = y0; y <= y1; y++) {
+      int? lo, hi;
+      for (var x = x0; x <= x1; x++) {
+        final i = (y * width + x) * 4;
+        if ((bytes[i] - bgR).abs() > 40 ||
+            (bytes[i + 1] - bgG).abs() > 40 ||
+            (bytes[i + 2] - bgB).abs() > 40) {
+          lo ??= x;
+          hi = x;
+        }
+      }
+      if (lo == null) continue;
+      // a caret-only row is a few pixels wide; a text row is a whole line
+      final isText = hi! - lo > 8 * dpr;
+      final grown = isText ? glyphs : caret;
+      final merged = (
+        lo < grown.$1 ? lo : grown.$1,
+        hi > grown.$2 ? hi : grown.$2,
+      );
+      if (isText) {
+        glyphs = merged;
+      } else {
+        caret = merged;
+      }
+    }
+    image.dispose();
+    return (glyphs, caret);
+  }
+
+  /// Opens the inline editor over a free-text box of [align]ment, zoomed to
+  /// [zoom] logical pixels per point, and reports what the frame shows.
+  Future<
+      ({
+        Ink glyphs,
+        Ink caretAtStart,
+        Ink caretAtEnd,
+        Rect textArea,
+        double dpr,
+      })> measure(
+    WidgetTester tester, {
+    required PdfTextAlign align,
+    required double zoom,
+  }) async {
+    final (editing, viewer) = await pumpEditor(tester);
+    editing.preferences
+      ..fontSize = fontSize
+      ..textAlign = align;
+    editing
+      ..addFreeText(0, rect, text)
+      ..selectAnnotation(0, 0);
+    await tester.pump();
+    viewer.setZoom(zoom);
+    await tester.pump();
+    expect(editing.requestEditSelectedTextInline(), isTrue);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    final finder = find.byKey(editorKey);
+    final field = tester.widget<TextField>(finder);
+    final editable =
+        find.descendant(of: finder, matching: find.byType(EditableText));
+    final render = tester.state<EditableTextState>(editable).renderEditable;
+    // screen pixels per point, straight off the viewer (the transform
+    // clamps, so this is the zoom the user got, not the one asked for)
+    final perPoint = viewer.zoom;
+    // the editor's content box is the annotation rect: the chrome border
+    // lives in the gutter the box inflates itself by
+    final box = tester.getRect(finder);
+    // what the committed appearance aligns inside: less its 3pt text inset
+    final textArea = Rect.fromLTRB(box.left + 3 * perPoint, box.top,
+        box.left + (rectWidth - 3) * perPoint, box.bottom);
+    // everything is read inside the box and inside the window, clear of the
+    // chrome border and of the viewer's scrollbar gutter
+    final view = tester.view;
+    final screen = Rect.fromLTWH(0, 0,
+        view.physicalSize.width / view.devicePixelRatio - 20,
+        view.physicalSize.height / view.devicePixelRatio);
+    // the box interior, for the wash colour
+    final wash = box.deflate(4).intersect(screen);
+    // the line's own band, for the ink
+    final region = Rect.fromPoints(
+            render.localToGlobal(Offset.zero),
+            render.localToGlobal(render.size.bottomRight(Offset.zero)))
+        .intersect(wash);
+
+    Future<(Ink, Ink)> at(int offset) async {
+      field.controller!.selection = TextSelection.collapsed(offset: offset);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      return paintedInk(tester, region, wash);
+    }
+
+    // the caret parked mid-word never extends the run, so this reads the
+    // glyphs alone
+    final (glyphs, _) = await at(1);
+    final (_, caretAtStart) = await at(0);
+    final (_, caretAtEnd) = await at(text.length);
+    return (
+      glyphs: glyphs,
+      caretAtStart: caretAtStart,
+      caretAtEnd: caretAtEnd,
+      textArea: textArea,
+      dpr: tester.view.devicePixelRatio,
+    );
+  }
+
+  group('the inline free-text caret at deep zoom', () {
+    for (final align in PdfTextAlign.values) {
+      // 4 px/pt is an ordinary reading zoom; the deep one is the viewer's
+      // ceiling, where a constant in layout pixels turns into a visible gap
+      for (final zoom in const <double>[4, 40]) {
+        testWidgets('$align free text: painted caret hugs the glyphs at '
+            '${zoom.toInt()} px/pt', (tester) async {
+          tester.view.physicalSize = const Size(1600, 1600);
+          tester.view.devicePixelRatio = 2;
+          addTearDown(tester.view.reset);
+
+          final shot = await measure(tester, align: align, zoom: zoom);
+          expect(shot.glyphs.$2, greaterThan(shot.glyphs.$1),
+              reason: 'the live text should be on screen');
+
+          // The caret at either end of the line sits on the glyph it marks -
+          // in physical pixels of the composited frame, at any zoom. Two
+          // physical pixels of that is Flutter's own Apple-platform nudge.
+          expect(shot.caretAtStart.$1, closeTo(shot.glyphs.$1, 4),
+              reason: 'caret at offset 0 left the first glyph behind');
+          expect(shot.caretAtEnd.$2, closeTo(shot.glyphs.$2 + 2 * shot.dpr, 4),
+              reason: 'caret at text.length landed inside the last glyph');
+
+          // ...and the line itself is laid out on the appearance's text area,
+          // not on what is left of the field after Flutter reserves its caret
+          // gutter. Left-aligned text never noticed that gutter; centred text
+          // lost half of it and right-aligned text all of it, as a constant
+          // number of *layout* pixels that the transform magnified - a gap
+          // that grew with zoom until the caret sat inside the last glyph.
+          final area = shot.textArea;
+          final left = shot.glyphs.$1 / shot.dpr;
+          final right = shot.glyphs.$2 / shot.dpr;
+          switch (align) {
+            case PdfTextAlign.left:
+              expect(left, closeTo(area.left, 2));
+            case PdfTextAlign.center:
+              expect((left + right) / 2, closeTo(area.center.dx, 2));
+            case PdfTextAlign.right:
+              expect(right, closeTo(area.right, 2));
+          }
+        }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Closes #692.

#691 fixed one half of the macOS caret detachment — Flutter's Apple `-2 / devicePixelRatio` cursor nudge, a *screen*-space constant applied in the editor's local pixels and therefore multiplied by the viewer's transform. The app still reproduced the defect afterwards, and the regression asserting `RenderEditable.cursorOffset` and `getLocalRectForCaret` still passed. Both facts have the same explanation: **within a `RenderEditable` the caret and the glyphs come out of the same `TextPainter`**, so the only things that can separate them are `cursorOffset` and `_snapToPhysicalPixel` — which is exactly what that test measured, and exactly what #691 had already fixed. What was still moving is the whole live line, off the box.

`RenderEditable` reserves a gutter at the end of every editable line for the caret — `_kCaretGap` (a hard-coded `1.0`) plus `cursorWidth` — out of the width the text is laid out and aligned in, then paints the paragraph at the field's origin:

```dart
double get _caretMargin => _kCaretGap + cursorWidth;      // rendering/editable.dart
final double availableMaxWidth = math.max(0.0, maxWidth - _caretMargin);
```

So a centred line sits half a gutter, and a right-aligned line a whole one, left of where the box centres it. Left-aligned text never notices — which is why this only ever showed on a centred box. The gutter is a constant in **layout** pixels and the inline editor lives under the viewer's zoom transform, so on screen it is `zoom ×` that constant. Measured off the composited frame:

| zoom | centred line vs box centre | right-aligned line vs text area |
| --- | --- | --- |
| 4 px/pt | −2.75 logical px | −5.5 logical px |
| 40 px/pt (transform 24×) | −13.25 logical px | −26.5 logical px |

On a CAD sheet the fit scale is small, so an 8pt em is only two or three layout pixels wide and half a gutter is ~20% of a glyph: the caret at offset 0 stands off the first glyph, and the caret at `text.length` lands *inside* the last one — the two symptoms in the issue, both growing with zoom.

**The fix** hands the gutter back out of the field's trailing content padding, so the band the text aligns inside is the appearance's own text area at any zoom. A box on a large sheet can have a 3pt inset narrower than the gutter; the remainder comes out of the 2px chrome gutter, which the border paints over either way, so nothing visible moves.

`pdfZoomAwareCaret` / `pdfCaretGutter` move into `editing_text_menu.dart` (already the shared home for in-page text-field fixes) and the **form-field inline editor** now uses both — it had neither, so its caret carried the full uncompensated nudge at zoom. That is one step beyond the issue's scope; it is the same defect in the sibling editor, and it's easy to drop if you'd rather keep this to free text.

Behaviour and API are otherwise unchanged: no public API, no committed-appearance change, and left-aligned free text is byte-for-byte where it was.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (workspace, clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2358 passed, 35 skipped, 0 failed
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `dart_pdf_editor`'s two in-page text editors, touching no parsing, writing or rendering path, so the pure-Dart package suites and the corpus/Ghent sweeps have nothing to exercise. **The macOS app itself has not been driven** — this environment is Linux-only, so the evidence here is the composited-frame measurement below rather than a screenshot from the real app.

## PDF fixtures and screenshots

The new regression, `packages/dart_pdf_editor/test/editing_caret_zoom_test.dart`, is the "validate final painted pixels" the issue asked for: it measures the **composited frame** in physical pixels with the editor inside the viewer transform, via `RepaintBoundary.toImage` under `tester.runAsync` (the byte conversion never completes in the fake async zone). The box wash is taken as the modal colour over the whole box interior — a band tight around one line can be more glyph than background — and glyph rows are told from caret rows by run width, since the Apple caret is drawn taller than the text and so owns rows above and below the line.

For left, centred and right free text at 4 and 40 px/pt it asserts that the painted caret hugs the glyph it marks, and that the painted line sits on the appearance's text area. Removing the gutter give-back fails the four centred/right cases (with the numbers in the table above); removing #691's nudge compensation fails all six, by 5 physical px at 4 px/pt and 38 at 40 px/pt.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **Please confirm on the real drawing.** I could measure and fix a displacement with exactly the reported signature (centred-only, growing with zoom, invisible to `RenderEditable`-local assertions), but I cannot run the macOS app here. If anything remains after this, the next thing I'd measure is the live text against the *committed* appearance for that specific annotation — this PR aligns the editor to the box's text area assuming the appearance's 3pt inset, and a Bluebeam `/DS` margin that disagrees would show up the same way.
- `pdfCaretGutter` mirrors a private framework constant (`_kCaretGap = 1.0`). If a future Flutter changes it, the new test fails with the drift measured in physical pixels rather than silently regressing.
- Test gotchas worth knowing before extending it: `pumpAndSettle` never returns with an editor open (the caret blinks), `setZoom` zooms about the viewport centre so the box must be *placed* there rather than scrolled to afterwards, and the viewer clamps the transform at 24× — `setZoom(40)` on a fit-width page is 24×, not 31×.
- Session notes: `doc/dev-log/2026-08-19-freetext-caret-gutter-zoom.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVoYC6k4sM2191GeLUCdgm)_