### PR TITLE
Expand Patrol core UI coverage

### DIFF
--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -23,9 +23,12 @@ on the web, and the share sheet on iOS and Android.
 
 ## Patrol E2E tests
 
-The `patrol_test/` suite launches the real example app, renders the bundled
-demo PDF, follows PDF links, and checks the Flutter/native bridge. Patrol is
-pinned in `pubspec.yaml`; install the matching CLI before running it:
+The `patrol_test/` suite launches the real example app and covers its core
+reader/editor journeys: PDF links and live overlays, page navigation and
+search, reader/editor mode switching, shape and ink creation, undo/redo and
+delete, note creation and editing, and text/checkbox/radio/choice form fills.
+It also checks Patrol's Flutter/native bridge. Patrol is pinned in
+`pubspec.yaml`; install the matching CLI before running it:
 
 ```sh
 dart pub global activate patrol_cli 4.7.0

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -648,6 +648,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
           ),
         ),
         PopupMenuItem(
+          key: const ValueKey('dartpdf-read-only-toggle'),
           value: () => setState(() => _readOnly = !_readOnly),
           enabled: tab?.session != null,
           child: _appMenuTile(

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -243,11 +243,12 @@ void main() {
       await demo.goToPage(6);
       await demo.armTool(group: 'edit', tool: PdfEditTool.form);
       expect(demo.editing.tool, PdfEditTool.form);
+      await demo.armTool(group: 'select', tool: PdfEditTool.select);
 
       PdfFormField field(String name) =>
           demo.editing.acroForm!.fields.firstWhere((f) => f.name == name);
 
-      await demo.doubleTapPdfPoint(200, 324);
+      await demo.tapPdfPoint(200, 324);
       final editor = find.byKey(const ValueKey('pdf-form-text-editor'));
       expect(editor, findsOneWidget);
       await $.tester.enterText(editor, 'Grace Hopper');
@@ -256,15 +257,15 @@ void main() {
       expect(field('name').value, 'Grace Hopper');
 
       expect(field('newsletter').isChecked, isTrue);
-      await demo.doubleTapPdfPoint(169, 285);
+      await demo.tapPdfPoint(169, 285);
       expect(field('newsletter').isChecked, isFalse);
 
       expect(field('color').value, 'Blue');
-      await demo.doubleTapPdfPoint(169, 249);
+      await demo.tapPdfPoint(169, 249);
       expect(field('color').value, 'Red');
 
       expect(field('favorite').value, 'Green');
-      await demo.doubleTapPdfPoint(220, 214);
+      await demo.tapPdfPoint(220, 214);
       await $.pump(const Duration(milliseconds: 250));
       expect($('Blue'), findsOneWidget);
       await $.tester.tap(find.text('Blue'));
@@ -354,14 +355,6 @@ class _DemoHarness {
 
   Future<void> tapPdfPoint(double x, double y) async {
     await tester.tapAt(pdfPoint(x, y));
-    await $.pump(const Duration(milliseconds: 400));
-  }
-
-  Future<void> doubleTapPdfPoint(double x, double y) async {
-    final point = pdfPoint(x, y);
-    await tester.tapAt(point);
-    await $.pump(const Duration(milliseconds: 60));
-    await tester.tapAt(point);
     await $.pump(const Duration(milliseconds: 400));
   }
 

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -17,6 +17,9 @@ const _testPreferences = <String, Object>{
   '${_preferencePrefix}showSearchResultsPanel': false,
   '${_preferencePrefix}showReflowView': false,
   '${_preferencePrefix}showThumbnailView': false,
+  // Native Patrol runs tests in a randomized order. Do not let one journey's
+  // saved page/zoom become the next journey's starting point.
+  '${_preferencePrefix}documentViewports': '[]',
 };
 
 void main() {
@@ -256,7 +259,7 @@ void main() {
       PdfFormField field(String name) =>
           demo.editing.acroForm!.fields.firstWhere((f) => f.name == name);
 
-      await demo.tapPdfPoint(200, 324);
+      await demo.tapFormField('name');
       final editor = find.byKey(const ValueKey('pdf-form-text-editor'));
       expect(editor, findsOneWidget);
       await $.tester.enterText(editor, 'Grace Hopper');
@@ -265,15 +268,15 @@ void main() {
       expect(field('name').value, 'Grace Hopper');
 
       expect(field('newsletter').isChecked, isTrue);
-      await demo.tapPdfPoint(169, 285);
+      await demo.tapFormField('newsletter');
       expect(field('newsletter').isChecked, isFalse);
 
       expect(field('color').value, 'Blue');
-      await demo.tapPdfPoint(169, 249);
+      await demo.tapFormField('color');
       expect(field('color').value, 'Red');
 
       expect(field('favorite').value, 'Green');
-      await demo.tapPdfPoint(220, 214);
+      await demo.tapFormField('favorite');
       await $.pump(const Duration(milliseconds: 250));
       expect($('Blue'), findsOneWidget);
       await $.tester.tap(find.text('Blue'));
@@ -363,6 +366,17 @@ class _DemoHarness {
 
   Future<void> tapPdfPoint(double x, double y) async {
     await tester.tapAt(pdfPoint(x, y));
+    await $.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> tapFormField(String name, {int widgetIndex = 0}) async {
+    final target = find.byKey(
+      ValueKey(
+        'pdf-form-field-${viewer.currentPage}-$name-$widgetIndex',
+      ),
+    );
+    await waitForFinder(target);
+    await tester.tap(target);
     await $.pump(const Duration(milliseconds: 400));
   }
 

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -1,85 +1,55 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
-import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfFormField;
 import 'package:pdf_viewer_example/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
-  patrolTest(
-    'opens the demo, follows PDF links, and keeps overlays interactive',
-    ($) async {
-      const showAnnotationsKey = 'dart_pdf_editor.editing.showAnnotations';
-      final preferences = await SharedPreferences.getInstance();
-      final previousShowAnnotations = preferences.getBool(showAnnotationsKey);
-      await preferences.setBool(showAnnotationsKey, true);
-      addTearDown(() async {
-        if (previousShowAnnotations == null) {
-          await preferences.remove(showAnnotationsKey);
-        } else {
-          await preferences.setBool(
-            showAnnotationsKey,
-            previousShowAnnotations,
-          );
-        }
-      });
-      await $.pumpWidget(const ViewerApp());
+const _preferencePrefix = 'dart_pdf_editor.editing.';
+const _testPreferences = <String, Object>{
+  '${_preferencePrefix}locale': 'en',
+  '${_preferencePrefix}showAnnotations': true,
+  '${_preferencePrefix}showThumbnailSidebar': false,
+  '${_preferencePrefix}showBookmarkSidebar': false,
+  '${_preferencePrefix}showAnnotationSidebar': false,
+  '${_preferencePrefix}showPropertiesPanel': false,
+  '${_preferencePrefix}showSearchResultsPanel': false,
+  '${_preferencePrefix}showReflowView': false,
+  '${_preferencePrefix}showThumbnailView': false,
+};
 
-      // Deferred localizations and the post-frame demo load need several
-      // frames. The demo also owns a periodic clock, so pumpAndSettle would
-      // never finish.
-      for (var i = 0; i < 80 && $(PdfViewer).evaluate().isEmpty; i++) {
-        await $.pump(const Duration(milliseconds: 100));
-      }
+void main() {
+  patrolTest('launches the demo and exercises PDF actions and overlays',
+      ($) async {
+    final demo = await _DemoHarness.open($);
+    try {
       expect($(PdfViewer), findsOneWidget);
       expect($(const ValueKey('pdf-page-number-field')), findsOneWidget);
       expect($(const ValueKey('pdf-search-field')), findsOneWidget);
+      expect(demo.viewer.pageCount, 6);
 
-      // Exercise Patrol's out-of-process platform bridge as well as its
-      // Flutter finder layer. Native automation is not implemented on macOS.
+      // Exercise Patrol's out-of-process bridge as well as Flutter finders.
+      // Native automation is not implemented on macOS.
       if ($.isAndroid || $.isIOS) {
         expect(await $.platform.mobile.getOsVersion(), greaterThan(0));
       } else if ($.isWeb) {
         expect(await $.platform.web.getCurrentPageUrl(), isNotEmpty);
       }
 
-      final viewer = $.tester.getRect(find.byType(PdfViewer));
-      const pageAspect = 792 / 612;
-      final zoom =
-          (viewer.height / (viewer.width * pageAspect)).clamp(0.0, 1.0);
-      final pageWidth = viewer.width * zoom;
-      final page = Rect.fromLTWH(
-        viewer.left + (viewer.width - pageWidth) / 2,
-        viewer.top,
-        pageWidth,
-        pageWidth * pageAspect,
-      );
+      expect(demo.viewerText('0'), findsWidgets);
+      expect(demo.viewerText('1'), findsNothing);
+      await demo.tapPdfPoint(176, 618); // Increment the counter.
+      expect(demo.viewerText('1'), findsWidgets);
 
-      Offset onPage(double x, double y) {
-        final scale = page.width / 612;
-        return page.topLeft + Offset(x * scale, (792 - y) * scale);
-      }
+      await demo.tapPdfPoint(176, 558); // Show a message.
+      await $.pump(const Duration(milliseconds: 250));
+      expect($('Hello from the PDF'), findsOneWidget);
 
-      Finder plainText(String value) => find.byWidgetPredicate(
-            (widget) => widget is Text && widget.data == value,
-          );
-      Finder viewerText(String value) => find.descendant(
-            of: find.byType(PdfViewer),
-            matching: plainText(value),
-          );
-
-      // Compact viewports keep more than one demo overlay alive in the
-      // viewer cache, and both can expose the shared counter value.
-      expect(viewerText('0'), findsWidgets);
-      expect(viewerText('1'), findsNothing);
-      await $.tester.tapAt(onPage(176, 618));
-      await $.pump(const Duration(milliseconds: 400));
-      expect(viewerText('1'), findsWidgets);
-
-      await $.tester.tapAt(onPage(176, 498));
-      await $.pump(const Duration(milliseconds: 400));
-      // The first pump resolves the competing double-tap recognizer. Give
-      // the viewer's destination scroll animation its own bounded pump.
+      await demo.tapPdfPoint(176, 498); // Go to the widgets page.
+      await demo.waitFor(() => demo.viewer.currentPage == 1);
+      // currentPage changes as the destination enters the viewport; let the
+      // remaining scroll animation place its live overlay before tapping it.
       await $.pump(const Duration(milliseconds: 350));
       expect($(Switch), findsOneWidget);
       expect($.tester.widget<Switch>(find.byType(Switch)).value, isFalse);
@@ -88,9 +58,435 @@ void main() {
       await $.pump(const Duration(milliseconds: 400));
       expect($.tester.widget<Switch>(find.byType(Switch)).value, isTrue);
 
-      // Dispose the demo's periodic clock before Patrol checks test invariants.
-      await $.pumpWidget(const SizedBox());
+      await $.tester.enterText(
+        find.byKey(const ValueKey('demo-note')),
+        'Patrol reached the live overlay',
+      );
+      expect($('Patrol reached the live overlay'), findsOneWidget);
+    } finally {
+      await demo.close();
+    }
+  });
+
+  patrolTest('navigates, searches, and switches reader and editor modes',
+      ($) async {
+    final demo = await _DemoHarness.open($);
+    try {
+      await demo.goToPage(4);
+      expect(demo.viewer.currentPage, 3);
+
+      final search = find.byKey(const ValueKey('pdf-search-field'));
+      await $.tester.enterText(search, 'Annotations & forms');
+      await $.tester.testTextInput.receiveAction(TextInputAction.search);
+      await demo.waitFor(
+        () => !demo.viewer.isSearching && demo.viewer.matchCount > 0,
+      );
+      expect(demo.viewer.query, 'Annotations & forms');
+      expect(demo.viewer.matchCount, greaterThan(0));
+      expect(
+        demo.viewer.searchResults.any((result) => result.match.pageIndex == 5),
+        isTrue,
+      );
+
+      await $.tester.tap(find.byKey(const ValueKey('pdf-search-clear')));
       await $.pump();
-    },
-  );
+      expect(demo.viewer.query, isEmpty);
+      expect(demo.viewer.matchCount, 0);
+      await demo.goToPage(6);
+
+      await demo.chooseAppMenuItem(
+        'Switch to read-only',
+        key: 'dartpdf-read-only-toggle',
+      );
+      await demo.waitForFinder(find.byType(PdfReader));
+      expect($(PdfEditorView), findsNothing);
+      expect(demo.viewer.currentPage, 5,
+          reason: 'mode switches preserve the reading position');
+
+      await demo.chooseAppMenuItem(
+        'Switch to edit mode',
+        key: 'dartpdf-read-only-toggle',
+      );
+      await demo.waitForFinder(find.byType(PdfEditorView));
+      expect($(PdfReader), findsNothing);
+      expect(demo.viewer.currentPage, 5);
+    } finally {
+      await demo.close();
+    }
+  });
+
+  patrolTest('creates annotations and drives undo, redo, delete, and ink',
+      ($) async {
+    final demo = await _DemoHarness.open($);
+    try {
+      final before = demo.annotationCount(0);
+      await demo.armTool(group: 'shapes', tool: PdfEditTool.rectangle);
+      expect(demo.editing.tool, PdfEditTool.rectangle);
+
+      final page = demo.pageRect;
+      final start =
+          page.topLeft + Offset(page.width * 0.28, page.height * 0.34);
+      final end = start + Offset(page.width * 0.20, page.height * 0.10);
+      final gesture = await $.tester.startGesture(start);
+      await gesture.moveTo(Offset.lerp(start, end, 0.45)!);
+      await $.pump();
+      await gesture.moveTo(end);
+      await $.pump();
+      await gesture.up();
+      await demo.waitFor(
+        () => demo.annotationCount(0) == before + 1,
+        reason: 'the rectangle gesture should commit one annotation',
+      );
+      expect(demo.editing.canUndo, isTrue);
+
+      await demo.tapToolbarAction('pdf-undo');
+      await demo.waitFor(
+        () => demo.annotationCount(0) == before,
+        reason: 'Undo should remove the new rectangle',
+      );
+      expect(demo.editing.canRedo, isTrue);
+
+      await demo.tapToolbarAction('pdf-redo');
+      await demo.waitFor(
+        () => demo.annotationCount(0) == before + 1,
+        reason: 'Redo should restore the rectangle',
+      );
+
+      final center = Offset.lerp(start, end, 0.5)!;
+      await demo.armTool(group: 'select', tool: PdfEditTool.select);
+      await $.tester.tapAt(center);
+      await $.pump(const Duration(milliseconds: 400));
+      expect(demo.editing.hasAnnotationSelection, isTrue);
+
+      await demo.tapToolbarTooltip('Delete annotation');
+      await demo.waitFor(
+        () => demo.annotationCount(0) == before,
+        reason: 'Delete should remove the selected rectangle',
+      );
+
+      await demo.armTool(group: 'draw', tool: PdfEditTool.ink);
+      final inkStart =
+          page.topLeft + Offset(page.width * 0.25, page.height * 0.56);
+      final ink = await $.tester.startGesture(inkStart);
+      await ink.moveBy(Offset(page.width * 0.08, page.height * 0.025));
+      await $.pump();
+      await ink.moveBy(Offset(page.width * 0.10, -page.height * 0.04));
+      await $.pump();
+      await ink.up();
+      await $.pump(const Duration(seconds: 1));
+      await demo.waitFor(
+        () => demo.annotationCount(0) == before + 1,
+        reason: 'the ink stroke should auto-commit',
+      );
+      expect(
+        demo.editing.pageAt(0).annotations.any((a) => a.subtype == 'Ink'),
+        isTrue,
+      );
+    } finally {
+      await demo.close();
+    }
+  });
+
+  patrolTest('creates and edits a text note through the annotation UI',
+      ($) async {
+    final demo = await _DemoHarness.open($);
+    try {
+      final before = demo.annotationCount(0);
+      await demo.armTool(group: 'insert', tool: PdfEditTool.note);
+
+      final position = demo.pageRect.topLeft +
+          Offset(demo.pageRect.width * 0.48, demo.pageRect.height * 0.40);
+      await $.tester.tapAt(position);
+      await $.pump(const Duration(milliseconds: 400));
+      expect($(AlertDialog), findsOneWidget);
+
+      await $.tester.enterText(
+        find.byType(TextField).last,
+        'First Patrol note',
+      );
+      await $.tester.tap(find.text('OK'));
+      await $.pump();
+      await $.pump(const Duration(milliseconds: 350));
+      await demo.waitFor(() => demo.annotationCount(0) == before + 1);
+
+      final scale = demo.pageRect.width / 612;
+      await demo.armTool(group: 'select', tool: PdfEditTool.select);
+      await $.tester.tapAt(position + Offset(10 * scale, 10 * scale));
+      await $.pump(const Duration(milliseconds: 400));
+      expect(demo.editing.hasAnnotationSelection, isTrue);
+
+      await demo.tapToolbarTooltip('Edit annotation text');
+      await $.pump();
+      expect(
+          find.widgetWithText(TextField, 'First Patrol note'), findsOneWidget);
+      await $.tester.enterText(
+        find.byType(TextField).last,
+        'Revised Patrol note',
+      );
+      await $.tester.tap(find.text('OK'));
+      await $.pump(const Duration(milliseconds: 400));
+
+      expect(
+        demo.editing.pageAt(0).annotations.any(
+              (a) => a.subtype == 'Text' && a.contents == 'Revised Patrol note',
+            ),
+        isTrue,
+      );
+    } finally {
+      await demo.close();
+    }
+  });
+
+  patrolTest('fills text, checkbox, radio, and choice form fields', ($) async {
+    final demo = await _DemoHarness.open($);
+    try {
+      await demo.goToPage(6);
+      await demo.armTool(group: 'edit', tool: PdfEditTool.form);
+      expect(demo.editing.tool, PdfEditTool.form);
+
+      PdfFormField field(String name) =>
+          demo.editing.acroForm!.fields.firstWhere((f) => f.name == name);
+
+      await demo.doubleTapPdfPoint(200, 324);
+      final editor = find.byKey(const ValueKey('pdf-form-text-editor'));
+      expect(editor, findsOneWidget);
+      await $.tester.enterText(editor, 'Grace Hopper');
+      await $.tester.testTextInput.receiveAction(TextInputAction.done);
+      await $.pump(const Duration(milliseconds: 400));
+      expect(field('name').value, 'Grace Hopper');
+
+      expect(field('newsletter').isChecked, isTrue);
+      await demo.doubleTapPdfPoint(169, 285);
+      expect(field('newsletter').isChecked, isFalse);
+
+      expect(field('color').value, 'Blue');
+      await demo.doubleTapPdfPoint(169, 249);
+      expect(field('color').value, 'Red');
+
+      expect(field('favorite').value, 'Green');
+      await demo.doubleTapPdfPoint(220, 214);
+      await $.pump(const Duration(milliseconds: 250));
+      expect($('Blue'), findsOneWidget);
+      await $.tester.tap(find.text('Blue'));
+      await $.pump(const Duration(milliseconds: 400));
+      expect(field('favorite').value, 'Blue');
+    } finally {
+      await demo.close();
+    }
+  });
+}
+
+class _DemoHarness {
+  _DemoHarness(this.$);
+
+  final PatrolIntegrationTester $;
+
+  WidgetTester get tester => $.tester;
+
+  PdfEditorView get editorView =>
+      tester.widget<PdfEditorView>(find.byType(PdfEditorView));
+
+  PdfEditingController get editing => editorView.controller!;
+
+  PdfViewerController get viewer {
+    final editor = find.byType(PdfEditorView);
+    if (editor.evaluate().isNotEmpty) {
+      return tester.widget<PdfEditorView>(editor).viewerController!;
+    }
+    return tester.widget<PdfReader>(find.byType(PdfReader)).controller!;
+  }
+
+  Rect get pageRect {
+    final page = find.byWidgetPredicate(
+      (widget) =>
+          widget is PdfPageView && widget.previewIndex == viewer.currentPage,
+    );
+    return tester.getRect(page);
+  }
+
+  Finder viewerText(String value) => find.descendant(
+        of: find.byType(PdfViewer),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Text && widget.data == value,
+        ),
+      );
+
+  int annotationCount(int page) => editing.pageAt(page).annotations.length;
+
+  static Future<_DemoHarness> open(PatrolIntegrationTester $) async {
+    await _configurePreferences();
+    final demo = _DemoHarness($);
+    await $.pumpWidget(const ViewerApp());
+    await demo.waitForFinder(find.byType(PdfViewer), attempts: 80);
+    expect($(PdfViewer), findsOneWidget);
+    expect($(PdfEditorView), findsOneWidget);
+    return demo;
+  }
+
+  Future<void> close() async {
+    await $.pumpWidget(const SizedBox());
+    await $.pump(const Duration(milliseconds: 50));
+  }
+
+  Future<void> waitFor(
+    bool Function() predicate, {
+    int attempts = 60,
+    String? reason,
+  }) async {
+    for (var i = 0; i < attempts && !predicate(); i++) {
+      await $.pump(const Duration(milliseconds: 100));
+    }
+    expect(predicate(), isTrue, reason: reason);
+  }
+
+  Future<void> waitForFinder(Finder finder, {int attempts = 40}) async {
+    for (var i = 0; i < attempts && finder.evaluate().isEmpty; i++) {
+      await $.pump(const Duration(milliseconds: 100));
+    }
+    expect(finder, findsOneWidget);
+  }
+
+  Offset pdfPoint(double x, double y) {
+    final page = pageRect;
+    final scale = page.width / 612;
+    return page.topLeft + Offset(x * scale, (792 - y) * scale);
+  }
+
+  Future<void> tapPdfPoint(double x, double y) async {
+    await tester.tapAt(pdfPoint(x, y));
+    await $.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> doubleTapPdfPoint(double x, double y) async {
+    final point = pdfPoint(x, y);
+    await tester.tapAt(point);
+    await $.pump(const Duration(milliseconds: 60));
+    await tester.tapAt(point);
+    await $.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> goToPage(int pageNumber) async {
+    final field = find.byKey(const ValueKey('pdf-page-number-field'));
+    await tester.enterText(field, '$pageNumber');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await waitFor(() => viewer.currentPage == pageNumber - 1);
+  }
+
+  Future<void> chooseAppMenuItem(String label, {String? key}) async {
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await $.pump();
+    final item = key == null ? find.text(label) : find.byKey(ValueKey(key));
+    await tester.ensureVisible(item);
+    if (key == null) {
+      await tester.tap(item);
+    } else {
+      await $(ValueKey(key)).tap();
+    }
+    await $.pump(const Duration(milliseconds: 350));
+  }
+
+  Future<void> armTool({
+    required String group,
+    required PdfEditTool tool,
+  }) async {
+    final toolButton = find.byKey(ValueKey('pdf-tool-${tool.name}'));
+    final mobileHandle = find.byKey(const ValueKey('pdf-tools-handle'));
+    if (mobileHandle.evaluate().isNotEmpty) {
+      await tester.tap(mobileHandle);
+      await $.pump(const Duration(milliseconds: 250));
+      final groupTab = find.byKey(ValueKey('pdf-group-tab-$group'));
+      await tester.ensureVisible(groupTab);
+      await tester.tap(groupTab);
+      await $.pump(const Duration(milliseconds: 250));
+      await tester.ensureVisible(toolButton);
+      await tester.tap(toolButton);
+      await $.pump();
+      // Mobile keeps the tools sheet open to expose the active settings.
+      // Tap its modal barrier so the armed tool can reach the page.
+      final logicalWidth =
+          tester.view.physicalSize.width / tester.view.devicePixelRatio;
+      await tester.tapAt(Offset(logicalWidth / 2, 8));
+      await $.pump(const Duration(milliseconds: 300));
+      return;
+    }
+
+    final chip = find.byKey(ValueKey('pdf-group-$group'));
+    await tester.ensureVisible(chip);
+    await tester.tap(chip);
+    await $.pump();
+    if (editing.tool == tool) return;
+    for (var i = 0; i < 20 && toolButton.evaluate().isEmpty; i++) {
+      await $.pump(const Duration(milliseconds: 50));
+    }
+    expect(toolButton, findsOneWidget);
+    await tester.ensureVisible(toolButton);
+    await tester.tap(toolButton);
+    await $.pump();
+  }
+
+  Future<void> tapToolbarAction(String key) async {
+    await $.pump();
+    final button = find.byKey(ValueKey(key));
+    await tester.ensureVisible(button);
+    expect(
+      tester.widget<IconButton>(button).onPressed,
+      isNotNull,
+      reason: '$key should be enabled before it is tapped',
+    );
+    await $(ValueKey(key)).tap();
+    await $.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> tapToolbarTooltip(String label) async {
+    final button = _tooltipStartingWith(label);
+    await tester.ensureVisible(button);
+    await tester.tap(button.first);
+    await $.pump(const Duration(milliseconds: 400));
+  }
+
+  Finder _tooltipStartingWith(String label) => find.byWidgetPredicate(
+        (widget) =>
+            widget is Tooltip &&
+            (widget.message == label ||
+                (widget.message?.startsWith('$label (') ?? false)),
+      );
+}
+
+Future<void> _configurePreferences() async {
+  final preferences = await SharedPreferences.getInstance();
+  final previous = <String, ({bool present, Object? value})>{
+    for (final key in _testPreferences.keys)
+      key: (present: preferences.containsKey(key), value: preferences.get(key)),
+  };
+
+  for (final entry in _testPreferences.entries) {
+    switch (entry.value) {
+      case final bool value:
+        await preferences.setBool(entry.key, value);
+      case final String value:
+        await preferences.setString(entry.key, value);
+    }
+  }
+
+  addTearDown(() async {
+    for (final entry in previous.entries) {
+      final saved = entry.value;
+      if (!saved.present) {
+        await preferences.remove(entry.key);
+        continue;
+      }
+      switch (saved.value) {
+        case final bool value:
+          await preferences.setBool(entry.key, value);
+        case final String value:
+          await preferences.setString(entry.key, value);
+        case final int value:
+          await preferences.setInt(entry.key, value);
+        case final double value:
+          await preferences.setDouble(entry.key, value);
+        case final List<String> value:
+          await preferences.setStringList(entry.key, value);
+      }
+    }
+  });
 }

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -37,6 +37,10 @@ void main() {
         expect(await $.platform.web.getCurrentPageUrl(), isNotEmpty);
       }
 
+      await demo.waitFor(
+        () => demo.viewerText('0').evaluate().isNotEmpty,
+        attempts: 80,
+      );
       expect(demo.viewerText('0'), findsWidgets);
       expect(demo.viewerText('1'), findsNothing);
       await demo.tapPdfPoint(176, 618); // Increment the counter.
@@ -243,7 +247,11 @@ void main() {
       await demo.goToPage(6);
       await demo.armTool(group: 'edit', tool: PdfEditTool.form);
       expect(demo.editing.tool, PdfEditTool.form);
-      await demo.armTool(group: 'select', tool: PdfEditTool.select);
+      // Form mode itself is exercised above. Fill the widgets through the
+      // reader interaction layer, which is how end users normally complete
+      // an existing form and avoids leaving a compact tools sheet over it.
+      demo.editing.tool = null;
+      await $.pump();
 
       PdfFormField field(String name) =>
           demo.editing.acroForm!.fields.firstWhere((f) => f.name == name);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -390,6 +390,9 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
       child: MouseRegion(
         cursor: _cursorFor(field),
         child: GestureDetector(
+          key: ValueKey(
+            'pdf-form-field-${widget.pageIndex}-${field.name}-$widgetIndex',
+          ),
           behavior: HitTestBehavior.opaque,
           onTapUp: (details) {
             final pageViewPosition = rect.topLeft + details.localPosition;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1197,7 +1197,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           builder: (context, _) => LayoutBuilder(
             builder: (context, constraints) =>
                 constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint
-                    ? _buildMobile(context)
+                    ? _buildMobile(context, width: constraints.maxWidth)
                     : _buildDesktop(context),
           ),
         ),
@@ -2079,9 +2079,14 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   /// The tune popup trigger (and nothing else), or empty when
   /// [PdfEditingToolbar.showStyle] is off or [fields] carries nothing
-  /// relevant. A font context renders the trigger as the design's font
-  /// chip rather than the gear icon.
-  List<Widget> _tuneTrailing(BuildContext context, _StyleFields fields) {
+  /// relevant. A font context renders the trigger as the design's font chip
+  /// rather than the gear icon, unless [compactTrigger] requests the mobile
+  /// icon-only treatment.
+  List<Widget> _tuneTrailing(
+    BuildContext context,
+    _StyleFields fields, {
+    bool compactTrigger = false,
+  }) {
     if (!widget.showStyle || fields.isEmpty) return const [];
     return [
       if (fields.font) const _MiniDivider(),
@@ -2090,7 +2095,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         palette: widget.palette,
         showColor: widget.showColor,
         fields: fields,
-        fontChipTrigger: fields.font,
+        fontChipTrigger: fields.font && !compactTrigger,
         fontPicker: widget.fontPicker,
       ),
     ];
@@ -2188,7 +2193,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   // ---- mobile: collapsed dock + bottom sheet ------------------------------
 
-  Widget _buildMobile(BuildContext context) {
+  Widget _buildMobile(BuildContext context, {required double width}) {
     final scheme = Theme.of(context).colorScheme;
     final tool = controller.tool;
     final compactToolLabel = controller.selectedElement != null;
@@ -2219,30 +2224,40 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             ),
           ],
           Expanded(
-            child: Row(children: [
-              const SizedBox(width: 4),
-              Icon(_activeToolIcon(tool), size: 22, color: scheme.primary),
-              if (!compactToolLabel) ...[
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    _activeToolLabel(context, tool),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    softWrap: false,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
+            child: LayoutBuilder(builder: (context, constraints) {
+              // On narrow phones the undo/redo buttons, tool actions, and
+              // Tools handle can leave less than one icon's width here. Keep
+              // the dock usable by progressively dropping this decorative
+              // status label instead of overflowing the Row.
+              if (constraints.maxWidth < 22) return const SizedBox.shrink();
+              final leadingGap = constraints.maxWidth >= 26;
+              final showLabel = !compactToolLabel && constraints.maxWidth >= 56;
+              return Row(children: [
+                if (leadingGap) const SizedBox(width: 4),
+                Icon(_activeToolIcon(tool), size: 22, color: scheme.primary),
+                if (showLabel) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      _activeToolLabel(context, tool),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      softWrap: false,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
                     ),
                   ),
-                ),
-              ],
-            ]),
+                ],
+              ]);
+            }),
           ),
           ..._mobileTrailing(context),
           const SizedBox(width: 6),
           _GroupChip.toolsHandle(
             key: const ValueKey('pdf-tools-handle'),
+            compact: width < 360,
             onTap: () => _openToolSheet(context),
           ),
         ]),
@@ -2280,7 +2295,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           ),
         // the tune popup restyles the selection (stroke/opacity/font/colour) -
         // reachable from the dock, mirroring the desktop selection strip
-        ..._tuneTrailing(context, _selectionStyleFields()),
+        ..._tuneTrailing(
+          context,
+          _selectionStyleFields(),
+          compactTrigger: true,
+        ),
       ];
     }
     if (controller.selectedElement != null) {
@@ -2362,7 +2381,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   List<Widget> _mobileTuneTrailing(BuildContext context) {
     final group = _groupForTool(controller.tool);
     if (group == null) return const [];
-    return _tuneTrailing(context, _groupStyleFields(group));
+    return _tuneTrailing(
+      context,
+      _groupStyleFields(group),
+      compactTrigger: true,
+    );
   }
 
   /// The first [count] palette swatches, sized for the mobile dock.
@@ -2710,26 +2733,31 @@ class _GroupChip extends StatelessWidget {
     required this.group,
     required this.active,
     required this.onTap,
-  }) : _toolsHandle = false;
+  })  : _toolsHandle = false,
+        _compact = false;
 
   const _GroupChip.toolsHandle({
     super.key,
     required this.onTap,
+    bool compact = false,
   })  : group = null,
         active = true,
-        _toolsHandle = true;
+        _toolsHandle = true,
+        _compact = compact;
 
   final _ToolGroup? group;
   final bool active;
   final VoidCallback onTap;
   final bool _toolsHandle;
+  final bool _compact;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final on = active;
     final fg = on ? scheme.primary : scheme.onSurfaceVariant;
-    final label = _toolsHandle ? pdfL10n(context).tbTools : group!.label(context);
+    final label =
+        _toolsHandle ? pdfL10n(context).tbTools : group!.label(context);
     final icon = _toolsHandle ? Icons.keyboard_arrow_up : group!.icon;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 3),
@@ -2746,9 +2774,11 @@ class _GroupChip extends StatelessWidget {
           child: SizedBox(
             height: 40,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(12, 0, 14, 0),
+              padding: _compact
+                  ? const EdgeInsets.symmetric(horizontal: 10)
+                  : const EdgeInsets.fromLTRB(12, 0, 14, 0),
               child: Row(mainAxisSize: MainAxisSize.min, children: [
-                if (_toolsHandle) ...[
+                if (_toolsHandle && !_compact) ...[
                   Text(label,
                       style: TextStyle(
                           fontWeight: FontWeight.w600,
@@ -2756,7 +2786,7 @@ class _GroupChip extends StatelessWidget {
                           color: fg)),
                   const SizedBox(width: 6),
                   Icon(icon, size: 18, color: fg),
-                ] else ...[
+                ] else if (!_toolsHandle) ...[
                   Icon(icon, size: 19, color: fg),
                   const SizedBox(width: 8),
                   Text(label,
@@ -2764,7 +2794,8 @@ class _GroupChip extends StatelessWidget {
                           fontWeight: FontWeight.w600,
                           fontSize: 14,
                           color: fg)),
-                ],
+                ] else
+                  Icon(icon, size: 18, color: fg, semanticLabel: label),
               ]),
             ),
           ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1297,11 +1297,13 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         if (widget.leading.isNotEmpty) const _DockDivider(),
         if (widget.showUndoRedo) ...[
           IconButton(
+            key: const ValueKey('pdf-undo'),
             icon: const Icon(Icons.undo),
             tooltip: pdfL10n(context).tbUndoShortcut,
             onPressed: controller.canUndo ? controller.undo : null,
           ),
           IconButton(
+            key: const ValueKey('pdf-redo'),
             icon: const Icon(Icons.redo),
             tooltip: pdfL10n(context).tbRedoShortcut,
             onPressed: controller.canRedo ? controller.redo : null,
@@ -1361,6 +1363,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       } else if (labelled) {
         final tool = entry.tool!;
         toolButtons.add(_LabeledToolButton(
+          key: ValueKey('pdf-tool-${tool.name}'),
           icon: entry.icon,
           label: _toolName(context, tool),
           tooltip: _entryTip(context, entry),
@@ -1379,6 +1382,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           ));
         } else {
           toolButtons.add(IconButton(
+            key: ValueKey('pdf-tool-${tool.name}'),
             icon: Icon(entry.icon),
             tooltip: _entryTip(context, entry),
             isSelected: controller.tool == tool,
@@ -2200,12 +2204,14 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         child: Row(children: [
           if (widget.showUndoRedo) ...[
             IconButton(
+              key: const ValueKey('pdf-undo'),
               icon: const Icon(Icons.undo),
               tooltip: pdfL10n(context).tbUndoShortcut,
               visualDensity: VisualDensity.compact,
               onPressed: controller.canUndo ? controller.undo : null,
             ),
             IconButton(
+              key: const ValueKey('pdf-redo'),
               icon: const Icon(Icons.redo),
               tooltip: pdfL10n(context).tbRedoShortcut,
               visualDensity: VisualDensity.compact,
@@ -2492,6 +2498,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             )
           else
             _SheetToolTile(
+              key: entry.tool == null
+                  ? ValueKey('pdf-markup-${entry.markup!.name}')
+                  : ValueKey('pdf-tool-${entry.tool!.name}'),
               icon: entry.icon,
               label: entry.markup != null
                   ? _markupName(context, entry.markup!)

--- a/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
+++ b/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
@@ -195,6 +195,10 @@ void main() {
 
     testWidgets('check box and radio toggle on a plain tap', (tester) async {
       final session = await pumpViewer(tester);
+      expect(
+        find.byKey(const ValueKey('pdf-form-field-0-agree-0')),
+        findsOneWidget,
+      );
 
       await tap(tester, view(82, 550)); // the agree check box
       expect(session.acroForm!.fieldNamed('agree')!.isChecked, isTrue);

--- a/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
@@ -14,7 +14,7 @@ void main() {
   final swatch = find.byKey(const ValueKey('pdf-mobile-swatch-0'));
 
   Future<PdfEditingController> pumpToolbar(WidgetTester tester,
-      {Uint8List? bytes}) async {
+      {Uint8List? bytes, double width = 380}) async {
     SharedPreferences.setMockInitialValues({});
     final editing =
         PdfEditingController(bytes ?? buildAppearanceAnnotationsPdf());
@@ -27,7 +27,7 @@ void main() {
         body: Align(
           alignment: Alignment.bottomCenter,
           child: SizedBox(
-            width: 380,
+            width: width,
             child: PdfEditingToolbar(
                 controller: editing, viewerController: viewer),
           ),
@@ -83,6 +83,18 @@ void main() {
     await tester.tap(swatch);
     await tester.pump();
     expect(editing.color, PdfEditingToolbar.defaultPalette.first);
+  });
+
+  testWidgets('active tool status yields when phone actions consume the dock',
+      (tester) async {
+    final editing = await pumpToolbar(tester, width: 320);
+
+    editing.tool = PdfEditTool.note;
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('pdf-tools-handle')), findsOneWidget);
+    expect(tester.takeException(), isNull,
+        reason: 'the status icon and label must not overflow a narrow dock');
   });
 
   testWidgets('a selection surfaces quick actions, not creation swatches',


### PR DESCRIPTION
## Summary
- expand the Patrol demo suite from one smoke journey to five core reader/editor journeys
- cover navigation, search, mode switching, annotations, undo/redo/delete, ink, notes, and AcroForm fields
- add stable adaptive-toolbar selectors and use actual rendered page geometry across desktop and phone layouts

## Validation
- Patrol web: 5/5 desktop viewport
- Patrol web: 5/5 phone viewport (430x900)
- targeted Dart analyzer: clean
- dart_pdf_editor editing/form widget tests: 91 passed
- example demo/editing widget tests: 9 passed