### PR TITLE
feat(editor): let annotations be placed and edited past the page edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,16 @@ and the renderer's page clip trims them. The only tethered placement is the
 point-less paste cascade (`PdfEditingController._tetherShift` /
 `pageTether`, which keeps 24pt on the paper so repeats can't march copies
 out of sight); auto-sizing still caps a stamp/image/signature at 90% of the
-page, which is a size rule, not a boundary one. See
+page, which is a size rule, not a boundary one. The off-page half is
+grabbable too: `PdfEditingReach` (`editing_reach.dart`, wrapped immediately
+outside the item's `FractionallySizedBox` - the outermost box that would
+refuse a margin position) routes those presses into the page at its nearest
+inside point, which is sound because hit testing only picks the target while
+`PointerEvent.localPosition` still comes from the true position. It claims
+only presses on the selection (`selectionGrabAt` + `_selectionGrabMargin`),
+never the whole margin - the canvas stays the touch-scroll gesture's, and
+`_touchPanEnabledAt` draws the same line. Starting a *new* annotation still
+has to happen on the page. See
 doc/dev-log/2026-08-20-annotations-past-the-page-edge.md. AcroForm support is in: `PdfAcroForm`/`PdfFormField`
 model (`form.dart`) plus filling with regenerated appearances
 (`form_editor.dart` - text/checkbox/radio/choice, auto-size, quadding).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,15 @@ so `{{date}}` stays live - as private metadata (`DartPdfStampTemplate` →
 `maxStampTemplateMetadataBytes`), which is how the editor's right-click
 "Save to stamps" (`customStampOf` / `saveSelectedAsCustomStamp`) puts a
 placed stamp back into the collection; see
-doc/dev-log/2026-08-06-save-stamp-from-page.md. AcroForm support is in: `PdfAcroForm`/`PdfFormField`
+doc/dev-log/2026-08-06-save-stamp-from-page.md. Annotation geometry is
+**not confined to the crop box**: a point the user picked is authoritative,
+so placements, drags, resizes and paste-at-a-point commit off the page edge
+and the renderer's page clip trims them. The only tethered placement is the
+point-less paste cascade (`PdfEditingController._tetherShift` /
+`pageTether`, which keeps 24pt on the paper so repeats can't march copies
+out of sight); auto-sizing still caps a stamp/image/signature at 90% of the
+page, which is a size rule, not a boundary one. See
+doc/dev-log/2026-08-20-annotations-past-the-page-edge.md. AcroForm support is in: `PdfAcroForm`/`PdfFormField`
 model (`form.dart`) plus filling with regenerated appearances
 (`form_editor.dart` - text/checkbox/radio/choice, auto-size, quadding).
 Page manipulation is in (`page_editor.dart`): reorder/move/remove flatten

--- a/doc/dev-log/2026-08-20-annotations-past-the-page-edge.md
+++ b/doc/dev-log/2026-08-20-annotations-past-the-page-edge.md
@@ -1,0 +1,88 @@
+# Annotations may run past the page edge
+
+Annotation authoring used to be confined to the page's crop box: a
+placement near an edge silently jumped back inside so the whole annotation
+"fits". Drawing a stamp against the corner of a sheet, signing over the
+bottom margin, or pasting a callout half off the paper were all impossible
+- the editor moved your annotation for you.
+
+Nothing in PDF requires that. `/Rect` is page-space geometry like any
+other; a viewer clips annotation appearances against the page, so a
+markup that hangs off the edge simply shows the part that lands on paper.
+Our own renderer already did exactly that (`drawAnnotations` →
+`_drawAppearance`, painted inside the page clip) - the confinement was
+purely authoring-side.
+
+## The rule
+
+**A point the user picked is authoritative.** Tap-to-place, drop, and
+paste-at-a-point commit where the pointer was, edge or not.
+
+The one exception is a placement with *no* point behind it: the paste
+cascade (⌘V with no cursor target, which shifts 12pt down-right per
+repeat) has nothing the user aimed at, so an unbounded repeat would walk
+the copies clean off the paper and out of sight. Those stay **tethered**:
+`PdfEditingController._tetherShift` keeps `pageTether` (24pt) of the rect
+over the crop box on each axis - or the whole rect when it is shorter
+than the tether, or the whole page when the page is shorter still. An
+interval already inside the tether does not move, so a paste that hangs
+off the edge keeps hanging off it. This replaced `_clampShift`, which
+pushed the whole rect back onto the page.
+
+## What changed
+
+`editing_controller.dart`:
+
+- `_pageRectForVisualSize` - the shared "rect of this visual size centered
+  on (x, y)" helper behind free text placement, image drop, stamp and
+  template placement, and image element replacement. Dropped the centre
+  clamp; the centre is now the point it was handed.
+- `placeCheckMark` - split out `checkMarkPlacement`, which the count
+  tool's hover preview now calls too (see below), and dropped the
+  position clamp.
+- `signaturePlacement` - dropped the position clamp.
+- `pasteAnnotations` / `pasteSnapshot` - shift only when `at == null`,
+  through `_tetherShift`.
+- `_autosizeTextRect` - a free-text box grows from the anchor the user
+  left it at, off the edge, instead of sliding inward to fit.
+
+`editing_overlay.dart`:
+
+- `_countPreviewAt` had its own copy of the check-mark placement math.
+  Two copies of a placement rule is one drift away from the preview and
+  the commit disagreeing (the mark visibly jumping on release), so it now
+  calls `controller.checkMarkPlacement`.
+
+Move and resize needed nothing: `moveSelected` / `resizeSelected` and the
+overlay's drag math were already unclamped, as were shape/ink/markup
+drags. Those paths just had no test pinning the behaviour - `editing_test`
+now has one that drags a rectangle off the left edge and reopens the saved
+bytes to prove `/Rect` survives the round trip.
+
+## Size caps are not boundary rules
+
+Auto-sizing still caps a stamp, image, or signature at 90% of the page.
+That is about *size* - an auto-sized annotation bigger than the paper it
+lives on is a bug, not a feature - and is unrelated to where the thing
+sits. Both survive together: `placeStamp(height: 5000)` at the corner
+gives a page-capped box centered off the corner.
+
+Surfacing that cap found a real bug: `textStampPlacement` computed the
+width as `measured.clamp(h, pageWidth * 0.9)`, and a tall stamp on a
+landscape-ish page makes the floor (`h`) exceed the ceiling, which
+`double.clamp` throws on. The floor is now `min(h, maxW)`.
+
+## The one placement that still yields to the page
+
+`EditingPageOverlay._defaultPlacementRect` still nudges a *default-sized*
+tap-placed text box back on. That nudge is about the **editor**, not the
+annotation: the rect it returns opens the inline text field, which the
+page's `Stack` clips like everything else in this overlay, so a
+200pt-wide box hung off the corner would have the user typing into pixels
+they cannot see. Only the size there is the editor's guess - a box the
+user drags out themselves keeps the bounds they drew.
+
+Same clip is why an annotation dragged mostly off the page keeps only its
+on-page resize handles. The on-page part is still grabbable, and the
+annotation sidebar selects by slot regardless, so nothing becomes
+unreachable.

--- a/doc/dev-log/2026-08-20-annotations-past-the-page-edge.md
+++ b/doc/dev-log/2026-08-20-annotations-past-the-page-edge.md
@@ -86,3 +86,74 @@ Same clip is why an annotation dragged mostly off the page keeps only its
 on-page resize handles. The on-page part is still grabbable, and the
 annotation sidebar selects by slot regardless, so nothing becomes
 unreachable.
