### PR TITLE
app: keep an OS file-open last in the tab strip and on screen

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -268,6 +268,17 @@ class _EditorScreenState extends State<EditorScreen>
   /// opening. Only the tab active when restore finishes materializes.
   bool _restoringSession = false;
 
+  /// How many tabs at the head of [_tabs] were put there by startup restore
+  /// (recovered unsaved work, then the last session's documents).
+  ///
+  /// Restore races the OS file-open that launched the app: on macOS the file
+  /// arrives on the warm `openFile` stream whenever the runner finishes
+  /// building its payload, which can land before, during, or after the store
+  /// read. Restored tabs therefore slot in at this index rather than at the
+  /// end, so the document the user actually double-clicked stays last in the
+  /// strip - and keeps focus (see [_addTab]).
+  int _restoredTabs = 0;
+
   /// The update checker, owned here unless the host injected one.
   late final UpdateService _updates = widget.updateService ??
       UpdateService(
@@ -700,7 +711,7 @@ class _EditorScreenState extends State<EditorScreen>
       // open path, so continued editing appends to it instead of mirroring the
       // whole document again under a fresh id.
       _autosave.track(tab, recovered: record);
-      _addTab(tab);
+      _addTab(tab, restored: true);
     }
     // Anything nothing adopted (bytes gone, a record we couldn't read) would
     // otherwise be offered back on every launch forever.
@@ -728,12 +739,15 @@ class _EditorScreenState extends State<EditorScreen>
     // the user can switch to another restored document while a remote one is
     // hydrating. A missing file is dropped when its lazy open fails.
     if (progressiveOpenSupported(originPath)) {
-      _addTab(DocumentTab.deferredPath(
-        title: doc.title,
-        originPath: originPath!,
-        originBookmark: doc.bookmark,
-        cachePath: doc.cachePath,
-      ));
+      _addTab(
+        DocumentTab.deferredPath(
+          title: doc.title,
+          originPath: originPath!,
+          originBookmark: doc.bookmark,
+          cachePath: doc.cachePath,
+        ),
+        restored: true,
+      );
       _recents.add(
           title: doc.title,
           path: originPath,
@@ -749,6 +763,7 @@ class _EditorScreenState extends State<EditorScreen>
       originPath: originPath,
       originBookmark: doc.bookmark,
       cachePath: doc.cachePath,
+      restored: true,
     );
     try {
       final bytes = await readPdfAtPath(readPath, bookmark: doc.bookmark);
@@ -1009,12 +1024,30 @@ class _EditorScreenState extends State<EditorScreen>
     return 0;
   }
 
-  void _addTab(DocumentTab tab) {
+  /// Adds [tab] to the strip and makes it active.
+  ///
+  /// A tab added by startup restore ([restored]) is the exception on both
+  /// counts: it joins the restored block at the head of the strip instead of
+  /// the end, and it takes focus only while nothing else is open. A document
+  /// the user asked for - the file the OS launched us with - keeps its place
+  /// at the end and stays the one on screen, whichever order the two
+  /// asynchronous sources happen to resolve in.
+  void _addTab(DocumentTab tab, {bool restored = false}) {
     setState(() {
       // A new tab shrinks the others to fit; drop any close-streak width hold.
       _heldTabWidth = null;
-      _tabs.add(tab);
-      _activeIndex = _tabs.length - 1;
+      if (!restored) {
+        _tabs.add(tab);
+        _activeIndex = _tabs.length - 1;
+        return;
+      }
+      final at = _restoredTabs.clamp(0, _tabs.length);
+      // Anything at or past the restored block was opened explicitly this
+      // launch; if one of those is active it stays active, just shifted along.
+      final userTabActive = _tabs.isNotEmpty && _activeIndex >= at;
+      _tabs.insert(at, tab);
+      _restoredTabs = at + 1;
+      _activeIndex = userTabActive ? _activeIndex + 1 : at;
     });
     unawaited(_persistSession());
   }
@@ -1030,14 +1063,15 @@ class _EditorScreenState extends State<EditorScreen>
       {String? originPath,
       String? originBookmark,
       String? originToken,
-      String? cachePath}) {
+      String? cachePath,
+      bool restored = false}) {
     final tab = DocumentTab.loading(
         title: title,
         originPath: originPath,
         originBookmark: originBookmark,
         originToken: originToken,
         cachePath: cachePath);
-    _addTab(tab);
+    _addTab(tab, restored: restored);
     return tab;
   }
 
@@ -1047,10 +1081,11 @@ class _EditorScreenState extends State<EditorScreen>
       replacement.dispose();
       return false;
     }
