### PR TITLE
Signature ink: any colour, and an adjustable pen thickness

### DIFF
--- a/app/lib/signature_raster.dart
+++ b/app/lib/signature_raster.dart
@@ -6,8 +6,10 @@ import 'package:pdf_document/pdf_document.dart' show pdfInkStrokeWidth;
 
 /// Rasterizes a hand-drawn [PdfInkSignature] to a transparent PNG so it can
 /// ride in a visible signature box as the appearance graphic
-/// ([PdfSignatureAppearance.graphic]). The ink color and pressure-varied
-/// width mirror the signature pad's own preview.
+/// ([PdfSignatureAppearance.graphic]). The ink color, pen width, and
+/// pressure-varied width mirror the signature pad's own preview - the pen
+/// is scaled to the raster ([PdfInkSignature.strokeWidthFor]), so a
+/// thicker pen reads as thicker here too.
 ///
 /// [height] is the raster height in pixels; the width follows the drawing's
 /// aspect ratio. Returns null when nothing was drawn or the image can't be
@@ -24,7 +26,7 @@ Future<Uint8List?> rasterizeInkSignature(
   final recorder = ui.PictureRecorder();
   final canvas = ui.Canvas(recorder);
   final color = ui.Color(0xFF000000 | signature.color);
-  const baseWidth = 3.0;
+  final baseWidth = signature.strokeWidthFor(w);
 
   for (var i = 0; i < signature.strokes.length; i++) {
     final stroke = signature.strokes[i];

--- a/doc/dev-log/2026-08-20-signature-colour-thickness.md
+++ b/doc/dev-log/2026-08-20-signature-colour-thickness.md
@@ -1,0 +1,58 @@
+# Signature ink: any colour, and a pen thickness
+
+The signature pad offered three fixed inks (black, navy, dark red) and no
+pen control at all - `PdfEditingController.signaturePlacement` hard-coded
+`strokeWidth: w / 60`. And although the placed ink already followed the
+toolbar colour, the signature tool carried no style scope, so
+`toolUsesColor` was false and the strip showed no colour row while it was
+armed: there was nowhere to change the colour either.
+
+Both are now first-class.
+
+## The record carries a pen
+
+`PdfInkSignature` gained `strokeWidth`, in **points quoted at
+`PdfInkSignature.referenceWidth` (160pt - `placeSignature`'s default
+size)**. Consumers scale it with `strokeWidthFor(width)` to whatever size
+they draw the signature at, so the proportions hold whether it lands on a
+page, in a stamp template, or in a signature-box raster:
+
+- `signaturePlacement` - `preferences.strokeWidth * w / referenceWidth`
+- `editing_stamps.dart` `_addSignature` - was `max(0.8, width / 75)`
+- `app/lib/signature_raster.dart` - was a flat `3.0` px
+
+`decode` defaults a missing (or non-finite, or non-positive) `strokeWidth`
+to `defaultStrokeWidth` = `referenceWidth / 60`, which is exactly the pen
+the old hard-coded formula produced - a signature saved by an older build
+still stamps as it always did.
+
+## The pad
+
+The pad is 360px wide and a signature is stamped 160pt wide, so the pad
+draws at `360 / referenceWidth` px per point: the pen thickness on the pad
+is the pen thickness on the page. The colour row keeps the three presets
+and gains a fourth swatch - tinted with the current ink, carrying a
+`colorize` glyph - that opens the full picker, so any colour at all is
+reachable. `showPdfSignatureDialog` grew `initialColor`,
+`initialStrokeWidth` and a `pickColor` hook (`PdfSignatureColorPicker`);
+the toolbar wires the hook to `pickEditingColor` so the pad's picker shows
+the same recents and document colours as every other colour in the editor.
+Callers that don't pass one fall back to a plain `showPdfColorPicker`.
+
+## The tool
+
+`PdfEditTool.signature` now has a style scope (`'signature'`, remembering
+`color` + `strokeWidth`, seeded `strokeWidth: defaultStrokeWidth`) and
+`stroke: true` in its `styleFields`. So the strip shows the colour row and
+the tune popup the stroke-width slider while the signature tool is armed,
+both persisted per tool - and a placed signature can still be restyled
+afterwards through the ordinary Ink path.
+
+**The ordering gotcha:** arming a tool calls `beginStyleScope`, which
+restores the scope over the live values. `_drawSignature` seeds
+`controller.color` / `preferences.strokeWidth` from what the pad came back
+with, so on the *first* draw (pad opens, then the tool arms) the restore
+lands on top of the seed and throws it away. `_toggleSignatureTool` now
+re-seeds after `_toggleTool`, via the shared `_seedSignatureStyle`. The
+redraw button in `_insertToolExtras` runs with the tool already armed, so
+its single seed records straight into the live scope.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -14,6 +14,7 @@ import 'editing_annotation_clipboard.dart';
 import 'editing_measure.dart';
 import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
+import 'editing_signature.dart';
 import 'editing_snapshot_clipboard.dart';
 import 'editing_tool_behavior.dart';
 import 'line_style.dart';
@@ -3031,16 +3032,18 @@ class PdfEditingController extends ChangeNotifier {
   /// The layout [placeSignature] would commit for a tap at ([x], [y]):
   /// the page-space strokes, pressures, ink color, and stroke width -
   /// what the signature tool's live preview paints under the pointer.
-  /// The ink follows the currently selected [color] (not the colour the
-  /// signature was drawn in), so recolouring the toolbar recolours the
-  /// signature. Null when no signature is saved.
+  /// The ink and the pen both follow the tool's current [color] and
+  /// [PdfEditingPreferences.strokeWidth] (not the colour and pen the
+  /// signature was drawn in - drawing one only seeds them), so retuning
+  /// the toolbar retunes the signature without a redraw. Null when no
+  /// signature is saved.
   ({
     List<List<(double, double)>> strokes,
     List<List<double>?> pressures,
     int color,
     double strokeWidth,
   })? signaturePlacement(int pageIndex, double x, double y,
-      {double width = 160}) {
+      {double width = PdfInkSignature.referenceWidth}) {
     final signature = preferences.signature;
     if (signature == null) return null;
     final box = _page(pageIndex).cropBox;
@@ -3065,15 +3068,22 @@ class PdfEditingController extends ChangeNotifier {
       pressures: signature.pressures,
       // follow the selected toolbar colour, like every other tool
       color: _colorValue,
-      strokeWidth: w / 60, // pen-like: ~2.7pt at the default width
+      // and the tool's pen width, quoted at the default size and scaled
+      // with the size actually placed, so a signature squeezed onto a
+      // small page keeps its proportions
+      strokeWidth: math.max(
+          0.1,
+          preferences.strokeWidth * w / PdfInkSignature.referenceWidth),
     );
   }
 
   /// Stamps [preferences.signature] as an Ink annotation centered on ([x], [y]) in
   /// page space, [width] points wide (clamped, with the center, so the
-  /// whole signature stays on the page). Keeps the signature's own ink
-  /// color and pen pressures. Returns false when none is saved.
-  bool placeSignature(int pageIndex, double x, double y, {double width = 160}) {
+  /// whole signature stays on the page). Keeps the signature's pen
+  /// pressures; the ink colour and pen width come from the tool - see
+  /// [signaturePlacement]. Returns false when none is saved.
+  bool placeSignature(int pageIndex, double x, double y,
+      {double width = PdfInkSignature.referenceWidth}) {
     final placement = signaturePlacement(pageIndex, x, y, width: width);
     if (placement == null) return false;
     return apply(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
@@ -7,13 +7,15 @@ import 'package:pdf_document/pdf_document.dart'
 
 import '../dialog.dart';
 import '../l10n/pdf_l10n.dart';
+import 'editing_color_picker.dart';
 import 'stroke_prediction.dart';
 
 /// A hand-drawn signature, stored device-side and stamped onto pages as
 /// an Ink annotation ([PdfEditingController.placeSignature]).
 ///
 /// Strokes are normalized to the drawing's bounding box (0–1, y down,
-/// like the pad it was drawn on); [aspect] preserves its proportions.
+/// like the pad it was drawn on); [aspect] preserves its proportions and
+/// [strokeWidth] the pen it was drawn with.
 /// Serializes to JSON so [PdfEditingPreferences] can persist it.
 class PdfInkSignature {
   PdfInkSignature({
@@ -21,15 +23,38 @@ class PdfInkSignature {
     required this.pressures,
     required this.color,
     required this.aspect,
+    this.strokeWidth = defaultStrokeWidth,
   }) : assert(strokes.length == pressures.length);
+
+  /// The point width a signature is laid out at by default - see
+  /// [PdfEditingController.placeSignature]'s `width`.
+  ///
+  /// [strokeWidth] is quoted at this size; every consumer scales the pen
+  /// with the size it actually draws the signature at ([strokeWidthFor]),
+  /// so a signature stamped small keeps its proportions.
+  static const referenceWidth = 160.0;
+
+  /// The pen a signature carries when it doesn't name one - what
+  /// [PdfEditingController.placeSignature] used to hard-code (`width / 60`)
+  /// before the pad had a thickness control, so signatures drawn by an
+  /// older build still stamp exactly as they did.
+  static const defaultStrokeWidth = referenceWidth / 60;
+
+  /// The pen width slider's range in the pad, in points - the same range
+  /// the toolbar's stroke-width slider offers.
+  static const minStrokeWidth = 0.5;
+  static const maxStrokeWidth = 12.0;
 
   /// Normalizes pad-space [strokes] (logical pixels, y down) to the
   /// drawing's bounding box. Returns null when nothing was drawn.
+  /// [strokeWidth] is the pen the pad drew with, in points at
+  /// [referenceWidth].
   static PdfInkSignature? fromPad(
     List<List<Offset>> strokes,
     List<List<double>?> pressures,
-    Color color,
-  ) {
+    Color color, {
+    double strokeWidth = defaultStrokeWidth,
+  }) {
     final points = strokes.expand((s) => s);
     if (points.isEmpty) return null;
     var minX = double.infinity, minY = double.infinity;
@@ -54,6 +79,7 @@ class PdfInkSignature {
       pressures: [for (final p in pressures) p?.toList()],
       color: color.toARGB32() & 0xFFFFFF,
       aspect: width / height,
+      strokeWidth: strokeWidth,
     );
   }
 
@@ -70,9 +96,20 @@ class PdfInkSignature {
   /// Bounding-box width / height.
   final double aspect;
 
+  /// Pen width in points, quoted at [referenceWidth]. Scale it with
+  /// [strokeWidthFor] to draw the signature at any other size.
+  final double strokeWidth;
+
+  /// The pen width to draw this signature with when it is laid out
+  /// [width] wide - points for a page, pixels for a raster; only the
+  /// ratio to [referenceWidth] matters.
+  double strokeWidthFor(double width) =>
+      strokeWidth * width / referenceWidth;
+
   String encode() => jsonEncode({
         'color': color,
         'aspect': aspect,
+        'strokeWidth': strokeWidth,
         'strokes': [
           for (final stroke in strokes)
             [
@@ -98,11 +135,17 @@ class PdfInkSignature {
           p == null ? null : [for (final v in p as List) (v as num).toDouble()]
       ];
       if (strokes.length != pressures.length) return null;
+      // written since the pad grew a thickness control; anything older (or
+      // nonsensical) falls back to the pen those signatures were stamped with
+      final width = (map['strokeWidth'] as num?)?.toDouble();
       return PdfInkSignature(
         strokes: strokes,
         pressures: pressures,
         color: map['color'] as int,
         aspect: (map['aspect'] as num).toDouble(),
+        strokeWidth: width != null && width.isFinite && width > 0
+            ? width
+            : defaultStrokeWidth,
       );
     } catch (_) {
       return null;
@@ -110,28 +153,74 @@ class PdfInkSignature {
   }
 }
 
+/// Opens a full colour picker over the signature pad, seeded with the
+/// pad's current ink; resolves to the chosen colour or null when
+/// dismissed. The stock chrome wires this to `pickEditingColor` so the
+/// pad's picker offers the same recents and document colours as every
+/// other colour in the editor.
+typedef PdfSignatureColorPicker = Future<Color?> Function(
+    BuildContext context, Color initial);
+
 /// Shows the signature pad dialog; resolves to the drawn signature, or
 /// null on cancel. [predictStrokes] forward-extrapolates the in-progress
 /// stroke to mask input latency, exactly like the ink tool (see
 /// [PdfViewer.predictStrokes]); display only, never committed.
-Future<PdfInkSignature?> showPdfSignatureDialog(BuildContext context,
-        {bool predictStrokes = true}) =>
+///
+/// [initialColor] and [initialStrokeWidth] seed the pad's ink and pen so
+/// it reopens on the style the last signature was drawn with, and
+/// [pickColor] supplies the "any colour" picker behind the pad's custom
+/// swatch (defaulting to a plain [showPdfColorPicker]).
+Future<PdfInkSignature?> showPdfSignatureDialog(
+  BuildContext context, {
+  bool predictStrokes = true,
+  Color? initialColor,
+  double initialStrokeWidth = PdfInkSignature.defaultStrokeWidth,
+  PdfSignatureColorPicker? pickColor,
+}) =>
     showPdfDialog<PdfInkSignature>(
       context: context,
-      builder: (context) => PdfSignatureDialog(predictStrokes: predictStrokes),
+      builder: (context) => PdfSignatureDialog(
+        predictStrokes: predictStrokes,
+        initialColor: initialColor,
+        initialStrokeWidth: initialStrokeWidth,
+        pickColor: pickColor,
+      ),
     );
 
 /// A dialog with a drawing pad for capturing a signature: draw with
 /// mouse, finger, or stylus (pressure is recorded and rendered as
-/// variable width, like the ink tool), pick an ink color, clear, done.
+/// variable width, like the ink tool), pick an ink color - one of the
+/// three pen presets or any colour at all, through the picker behind the
+/// custom swatch - set the pen thickness, clear, done.
+///
+/// The pad draws at the scale the signature is stamped at
+/// ([PdfInkSignature.referenceWidth]), so the pen thickness on the pad is
+/// the pen thickness on the page.
 class PdfSignatureDialog extends StatefulWidget {
-  const PdfSignatureDialog({super.key, this.predictStrokes = true});
+  const PdfSignatureDialog({
+    super.key,
+    this.predictStrokes = true,
+    this.initialColor,
+    this.initialStrokeWidth = PdfInkSignature.defaultStrokeWidth,
+    this.pickColor,
+  });
 
   /// Forward-extrapolates a short speculative lead beyond the pen tip on
   /// the in-progress stroke, the same predictive ink the ink tool uses
   /// ([PdfViewer.predictStrokes]). Display only - the lead is redrawn each
   /// frame and never enters the captured signature.
   final bool predictStrokes;
+
+  /// The ink the pad opens on; null starts on the first pen preset.
+  final Color? initialColor;
+
+  /// The pen width the pad opens on, in points at
+  /// [PdfInkSignature.referenceWidth] (clamped to the slider's range).
+  final double initialStrokeWidth;
+
+  /// Opens the "any colour" picker for the pad's custom swatch. Null
+  /// falls back to [showPdfColorPicker] with no recents wired.
+  final PdfSignatureColorPicker? pickColor;
 
   @override
   State<PdfSignatureDialog> createState() => _PdfSignatureDialogState();
@@ -144,14 +233,38 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
     Color(0xFFB71C1C)
   ];
 
+  static const _padWidth = 360.0;
+  static const _padHeight = 180.0;
+
+  /// Pad pixels per point: the pad is as wide as a signature stamped at
+  /// [PdfInkSignature.referenceWidth], so a pen drawn here is the pen that
+  /// lands on the page.
+  static const _padScale = _padWidth / PdfInkSignature.referenceWidth;
+
   final List<List<Offset>> _strokes = [];
   final List<List<double>?> _pressures = [];
   List<Offset>? _active;
   List<double>? _activePressures;
   double? _pointerPressure;
-  Color _ink = _inks.first;
+  late Color _ink = widget.initialColor ?? _inks.first;
+  late double _strokeWidth = widget.initialStrokeWidth
+      .clamp(PdfInkSignature.minStrokeWidth, PdfInkSignature.maxStrokeWidth);
 
   bool get _isEmpty => _strokes.isEmpty && _active == null;
+
+  static String _hexOf(Color color) =>
+      (color.toARGB32() & 0xFFFFFF).toRadixString(16).padLeft(6, '0');
+
+  /// Opens the full picker so the signature can be drawn in any colour at
+  /// all, not just the three pen presets.
+  Future<void> _pickInk() async {
+    final pick = widget.pickColor ??
+        (BuildContext context, Color initial) =>
+            showPdfColorPicker(context, initial: initial);
+    final picked = await pick(context, _ink);
+    if (picked == null || !mounted) return;
+    setState(() => _ink = Color(0xFF000000 | (picked.toARGB32() & 0xFFFFFF)));
+  }
 
   /// 0–1 within the device's range; null when the device has none
   /// (mouse, finger) - same convention as the ink overlay.
@@ -220,8 +333,8 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            width: 360,
-            height: 180,
+            width: _padWidth,
+            height: _padHeight,
             decoration: BoxDecoration(
               // the pad is always paper-white, like the page the
               // signature will land on - only its border follows the theme
@@ -241,7 +354,7 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
                   onPanEnd: _panEnd,
                   child: CustomPaint(
                     key: const ValueKey('pdf-signature-pad'),
-                    size: const Size(360, 180),
+                    size: const Size(_padWidth, _padHeight),
                     painter: _SignaturePadPainter(
                       strokes: [
                         ..._strokes,
@@ -252,6 +365,7 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
                         if (activeDisplay != null) activeDisplay.pressures
                       ],
                       color: _ink,
+                      strokeWidth: _strokeWidth * _padScale,
                     ),
                   ),
                 ),
@@ -263,25 +377,22 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
             for (final ink in _inks)
               Padding(
                 padding: const EdgeInsetsDirectional.only(end: 8),
-                child: InkWell(
+                child: _InkSwatch(
+                  key: ValueKey('pdf-signature-ink-${_hexOf(ink)}'),
+                  color: ink,
+                  selected: _ink == ink,
                   onTap: () => setState(() => _ink = ink),
-                  customBorder: const CircleBorder(),
-                  child: Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: ink,
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: _ink == ink
-                            ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context).colorScheme.outline,
-                        width: _ink == ink ? 3 : 1,
-                      ),
-                    ),
-                  ),
                 ),
               ),
+            // any colour at all, through the full picker
+            _InkSwatch(
+              key: const ValueKey('pdf-signature-custom-ink'),
+              color: _ink,
+              selected: !_inks.contains(_ink),
+              tooltip: pdfL10n(context).colorPickColor,
+              icon: Icons.colorize,
+              onTap: _pickInk,
+            ),
             const Spacer(),
             TextButton(
               onPressed: _isEmpty
@@ -295,6 +406,26 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
               child: Text(pdfL10n(context).clear),
             ),
           ]),
+          Row(children: [
+            Text(pdfL10n(context).tbStrokeWidthLabel),
+            Expanded(
+              child: Slider(
+                key: const ValueKey('pdf-signature-stroke-width'),
+                value: _strokeWidth,
+                min: PdfInkSignature.minStrokeWidth,
+                max: PdfInkSignature.maxStrokeWidth,
+                onChanged: (value) => setState(() => _strokeWidth = value),
+              ),
+            ),
+            SizedBox(
+              width: 44,
+              child: Text(
+                '${_strokeWidth.toStringAsFixed(1)} pt',
+                textAlign: TextAlign.end,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ]),
         ],
       ),
       actions: [
@@ -305,12 +436,66 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
         FilledButton(
           onPressed: _isEmpty
               ? null
-              : () => Navigator.of(context)
-                  .pop(PdfInkSignature.fromPad(_strokes, _pressures, _ink)),
+              : () => Navigator.of(context).pop(PdfInkSignature.fromPad(
+                  _strokes, _pressures, _ink,
+                  strokeWidth: _strokeWidth)),
           child: Text(pdfL10n(context).done),
         ),
       ],
     );
+  }
+}
+
+/// One round ink well in the pad's colour row - a preset pen, or (with an
+/// [icon]) the custom swatch that opens the full picker.
+class _InkSwatch extends StatelessWidget {
+  const _InkSwatch({
+    super.key,
+    required this.color,
+    required this.selected,
+    required this.onTap,
+    this.icon,
+    this.tooltip,
+  });
+
+  final Color color;
+  final bool selected;
+  final VoidCallback onTap;
+  final IconData? icon;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final swatch = InkWell(
+      onTap: onTap,
+      customBorder: const CircleBorder(),
+      child: Container(
+        width: 24,
+        height: 24,
+        decoration: BoxDecoration(
+          color: color,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: selected ? scheme.primary : scheme.outline,
+            width: selected ? 3 : 1,
+          ),
+        ),
+        child: icon == null
+            ? null
+            : Icon(
+                icon,
+                size: 13,
+                // the icon rides on the ink itself, so pick the side of
+                // the swatch it can actually be read against
+                color: ThemeData.estimateBrightnessForColor(color) ==
+                        Brightness.dark
+                    ? Colors.white
+                    : Colors.black87,
+              ),
+      ),
+    );
+    return tooltip == null ? swatch : Tooltip(message: tooltip!, child: swatch);
   }
 }
 
@@ -319,13 +504,16 @@ class _SignaturePadPainter extends CustomPainter {
     required this.strokes,
     required this.pressures,
     required this.color,
+    required this.strokeWidth,
   });
 
   final List<List<Offset>> strokes;
   final List<List<double>?> pressures;
   final Color color;
 
-  static const _baseWidth = 3.0;
+  /// The pen width in pad pixels - the chosen point width scaled to the
+  /// pad, so what is drawn here is what lands on the page.
+  final double strokeWidth;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -338,7 +526,7 @@ class _SignaturePadPainter extends CustomPainter {
     final paint = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = _baseWidth
+      ..strokeWidth = strokeWidth
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round;
     for (var i = 0; i < strokes.length; i++) {
@@ -364,13 +552,13 @@ class _SignaturePadPainter extends CustomPainter {
         if (stroke.length == 1) {
           canvas.drawCircle(
               stroke.single,
-              pdfInkStrokeWidth(_baseWidth, pressure.first) / 2,
+              pdfInkStrokeWidth(strokeWidth, pressure.first) / 2,
               Paint()..color = color);
           continue;
         }
         for (var j = 0; j + 1 < stroke.length; j++) {
           final avg = (pressure[j] + pressure[j + 1]) / 2;
-          segment.strokeWidth = pdfInkStrokeWidth(_baseWidth, avg);
+          segment.strokeWidth = pdfInkStrokeWidth(strokeWidth, avg);
           final ((c1x, c1y), (c2x, c2y)) = controls[j];
           canvas.drawPath(
               Path()
@@ -385,5 +573,7 @@ class _SignaturePadPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_SignaturePadPainter old) =>
-      old.strokes != strokes || old.color != color;
+      old.strokes != strokes ||
+      old.color != color ||
+      old.strokeWidth != strokeWidth;
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -821,7 +821,8 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
       strokes: signature.strokes,
       pressures: signature.pressures,
       color: signature.color,
-      strokeWidth: math.max(0.8, width / 75),
+      // the pen the pad drew with, scaled to the size it lands in the stamp
+      strokeWidth: math.max(0.8, signature.strokeWidthFor(width)),
     );
     setState(() {
       _color = signature.color;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
@@ -2,6 +2,7 @@ import 'package:pdf_document/pdf_document.dart'
     show PdfMeasurementKind, PdfRect;
 
 import 'editing_controller.dart';
+import 'editing_signature.dart';
 
 /// Which controls the style popup should show for a tool (or an annotation
 /// selection) - each context only carries the settings it can actually use,
@@ -143,8 +144,8 @@ abstract class PdfEditToolBehavior {
 
   /// The persisted-style scope key - a stable slot name for the tool's
   /// remembered style, or null for the tools that create nothing styled
-  /// (select, content, form, redact, signature, image, snapshot,
-  /// signatureBox, calibrate). See [PdfEditingController.preferences].
+  /// (select, content, form, redact, image, snapshot, signatureBox,
+  /// calibrate). See [PdfEditingController.preferences].
   String? get styleScopeKey => null;
 
   /// The style fields this tool remembers - mirrors the controls its toolbar
@@ -587,9 +588,17 @@ final Map<PdfEditTool, PdfEditToolBehavior> _behaviors = {
         styleScopeFields: {'color', 'opacity'},
         styleFields:
             PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    // A stamped signature is ink like any other: it carries the tool's
+    // colour and pen width, so the strip offers the colour row and the tune
+    // popup the stroke-width slider, and both are remembered per tool.
     const _SimpleTool(PdfEditTool.signature,
-        styleFields:
-            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+        styleScopeKey: 'signature',
+        styleScopeFields: {'color', 'strokeWidth'},
+        styleScopeDefaults: {
+          'strokeWidth': PdfInkSignature.defaultStrokeWidth,
+        },
+        styleFields: PdfToolStyleFields(
+            stroke: true, opacity: true, font: true, boxColors: true)),
     const _SimpleTool(PdfEditTool.image,
         styleFields:
             PdfToolStyleFields(opacity: true, font: true, boxColors: true)),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -621,20 +621,34 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       controller.tool = PdfEditTool.select;
       return;
     }
-    if (controller.preferences.signature == null && !await _drawSignature(context)) {
-      return;
-    }
+    final drawn = controller.preferences.signature == null;
+    if (drawn && !await _drawSignature(context)) return;
     _toggleTool(PdfEditTool.signature);
+    // Arming the tool restores the signature style scope over whatever
+    // _drawSignature just seeded, so seed it again now the scope is live.
+    if (drawn) _seedSignatureStyle(controller.preferences.signature!);
   }
 
   Future<bool> _drawSignature(BuildContext context) async {
-    final signature = await showPdfSignatureDialog(context);
+    final signature = await showPdfSignatureDialog(
+      context,
+      initialColor: controller.color,
+      initialStrokeWidth: controller.preferences.strokeWidth,
+      pickColor: (context, initial) =>
+          pickEditingColor(context, controller, initial: initial),
+    );
     if (signature == null) return false;
     controller.preferences.signature = signature;
-    // the signature follows the selected colour, so seed it with the ink
-    // the user just drew in - they can recolour it from the toolbar after
-    controller.color = Color(0xFF000000 | signature.color);
+    _seedSignatureStyle(signature);
     return true;
+  }
+
+  /// Points the tool's colour and pen width at what [signature] was drawn
+  /// with - the placed ink follows the toolbar, not the record, so this is
+  /// what makes the stamp match the pad. Both stay editable afterwards.
+  void _seedSignatureStyle(PdfInkSignature signature) {
+    controller.color = Color(0xFF000000 | signature.color);
+    controller.preferences.strokeWidth = signature.strokeWidth;
   }
 
   void _armStampToolForMenu() {

--- a/packages/dart_pdf_editor/test/editing_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_test.dart
@@ -31,6 +31,34 @@ void main() {
       expect(decoded.aspect, signature.aspect);
     });
 
+    test('carries the pen width, quoted at the reference size', () {
+      final signature = PdfInkSignature.fromPad(
+        [
+          [const Offset(0, 0), const Offset(100, 50)]
+        ],
+        [null],
+        const Color(0xFF000000),
+        strokeWidth: 4,
+      )!;
+      expect(signature.strokeWidth, 4);
+      // the pen scales with whatever size the signature is drawn at
+      expect(signature.strokeWidthFor(PdfInkSignature.referenceWidth), 4);
+      expect(signature.strokeWidthFor(PdfInkSignature.referenceWidth / 2), 2);
+      expect(PdfInkSignature.decode(signature.encode())!.strokeWidth, 4);
+    });
+
+    test('a signature saved before the pad had a pen keeps the old one', () {
+      const legacy = '{"color":0,"aspect":2.0,'
+          '"strokes":[[0.0,0.0,1.0,1.0]],"pressures":[null]}';
+      expect(PdfInkSignature.decode(legacy)!.strokeWidth,
+          PdfInkSignature.defaultStrokeWidth);
+      // and a nonsensical width is no better than none
+      const zero = '{"color":0,"aspect":2.0,"strokeWidth":0,'
+          '"strokes":[[0.0,0.0,1.0,1.0]],"pressures":[null]}';
+      expect(PdfInkSignature.decode(zero)!.strokeWidth,
+          PdfInkSignature.defaultStrokeWidth);
+    });
+
     test('an empty pad yields no signature; junk decodes to null', () {
       expect(PdfInkSignature.fromPad([], [], const Color(0xFF000000)), isNull);
       expect(PdfInkSignature.decode('not json'), isNull);
@@ -114,6 +142,23 @@ void main() {
         ..color = const Color(0xFF00AA00);
       expect(editing.placeSignature(0, 300, 400, width: 100), isTrue);
       expect(editing.document.page(0).annotations.single.color, 0x00AA00);
+    });
+
+    test('the placed pen follows the tool width, scaled with the size', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.signature = signature()
+        ..preferences.strokeWidth = 4;
+      expect(editing.placeSignature(0, 300, 400), isTrue);
+      expect(editing.document.page(0).annotations.single.borderWidth,
+          closeTo(4, 1e-9));
+
+      // half the default size, so half the pen - the proportions hold
+      expect(
+          editing.placeSignature(0, 300, 200,
+              width: PdfInkSignature.referenceWidth / 2),
+          isTrue);
+      expect(editing.document.page(0).annotations.last.borderWidth,
+          closeTo(2, 1e-9));
     });
 
     test('without a saved signature nothing happens', () {
@@ -210,6 +255,131 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(PdfSignatureDialog), findsNothing);
       expect(editing.tool, PdfEditTool.signature);
+    });
+
+    testWidgets('the pad takes any ink colour and a pen thickness',
+        (tester) async {
+      PdfInkSignature? result;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) => Center(
+            child: FilledButton(
+              onPressed: () async {
+                result = await showPdfSignatureDialog(
+                  context,
+                  initialStrokeWidth: 2,
+                  // stands in for the editor's full colour picker
+                  pickColor: (context, initial) async =>
+                      const Color(0xFF00AA88),
+                );
+              },
+              child: const Text('sign'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('sign'));
+      await tester.pumpAndSettle();
+      expect(find.text('2.0 pt'), findsOneWidget);
+
+      await tester.timedDrag(find.byKey(const ValueKey('pdf-signature-pad')),
+          const Offset(120, 30), const Duration(milliseconds: 200));
+      await tester.pump();
+
+      // any colour at all, not just the three pen presets
+      await tester.tap(find.byKey(const ValueKey('pdf-signature-custom-ink')));
+      await tester.pumpAndSettle();
+
+      // and a pen as thick as the slider goes
+      await tester.drag(
+          find.byKey(const ValueKey('pdf-signature-stroke-width')),
+          const Offset(400, 0));
+      await tester.pump();
+      expect(
+          find.text(
+              '${PdfInkSignature.maxStrokeWidth.toStringAsFixed(1)} pt'),
+          findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Done'));
+      await tester.pumpAndSettle();
+      expect(result!.color, 0x00AA88);
+      expect(result!.strokeWidth, PdfInkSignature.maxStrokeWidth);
+    });
+
+    testWidgets('drawing seeds the tool colour and pen width',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      editing.preferences.strokeWidth = 5;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final dockScrollable = find
+          .descendant(
+              of: find.byType(PdfEditingToolbar),
+              matching: find.byType(Scrollable))
+          .last;
+      final stripScrollable = find
+          .descendant(
+              of: find.byType(PdfEditingToolbar),
+              matching: find.byType(Scrollable))
+          .first;
+      final insertChip = find.byKey(const ValueKey('pdf-group-insert'));
+      await tester.scrollUntilVisible(insertChip, 80,
+          scrollable: dockScrollable);
+      await tester.tap(insertChip);
+      await tester.pump();
+      const signatureTip = 'Signature - tap a page to place it (H)';
+      await tester.scrollUntilVisible(find.byTooltip(signatureTip), 100,
+          scrollable: stripScrollable);
+      await tester.tap(find.byTooltip(signatureTip));
+      await tester.pumpAndSettle();
+
+      // the pad opens on the tool's current pen, not a fixed one
+      expect(find.text('5.0 pt'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('pdf-signature-ink-b71c1c')));
+      await tester.pump();
+      await tester.drag(
+          find.byKey(const ValueKey('pdf-signature-stroke-width')),
+          const Offset(-400, 0));
+      await tester.pump();
+
+      await tester.timedDrag(find.byKey(const ValueKey('pdf-signature-pad')),
+          const Offset(120, 30), const Duration(milliseconds: 200));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Done'));
+      await tester.pumpAndSettle();
+
+      // arming the tool must not restore the signature scope over the ink
+      // and pen the pad just came back with
+      expect(editing.tool, PdfEditTool.signature);
+      expect(editing.color.toARGB32() & 0xFFFFFF, 0xB71C1C);
+      expect(editing.preferences.strokeWidth, PdfInkSignature.minStrokeWidth);
+
+      // and the stamped ink carries them
+      await tester.tapAt(tester.getCenter(find.byType(PdfViewer)));
+      await tester.pumpAndSettle(const Duration(milliseconds: 350));
+      final ink = editing.document.page(0).annotations.single;
+      expect(ink.color, 0xB71C1C);
+      expect(ink.borderWidth, closeTo(PdfInkSignature.minStrokeWidth, 1e-9));
     });
 
     testWidgets('Clear wipes the pad and disables Done', (tester) async {

--- a/packages/dart_pdf_editor/test/editing_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_test.dart
@@ -306,6 +306,48 @@ void main() {
       expect(result!.strokeWidth, PdfInkSignature.maxStrokeWidth);
     });
 
+    testWidgets('the custom swatch falls back to the stock colour picker',
+        (tester) async {
+      PdfInkSignature? result;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) => Center(
+            child: FilledButton(
+              // no pickColor injected: the pad opens the stock picker
+              onPressed: () async {
+                result = await showPdfSignatureDialog(context);
+              },
+              child: const Text('sign'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('sign'));
+      await tester.pumpAndSettle();
+      await tester.timedDrag(find.byKey(const ValueKey('pdf-signature-pad')),
+          const Offset(120, 30), const Duration(milliseconds: 200));
+      await tester.pump();
+
+      // dismissing the picker leaves the ink as it was
+      await tester.tap(find.byKey(const ValueKey('pdf-signature-custom-ink')));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsOneWidget);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel').last);
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsNothing);
+
+      // committing one takes it
+      await tester.tap(find.byKey(const ValueKey('pdf-signature-custom-ink')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'OK'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Done'));
+      await tester.pumpAndSettle();
+      // the pad's default ink, round-tripped through the picker unchanged
+      expect(result!.color, 0x000000);
+    });
+
     testWidgets('drawing seeds the tool colour and pen width',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
@@ -355,6 +397,15 @@ void main() {
 
       // the pad opens on the tool's current pen, not a fixed one
       expect(find.text('5.0 pt'), findsOneWidget);
+
+      // the custom swatch routes through the editor's own picker (recents and
+      // document colours wired), not a bare one
+      await tester.tap(find.byKey(const ValueKey('pdf-signature-custom-ink')));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsOneWidget);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel').last);
+      await tester.pumpAndSettle();
+
       await tester.tap(find.byKey(const ValueKey('pdf-signature-ink-b71c1c')));
       await tester.pump();
       await tester.drag(

--- a/packages/dart_pdf_editor/test/editing_tool_behavior_test.dart
+++ b/packages/dart_pdf_editor/test/editing_tool_behavior_test.dart
@@ -93,12 +93,14 @@ void main() {
       expect(
           PdfEditToolBehavior.of(PdfEditTool.measureArc).styleScopeKey,
           'measureArc');
+      // a stamped signature is ink: it carries the tool's colour and pen
+      expect(PdfEditToolBehavior.of(PdfEditTool.signature).styleScopeKey,
+          'signature');
       for (final tool in [
         PdfEditTool.select,
         PdfEditTool.content,
         PdfEditTool.form,
         PdfEditTool.redact,
-        PdfEditTool.signature,
         PdfEditTool.image,
         PdfEditTool.snapshot,
         PdfEditTool.calibrate,
@@ -111,6 +113,12 @@ void main() {
     test('scope fields drive toolUsesColor', () {
       expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).usesColor, isTrue);
       expect(PdfEditToolBehavior.of(PdfEditTool.eraser).usesColor, isFalse);
+      // the signature strip offers a colour row and a stroke-width slider
+      expect(PdfEditToolBehavior.of(PdfEditTool.signature).usesColor, isTrue);
+      expect(PdfEditToolBehavior.of(PdfEditTool.signature).styleScopeFields,
+          contains('strokeWidth'));
+      expect(PdfEditToolBehavior.of(PdfEditTool.signature).styleFields.stroke,
+          isTrue);
       expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).styleScopeFields,
           contains('cornerRadius'));
       expect(PdfEditToolBehavior.of(PdfEditTool.ellipse).styleScopeFields,


### PR DESCRIPTION
## Summary

The hand-drawn signature could only be inked in one of three preset colours, and its pen width was not adjustable at all — `PdfEditingController.signaturePlacement` hard-coded `strokeWidth: w / 60`. The placed ink already followed the toolbar colour, but `PdfEditTool.signature` carried no style scope, so `toolUsesColor` was false and the strip showed **no colour row** while the tool was armed: there was nowhere to change the colour either.

Both are now first-class.

**`PdfInkSignature` carries a pen.** New `strokeWidth`, in points quoted at `PdfInkSignature.referenceWidth` (160pt — `placeSignature`'s default size). Consumers scale it with `strokeWidthFor(width)`, so the proportions hold whether the signature lands on a page, in a stamp template, or in a signature-box raster. `decode` falls back to `defaultStrokeWidth` = `referenceWidth / 60` for a missing (or non-finite, or non-positive) value — exactly the pen the old hard-coded formula produced, so a signature saved by an older build still stamps as it always did.

**The pad** keeps its three presets and gains a fourth swatch — tinted with the current ink, carrying a `colorize` glyph — that opens the full colour picker, so any colour at all is reachable. It also gains a thickness slider, and draws at `360px / referenceWidth` per point, so the pen thickness on the pad is the pen thickness on the page. `showPdfSignatureDialog` grew `initialColor`, `initialStrokeWidth` and a `pickColor` hook (`PdfSignatureColorPicker`); the toolbar wires the hook to `pickEditingColor` so the pad's picker offers the same recents and document colours as every other colour in the editor. Callers that pass nothing fall back to a plain `showPdfColorPicker`.

**The tool** now has a style scope (`'signature'`, remembering `color` + `strokeWidth`) and `stroke: true` in its `styleFields`, so the strip shows the colour row and the tune popup the stroke-width slider while the signature tool is armed — both persisted per tool, and retunable without a redraw. A placed signature can still be restyled afterwards through the ordinary Ink path.

Two other consumers now scale the same pen instead of guessing one: `editing_stamps.dart`'s `_addSignature` (was `max(0.8, width / 75)`) and `app/lib/signature_raster.dart` (was a flat `3.0` px).

### API impact

- `PdfInkSignature` gains `strokeWidth` (defaulted), `strokeWidthFor`, and the `referenceWidth` / `defaultStrokeWidth` / `minStrokeWidth` / `maxStrokeWidth` constants; `fromPad` gains an optional `strokeWidth:`. All additive — existing call sites compile unchanged.
- `showPdfSignatureDialog` / `PdfSignatureDialog` gain `initialColor`, `initialStrokeWidth`, `pickColor`; new `PdfSignatureColorPicker` typedef.
- `signaturePlacement` / `placeSignature` default `width` is now `PdfInkSignature.referenceWidth`, the same 160 as before.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app (`app/lib/signature_raster.dart`)
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean over `dart_pdf_editor` + `app`)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — **2376 passed, 0 failed**
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to the editor's signature flow, so the pure-Dart package suites and the render corpora aren't exercised by it.

The first full-suite run caught one real regression from this change — `editing_tool_behavior_test.dart` pins which tools name a persisted style slot, and listed the signature tool among the ones that create nothing styled. That is the second commit here; the suite is green on the current head.

### New tests

- `PdfInkSignature` carries the pen width and scales it with the size drawn at, round-tripping through JSON.
- A signature saved before the pad had a pen — and one with a nonsensical `strokeWidth` — falls back to the old hard-coded pen.
- `placeSignature` takes the pen from the tool, scaled with the placed size.
- The pad takes any ink colour (through an injected picker) and a pen thickness.
- Drawing seeds the tool colour and pen width, and they survive the tool arming.
- The tool-behaviour table pins the signature scope key, its `strokeWidth` field, `usesColor`, and `styleFields.stroke`.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

**The ordering gotcha.** Arming a tool calls `beginStyleScope`, which restores the scope over the live values. `_drawSignature` seeds `controller.color` / `preferences.strokeWidth` from what the pad came back with, so on the *first* draw (pad opens, then the tool arms) the restore landed on top of the seed and threw it away. `_toggleSignatureTool` now re-seeds after `_toggleTool`, via the shared `_seedSignatureStyle`. The redraw button in `_insertToolExtras` runs with the tool already armed, so its single seed records straight into the live scope. `editing_signature_test.dart`'s "drawing seeds the tool colour and pen width" pins this.

**Deliberate appearance changes.** The stamp-template and signature-box-raster pens now come from the signature instead of a formula of their own, so a signature reused in either will render at a slightly different weight than before — that is the point: all three now agree with what the pad showed. Placement itself is unchanged for existing users on the default pen.

**Design note.** Colour and pen both live on the *tool*, not the record; drawing a signature only seeds them. That keeps one rule for both (the pre-existing rule for colour), lets either be retuned from the toolbar without a redraw, and keeps the placed ink restyleable as ordinary Ink. The record's own `strokeWidth` is what the non-toolbar consumers (raster, stamp template) read.

Background and the full rationale: `doc/dev-log/2026-08-20-signature-colour-thickness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm14nYFqsj2rzCodRGWpCE