### PR TITLE
Fix release-mode annotation picture disposal

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1033,6 +1033,21 @@ typedef PdfScrollIndicatorBuilder = Widget Function(BuildContext context,
 /// search with highlights. Pages re-rasterize at the settled zoom; past the
 /// full-page raster caps a detail patch keeps the visible region sharp.
 class PdfViewer extends StatefulWidget {
+  /// Test hook for delaying annotation appearance rendering across lifecycle
+  /// transitions. Null uses [PdfPageRenderer.renderAnnotationPicture].
+  @visibleForTesting
+  static Future<ui.Picture?> Function(
+    PdfPage page,
+    PdfAnnotation annotation,
+    int rotation,
+  )? debugAnnotationAppearanceRendererOverride;
+
+  /// Test observer called immediately before an annotation appearance picture
+  /// is disposed. Production ownership and disposal remain unchanged.
+  @visibleForTesting
+  static void Function(ui.Picture picture)?
+      debugAnnotationAppearanceDisposeObserver;
+
   /// Raw content size above which a page is treated as "heavy" and its text is
   /// NOT extracted synchronously just to pick a hover cursor. A normal page is
   /// a few KB; a dense CAD sheet is megabytes and its extraction (a full
@@ -7955,16 +7970,19 @@ class _AnnotationAppearanceLayerState
   }
 
   void _disposeCache() {
-    for (final picture in _cache.values) {
-      picture.dispose();
-    }
+    // Snapshot identity ownership before clearing. Cache and retirement are
+    // normally disjoint, but overlapping render generations must still never
+    // dispose the same native handle twice.
+    final owned = Set<ui.Picture>.identity()
+      ..addAll(_cache.values)
+      ..addAll(_retired);
     _cache.clear();
     _cacheRotation = null;
     _cacheSize = null;
-    for (final picture in _retired) {
-      if (!picture.debugDisposed) picture.dispose();
-    }
     _retired.clear();
+    for (final picture in owned) {
+      _disposePicture(picture);
+    }
   }
 
   void _notifyReady(int generation) {
@@ -8027,7 +8045,7 @@ class _AnnotationAppearanceLayerState
     ]).then((rendered) {
       if (!mounted || generation != _generation) {
         for (final (_, picture) in rendered) {
-          picture?.dispose();
+          if (picture != null) _disposePicture(picture);
         }
         return;
       }
@@ -8036,7 +8054,7 @@ class _AnnotationAppearanceLayerState
         // A concurrent render may have filled this slot; keep one owner.
         final existing = _cache[source];
         if (existing != null) {
-          picture.dispose();
+          _disposePicture(picture);
           continue;
         }
         _cache[source] = picture;
@@ -8078,7 +8096,7 @@ class _AnnotationAppearanceLayerState
     if (_retired.isEmpty) return;
     final live = Set<ui.Picture>.identity()..addAll(_pictures);
     for (final picture in _retired) {
-      if (!live.contains(picture)) picture.dispose();
+      if (!live.contains(picture)) _disposePicture(picture);
     }
     _retired.clear();
   }
@@ -8086,11 +8104,18 @@ class _AnnotationAppearanceLayerState
   Future<ui.Picture?> _renderAnnotation(
       PdfPage page, PdfAnnotation annotation, int rotation) async {
     try {
+      final override = PdfViewer.debugAnnotationAppearanceRendererOverride;
+      if (override != null) return await override(page, annotation, rotation);
       return await PdfPageRenderer.renderAnnotationPicture(page, annotation,
           rotation: rotation);
     } catch (_) {
       return null;
     }
+  }
+
+  void _disposePicture(ui.Picture picture) {
+    PdfViewer.debugAnnotationAppearanceDisposeObserver?.call(picture);
+    picture.dispose();
   }
 
   @override

--- a/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
+++ b/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
@@ -17,6 +17,8 @@
 // one appearance stream and deleting drops one, so both evict. The first only
 // adds annotations, so nothing is ever evicted and it passes either way - it
 // is here to cover the plain repeat-commit path, not the lifetime bug.
+import 'dart:async';
+import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -29,6 +31,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('annotation picture disposal is release-safe', () {
+    final source = File('lib/src/pdf_viewer.dart').readAsStringSync();
+
+    expect(
+      source.contains('.debugDisposed'),
+      isFalse,
+      reason: 'Picture.debugDisposed throws when asserts are disabled',
+    );
+  });
 
   Future<PdfEditingController> pumpViewer(WidgetTester tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1));