-    setState(() {
-      _tabs[index] = replacement;
-      _activeIndex = index;
-    });
+    // Swap in place, leaving the selection alone: the placeholder is normally
+    // the active tab already, and when it isn't - a session restore finishing
+    // behind the file the OS launched us with - stealing focus here would undo
+    // the ordering _addTab just got right.
+    setState(() => _tabs[index] = replacement);
     loading.dispose();
     unawaited(_persistSession());
     return true;
@@ -1718,17 +1753,37 @@ class _EditorScreenState extends State<EditorScreen>
 
   /// Opens a file the OS handed us (association, share, launch arg).
   ///
+  /// The document lands at the end of the strip and becomes the active tab -
+  /// it is the one the user just asked for. Startup restore keeps out of its
+  /// way (see [_addTab]), so this holds however the two race.
+  ///
   /// If a tab already holds this exact path, focus it instead of opening a
   /// duplicate. The same launch file can arrive twice - once via the
   /// command-line launch args and once via the native `getInitialFile`
   /// channel (Windows delivers both) - and re-opening an already-open
   /// document from the OS should surface the existing tab, not stack copies.
+  /// When that existing tab is one startup restore put back, it moves to the
+  /// end: the user opened this file, so it belongs exactly where it would
+  /// have landed had the OS beaten restore to it.
   Future<void> _openIncoming(IncomingFile file) async {
     final path = file.path;
     if (path != null && path.isNotEmpty) {
       final existing = _tabs.indexWhere((t) => t.originPath == path);
       if (existing != -1) {
-        setState(() => _activeIndex = existing);
+        final tab = _tabs[existing];
+        // Only a restored tab the user has never opened moves: it is still a
+        // placeholder, so re-slotting it is invisible. A document already on
+        // its feet keeps its place - the user put it there.
+        final move = existing < _restoredTabs &&
+            (tab.isDeferredPath || tab.isDeferred || tab.isLoading);
+        setState(() {
+          if (move) {
+            _restoredTabs--;
+            _tabs.add(_tabs.removeAt(existing));
+          }
+          _activeIndex = move ? _tabs.length - 1 : existing;
+        });
+        if (move) unawaited(_persistSession());
         return;
       }
     }
@@ -2091,7 +2146,12 @@ class _EditorScreenState extends State<EditorScreen>
     }
     setState(() {
       for (final tab in targets) {
-        _tabs.remove(tab);
+        final index = _tabs.indexOf(tab);
+        if (index == -1) continue;
+        // Keep the restored-block count honest: a session document whose file
+        // has vanished drops its placeholder mid-restore.
+        if (index < _restoredTabs) _restoredTabs--;
+        _tabs.removeAt(index);
       }
       // Keep the previously active document active when it survived.
       final keep = active == null ? -1 : _tabs.indexOf(active);

--- a/app/test/session_restore_test.dart
+++ b/app/test/session_restore_test.dart
@@ -102,6 +102,31 @@ void main() {
     await tester.pump();
   }
 
+  // Real frames: restore and the progressive opener both do file I/O, which
+  // only progresses under runAsync.
+  Future<void> pumpFrames(WidgetTester tester) async {
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  // Hands the app a file the way a native runner does - the macOS
+  // `application(_:open:)` payload is a path (plus a security bookmark), no
+  // bytes. Call inside runAsync.
+  Future<void> deliverOpenFile(WidgetTester tester,
+      {required String name, required String path}) async {
+    const codec = StandardMethodCodec();
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      IncomingFileService.channelName,
+      codec.encodeMethodCall(MethodCall('openFile', {
+        'name': name,
+        'path': path,
+      })),
+      (_) {},
+    );
+  }
+
   testWidgets('re-opens the documents from the last session on startup',
       (tester) async {
     final a = seedFile('a.pdf');
@@ -287,5 +312,68 @@ void main() {
     expect(find.textContaining('Could not open'), findsNothing);
     expect(tabTitle('a.pdf'), findsOneWidget);
     expect(find.byType(PdfEditorView), findsOneWidget);
+  });
+
+  testWidgets('an OS file-open beats session restore to the end of the strip',
+      (tester) async {
+    final a = seedFile('a.pdf');
+    final b = seedFile('b.pdf');
+    seedSession([(title: 'a.pdf', path: a), (title: 'b.pdf', path: b)]);
+    final clicked = seedFile('clicked.pdf');
+    // Hold restore at its first await so the OS file-open lands first. That is
+    // the macOS "open with" shape: the runner builds its payload off the
+    // AppKit thread and pushes it whenever it is ready, which can be before
+    // the stored session has even been read back.
+    final recovery = _DelayedRecoveryStore();
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(prefs: prefs, unsavedChangesStore: recovery),
+      ));
+      await tester.pump();
+      await deliverOpenFile(tester, name: 'clicked.pdf', path: clicked);
+      await pumpFrames(tester);
+      recovery.gate.complete(const []);
+      await pumpFrames(tester);
+    });
+    await tester.pump();
+
+    expect(tabTitle('a.pdf'), findsOneWidget);
+    expect(tabTitle('b.pdf'), findsOneWidget);
+    // The restored session slots in ahead of the clicked document, which keeps
+    // the end of the strip...
+    expect(tester.getCenter(tabTitle('a.pdf')).dx,
+        lessThan(tester.getCenter(tabTitle('b.pdf')).dx));
+    expect(tester.getCenter(tabTitle('b.pdf')).dx,
+        lessThan(tester.getCenter(tabTitle('clicked.pdf')).dx));
+    // ...and stays the document on screen.
+    expect(tester.widget<Text>(tabTitle('clicked.pdf')).style?.fontWeight,
+        FontWeight.w600);
+    expect(tester.widget<Text>(tabTitle('b.pdf')).style?.fontWeight,
+        FontWeight.normal);
+  });
+
+  testWidgets('an OS file-open of an already-restored document moves it last',
+      (tester) async {
+    final a = seedFile('a.pdf');
+    final b = seedFile('b.pdf');
+    seedSession([(title: 'a.pdf', path: a), (title: 'b.pdf', path: b)]);
+
+    // Restore runs to completion first, then the OS hands over one of the very
+    // files it just restored. Focusing it in place would leave it buried
+    // mid-strip - the same double-click has to land the same way whichever
+    // side wins the race.
+    await pumpEditor(tester);
+    await tester.runAsync(() async {
+      await deliverOpenFile(tester, name: 'a.pdf', path: a);
+      await pumpFrames(tester);
+    });
+    await tester.pump();
+
+    expect(find.byTooltip('Close tab'), findsNWidgets(2)); // no duplicate tab
+    expect(tester.getCenter(tabTitle('b.pdf')).dx,
+        lessThan(tester.getCenter(tabTitle('a.pdf')).dx));
+    expect(tester.widget<Text>(tabTitle('a.pdf')).style?.fontWeight,
+        FontWeight.w600);
   });
 }

