### PR TITLE
fix(editor): anchor thumbnail menus in nested overlays

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.7.0
 
+- Anchor thumbnail context menus to the correct position when the editor is
+  hosted inside an offset nested navigator.
 - Render ordinary pages *through* a scroll instead of waiting it out.
   `PdfPageRenderScheduler` gains a motion lane: a request declares a
   `PdfRenderMotionClass`, evaluated at grant time rather than baked in, so a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -2703,10 +2703,13 @@ Future<void> _showPageTileMenu({
   if (items.isEmpty) return;
 
   final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
+  final overlayPosition = overlay.globalToLocal(position);
   final picked = await showMenu<_PageTileAction>(
     context: context,
-    position:
-        RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
+    position: RelativeRect.fromRect(
+      overlayPosition & Size.zero,
+      Offset.zero & overlay.size,
+    ),
     items: items,
   );
   switch (picked) {

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -1263,6 +1263,64 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
     });
 
+    testWidgets('the menu is anchored in an offset navigator overlay',
+        (tester) async {
+      tester.view.physicalSize = const Size(1000, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            const SizedBox(width: 220),
+            Expanded(
+              child: Navigator(
+                onGenerateRoute: (_) => MaterialPageRoute<void>(
+                  builder: (_) => Scaffold(
+                    body: Row(children: [
+                      PdfThumbnailSidebar(
+                        controller: editing,
+                        viewerController: viewer,
+                        allowPageEditing: false,
+                        onExportPages: (_) {},
+                      ),
+                      const Expanded(child: SizedBox()),
+                    ]),
+                  ),
+                ),
+              ),
+            ),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      final clickPosition = tester.getCenter(find.text('Page 1'));
+      await tester.tapAt(
+        clickPosition,
+        buttons: kSecondaryMouseButton,
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pumpAndSettle();
+
+      final menuPosition = tester.getTopLeft(
+        find.byKey(const ValueKey('pdf-thumbnail-menu-export')),
+      );
+      expect(
+        (menuPosition.dx - clickPosition.dx).abs(),
+        lessThan(100),
+        reason: 'The nested overlay origin must not be added twice.',
+      );
+
+      await tester.tapAt(const Offset(900, 1200));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
+    });
+
     testWidgets('right-clicking within a multi-selection spans the selection',
         (tester) async {
       final editing = await pumpStrip(tester, count: 5);


### PR DESCRIPTION
## Summary

- convert the thumbnail menu pointer from global coordinates into the nearest overlay coordinate space
- keep page menus aligned when dart_pdf_editor is hosted in an offset nested Navigator
- add a widget regression covering a 220px host rail and nested overlay

## Root cause

The thumbnail menu used TapUpDetails.globalPosition directly to build a RelativeRect for the nearest Overlay. showMenu interpreted that value as overlay-local, so hosts with an offset nested Navigator added the shell offset a second time.

## Testing

- fvm dart analyze --fatal-infos packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart packages/dart_pdf_editor/test/editing_page_ops_test.dart
- fvm flutter test packages/dart_pdf_editor/test/editing_page_ops_test.dart (65 tests)