@@ -90,6 +102,53 @@ void main() {
     editing.undo();
     await tester.pumpAndSettle();
     expect(editing.document.page(0).annotations, hasLength(2));
+  });
+
+  testWidgets(
+      'unmount while a replacement renders disposes every appearance once',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing.addRectangle(0, const PdfRect(100, 600, 250, 640));
+    editing.addRectangle(0, const PdfRect(300, 600, 450, 640));
+    await tester.pumpAndSettle();
+
+    final pending = Completer<ui.Picture?>();
+    final disposals = Map<ui.Picture, int>.identity();
+    var delayedRenders = 0;
+    PdfViewer.debugAnnotationAppearanceRendererOverride = (_, __, ___) {
+      delayedRenders++;
+      return pending.future;
+    };
+    PdfViewer.debugAnnotationAppearanceDisposeObserver = (picture) {
+      disposals.update(picture, (count) => count + 1, ifAbsent: () => 1);
+    };
+    addTearDown(() {
+      PdfViewer.debugAnnotationAppearanceRendererOverride = null;
+      PdfViewer.debugAnnotationAppearanceDisposeObserver = null;
+    });
+
+    expect(editing.selectAnnotation(0, 0), isTrue);
+    expect(editing.restyleSelected(color: const Color(0xFF00FF00)), isTrue);
+    await tester.pump();
+    expect(delayedRenders, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(find.byType(PdfViewer), findsNothing);
+    expect(disposals, hasLength(2));
+    expect(disposals.values, everyElement(1));
+
+    final recorder = ui.PictureRecorder();
+    Canvas(recorder).drawRect(
+      const Rect.fromLTWH(0, 0, 1, 1),
+      Paint()..color = const Color(0xFF000000),
+    );
+    pending.complete(recorder.endRecording());
+    await tester.pump();
+    await tester.pump();
+
+    expect(disposals, hasLength(3));
+    expect(disposals.values, everyElement(1));
+    expect(tester.takeException(), isNull);
   });
 
   // Regression (#418 follow-up): the appearance cache is keyed on the


### PR DESCRIPTION
## Summary\n\nFlutter release builds throw a StateError when annotation-layer teardown reads the assert-only Picture.debugDisposed property. Replace that check with an identity ownership snapshot of cached and retired pictures, then dispose each owned native handle exactly once.\n\nThe appearance-cache regression now delays a replacement render, retires an existing picture, unmounts the viewer, and completes the render afterward. It verifies cached, retired, and late-pending pictures are each disposed once and that no framework exception escapes. A source guard prevents debug-only picture state from returning to production disposal.\n\nTrax issue: https://github.com/Railway-Engineering-Solutions/trax/issues/6324\n\n## Affected packages\n\n- [ ] pdf_cos\n- [ ] pdf_document\n- [ ] pdf_graphics\n- [x] dart_pdf_editor\n- [ ] pdf_test_fixtures\n- [ ] Example app\n- [ ] Documentation / CI / repository metadata only\n\n## Change type\n\n- [x] Bug fix\n- [ ] Feature\n- [ ] Rendering change\n- [ ] Editing behavior change\n- [ ] Performance change\n- [ ] Refactor / cleanup\n- [ ] Tests / fixtures only\n- [ ] Documentation only\n\n## Validation\n\n- [x] fvm flutter pub get\n- [x] fvm dart analyze\n- [ ] cd packages/pdf_cos and fvm dart test\n- [ ] cd packages/pdf_document and fvm dart test\n- [ ] cd packages/pdf_graphics and fvm dart test\n- [x] cd packages/dart_pdf_editor and fvm flutter test — 2,395 passed, 36 skipped, 0 failed\n- [ ] Ghent corpus test or baseline update\n- [ ] Real PDF corpus parse/render smoke test\n- [ ] Example app smoke test\n\nThe change is confined to Flutter annotation-picture lifecycle ownership. It does not alter PDF parsing, writing, or rendered output, so pure-Dart and corpus suites are not relevant.\n\n## PDF fixtures and screenshots\n\nNone. The regression uses the existing programmatic one-page fixture and deterministic render delay.\n\n## Compatibility checklist\n\n- [x] No dart:ui or Flutter imports outside packages/dart_pdf_editor.\n- [x] No dart:io imports in any lib directory.\n- [x] Layering is preserved: pdf_cos to pdf_document to pdf_graphics to dart_pdf_editor.\n- [x] Parsers remain lenient on real-world input and writers remain strict on output.\n- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.\n- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.\n\n## Notes for reviewers\n\nThe cache and retirement lists are intended to be disjoint, but release teardown should not infer ownership by consulting an assert-only engine diagnostic. The identity set makes the at-most-once rule explicit even if overlapping render generations ever alias a picture. A render completing after unmount remains independently owned by its stale generation and is disposed in the existing generation guard.