--- a/doc/dev-log/2026-08-20-os-file-open-tab-order.md
+++ b/doc/dev-log/2026-08-20-os-file-open-tab-order.md
@@ -1,0 +1,62 @@
+# An OS file-open lands last in the tab strip, and on screen
+
+Double-clicking a PDF in Finder while DartPDF was closed launched the app,
+restored the previous session - and left the user looking at whichever
+document restore happened to add last, with the file they had actually
+clicked buried at the *front* of the tab strip.
+
+## Root cause
+
+Two asynchronous sources add tabs at startup and neither knows about the
+other:
+
+- `_restoreSession()` - recovered unsaved work, then the stored session.
+- `_openIncoming()` - the file the OS launched us with.
+
+On Windows the launch file arrives as a command-line argument, so
+`_hasExplicitLaunchTarget` sees it synchronously and restore stands down
+entirely. macOS has no such signal. `AppDelegate.application(_:open:)`
+builds its payload on a background executor (deliberately - resolving an
+iCloud placeholder's security scope on the AppKit thread beachballs the
+launch), so the file reaches Dart via `getInitialFile` *or* the warm
+`openFile` stream, whenever the bookmark is ready. That can be before,
+during, or after the store read.
+
+Every `_addTab` appended and took focus, so whoever finished last won the
+selection, and the clicked file - which usually arrived first - sat at
+index 0. `_replaceLoadingTab` then also yanked focus back to whatever
+placeholder it was swapping, which is why the symptom felt intermittent.
+
+## Fix (`app/lib/editor_screen.dart`)
+
+- `_addTab(tab, {restored})`. Restored tabs form a block at the *head* of
+  the strip, counted by `_restoredTabs`, and take focus only while nothing
+  else is open. A tab the user asked for keeps its place at the end and
+  stays the one on screen, whichever order the two sources resolve in.
+  The three restore call sites (`_recoverUnsavedChanges`, and both arms of
+  `_reopenSessionDocument`) pass `restored: true`; `_openLoading` forwards
+  it. `_removeTabs` decrements the count when a restored placeholder is
+  dropped (a session file that has since vanished), so the head-block index
+  stays honest.
+- `_replaceLoadingTab` no longer writes `_activeIndex`. In the normal open
+  path the placeholder is already active, so the assignment was a no-op;
+  the only case where it did anything was the one where it was wrong.
+- `_openIncoming`'s de-dupe moves the matched tab to the end when it is a
+  restored placeholder the user has never opened. Without that, the same
+  double-click landed in two different places depending on who won the
+  race - at the end when the OS beat restore to the file, mid-strip when it
+  didn't.
+
+## Tests
+
+`app/test/session_restore_test.dart`:
+
+- *an OS file-open beats session restore to the end of the strip* - gates
+  restore on a `_DelayedRecoveryStore` so the `openFile` push lands first
+  (the macOS ordering), then asserts strip order and the selected-tab font
+  weight.
+- *an OS file-open of an already-restored document moves it last* - the
+  other half of the race: restore finishes, then the OS hands over a file
+  it just restored.
+
+Both fail on the pre-fix `editor_screen.dart`.