+
+## Follow-up: the off-page half was paint-only
+
+Shipping the above was half the job. The geometry was free, and the editor
+*painted* the part of an annotation that hung off the paper (the overlay's
+painters are `CustomPaint` children that fit their box exactly, so the
+page `Stack` never sets `_hasVisualOverflow` and never clips them) - but
+pointer routing did not follow. `RenderBox.hitTest` refuses any position
+outside `size`, so a press on the visible off-page half of a selected
+markup reached nothing at all. It could only be moved or resized by
+whatever was still on the paper.
+
+### The reach
+
+`PdfEditingReach` (`editing_reach.dart`) is a `RenderProxyBox` that accepts
+those positions and forwards them into the page subtree at the nearest
+point *inside* it.
+
+Clamping is sound because **hit testing only decides routing**. Every
+pointer event carries its true global position, and
+`PointerEvent.localPosition` is derived from that through the target's own
+transform - never from the position the hit test ran at. So the overlay
+reads the real off-page point (negative, or past the page's width) and all
+of its existing drag math works untouched. The move test asserts the
+annotation travels the *whole* drag delta, which is exactly what would
+break if the clamp leaked into the coordinates.
+
+### Where it has to sit
+
+Not inside the page. The first attempt wrapped `_PdfViewerPage`'s own
+`Stack` and did nothing, because the gate is higher: the item is
+`Padding → Center → FractionallySizedBox → page`, and
+`RenderFractionallySizedOverflowBox` sizes itself to **its child** - so it
+is the outermost box that refuses a margin position. Everything above it
+(`Center`, `Padding`, the sliver) spans the viewport and forwards hit tests
+through `RenderShiftedBox.hitTestChildren`, which does not gate on the
+child's size. So the reach goes immediately outside the
+`FractionallySizedBox`, and needs no reach distance of its own - its
+ancestors bound it to this page's slot, margin and inter-page spacing
+included.
+
+Debugging this is easy if you stop guessing: dump
+`tester.binding.hitTestInView(result, point, view)`'s path and read which
+render object the walk stops at.
+
+### Why it is not simply "the margin belongs to the page"
+
+Because the canvas is already spoken for. `_touchPanEnabledAt` deliberately
+hands canvas and inter-page gaps to the viewer's own touch pan while a tool
+or selection is live - "a phone at `PdfViewerFit.page` leaves canvas down
+both sides of a portrait page for a thumb to land on". Claiming every
+margin press for the page would have quietly broken thumb-scrolling on
+phones to buy off-page drawing nobody asked for.
+
+So the reach takes a **predicate**, not a flag: `grabs(position)`, which the
+viewer answers from `PdfEditingController.selectionGrabAt` - the selection's
+own chrome rects (a markup's first quad, a callout's text box, else /Rect)
+inflated by `_selectionGrabMargin` (24 view px, converted to points through
+the page's scale) for the resize handles and rotate knob. A selection
+hanging off the paper is the one thing out there worth grabbing; everything
+else in the margin falls through exactly as before.
+
+`_touchPanEnabledAt` draws the same line via `_selectionGrabsCanvasPoint`,
+so the viewer yields precisely the positions the reach claims and the two
+recognizers never meet in the arena.
+
+### Consequence
+
+Drawing a *new* annotation still has to start on the page - the canvas is
+scrolling's. A stroke, shape or drag started on the page continues past the
+edge as far as you like, which is what the geometry change above unlocked.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2678,6 +2678,15 @@ class PdfEditingController extends ChangeNotifier {
         : (width: rect.width, height: rect.height);
   }
 
+  /// A page-space rect of the given *visual* size - the size the reader
+  /// sees, so a sideways page swaps the axes - centered on ([x], [y]).
+  ///
+  /// The centre is taken as given. A placement near (or past) the page edge
+  /// keeps the point the user picked and lets the annotation hang off the
+  /// paper; the renderer clips it against the page the way any conforming
+  /// viewer does, so what is committed is what the preview showed. Only
+  /// placements with no user-chosen point - the paste cascade - stay
+  /// tethered to the page ([_tetherShift]).
   PdfRect _pageRectForVisualSize(
     int pageIndex,
     double x,
@@ -2685,17 +2694,14 @@ class PdfEditingController extends ChangeNotifier {
     required double width,
     required double height,
   }) {
-    final box = _page(pageIndex).cropBox;
     final sideways = _pageIsSideways(pageIndex);
     final pageW = sideways ? height : width;
     final pageH = sideways ? width : height;
-    final cx = x.clamp(box.left + pageW / 2, box.right - pageW / 2);
-    final cy = y.clamp(box.bottom + pageH / 2, box.top - pageH / 2);
     return PdfRect(
-      cx - pageW / 2,
-      cy - pageH / 2,
-      cx + pageW / 2,
-      cy + pageH / 2,
+      x - pageW / 2,
+      y - pageH / 2,
+      x + pageW / 2,
+      y + pageH / 2,
     );
   }
 
@@ -2876,7 +2882,9 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Places [imageBytes] (PNG or JPEG) centered on ([x], [y]) in page
   /// space, [maxSize] points on its longest side, preserving the image's
-  /// aspect ratio and clamped so the whole image stays on the page.
+  /// aspect ratio and capped at 90% of the page so it is never larger than
+  /// the paper. The centre is the point given, so an image dropped at the
+  /// edge hangs off the page rather than jumping inward.
   /// Returns false when the bytes aren't a decodable PNG or JPEG.
   bool placeImage(
     int pageIndex,
@@ -3051,9 +3059,9 @@ class PdfEditingController extends ChangeNotifier {
       h = box.height * 0.9;
       w = h * aspect;
     }
-    final cx = x.clamp(box.left + w / 2, box.right - w / 2);
-    final cy = y.clamp(box.bottom + h / 2, box.top - h / 2);
-    final left = cx - w / 2, top = cy + h / 2;
+    // the tap is authoritative: a signature dropped at the edge hangs off
+    // the page rather than jumping back onto it
+    final left = x - w / 2, top = y + h / 2;
     return (
       strokes: [
         for (final stroke in signature.strokes)
@@ -3070,9 +3078,11 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// Stamps [preferences.signature] as an Ink annotation centered on ([x], [y]) in
-  /// page space, [width] points wide (clamped, with the center, so the
-  /// whole signature stays on the page). Keeps the signature's own ink
-  /// color and pen pressures. Returns false when none is saved.
+  /// page space, [width] points wide (capped at 90% of the page so a
+  /// signature is never wider than the paper it sits on; the centre is
+  /// taken as given, so one dropped at the edge hangs off it). Keeps the
+  /// signature's own ink color and pen pressures. Returns false when none
+  /// is saved.
   bool placeSignature(int pageIndex, double x, double y, {double width = 160}) {
     final placement = signaturePlacement(pageIndex, x, y, width: width);
     if (placement == null) return false;
@@ -3289,7 +3299,8 @@ class PdfEditingController extends ChangeNotifier {
   /// stamps default to 40 points tall and auto-size from their caption;
   /// template stamps default to the template's own width/height. Passing
   /// [height] keeps the old explicit-height behavior for either kind. The
-  /// result is clamped with the center so the whole stamp stays on the page.
+  /// stamp is never sized past 90% of the page, but the centre is the point
+  /// given, so one dropped at the edge hangs off the page.
   /// Returns false when no stamp is active.
   bool placeStamp(int pageIndex, double x, double y, {double? height}) {
     final stamp = _activeStamp;
@@ -3411,7 +3422,9 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
-  /// The page-space rect [placeTextStamp] would use.
+  /// The page-space rect [placeTextStamp] would use. The box is centered on
+  /// the tap - off the page edge when that is where the tap was - but never
+  /// sized past 90% of the page.
   PdfRect textStampPlacement(
     int pageIndex,
     double x,
@@ -3423,10 +3436,13 @@ class PdfEditingController extends ChangeNotifier {
     // mirror addStamp's appearance math (6pt padding, text 72% of the
     // height) so the caption fills the box without shrinking
     final fontSize = (h - 12) * 0.72;
-    final w = (measureHelvetica(text, fontSize, bold: true) + 24).clamp(
-      h,
-      _visualPageWidth(pageIndex) * 0.9,
-    );
+    // a stamp is at least as wide as it is tall, but the page cap wins:
+    // on a page shorter than it is wide, a tall stamp would otherwise ask
+    // for a floor above the ceiling
+    final maxW = _visualPageWidth(pageIndex) * 0.9;
+    final w = (measureHelvetica(text, fontSize, bold: true) + 24)
+        .clamp(math.min(h, maxW), maxW)
+        .toDouble();
     return _pageRectForVisualSize(pageIndex, x, y, width: w, height: h);
   }
 
@@ -3437,9 +3453,27 @@ class PdfEditingController extends ChangeNotifier {
   /// count tool drops a mark this big centered on the pointer.
   static const double checkMarkSize = 18.0;
 
+  /// The page-space rect [placeCheckMark] would use for a tap at ([x], [y]).
+  ///
+  /// [size] is capped at 90% of the page's shorter side - a mark is never
+  /// bigger than the paper - but the centre is the tap, so a mark dropped
+  /// at the edge hangs off the page instead of jumping inward. The count
+  /// tool's hover preview draws this same rect, so preview and commit
+  /// cannot drift apart.
+  PdfRect checkMarkPlacement(
+    int pageIndex,
+    double x,
+    double y, {
+    double size = checkMarkSize,
+  }) {
+    final box = _page(pageIndex).cropBox;
+    final s = size.clamp(4.0, math.min(box.width, box.height) * 0.9);
+    return PdfRect(x - s / 2, y - s / 2, x + s / 2, y + s / 2);
+  }
+
   /// Drops a check-mark centered on ([x], [y]) in page space, [size] points
-  /// per side (clamped, with the centre, so the whole mark stays on the
-  /// page). The mark follows the selected toolbar [color] and [preferences.opacity] and
+  /// per side (see [checkMarkPlacement] for the sizing). The mark follows
+  /// the selected toolbar [color] and [preferences.opacity] and
   /// is a real /Stamp annotation, so it can be moved, resized, and deleted
   /// like any other. This is the count tool's tap-to-place - repeated taps
   /// build the tally exposed by [checkMarkCount], Bluebeam-style.
@@ -3449,14 +3483,10 @@ class PdfEditingController extends ChangeNotifier {
     double y, {
     double size = checkMarkSize,
   }) {
-    final box = _page(pageIndex).cropBox;
-    final s = size.clamp(4.0, math.min(box.width, box.height) * 0.9);
-    final cx = x.clamp(box.left + s / 2, box.right - s / 2);
-    final cy = y.clamp(box.bottom + s / 2, box.top - s / 2);
     return apply(
       (e) => e.addCheckMark(
         pageIndex,
-        PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
+        checkMarkPlacement(pageIndex, x, y, size: size),
         color: _colorValue,
         opacity: preferences.opacity,
         pageRotation: _page(pageIndex).rotation,
@@ -4990,9 +5020,11 @@ class PdfEditingController extends ChangeNotifier {
   /// pastes where the right-click landed). Without it the group keeps
   /// its position, shifted 12pt down-right per repeat paste - and per
   /// the first paste too when it would sit exactly on the source (the
-  /// page it was copied from, in the document it was copied from). The
-  /// group always clamps into the page's crop box. Returns whether
-  /// anything was pasted.
+  /// page it was copied from, in the document it was copied from). A
+  /// paste at a point lands there even when the group then hangs off the
+  /// page; the cascade, which has no point the user aimed at, stays
+  /// tethered to the page ([_tetherShift]). Returns whether anything was
+  /// pasted.
   bool pasteAnnotations(int pageIndex, {(double, double)? at}) {
     final clipboard = annotationClipboard.snapshots;
     if (clipboard.isEmpty) return false;
@@ -5017,9 +5049,15 @@ class PdfEditingController extends ChangeNotifier {
       dx = cascade;
       dy = -cascade;
     }
-    final box = _page(pageIndex).cropBox;
-    dx += _clampShift(left + dx, right + dx, box.left, box.right);
-    dy += _clampShift(bottom + dy, top + dy, box.bottom, box.top);
+    if (at == null) {
+      // Only the cascade needs a rail. A paste *at* a point keeps that
+      // point - edge or not - but a repeat paste has no point the user
+      // aimed at, so without this it would walk the copies clean off the
+      // paper and out of sight.
+      final box = _page(pageIndex).cropBox;
+      dx += _tetherShift(left + dx, right + dx, box.left, box.right);
+      dy += _tetherShift(bottom + dy, top + dy, box.bottom, box.top);
+    }
     final count = clipboard.length;
     final pasted = apply(
       (e) {
@@ -5140,9 +5178,10 @@ class PdfEditingController extends ChangeNotifier {
   /// graphics as vectors.
   ///
   /// With [at] the region centers on that page point (a right-click /
-  /// ⌘V at the cursor). Without it the paste keeps the captured position,
-  /// cascading 12pt down-right per repeat. The region always clamps into
-  /// the page's crop box. Returns whether anything was pasted.
+  /// ⌘V at the cursor), even when it then hangs off the page. Without it
+  /// the paste keeps the captured position, cascading 12pt down-right per
+  /// repeat and staying tethered to the page ([_tetherShift]). Returns
+  /// whether anything was pasted.
   bool pasteSnapshot(int pageIndex, {(double, double)? at}) {
     final snapshot = snapshotClipboard.snapshot;
     if (snapshot == null) return false;
@@ -5167,9 +5206,12 @@ class PdfEditingController extends ChangeNotifier {
       left = snapshot.region.left + cascade;
       bottom = snapshot.region.bottom - cascade;
     }
-    final box = _page(pageIndex).cropBox;
-    left += _clampShift(left, left + w, box.left, box.right);
-    bottom += _clampShift(bottom, bottom + h, box.bottom, box.top);
+    if (at == null) {
+      // as in [pasteAnnotations]: only the point-less cascade is tethered
+      final box = _page(pageIndex).cropBox;
+      left += _tetherShift(left, left + w, box.left, box.right);
+      bottom += _tetherShift(bottom, bottom + h, box.bottom, box.top);
+    }
     final target = PdfRect(left, bottom, left + w, bottom + h);
     int? captured;
     final pasted = apply(
@@ -5196,11 +5238,24 @@ class PdfEditingController extends ChangeNotifier {
     return true;
   }
 
-  /// How far to move the interval [lo, hi] so it fits inside
-  /// [min, max]; an oversized interval pins to the low edge.
-  static double _clampShift(double lo, double hi, double min, double max) {
-    if (hi - lo >= max - min || lo < min) return min - lo;
-    if (hi > max) return max - hi;
+  /// How much of an annotation a tether keeps over the page, in points.
+  ///
+  /// Annotation geometry is free to run past the page edge - that is what
+  /// the renderer's page clip is for. The tether exists only where no
+  /// user-chosen point justifies the position (the paste cascade): it
+  /// keeps a strip this wide on the paper so repeats can never march the
+  /// copies out of sight.
+  static const double pageTether = 24.0;
+
+  /// How far to move the interval [lo, hi] so at least [pageTether] of it
+  /// stays inside [min, max] - the whole interval when it is shorter than
+  /// the tether, and the whole of [min, max] when the page is shorter
+  /// still. Already-tethered intervals do not move, so an interval that
+  /// hangs off the edge keeps hanging off it.
+  static double _tetherShift(double lo, double hi, double min, double max) {
+    final keep = math.min(pageTether, math.min(hi - lo, max - min));
+    if (hi < min + keep) return min + keep - hi;
+    if (lo > max - keep) return max - keep - lo;
     return 0;
   }
 
@@ -6355,23 +6410,19 @@ class PdfEditingController extends ChangeNotifier {
     });
     final width = math.max(24.0, maxLineWidth + 2 * pad);
     final height = math.max(18.0, lines.length * size * 1.2 + 2 * pad);
-    final page = _page(_selected.last.$1);
-    final bounds = page.cropBox;
     // a callout autosizes its text box, not the /Rect that also spans the
-    // leader + arrow: anchor at the box's top-left so the arrow stays put
+    // leader + arrow: anchor at the box's top-left so the arrow stays put.
+    // The anchor is where the user left the box, so a box sitting at (or
+    // over) the page edge grows from there rather than sliding inward.
     final anchor = annotation.calloutBox ?? annotation.rect;
-    final left = anchor.left
-        .clamp(bounds.left, math.max(bounds.left, bounds.right - width))
-        .toDouble();
-    final top = anchor.top
-        .clamp(math.min(bounds.top, bounds.bottom + height), bounds.top)
-        .toDouble();
-    return PdfRect(left, top - height, left + width, top);
+    return PdfRect(
+        anchor.left, anchor.top - height, anchor.left + width, anchor.top);
   }
 
   /// Shrinks or grows the selected free-text annotation to the natural
   /// bounds of its contents. Explicit newlines are preserved and the box is
-  /// anchored at its current top-left corner, clamped to the page crop box.
+  /// anchored at its current top-left corner - it grows off the page edge
+  /// rather than sliding inward to fit.
   void autosizeSelectedTextBox() {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleSelectedText) return;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4287,6 +4287,39 @@ class PdfEditingController extends ChangeNotifier {
       selectedAnnotation == null ? null : _selected.last;
 
   /// Every selected (pageIndex, /Annots slot), in selection order.
+  /// Whether ([x], [y]) in [pageIndex]'s page space lands on the current
+  /// annotation selection - its body, or the ring of chrome around it
+  /// (resize handles, the rotate knob), whose width the caller passes as
+  /// [margin] in page points.
+  ///
+  /// The viewer asks this about points *outside* the page. A selection that
+  /// hangs off the paper has to stay grabbable out there, but the rest of
+  /// the canvas beside a page belongs to scrolling - a thumb landing in the
+  /// margin of a phone-sized page still has to scroll it. This is the line
+  /// between the two.
+  ///
+  /// The rects match the chrome the overlay draws: a text markup's first
+  /// quad, a callout's text box, otherwise /Rect.
+  bool selectionGrabAt(int pageIndex, double x, double y,
+      {double margin = 0}) {
+    for (final slot in _selected) {
+      if (slot.$1 != pageIndex) continue;
+      final annotation = _annotationAt(slot);
+      if (annotation == null) continue;
+      final quads = annotation.behavior.markupQuads;
+      final rect = quads != null && quads.isNotEmpty
+          ? quads.first
+          : (annotation.calloutBox ?? annotation.rect);
+      if (x >= rect.left - margin &&
+          x <= rect.right + margin &&
+          y >= rect.bottom - margin &&
+          y <= rect.top + margin) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   List<(int page, int index)> get selectedAnnotationSlots =>
       List.unmodifiable(_selected);
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -2031,19 +2031,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   _StampAfterimage _countPreviewAt(Offset position) {
     final (x, y) = _geometry.toPagePoint(position);
-    final box = _controller.pageAt(widget.pageIndex).cropBox;
-    final s = PdfEditingController.checkMarkSize
-        .clamp(4.0, math.min(box.width, box.height) * 0.9)
-        .toDouble();
-    final cx = x.clamp(box.left + s / 2, box.right - s / 2).toDouble();
-    final cy = y.clamp(box.bottom + s / 2, box.top - s / 2).toDouble();
+    // the commit's own placement, so the preview under the pointer is
+    // exactly the mark the tap drops - including one that hangs off the
+    // page edge, which the page clip trims in both
     return (
-      rect: _geometry.toViewRect(PdfRect(
-        cx - s / 2,
-        cy - s / 2,
-        cx + s / 2,
-        cy + s / 2,
-      )),
+      rect: _geometry.toViewRect(
+          _controller.checkMarkPlacement(widget.pageIndex, x, y)),
       text: null,
       template: null,
       check: true,
@@ -2681,6 +2674,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// top-left at [tap]: ~200pt wide and one line of the current font tall
   /// (in page points, mapped through the zoom). Nudged back onto the page
   /// when the tap is near the right or bottom edge so the whole box fits.
+  ///
+  /// This nudge is the one placement that still yields to the page, and it
+  /// is about the *editor*, not the annotation: this rect opens the inline
+  /// text field, which the page clips like everything else in this overlay,
+  /// so a default-sized box hung off the corner would have the user typing
+  /// into pixels they cannot see. Only the size is the editor's guess - a
+  /// box the user drags out themselves keeps the bounds they drew, off the
+  /// page edge included.
   Rect _defaultPlacementRect(Offset tap) {
     final scale = _geometry.scale;
     final w = 200.0 * scale;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_reach.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_reach.dart
@@ -1,0 +1,86 @@
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Lets a page's editing layer be grabbed from *outside* the page.
+///
+/// An annotation's geometry is not confined to the crop box - a markup can
+/// hang off the paper, and the editor paints the part that does. Pointer
+/// routing did not follow: a page's render box stops at the page edge and
+/// [RenderBox.hitTest] refuses any position outside `size`, so a press on
+/// the off-page half of a selected annotation reached nothing at all. The
+/// annotation could only be moved, resized, or drawn by its on-page half.
+///
+/// This proxy accepts those positions and forwards them into the page
+/// subtree at the nearest point *inside* it.
+///
+/// Clamping is sound because **hit testing only decides routing**. Every
+/// pointer event still carries its true global position, and
+/// `PointerEvent.localPosition` is derived from that through the target's
+/// own transform - never from the position the hit test was performed at.
+/// So the editing overlay reads the real off-page point (negative, or past
+/// the page's width) and every bit of its drag math works unchanged.
+///
+/// The reach needs no distance of its own: this widget's ancestors bound it.
+/// The page sits inside a list item that spans the viewport's cross axis and
+/// carries the inter-page spacing, and those boxes gate their own hit tests,
+/// so the reach covers exactly the margin beside and between pages and can
+/// never steal a press that belongs to a neighbouring page.
+///
+/// [grabs] decides which outside positions come in, and it must stay narrow:
+/// the canvas beside a page belongs to scrolling. A phone at
+/// `PdfViewerFit.page` leaves margin down both sides of a portrait page for
+/// a thumb to land on, and taking that away to hand every margin press to
+/// the page would cost scrolling far more than it buys editing. So the
+/// viewer only accepts positions that land on the selection hanging off the
+/// page - the one thing out there worth grabbing. Everything else falls
+/// through untouched.
+class PdfEditingReach extends SingleChildRenderObjectWidget {
+  const PdfEditingReach({super.key, required this.grabs, super.child});
+
+  /// Whether a press at this position - in the page's own view space, and
+  /// always outside it - should reach the page. See the class docs for why
+  /// this has to be selective rather than "anything in the margin".
+  final bool Function(Offset position) grabs;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      PdfRenderEditingReach(grabs: grabs);
+
+  @override
+  void updateRenderObject(
+          BuildContext context, PdfRenderEditingReach renderObject) =>
+      renderObject.grabs = grabs;
+}
+
+/// The render object behind [PdfEditingReach]. Public so tests can reach it.
+class PdfRenderEditingReach extends RenderProxyBox {
+  PdfRenderEditingReach({required this.grabs});
+
+  /// Routing only - nothing about layout or paint depends on this, so
+  /// changing it never needs to mark anything dirty.
+  bool Function(Offset position) grabs;
+
+  /// `Rect.contains` is half-open on the right and bottom edges, so a
+  /// position clamped exactly to `size` would be rejected by the very child
+  /// it is being routed to. Land a hair inside instead.
+  static const double _insetFromEdge = 0.01;
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (size.isEmpty || size.contains(position) || !grabs(position)) {
+      return super.hitTest(result, position: position);
+    }
+    return super.hitTest(result, position: _nearestInside(position));
+  }
+
+  Offset _nearestInside(Offset position) => Offset(
+        position.dx
+            .clamp(0.0, math.max(0.0, size.width - _insetFromEdge))
+            .toDouble(),
+        position.dy
+            .clamp(0.0, math.max(0.0, size.height - _insetFromEdge))
+            .toDouble(),
+      );
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -23,6 +23,7 @@ import 'editing/editing_interaction.dart';
 import 'editing/editing_link.dart';
 import 'editing/editing_menu.dart';
 import 'editing/editing_overlay.dart';
+import 'editing/editing_reach.dart';
 import 'editing/text_prompt.dart';
 import 'editing/text_style_prompt.dart';
 import 'editing/tool_shortcuts.dart';
@@ -58,6 +59,12 @@ const double _defaultMaxZoom = 24;
 
 /// Page-space distance an arrow-key press slides the selected annotation(s),
 /// and the coarser step Shift+arrow uses. Points, matching the drag move.
+/// How far past a selected annotation's edge a press still grabs it, in
+/// view pixels - the ring its resize handles and rotate knob occupy. Used
+/// only where the selection hangs off the page ([PdfEditingReach]); on the
+/// page the overlay does its own handle hit-testing.
+const double _selectionGrabMargin = 24;
+
 const double _annotationNudgeStep = 1;
 const double _annotationNudgeStepCoarse = 10;
 
@@ -2903,8 +2910,8 @@ class _PdfViewerState extends State<PdfViewer>
         // interpret this pass is about to pay for. The rungs differ only in
         // raster size, so warming them one at a time walked the same content
         // stream three times per page (#699).
-        final alsoFill = _ladderRungsFor(index, targetLongestSide,
-            vectorOnly: vectorOnly);
+        final alsoFill =
+            _ladderRungsFor(index, targetLongestSide, vectorOnly: vectorOnly);
         var deferredPreview = false;
         await _previews.renderPreview(index, page,
             pageColor: widget.pageColor,
@@ -4162,6 +4169,78 @@ class _PdfViewerState extends State<PdfViewer>
   double _crossFactor(int index) =>
       (_maxCrossPoint <= 0 ? 1.0 : _crossPointOf(index) / _maxCrossPoint) *
       _layoutZoom;
+
+  /// Wraps page [index] in the reach that lets a selected annotation be
+  /// grabbed where it hangs off the page - see [PdfEditingReach] for why
+  /// hit testing stops at the page edge without it, and why routing through
+  /// the nearest inside point is sound.
+  ///
+  /// Nothing else out there is claimed. The canvas beside and between pages
+  /// stays the scroll gesture's (see [_touchPanEnabledAt], which draws the
+  /// same line), so this costs no scrolling anywhere.
+  ///
+  /// `child:` keeps the page out of the rebuild: a controller notification
+  /// re-runs only the wrapper, and the wrapper only hands a fresh closure to
+  /// a render object - no layout, no paint. Rebuilding the page here would
+  /// drop its raster on every edit.
+  Widget _editingReach(int index, {required Widget child}) {
+    final editing = widget.editing;
+    if (editing == null) return child;
+    return ListenableBuilder(
+      listenable: editing,
+      builder: (context, child) => PdfEditingReach(
+        grabs: (position) => _selectionGrabsPageView(index, position),
+        child: child!,
+      ),
+      child: child,
+    );
+  }
+
+  /// Whether [local] (list space) lands on a selected annotation where it
+  /// hangs *off* its page - the only thing out in the canvas the editing
+  /// overlay owns. Mirrors [PdfEditingReach]'s own test, so exactly one of
+  /// the two claims a touch that starts there and they never fight in the
+  /// gesture arena.
+  bool _selectionGrabsCanvasPoint(Offset local) {
+    final editing = widget.editing;
+    if (editing == null || !editing.hasAnnotationSelection) return false;
+    if (_viewWidth <= 0 || !_scroll.hasClients || _pages.isEmpty) return false;
+    final contentMain = _scroll.offset + _mainOf(local);
+    final point = _axisOffset(contentMain, _crossOf(local));
+    var mainStart = 0.0;
+    for (var i = 0; i < _pages.length; i++) {
+      final pageMain = _pageMain(i);
+      if (contentMain <= mainStart + pageMain || i == _pages.length - 1) {
+        return _selectionGrabsPageView(
+            i, point - Offset(_pageContentX(i), _pageContentY(i)));
+      }
+      mainStart += pageMain + widget.pageSpacing;
+    }
+    return false;
+  }
+
+  /// Whether [position], in page [index]'s own view space (and outside it),
+  /// lands on that page's selected annotation - its body or the chrome ring
+  /// around it. The grab margin is [_selectionGrabMargin] view pixels, taken
+  /// into page points through the page's own scale so it stays a constant
+  /// size on screen at any zoom.
+  bool _selectionGrabsPageView(int index, Offset position) {
+    final editing = widget.editing;
+    if (editing == null || !editing.hasAnnotationSelection) return false;
+    if (index < 0 || index >= _pages.length) return false;
+    final width = _pageWidth(index), height = _pageHeight(index);
+    if (width <= 0 || height <= 0) return false;
+    final geometry = PdfPageGeometry(
+      cropBox: _pages[index].cropBox,
+      rotation: _effectiveRotation(index),
+      viewSize: Size(width, height),
+    );
+    final scale = geometry.scale;
+    if (scale <= 0) return false;
+    final (x, y) = geometry.toPagePoint(position);
+    return editing.selectionGrabAt(index, x, y,
+        margin: _selectionGrabMargin / scale);
+  }
 
   /// A page's slot extent in the scroll list, mirroring [itemExtentBuilder]:
   /// the leading [PdfViewer.pageSpacing] belongs to every page but the first.
@@ -6797,8 +6876,12 @@ class _PdfViewerState extends State<PdfViewer>
       // an absent fling is indistinguishable from a broken one.
       PdfPerfLog.log('touch-pan gate DISABLED (overlay owns page) '
           'tool=${editing.tool?.name ?? 'selection/eyedropper'}');
+      return false;
     }
-    return !overPage;
+    // One exception out in the canvas: a selection hanging off its page is
+    // reachable there ([PdfEditingReach]), and both recognizers claiming the
+    // same touch would put them in the arena against each other. Yield it.
+    return !_selectionGrabsCanvasPoint(localPosition);
   }
 
   /// Settles a finished zoom gesture into the layout/transform regime
@@ -7250,77 +7333,89 @@ class _PdfViewerState extends State<PdfViewer>
             // page (times the layout zoom), centred on the cross axis - so
             // pages keep their true sizes instead of stretching to the viewport
             child: Center(
-              child: FractionallySizedBox(
-                widthFactor: _horizontal ? null : _crossFactor(index),
-                heightFactor: _horizontal ? _crossFactor(index) : null,
-                child: _PdfViewerPage(
-                  page: _pages[index],
-                  tileCacheNamespace: _tileCacheNamespace,
-                  effectiveRotation: _effectiveRotation(index),
-                  index: index,
-                  pageColor: widget.pageColor,
-                  showAnnotations: widget.showAnnotations,
-                  pageImagesShowAnnotations: _pageImagesShowAnnotations,
-                  trustContentStamp: _annotationLayerController != null ||
-                      widget.editing != null ||
-                      (widget.interactiveForms &&
-                          widget.formController != null),
-                  formFields:
-                      widget.highlightFormFields && widget.showAnnotations
-                          ? _formFieldRects(index)
-                          : const [],
-                  interactiveForms:
-                      widget.interactiveForms && widget.showAnnotations,
-                  scale: _renderScale,
-                  settleGeneration: _settleGeneration,
-                  pageEpoch: _pageEpoch,
-                  contentStamp: _contentStamp(index),
-                  destructiveStamp: _destructiveStamp(index),
-                  renderPriority: _renderPriority(index),
-                  focusDistance:
-                      (index - (_jumpFocusPage ?? _controller.currentPage))
-                          .abs(),
-                  forceForeground: _jumpFocusPage == index,
-                  onScreenSpan: _onScreenSpan,
-                  matches: _controller._matchesOn(index),
-                  currentMatch: _controller._currentMatch >= 0
-                      ? _controller._matches[_controller._currentMatch]
-                      : null,
-                  selection: _selectionQuadsOn(index),
-                  textSelection: _textSelectionOn(index),
-                  overlayBuilder: widget.pageOverlayBuilder,
-                  editing: editing,
-                  formController: editing ?? widget.formController,
-                  editingTextPrompt:
-                      widget.editingTextPrompt ?? showPdfTextPrompt,
-                  formImagePicker: widget.formImagePicker,
-                  imagePicker: widget.imagePicker,
-                  onSnapshot: widget.onSnapshot,
-                  onPlaceSignature: widget.onPlaceSignature,
-                  onAnnotationTap: widget.onAnnotationTap,
-                  contextMenuEnabled: widget.contextMenuEnabled,
-                  interactionHost: PdfEditingInteractionHost(
-                    panViewport: _touchGrabPanBy,
-                    endViewportPan: _flingViewport,
-                    edgeAutoScroll: _edgeAutoScrollDelta,
-                    showAnnotationMenu: _showSelectionMenu,
-                    showFormFieldMenu: _showFormFieldMenu,
-                    requestContextMenu: _requestContextMenu,
-                    resolvePagePoint: _resolvePagePointGlobal,
-                    moveDragPreview: _onMoveDragPreview,
-                    textEditClosed: _reclaimFocusAfterTextEdit,
+              // An annotation is not confined to the crop box, and the
+              // editor paints the part that hangs off the paper - so a
+              // press out in the margin has to reach the page's editing
+              // layer. This is the outermost box that would otherwise
+              // refuse it: FractionallySizedBox sizes itself to the page,
+              // so the slack Center leaves around it is nobody's. Above it
+              // the item's own boxes span the viewport and forward hit
+              // tests without a size gate of their own, which is what
+              // bounds the reach to this page. See [PdfEditingReach].
+              child: _editingReach(
+                index,
+                child: FractionallySizedBox(
+                  widthFactor: _horizontal ? null : _crossFactor(index),
+                  heightFactor: _horizontal ? _crossFactor(index) : null,
+                  child: _PdfViewerPage(
+                    page: _pages[index],
+                    tileCacheNamespace: _tileCacheNamespace,
+                    effectiveRotation: _effectiveRotation(index),
+                    index: index,
+                    pageColor: widget.pageColor,
+                    showAnnotations: widget.showAnnotations,
+                    pageImagesShowAnnotations: _pageImagesShowAnnotations,
+                    trustContentStamp: _annotationLayerController != null ||
+                        widget.editing != null ||
+                        (widget.interactiveForms &&
+                            widget.formController != null),
+                    formFields:
+                        widget.highlightFormFields && widget.showAnnotations
+                            ? _formFieldRects(index)
+                            : const [],
+                    interactiveForms:
+                        widget.interactiveForms && widget.showAnnotations,
+                    scale: _renderScale,
+                    settleGeneration: _settleGeneration,
+                    pageEpoch: _pageEpoch,
+                    contentStamp: _contentStamp(index),
+                    destructiveStamp: _destructiveStamp(index),
+                    renderPriority: _renderPriority(index),
+                    focusDistance:
+                        (index - (_jumpFocusPage ?? _controller.currentPage))
+                            .abs(),
+                    forceForeground: _jumpFocusPage == index,
+                    onScreenSpan: _onScreenSpan,
+                    matches: _controller._matchesOn(index),
+                    currentMatch: _controller._currentMatch >= 0
+                        ? _controller._matches[_controller._currentMatch]
+                        : null,
+                    selection: _selectionQuadsOn(index),
+                    textSelection: _textSelectionOn(index),
+                    overlayBuilder: widget.pageOverlayBuilder,
+                    editing: editing,
+                    formController: editing ?? widget.formController,
+                    editingTextPrompt:
+                        widget.editingTextPrompt ?? showPdfTextPrompt,
+                    formImagePicker: widget.formImagePicker,
+                    imagePicker: widget.imagePicker,
+                    onSnapshot: widget.onSnapshot,
+                    onPlaceSignature: widget.onPlaceSignature,
+                    onAnnotationTap: widget.onAnnotationTap,
+                    contextMenuEnabled: widget.contextMenuEnabled,
+                    interactionHost: PdfEditingInteractionHost(
+                      panViewport: _touchGrabPanBy,
+                      endViewportPan: _flingViewport,
+                      edgeAutoScroll: _edgeAutoScrollDelta,
+                      showAnnotationMenu: _showSelectionMenu,
+                      showFormFieldMenu: _showFormFieldMenu,
+                      requestContextMenu: _requestContextMenu,
+                      resolvePagePoint: _resolvePagePointGlobal,
+                      moveDragPreview: _onMoveDragPreview,
+                      textEditClosed: _reclaimFocusAfterTextEdit,
+                    ),
+                    interactionSession: widget.interactionSession,
+                    crossPageGhost: _crossPageGhostFor(index),
+                    transformScale: _transformScale,
+                    transformChanges: _transform,
+                    renderScheduler: _renderScheduler,
+                    previewCache: widget.pagePreviews ? _previews : null,
+                    renderWorker: _effectiveRenderWorker,
+                    performance: widget.performance,
+                    tileRasterBackend: widget.tileRasterBackend,
+                    predictStrokes: widget.predictStrokes,
+                    onRasterStateChanged: _setPageRasterReady,
                   ),
-                  interactionSession: widget.interactionSession,
-                  crossPageGhost: _crossPageGhostFor(index),
-                  transformScale: _transformScale,
-                  transformChanges: _transform,
-                  renderScheduler: _renderScheduler,
-                  previewCache: widget.pagePreviews ? _previews : null,
-                  renderWorker: _effectiveRenderWorker,
-                  performance: widget.performance,
-                  tileRasterBackend: widget.tileRasterBackend,
-                  predictStrokes: widget.predictStrokes,
-                  onRasterStateChanged: _setPageRasterReady,
                 ),
               ),
             ),

--- a/packages/dart_pdf_editor/test/editing_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_clipboard_test.dart
@@ -3,6 +3,7 @@
 // toolbar wiring).
 
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart'
     show PointerDeviceKind, kSecondaryMouseButton;
@@ -79,7 +80,7 @@ void main() {
       expect(editing.selectedAnnotationSlots, [(1, 0)]);
     });
 
-    test('paste centers on a point and clamps into the crop box', () {
+    test('paste centers on a point, off the page edge included', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addRectangle(0, const PdfRect(100, 650, 250, 750));
       addTearDown(editing.dispose);
@@ -90,10 +91,38 @@ void main() {
       expect(editing.document.page(0).annotations[1].rect,
           const PdfRect(225, 350, 375, 450));
 
-      // a corner point clamps the 150×100 group inside the page
+      // a corner point is the point: the 150×100 group centers there and
+      // hangs off the page rather than jumping back inside it
       editing.pasteAnnotations(0, at: (5, 5));
       expect(editing.document.page(0).annotations[2].rect,
-          const PdfRect(0, 0, 150, 100));
+          const PdfRect(-70, -45, 80, 55));
+    });
+
+    test('the point-less paste cascade stays tethered to the page', () {
+      // Without a point to paste at there is nothing the user aimed at, so
+      // the cascade keeps a strip of the copy on the paper instead of
+      // marching it off the edge over repeats.
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(500, 40, 600, 100));
+      addTearDown(editing.dispose);
+      editing.selectAnnotation(0, 0);
+      editing.copySelectedAnnotations();
+
+      final box = editing.document.page(0).cropBox;
+      for (var i = 0; i < 40; i++) {
+        editing.pasteAnnotations(0);
+      }
+      const tether = PdfEditingController.pageTether;
+      expect(editing.document.page(0).annotations, hasLength(41));
+      for (final annotation in editing.document.page(0).annotations) {
+        final rect = annotation.rect;
+        final overlapX =
+            math.min(rect.right, box.right) - math.max(rect.left, box.left);
+        final overlapY =
+            math.min(rect.top, box.top) - math.max(rect.bottom, box.bottom);
+        expect(overlapX, greaterThanOrEqualTo(tether - 1e-6));
+        expect(overlapY, greaterThanOrEqualTo(tether - 1e-6));
+      }
     });
 
     test('cut removes in one undo step and the clipboard survives undo', () {

--- a/packages/dart_pdf_editor/test/editing_count_test.dart
+++ b/packages/dart_pdf_editor/test/editing_count_test.dart
@@ -68,17 +68,32 @@ void main() {
       expect(editing.document.page(0).annotations.single.color, 0xC03030);
     });
 
-    test('placeCheckMark clamps the mark to keep it on the page', () {
+    test('placeCheckMark centers on the tap, off the page edge included', () {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
 
+      // a tap 2pt in from the corner of the 612x792 crop box: the mark
+      // centers there and hangs off the page instead of jumping inward
       expect(editing.placeCheckMark(0, 2, 2), isTrue);
       final rect = editing.document.page(0).annotations.single.rect;
-      expect(rect.left, greaterThanOrEqualTo(0));
-      expect(rect.bottom, greaterThanOrEqualTo(0));
-      expect(rect.right, lessThanOrEqualTo(612));
-      expect(rect.top, lessThanOrEqualTo(792));
+      const half = PdfEditingController.checkMarkSize / 2;
+      expect(rect.left, closeTo(2 - half, 1e-9));
+      expect(rect.bottom, closeTo(2 - half, 1e-9));
+      expect(rect.right, closeTo(2 + half, 1e-9));
+      expect(rect.top, closeTo(2 + half, 1e-9));
+    });
+
+    test('checkMarkPlacement is the rect the tap commits', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      // the count tool's hover preview draws this rect; drift between it
+      // and the commit would show as the mark jumping on release
+      final preview = editing.checkMarkPlacement(0, 600, 780);
+      expect(editing.placeCheckMark(0, 600, 780), isTrue);
+      expect(editing.document.page(0).annotations.single.rect, preview);
     });
 
     test('checkMarkCount tallies marks across pages and tracks undo/redo', () {

--- a/packages/dart_pdf_editor/test/editing_image_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_test.dart
@@ -35,18 +35,19 @@ void main() {
       expect(appearance(editing.document, stamp), contains('/Img0 Do'));
     });
 
-    test('placeImage clamps the box to keep it on the page', () {
+    test('placeImage keeps the tap point when the box runs off the page', () {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
 
-      // a tap near the corner: the box stays inside the 612x792 crop box
+      // a tap near the corner of the 612x792 crop box: the box centers on
+      // the tap and hangs off the page rather than sliding inward
       expect(editing.placeImage(0, 10, 10, _png), isTrue);
       final rect = editing.document.page(0).annotations.single.rect;
-      expect(rect.left, greaterThanOrEqualTo(0));
-      expect(rect.bottom, greaterThanOrEqualTo(0));
-      expect(rect.right, lessThanOrEqualTo(612));
-      expect(rect.top, lessThanOrEqualTo(792));
+      expect((rect.left + rect.right) / 2, closeTo(10, 1e-9));
+      expect((rect.bottom + rect.top) / 2, closeTo(10, 1e-9));
+      expect(rect.left, lessThan(0));
+      expect(rect.bottom, lessThan(0));
     });
 
     test('addImageInRect fits the image within the dragged box', () {

--- a/packages/dart_pdf_editor/test/editing_off_page_reach_test.dart
+++ b/packages/dart_pdf_editor/test/editing_off_page_reach_test.dart
@@ -1,0 +1,162 @@
+// Editing past the page edge. An annotation's geometry is not confined to
+// the crop box, and the editor paints the part that hangs off the paper -
+// so a press out there has to reach the page's editing layer instead of
+// falling through to the scroll view. The reach is deliberately narrow: it
+// takes only presses on the selection itself, leaving the rest of the
+// canvas to scrolling. See PdfEditingReach.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_reach.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('reaching past the page edge', () {
+    // The default page fit leaves the 612x792 page narrower than the 800x600
+    // test surface, so there is a real margin either side to press in - the
+    // grey canvas the reader sees beside the paper.
+    Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(editing: editing),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    /// The page's on-screen rect. Read off the reach, which wraps the box
+    /// sized to the page and - unlike the editing overlay - is mounted even
+    /// in reading mode.
+    Rect pageRect(WidgetTester tester) =>
+        tester.getRect(find.byType(PdfEditingReach));
+
+    /// Global position of a page-space point, on or off the page.
+    Offset globalOf(
+        WidgetTester tester, PdfEditingController editing, double x, double y) {
+      final rect = pageRect(tester);
+      final geometry = PdfPageGeometry(
+        cropBox: editing.document.page(0).cropBox,
+        rotation: 0,
+        viewSize: rect.size,
+      );
+      return rect.topLeft + geometry.toViewOffset(x, y);
+    }
+
+    /// Drags in two steps: a recognizer that accepts on a single large move
+    /// never delivers a pan update for it.
+    Future<void> drag(WidgetTester tester, Offset from, Offset to) async {
+      final gesture = await tester.startGesture(from);
+      await gesture.moveTo(Offset.lerp(from, to, 0.5)!);
+      await gesture.moveTo(to);
+      await gesture.up();
+      await tester.pump();
+    }
+
+    /// Flushes the viewer's debounced settle timers (200/250ms).
+    Future<void> settle(WidgetTester tester) =>
+        tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    /// Does this margin position reach the page? The predicate the reach's
+    /// hit test consults, read straight off the render object.
+    bool grabsAt(WidgetTester tester, Offset global) {
+      final render = tester
+          .renderObject<PdfRenderEditingReach>(find.byType(PdfEditingReach));
+      return render.grabs(render.globalToLocal(global));
+    }
+
+    testWidgets('a selected annotation moves when grabbed by its off-page half',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      // a rectangle running 88pt past the right edge of the 612pt page
+      editing.addRectangle(0, const PdfRect(500, 400, 700, 500));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+
+      final rect = pageRect(tester);
+      final from = globalOf(tester, editing, 660, 450);
+      expect(from.dx, greaterThan(rect.right),
+          reason: 'the grab point must be off the page to test anything');
+      expect(from.dx, lessThan(800), reason: 'and still inside the viewport');
+
+      final before = editing.document.page(0).annotations.single.rect;
+      await drag(tester, from, from - const Offset(60, 0));
+
+      // Moved by the *whole* drag. The reach routes the hit test through the
+      // page at its nearest inside point, and this is what proves that clamp
+      // is routing only: had the overlay read the clamped point instead of
+      // the real one, the delta would come out short.
+      final after = editing.document.page(0).annotations.single.rect;
+      final scale = rect.width / editing.document.page(0).cropBox.width;
+      expect(after.left, closeTo(before.left - 60 / scale, 1));
+      expect(after.bottom, closeTo(before.bottom, 1));
+      expect(editing.document.page(0).annotations, hasLength(1));
+      expect(editing.selectedAnnotationSlots, [(0, 0)]);
+      await settle(tester);
+    });
+
+    testWidgets('the chrome ring off the page is grabbable too',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.addRectangle(0, const PdfRect(500, 400, 700, 500));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+
+      // just past the annotation's off-page corner: where its resize handle
+      // is drawn, so the press must still land on the page
+      expect(grabsAt(tester, globalOf(tester, editing, 703, 503)), isTrue);
+      // well clear of it, still in the same margin: not ours
+      expect(grabsAt(tester, globalOf(tester, editing, 780, 700)), isFalse);
+      await settle(tester);
+    });
+
+    testWidgets('the canvas stays the scroll gesture\'s, tool armed or not',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      final margin = globalOf(tester, editing, 700, 400);
+
+      // reading mode: nothing selected, nothing to reach for
+      expect(grabsAt(tester, margin), isFalse);
+
+      // an armed tool does NOT claim the margin. A phone at PdfViewerFit.page
+      // leaves canvas down both sides of a portrait page for a thumb to land
+      // on, and taking that away would cost scrolling more than it buys.
+      editing.tool = PdfEditTool.ink;
+      await tester.pump();
+      expect(grabsAt(tester, margin), isFalse);
+
+      // a selection elsewhere on the page doesn't make the whole margin ours
+      editing.tool = null;
+      editing.addRectangle(0, const PdfRect(100, 100, 200, 200));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+      expect(grabsAt(tester, margin), isFalse);
+      await settle(tester);
+    });
+
+    testWidgets('a press in the margin with no selection reaches nothing',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.rectangle;
+      await tester.pump();
+
+      final rect = pageRect(tester);
+      final from = globalOf(tester, editing, -60, 500);
+      expect(from.dx, lessThan(rect.left));
+
+      await drag(tester, from, globalOf(tester, editing, -20, 400));
+
+      // the drag never reached the page, so no annotation was drawn
+      expect(editing.document.page(0).annotations, isEmpty);
+      await settle(tester);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_test.dart
@@ -94,17 +94,30 @@ void main() {
       expect(ink.rect.width, lessThan(120));
     });
 
-    test('clamps so the whole signature stays on the page', () {
+    test('a signature dropped at the corner hangs off the page', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..preferences.signature = signature();
       final box = editing.document.page(0).cropBox;
-      expect(editing.placeSignature(0, box.right, box.bottom), isTrue);
+      expect(editing.placeSignature(0, box.right, box.bottom, width: 100),
+          isTrue);
 
+      // the tap is the centre, edge or not: roughly half the signature
+      // runs off each of the two sides it was dropped against
       final ink = editing.document.page(0).annotations.single;
-      // padded /Rect may poke out by the stroke margin, but the strokes
-      // themselves stay inside the crop box
-      expect(ink.rect.right, lessThan(box.right + 5));
-      expect(ink.rect.bottom, greaterThan(box.bottom - 5));
+      expect(ink.rect.right, greaterThan(box.right));
+      expect(ink.rect.bottom, lessThan(box.bottom));
+      expect(ink.rect.left, lessThan(box.right));
+      expect(ink.rect.top, greaterThan(box.bottom));
+    });
+
+    test('a signature is never sized wider than the page', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.signature = signature();
+      final box = editing.document.page(0).cropBox;
+      // running off the edge is a placement, not a size
+      expect(editing.placeSignature(0, 300, 400, width: 5000), isTrue);
+      final ink = editing.document.page(0).annotations.single;
+      expect(ink.rect.width, lessThan(box.width));
     });
 
     test('the placed signature follows the selected colour, not the drawn one',

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -2,6 +2,7 @@
 // as a raster image (handed to PdfViewer.onSnapshot) AND as detached
 // vector graphics kept on the clipboard for pasting back into the PDF.
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
@@ -128,16 +129,39 @@ void main() {
           editing.recolorSnapshotSelected(const Color(0xFF00FF00)), isFalse);
     });
 
-    test('the snapshot clipboard clamps an oversized region into the page', () {
+    test('a snapshot pasted at a point centers there, off the page included',
+        () {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
       editing.copyVectorSnapshot(0, const PdfRect(0, 0, 600, 780));
       expect(editing.pasteSnapshot(0, at: (10, 10)), isTrue);
       final rect = editing.document.page(0).annotations.single.rect;
-      // pinned to the low edge of the 612x792 crop box
-      expect(rect.left, closeTo(0, 1e-6));
-      expect(rect.bottom, closeTo(0, 1e-6));
+      // the 600x780 region centers on the point it was pasted at, running
+      // off three sides of the 612x792 crop box
+      expect(rect.left, closeTo(-290, 1e-6));
+      expect(rect.bottom, closeTo(-380, 1e-6));
+      expect(rect.right, closeTo(310, 1e-6));
+      expect(rect.top, closeTo(400, 1e-6));
+    });
+
+    test('the point-less snapshot cascade stays tethered to the page', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.copyVectorSnapshot(0, const PdfRect(520, 20, 600, 80));
+      final box = editing.document.page(0).cropBox;
+      for (var i = 0; i < 30; i++) {
+        expect(editing.pasteSnapshot(0), isTrue);
+      }
+      const tether = PdfEditingController.pageTether;
+      for (final annotation in editing.document.page(0).annotations) {
+        final rect = annotation.rect;
+        expect(math.min(rect.right, box.right) - math.max(rect.left, box.left),
+            greaterThanOrEqualTo(tether - 1e-6));
+        expect(math.min(rect.top, box.top) - math.max(rect.bottom, box.bottom),
+            greaterThanOrEqualTo(tether - 1e-6));
+      }
     });
 
     test('a snapshot captured in one tab pastes as vector in another', () {

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -577,15 +577,31 @@ void main() {
       expect(editing.document.page(0).annotations.single.contents, 'Signed');
     });
 
-    test('clamps so the whole stamp stays on the page', () {
+    test('a stamp dropped at the corner hangs off the page', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..activeStamp = approved;
       final box = editing.document.page(0).cropBox;
       expect(editing.placeStamp(0, box.right, box.top), isTrue);
 
+      // the tap is the centre, edge or not: the placement keeps where the
+      // user aimed and the page clip trims what runs off it
       final stamp = editing.document.page(0).annotations.single;
-      expect(stamp.rect.right, lessThanOrEqualTo(box.right + 0.01));
-      expect(stamp.rect.top, lessThanOrEqualTo(box.top + 0.01));
+      expect((stamp.rect.left + stamp.rect.right) / 2, closeTo(box.right, 1e-6));
+      expect((stamp.rect.bottom + stamp.rect.top) / 2, closeTo(box.top, 1e-6));
+      expect(stamp.rect.right, greaterThan(box.right));
+      expect(stamp.rect.top, greaterThan(box.top));
+    });
+
+    test('a stamp is never sized larger than the page', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..activeStamp = approved;
+      final box = editing.document.page(0).cropBox;
+      // running off the edge is a placement, not a size: the auto-sizing
+      // caps still hold
+      expect(editing.placeStamp(0, box.right, box.top, height: 5000), isTrue);
+      final stamp = editing.document.page(0).annotations.single;
+      expect(stamp.rect.width, lessThanOrEqualTo(box.width * 0.9 + 1e-6));
+      expect(stamp.rect.height, lessThanOrEqualTo(box.height * 0.9 + 1e-6));
     });
 
     test('changing colour keeps and recolours the active saved stamp', () {

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -613,6 +613,30 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('a shape dragged past the page edge keeps its off-page bounds',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.tool = PdfEditTool.rectangle;
+      await tester.pump();
+
+      // start on the page and drag out past its left edge: the annotation
+      // keeps the bounds that were drawn - the renderer's page clip is what
+      // trims it, not the authoring
+      await drag(tester, view(60, 700), view(-40, 640));
+
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.subtype, 'Square');
+      expect(annotation.rect.left, lessThan(0));
+      expect(annotation.rect.right, closeTo(60, 2));
+
+      // and it survives the save: nothing downstream normalizes /Rect back
+      // onto the page
+      final reopened = PdfDocument.open(editing.bytes);
+      expect(reopened.page(0).annotations.single.rect.left,
+          closeTo(annotation.rect.left, 1e-6));
+      await settle(tester);
+    });
+
     testWidgets('dragging with the cloud polygon tool adds a cloudy Polygon',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -86,6 +86,24 @@ void main() {
       expect(editing.selectedAnnotation, isNotNull);
     });
 
+    test('autosizeSelectedTextBox grows off the page edge, not inward', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..fontFamily = PdfStandardFont.courier
+        ..preferences.fontSize = 18
+        // a box the user parked against the right edge of the 612x792 page
+        ..addFreeText(0, const PdfRect(560, 600, 600, 720), 'Wide line\nshort');
+      expect(editing.selectAnnotation(0, 0), isTrue);
+
+      editing.autosizeSelectedTextBox();
+
+      // the anchor is where they left it: the box widens past the edge
+      // instead of sliding back onto the page
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.rect.left, 560);
+      expect(annotation.rect.top, 720);
+      expect(annotation.rect.right, greaterThan(612));
+    });
+
     test('textAlign preference flows into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..preferences.textAlign = PdfTextAlign.center


### PR DESCRIPTION
## Summary

Annotation authoring was confined to the page's crop box: a placement near an edge silently jumped back inside so the whole annotation would "fit". Stamping against a corner, signing over the bottom margin, or pasting a callout half off the paper were all impossible — the editor moved your annotation for you.

Nothing in PDF requires that. `/Rect` is page-space geometry like any other, and a viewer clips annotation appearances against the page, so a markup that hangs off the edge simply shows the part that lands on paper. Our own renderer already did exactly that (`drawAnnotations` → `_drawAppearance`, painted inside the page clip) — the confinement was purely authoring-side.

**The rule is now: a point the user picked is authoritative.** Tap-to-place, drop, and paste-at-a-point commit where the pointer was, edge or not.

The one exception is a placement with *no* point behind it. The paste cascade (⌘V with no cursor target, which shifts 12pt down-right per repeat) has nothing the user aimed at, so an unbounded repeat would walk the copies clean off the paper and out of sight. Those stay **tethered**: the new `_tetherShift` keeps `pageTether` (24pt) of the rect over the crop box on each axis, instead of pushing all of it back on the way the old `_clampShift` did. An interval already inside the tether does not move, so a paste that hangs off the edge keeps hanging off it.

### Part two: the off-page half was paint-only

Freeing the geometry was half the job, and the visible half didn't work: the editor already *painted* the part of an annotation hanging off the paper (the overlay's painters fit their box exactly, so the page `Stack` never flags visual overflow and never clips them) — but pointer routing didn't follow. `RenderBox.hitTest` refuses any position outside `size`, so a press on the visible off-page half of a selected markup reached **nothing**, and it could only be moved or resized by whatever was still on the paper.

`PdfEditingReach` (`editing_reach.dart`) is a `RenderProxyBox` that accepts those positions and forwards them into the page subtree at the nearest point *inside* it. The clamp is sound because **hit testing only decides routing**: every event carries its true global position, and `PointerEvent.localPosition` is derived from that through the target's own transform, never from the position the hit test ran at. So the overlay reads the real off-page point and its drag math is untouched. The move test asserts the annotation travels the *whole* drag delta, which is exactly what would break if the clamp leaked into the coordinates.

**Where it sits.** Immediately outside the list item's `FractionallySizedBox`, which sizes itself to *its child* and is therefore the outermost box that would refuse a margin position. Everything above it (`Center`, `Padding`, the sliver) spans the viewport and forwards hit tests through `RenderShiftedBox.hitTestChildren` without a size gate of its own — which is also what bounds the reach to this page's own slot.

**Why it is a predicate, not a flag.** The canvas is already spoken for: `_touchPanEnabledAt` deliberately hands canvas and inter-page gaps to the viewer's touch pan while a tool or selection is live — "a phone at `PdfViewerFit.page` leaves canvas down both sides of a portrait page for a thumb to land on". Claiming every margin press for the page would have quietly broken thumb-scrolling on phones to buy off-page drawing nobody asked for. So the reach takes `grabs(position)`, answered by the new `PdfEditingController.selectionGrabAt` — the selection's own chrome rects (a markup's first quad, a callout's text box, else `/Rect`) inflated by `_selectionGrabMargin` (24 view px, taken into points through the page's scale) for the handles and rotate knob. `_touchPanEnabledAt` draws the same line via `_selectionGrabsCanvasPoint`, so the viewer yields exactly the positions the reach claims and the two recognizers never meet in the arena.

Consequence: starting a *new* annotation still has to begin on the page — the canvas is scrolling's. A drag started on the page continues past the edge as far as you like.

### API impact

- New public `PdfEditingController.checkMarkPlacement(page, x, y, {size})`, `PdfEditingController.selectionGrabAt(page, x, y, {margin})` and `PdfEditingController.pageTether`.
- New `PdfEditingReach` / `PdfRenderEditingReach` (library-internal; public so tests can read the render object).
- Behaviour change (no signature change) for `placeImage` / `addImageInRect`, `placeStamp` / `placeTextStamp` / `textStampPlacement`, `placeCheckMark`, `placeSignature` / `signaturePlacement`, `placeFreeText`, `autosizeSelectedTextBox`, `pasteAnnotations`, `pasteSnapshot`. Each now commits at the point it was given rather than nudging it onto the page. Doc comments updated to say so.

### What changed

`editing_controller.dart`
- `_pageRectForVisualSize` — the shared "rect of this visual size centered on (x, y)" helper behind free-text placement, image drop, stamp/template placement and image element replacement. Centre clamp dropped.
- `placeCheckMark` — split out `checkMarkPlacement`; position clamp dropped.
- `signaturePlacement` — position clamp dropped.
- `pasteAnnotations` / `pasteSnapshot` — shift only when `at == null`, through `_tetherShift`.
- `_autosizeTextRect` — a free-text box grows from the anchor the user left it at, off the edge, rather than sliding inward.
- `selectionGrabAt` — new; the line between "the selection, off the page" and "the canvas".

`editing_overlay.dart`
- `_countPreviewAt` carried its own copy of the check-mark placement math. Two copies of a placement rule is one drift away from the preview and the commit disagreeing (the mark visibly jumping on release), so it now calls `checkMarkPlacement`.

`pdf_viewer.dart`
- `_editingReach` wraps each page's slot; `_selectionGrabsPageView` / `_selectionGrabsCanvasPoint` answer the predicate, and `_touchPanEnabledAt` yields the same positions.

Move and resize needed no *geometry* change — `moveSelected` / `resizeSelected` and the overlay's drag math were already unclamped, as were shape/ink/markup drags. Those paths just had no test pinning the behaviour; `editing_test` now has one that drags a rectangle off the left edge and reopens the saved bytes to prove `/Rect` survives the round trip.

### Size caps are not boundary rules

Auto-sizing still caps a stamp, image, or signature at 90% of the page — that is about *size* (an auto-sized annotation bigger than the paper it lives on is a bug) and is unrelated to where it sits. Both survive together: `placeStamp(height: 5000)` at the corner gives a page-capped box centered off the corner.

Writing that test surfaced a real pre-existing bug: `textStampPlacement` computed the width as `measured.clamp(h, pageWidth * 0.9)`, and a tall stamp on a wide-ish page makes the floor (`h`) exceed the ceiling, which `double.clamp` throws on. The floor is now `min(h, maxW)`.

Full rationale in `doc/dev-log/2026-08-20-annotations-past-the-page-edge.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix (the off-page half being unreachable; the `textStampPlacement` clamp inversion)
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (whole workspace, no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2388 passed, 36 skipped
- [x] `cd app && fvm flutter test` — 465 passed (run after merging `main`, which touched the app)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

The diff touches only `dart_pdf_editor`'s authoring and hit-testing layers — no parser, filter, or render-path code — so the `pdf_cos` / `pdf_document` / `pdf_graphics` suites and the corpus/Ghent render sweeps have nothing here to exercise. Rendering is unchanged: an off-page annotation reaches the renderer as ordinary `/Rect` geometry and is trimmed by the page clip that was already there.

No perf run. The two per-frame paths touched do the same work as before: the count tool's hover preview makes the same page lookup and clamp, now behind one method call; and the reach's predicate runs once per out-of-bounds hit test, only while something is selected, and returns false immediately when nothing is.

## PDF fixtures and screenshots

Tests use the existing programmatic `buildMultiPagePdf` fixture. New/updated coverage:

- `editing_off_page_reach_test` (new) — a selected annotation moves when grabbed by its off-page half, and by the full drag delta (which is what proves the routing clamp does not leak into coordinates); its chrome ring off the page is grabbable; the canvas is *not* claimed, with a tool armed or a selection elsewhere; a margin drag with a tool armed draws nothing.
- `editing_test` — a rectangle dragged past the left page edge keeps its off-page bounds, and they survive `PdfDocument.open(editing.bytes)`.
- `editing_clipboard_test` — paste-at-a-point centers off the page; 40 point-less cascade pastes all keep ≥ `pageTether` overlap on both axes.
- `editing_snapshot_test` — the same pair for vector snapshots.
- `editing_count_test` — a mark centers on the tap at the corner; `checkMarkPlacement` equals what the tap commits.
- `editing_signature_test`, `editing_stamps_test`, `editing_image_test` — corner placements hang off the page, and the 90% size caps still hold (including `height: 5000`, which used to throw).
- `editing_text_edit_test` — autosize grows a box parked at the right edge past it, not inward.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

**Merged `main`** (#702, #703) at bb9a29b. One conflict, in `placeSignature`'s doc comment and default `width`: #703 changed the default to `PdfInkSignature.referenceWidth` and moved the ink colour/pen width onto the tool, while this branch rewrote the same comment's clamping claim. Resolved by keeping #703's signature and prose and this branch's boundary wording. `signaturePlacement`'s body auto-merged (#703's stroke-width scaling, this branch's uncrossed centre); the editor and app suites were re-run green on the merge.

**One placement still yields to the page, deliberately.** `EditingPageOverlay._defaultPlacementRect` still nudges a *default-sized* tap-placed text box back on. That nudge is about the **editor**, not the annotation: the rect it returns opens the inline text field, which the page's `Stack` clips like everything else in the overlay, so a 200pt-wide box hung off the corner would have the user typing into pixels they cannot see. Only the size there is the editor's guess — a box the user drags out themselves keeps the bounds they drew. Documented at the call site.

**Still out of scope:** *starting* a gesture in the canvas beside a page — drawing a new annotation from the margin. That would mean taking the canvas back from touch scrolling, which `_touchPanEnabledAt` gives it on purpose. Reaching an existing selection out there does not conflict with scrolling and is what this PR does.