### PR DESCRIPTION
## Summary

Double-clicking a PDF in Finder while DartPDF was closed launched the app, restored the previous session — and left the user looking at whichever document restore happened to add last, with the file they actually clicked buried at the **front** of the tab strip.

Two asynchronous sources add tabs at startup and neither knew about the other: `_restoreSession()` (recovered unsaved work, then the stored session) and `_openIncoming()` (the file the OS launched us with). On Windows the launch file arrives as a command-line argument, so `_hasExplicitLaunchTarget` sees it synchronously and restore stands down. macOS has no such signal — `AppDelegate.application(_:open:)` builds its payload on a background executor (deliberately: resolving an iCloud placeholder's security scope on the AppKit thread beachballs the launch), so the file reaches Dart via `getInitialFile` *or* the warm `openFile` stream whenever the bookmark is ready, which can be before, during, or after the store read. Every `_addTab` appended and took focus, so whoever finished last won the selection; `_replaceLoadingTab` also yanked focus back to whatever placeholder it was swapping, which is why the symptom felt intermittent.

Changes in `app/lib/editor_screen.dart`:

- `_addTab(tab, {restored})` — restored tabs form a block at the *head* of the strip (counted by `_restoredTabs`) and take focus only while nothing else is open. A document the user asked for keeps its place at the end and stays on screen, whichever order the two sources resolve in. The three restore call sites (`_recoverUnsavedChanges` and both arms of `_reopenSessionDocument`) pass `restored: true`; `_openLoading` forwards it, and `_removeTabs` decrements the count when a restored placeholder is dropped (a session file that has since vanished) so the head-block index stays honest.
- `_replaceLoadingTab` no longer writes `_activeIndex`. In the normal open path the placeholder is already active, so the assignment was a no-op — the only case where it did anything was the one where it was wrong.
- `_openIncoming`'s de-dupe moves the matched tab to the end when it is a restored placeholder the user has never opened, so the same double-click lands in the same place whichever side wins the race.

No behavior change for Windows/Linux launch arguments, drag-drop, the picker, or warm opens of a document already on its feet.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app <!-- app/ (the DartPDF desktop/web app) -->
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean over `app`)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test <!-- `cd app && fvm flutter test`: 465 tests, all passing -->

If any relevant check was not run, explain why: the change is confined to `app/lib/editor_screen.dart` tab bookkeeping — no parser, renderer, or library package is touched, so the corpus/render suites have nothing to exercise here.

## PDF fixtures and screenshots

None — the regression is tab ordering/selection, covered by widget tests over programmatic fixtures (`buildClassicPdf`).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. <!-- app/ is a Flutter app -->
- [x] No `dart:io` imports in any `lib/` directory. <!-- none added -->
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Two new tests in `app/test/session_restore_test.dart` cover both halves of the race, and both fail on the pre-fix `editor_screen.dart`:

- *an OS file-open beats session restore to the end of the strip* — gates restore on a `_DelayedRecoveryStore` so the `openFile` push lands first (the macOS ordering), then asserts strip order and the selected-tab font weight.
- *an OS file-open of an already-restored document moves it last* — restore finishes, then the OS hands over a file it just restored.

Design note: restore still runs on macOS rather than standing down the way an explicit Windows launch argument makes it — that matches the documented intent in `doc/dev-log/2026-06-22-app-session-restore.md` and the reported expectation that the opened document sits at the *end* of a restored strip. Full write-up in `doc/dev-log/2026-08-20-os-file-open-tab-order.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015eNtg2iAkDWzs56fAy36ak)_