### PR TITLE
Improve editor tool workflows across mobile and desktop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,16 @@
 
 If any relevant check was not run, explain why:
 
+## User experience
+
+<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->
+
+- [ ] The affected user journey and expected outcome are described above.
+- [ ] Completion, cancellation, disabled, loading, and error states were considered.
+- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
+- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
+- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.
+
 ## PDF fixtures and screenshots
 
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,15 @@ committing new baselines.
 - Add or update tests for any behaviour change. New parser edge cases
   should come with an inline fixture and a regression test.
 
+### User-facing changes
+
+The [UX vision](doc/ux-vision.md) is the product-quality bar for viewer,
+editor, shell, and app work. Describe the user journey being improved, check
+the relevant input modes and accessibility states, and validate the committed
+and reopened PDF rather than stopping at the live preview. Performance work
+should measure the complete journey and report tail latency, not just an
+isolated subsystem average.
+
 ## Pull requests
 
 1. Branch off `main`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ viewer, a full annotation suite with appearance-stream generation,
 AcroForm filling, page manipulation, and editing that preserves digital
 signatures.
 
+Feature parity is only the foundation. The [UX vision](doc/ux-vision.md)
+defines the product north star, the journeys that matter, how their quality is
+measured, and the definition of done for user-facing work.
+
 > Status: the roadmap below is complete. COS parsing with xref recovery,
 > signature-preserving incremental updates with encrypt-on-write, a
 > content-stream interpreter with TrueType/CFF/Type3 font rendering,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -3686,34 +3686,41 @@ class _EditorScreenState extends State<EditorScreen>
                       mainAxisSize: MainAxisSize.max,
                       children: [
                         if (tabsWidth > 0)
-                          MouseRegion(
-                            onEnter: (_) => _tabStripHovered = true,
-                            onExit: (_) {
-                              _tabStripHovered = false;
-                              _releaseTabWidthHold();
-                            },
-                            // Grow back smoothly once the hold releases; both the strip
-                            // and each tab animate to the same width with a linear curve,
-                            // so they stay pixel-consistent throughout.
-                            child: AnimatedContainer(
-                              duration: _tabResizeDuration,
-                              curve: Curves.linear,
-                              width: tabsWidth,
-                              child: ReorderableListView.builder(
-                                key: const ValueKey('tab-strip'),
-                                scrollController: _tabScrollController,
-                                scrollDirection: Axis.horizontal,
-                                // The whole tab is the drag handle (see _buildTab); the
-                                // stock trailing handles don't fit a horizontal tab strip.
-                                buildDefaultDragHandles: false,
-                                padding: EdgeInsets.only(
-                                  left: rtl ? 4 + gapPadding : 4,
-                                  right: rtl ? 4 : 4 + gapPadding,
+                          // A window or AppBar-action resize can make the new
+                          // title constraint narrower than the container's
+                          // previous animated width. Clamp outside the animation
+                          // so even its first frame fits the current Row.
+                          ConstrainedBox(
+                            constraints: BoxConstraints(maxWidth: maxTabsWidth),
+                            child: MouseRegion(
+                              onEnter: (_) => _tabStripHovered = true,
+                              onExit: (_) {
+                                _tabStripHovered = false;
+                                _releaseTabWidthHold();
+                              },
+                              // Grow back smoothly once the hold releases; both the strip
+                              // and each tab animate to the same width with a linear curve,
+                              // so they stay pixel-consistent throughout.
+                              child: AnimatedContainer(
+                                duration: _tabResizeDuration,
+                                curve: Curves.linear,
+                                width: tabsWidth,
+                                child: ReorderableListView.builder(
+                                  key: const ValueKey('tab-strip'),
+                                  scrollController: _tabScrollController,
+                                  scrollDirection: Axis.horizontal,
+                                  // The whole tab is the drag handle (see _buildTab); the
+                                  // stock trailing handles don't fit a horizontal tab strip.
+                                  buildDefaultDragHandles: false,
+                                  padding: EdgeInsets.only(
+                                    left: rtl ? 4 + gapPadding : 4,
+                                    right: rtl ? 4 : 4 + gapPadding,
+                                  ),
+                                  itemCount: _tabs.length,
+                                  onReorderItem: _reorderTabs,
+                                  itemBuilder: (context, i) =>
+                                      _buildTab(i, tabWidth),
                                 ),
-                                itemCount: _tabs.length,
-                                onReorderItem: _reorderTabs,
-                                itemBuilder: (context, i) =>
-                                    _buildTab(i, tabWidth),
                               ),
                             ),
                           ),

--- a/app/test/tabs_sizing_test.dart
+++ b/app/test/tabs_sizing_test.dart
@@ -117,4 +117,23 @@ void main() {
 
     await mouse.removePointer();
   });
+
+  testWidgets('tab strip stays inside the AppBar while the window narrows',
+      (tester) async {
+    setDesktopSize(tester);
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    for (var i = 0; i < 8; i++) {
+      await openTab(tester, 't$i.pdf');
+    }
+    await tester.pumpAndSettle();
+
+    // The tab list fills all available title space at this width. Narrowing
+    // the window starts its resize animation from the old, wider constraint;
+    // that intermediate width must still be clamped to the new AppBar width.
+    tester.view.physicalSize = const Size(1390, 800);
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/doc/ux-vision.md
+++ b/doc/ux-vision.md
@@ -1,0 +1,165 @@
+# UX vision
+
+dart-pdf should make working with a PDF feel direct, dependable, and native on
+every supported platform. Its product goal is not merely to cover the same
+feature list as established editors. It is to offer the best end-to-end PDF
+editing experience.
+
+This document is the product-quality charter for the SDK, the example shells,
+and DartPDF. It complements the technical roadmap and the measured
+[PDFium parity work](benchmarks/pdfium-parity.md).
+
+## North star
+
+Minimize the time from a user's intent to a result they trust.
+
+A trusted result is correct, visibly complete, saved when the user expects,
+reversible when possible, and preserved when reopened in dart-pdf or another
+conforming PDF application. Speed without confidence is not good UX.
+
+## Product principles
+
+### Instant
+
+Opening, scrolling, zooming, searching, selecting a tool, and seeing an edit
+should feel immediate. Expensive work belongs off the interaction path. When
+work cannot finish immediately, show useful content and honest progress rather
+than a blank or frozen surface.
+
+### Obvious
+
+The next action, active tool, selection, save state, and result of an operation
+should be clear without a manual. Prefer contextual controls and progressive
+disclosure over a permanently crowded canvas. Labels, icons, cursors, previews,
+and disabled states should agree.
+
+### Forgiving
+
+Users should be free to experiment. Edits need reliable undo and redo;
+destructive operations need an escape path; interrupted sessions need recovery;
+and cancel must leave the document unchanged. Avoid modes that silently trap
+input or actions whose effect becomes clear only after saving.
+
+### Precise
+
+The preview must match the committed PDF. Hit targets, snapping, handles,
+selection bounds, text placement, zoom, and page navigation must remain stable
+at every scale. Mouse, keyboard, touch, trackpad, and stylus input should each
+feel intentional rather than emulated.
+
+### Coherent
+
+Reader and editor shells, toolbars, panels, context menus, shortcuts, and public
+widgets should share one interaction model. Follow platform conventions where
+they help users, while keeping document behavior consistent across desktop,
+mobile, and web.
+
+### Inclusive
+
+Accessibility is part of the interaction design, not a final audit. User-facing
+work should account for keyboard-only use, focus order, screen-reader semantics,
+contrast, text scaling, reduced motion, and sufficiently large touch targets.
+
+## Journeys that define the product
+
+These journeys matter more than isolated feature counts:
+
+| Journey | Quality bar |
+| --- | --- |
+| Open or recover | Reach a useful first page quickly, explain failures clearly, and never lose a recoverable edit. |
+| Read and navigate | Scrolling, zooming, page jumps, outlines, thumbnails, history, and links preserve orientation and never fight the user. |
+| Find and understand | Search responds promptly, exposes useful context, follows the active result, and works for scanned documents when OCR is available. |
+| Annotate and edit | Tools are easy to enter and leave; selection is predictable; live previews match commits; repeated work stays fast. |
+| Fill and sign | Field state and signature consequences are clear before commitment, with validation results phrased for people rather than PDF internals. |
+| Organize pages | Reorder, insert, extract, rotate, and delete operations provide strong spatial feedback and remain safely reversible. |
+| Save, export, and share | Users know what is saved, where it went, what changed, and whether compatibility or signatures were affected. |
+
+A feature that works in isolation but makes one of these journeys confusing,
+slow, or fragile is not finished.
+
+Text markup supports both natural orders of work: choose Highlight, Underline,
+Strike out, or Squiggly and then select text, or select text and then choose the
+markup. The chosen markup stays visibly armed for repeated passages until the
+user clears it or switches tools.
+
+## How quality is measured
+
+Use matched, reproducible journeys on the same hardware, document, viewport,
+and input sequence. Compare against the strongest relevant experience, which
+may be Acrobat, Bluebeam, PDF Expert, Preview, a browser PDF viewer, or another
+specialist tool. Record limitations instead of generalizing a result from one
+platform to all platforms.
+
+The scorecard for a user journey should include the measures that apply:
+
+- task completion and error rate;
+- time to first useful visual and time to stable visual;
+- time to complete the task;
+- p50 and p95 input latency or frame interval, including tail stalls;
+- peak and steady-state memory;
+- undo, recovery, save, and reopen correctness;
+- keyboard, touch, stylus, focus, semantics, contrast, and text-scale coverage.
+
+Prefer user-visible measurements over internal throughput. A faster decoder is
+valuable when it improves the journey; it is not by itself proof of a faster
+viewer. Performance claims and budgets belong in reproducible benchmark notes,
+including [the current parity methodology](benchmarks/pdfium-parity.md).
+
+## Prioritization
+
+When two pieces of work compete, prefer the one that removes more frequent or
+more severe friction from a core journey. Use this order to break close calls:
+
+1. Prevent data loss, corruption, privacy failures, and inaccessible dead ends.
+2. Fix incorrect, misleading, or incompatible document behavior.
+3. Remove stalls, input conflicts, and unnecessary waiting from common work.
+4. Reduce decisions, mode confusion, and repeated steps.
+5. Improve consistency, polish, and visual density.
+6. Add breadth that does not compromise the earlier qualities.
+
+Evidence should move priorities. Reports from real use, journey traces,
+accessibility findings, and reproducible documents outweigh feature-count
+comparisons.
+
+## Standing execution order
+
+The ongoing UX program is:
+
+1. Instrument complete user journeys with latency, frame-time, memory, and
+   success criteria.
+2. Audit friction on desktop, web, tablet, and phone with representative real
+   documents.
+3. Keep perfecting the core loop: open, find, edit, undo, save, and share.
+4. Improve orientation and navigation, including outlines, page labels, recent
+   locations, and search-result continuity.
+5. Make advanced capability discoverable without crowding routine work.
+6. Close accessibility gaps and make keyboard operation complete.
+7. Turn every material interaction or visual regression into durable coverage.
+
+This order is not a promise to build speculative features. Start from the
+largest demonstrated gap in a core journey, make the smallest coherent change,
+and measure the journey again.
+
+## Definition of done for user-facing changes
+
+Not every item applies to every change, but omissions should be deliberate and
+called out in review.
+
+- The entry point, active state, completion, cancellation, disabled state, and
+  error path are understandable.
+- Immediate feedback is shown, and any preview agrees with the committed and
+  reopened PDF.
+- Undo, redo, save, reopen, and crash recovery behave correctly where relevant.
+- Relevant keyboard, mouse, trackpad, touch, and stylus paths have been checked.
+- Focus, semantics, contrast, text scaling, reduced motion, and touch-target
+  size have been considered.
+- Loading, empty, malformed-document, long-document, and constrained-window
+  states degrade gracefully.
+- The change introduces no unexplained journey-level latency, frame-time, or
+  memory regression.
+- Behavior tests, visual tests, corpus cases, or performance traces protect the
+  risk at the appropriate layer.
+- Public APIs and host responsibilities are documented when they change.
+
+The final review question is simple: does this shorten the path from intent to
+a trusted result?

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -386,9 +386,24 @@ class _DemoHarness {
   }
 
   Future<void> tapFormField(String name, {int widgetIndex = 0}) async {
+    final field = editing.acroForm?.fieldNamed(name);
+    final rect = field?.widgetRect(widgetIndex);
+    final page = field?.widgetPageIndex(widgetIndex) ?? -1;
+    expect(field, isNotNull, reason: '$name should be an AcroForm field');
+    expect(rect, isNotNull, reason: '$name widget $widgetIndex needs a rect');
+    expect(page, greaterThanOrEqualTo(0),
+        reason: '$name widget $widgetIndex should be on a page');
+
+    // The compact editing dock floats over the bottom of the page. Lower
+    // fields (notably the radio buttons on the showcase page) can otherwise
+    // be present in the tree while their tap target is covered by the dock on
+    // a short Android viewport. Frame the widget before tapping it, just as a
+    // user would scroll the field into view.
+    await viewer.showRect(page, rect!);
+    await $.pump(const Duration(milliseconds: 350));
     final target = find.byKey(
       ValueKey(
-        'pdf-form-field-${viewer.currentPage}-$name-$widgetIndex',
+        'pdf-form-field-$page-$name-$widgetIndex',
       ),
     );
     await waitForFinder(target);

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -265,14 +265,26 @@ void main() {
       await $.tester.enterText(editor, 'Grace Hopper');
       await $.tester.testTextInput.receiveAction(TextInputAction.done);
       await $.pump(const Duration(milliseconds: 400));
+      await demo.waitFor(
+        () => field('name').value == 'Grace Hopper',
+        reason: 'the text-field revision should finish before validation',
+      );
       expect(field('name').value, 'Grace Hopper');
 
       expect(field('newsletter').isChecked, isTrue);
       await demo.tapFormField('newsletter');
+      await demo.waitFor(
+        () => !field('newsletter').isChecked,
+        reason: 'the checkbox revision should finish before validation',
+      );
       expect(field('newsletter').isChecked, isFalse);
 
       expect(field('color').value, 'Blue');
       await demo.tapFormField('color');
+      await demo.waitFor(
+        () => field('color').value == 'Red',
+        reason: 'the radio revision should finish before validation',
+      );
       expect(field('color').value, 'Red');
 
       expect(field('favorite').value, 'Green');
@@ -281,6 +293,10 @@ void main() {
       expect($('Blue'), findsOneWidget);
       await $.tester.tap(find.text('Blue'));
       await $.pump(const Duration(milliseconds: 400));
+      await demo.waitFor(
+        () => field('favorite').value == 'Blue',
+        reason: 'the choice revision should finish before validation',
+      );
       expect(field('favorite').value, 'Blue');
     } finally {
       await demo.close();
@@ -413,6 +429,12 @@ class _DemoHarness {
       await tester.ensureVisible(groupTab);
       await tester.tap(groupTab);
       await $.pump(const Duration(milliseconds: 250));
+      // Select is the mobile sheet's only single-option group, so tapping its
+      // group tab now arms it directly and closes the sheet. Multi-tool groups
+      // still expose their tiles below.
+      if (editing.tool == tool) return;
+      expect(toolButton, findsOneWidget,
+          reason: '$tool should be available in the $group tool group');
       await tester.ensureVisible(toolButton);
       await tester.tap(toolButton);
       await $.pump();

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "رسم",
   "tbNameEllipse": "قطع ناقص",
   "tbNameEraser": "محو خطوط الحبر",
+  "tbNameHand": "أداة اليد",
   "tbNameHighlight": "تمييز",
   "tbNameImage": "صورة",
   "tbNameLine": "خط",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Zeichnen",
   "tbNameEllipse": "Ellipse",
   "tbNameEraser": "Freihandstriche löschen",
+  "tbNameHand": "Hand-Werkzeug",
   "tbNameHighlight": "Hervorheben",
   "tbNameImage": "Bild",
   "tbNameLine": "Linie",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -2016,35 +2016,35 @@
   },
   "tbMarkupHighlight": "Highlight",
   "@tbMarkupHighlight": {
-    "description": "Text-markup action name: highlight the text selection."
+    "description": "Text-markup tool name: highlight text."
   },
-  "tbMarkupHighlightTip": "Highlight selection",
+  "tbMarkupHighlightTip": "Highlight text",
   "@tbMarkupHighlightTip": {
-    "description": "Tooltip: highlight the current text selection."
+    "description": "Tooltip for the text highlight tool."
   },
   "tbMarkupSquiggly": "Squiggly-underline",
   "@tbMarkupSquiggly": {
-    "description": "Text-markup action name: squiggly-underline the text selection."
+    "description": "Text-markup tool name: squiggly-underline text."
   },
-  "tbMarkupSquigglyTip": "Squiggly-underline selection",
+  "tbMarkupSquigglyTip": "Squiggly-underline text",
   "@tbMarkupSquigglyTip": {
-    "description": "Tooltip: squiggly-underline the current text selection."
+    "description": "Tooltip for the squiggly-underline tool."
   },
   "tbMarkupStrikeOut": "Strike out",
   "@tbMarkupStrikeOut": {
-    "description": "Text-markup action name: strike out the text selection."
+    "description": "Text-markup tool name: strike out text."
   },
-  "tbMarkupStrikeOutTip": "Strike out selection",
+  "tbMarkupStrikeOutTip": "Strike out text",
   "@tbMarkupStrikeOutTip": {
-    "description": "Tooltip: strike out the current text selection."
+    "description": "Tooltip for the strike-out tool."
   },
   "tbMarkupUnderline": "Underline",
   "@tbMarkupUnderline": {
-    "description": "Text-markup action name: underline the text selection."
+    "description": "Text-markup tool name: underline text."
   },
-  "tbMarkupUnderlineTip": "Underline selection",
+  "tbMarkupUnderlineTip": "Underline text",
   "@tbMarkupUnderlineTip": {
-    "description": "Tooltip: underline the current text selection."
+    "description": "Tooltip for the underline tool."
   },
   "tbMoreColors": "More colors…",
   "@tbMoreColors": {
@@ -2081,6 +2081,10 @@
   "tbNameEraser": "Erase ink strokes",
   "@tbNameEraser": {
     "description": "Tool name: erases ink strokes."
+  },
+  "tbNameHand": "Hand",
+  "@tbNameHand": {
+    "description": "Name of the default page-navigation mode, which pans the document by dragging."
   },
   "tbNameHighlight": "Highlight",
   "@tbNameHighlight": {
@@ -2242,9 +2246,9 @@
   "@tbScale": {
     "description": "Leading label of the measurement-scale chip."
   },
-  "tbSelectTextForMarkup": "Select text to use markup",
+  "tbSelectTextForMarkup": "Choose a markup, then select text",
   "@tbSelectTextForMarkup": {
-    "description": "Hint shown when the markup tools are open but no text is selected."
+    "description": "Hint explaining the arm-first text-markup workflow."
   },
   "tbSelectionCount": "{count, plural, =1{Selection} other{{count} selected}}",
   "@tbSelectionCount": {

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Dibujar",
   "tbNameEllipse": "Elipse",
   "tbNameEraser": "Borrar trazos",
+  "tbNameHand": "Mano",
   "tbNameHighlight": "Resaltar",
   "tbNameImage": "Imagen",
   "tbNameLine": "Línea",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Dessin",
   "tbNameEllipse": "Ellipse",
   "tbNameEraser": "Effacer les traits d'encre",
+  "tbNameHand": "Main",
   "tbNameHighlight": "Surlignage",
   "tbNameImage": "Image",
   "tbNameLine": "Ligne",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "ड्रा",
   "tbNameEllipse": "दीर्घवृत्त",
   "tbNameEraser": "इंक स्ट्रोक मिटाएँ",
+  "tbNameHand": "हाथ",
   "tbNameHighlight": "हाइलाइट",
   "tbNameImage": "छवि",
   "tbNameLine": "रेखा",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Gambar",
   "tbNameEllipse": "Elips",
   "tbNameEraser": "Hapus goresan tinta",
+  "tbNameHand": "Tangan",
   "tbNameHighlight": "Sorot",
   "tbNameImage": "Gambar",
   "tbNameLine": "Garis",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Disegna",
   "tbNameEllipse": "Ellisse",
   "tbNameEraser": "Cancella tratti a inchiostro",
+  "tbNameHand": "Mano",
   "tbNameHighlight": "Evidenzia",
   "tbNameImage": "Immagine",
   "tbNameLine": "Linea",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "描画",
   "tbNameEllipse": "楕円",
   "tbNameEraser": "手書きストロークを消去",
+  "tbNameHand": "手のひらツール",
   "tbNameHighlight": "ハイライト",
   "tbNameImage": "画像",
   "tbNameLine": "直線",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "그리기",
   "tbNameEllipse": "타원",
   "tbNameEraser": "잉크 획 지우기",
+  "tbNameHand": "손 도구",
   "tbNameHighlight": "형광펜",
   "tbNameImage": "이미지",
   "tbNameLine": "선",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -2882,52 +2882,52 @@ abstract class DartPdfEditorLocalizations {
   /// **'Manage stamps…'**
   String get tbManageStamps;
 
-  /// Text-markup action name: highlight the text selection.
+  /// Text-markup tool name: highlight text.
   ///
   /// In en, this message translates to:
   /// **'Highlight'**
   String get tbMarkupHighlight;
 
-  /// Tooltip: highlight the current text selection.
+  /// Tooltip for the text highlight tool.
   ///
   /// In en, this message translates to:
-  /// **'Highlight selection'**
+  /// **'Highlight text'**
   String get tbMarkupHighlightTip;
 
-  /// Text-markup action name: squiggly-underline the text selection.
+  /// Text-markup tool name: squiggly-underline text.
   ///
   /// In en, this message translates to:
   /// **'Squiggly-underline'**
   String get tbMarkupSquiggly;
 
-  /// Tooltip: squiggly-underline the current text selection.
+  /// Tooltip for the squiggly-underline tool.
   ///
   /// In en, this message translates to:
-  /// **'Squiggly-underline selection'**
+  /// **'Squiggly-underline text'**
   String get tbMarkupSquigglyTip;
 
-  /// Text-markup action name: strike out the text selection.
+  /// Text-markup tool name: strike out text.
   ///
   /// In en, this message translates to:
   /// **'Strike out'**
   String get tbMarkupStrikeOut;
 
-  /// Tooltip: strike out the current text selection.
+  /// Tooltip for the strike-out tool.
   ///
   /// In en, this message translates to:
-  /// **'Strike out selection'**
+  /// **'Strike out text'**
   String get tbMarkupStrikeOutTip;
 
-  /// Text-markup action name: underline the text selection.
+  /// Text-markup tool name: underline text.
   ///
   /// In en, this message translates to:
   /// **'Underline'**
   String get tbMarkupUnderline;
 
-  /// Tooltip: underline the current text selection.
+  /// Tooltip for the underline tool.
   ///
   /// In en, this message translates to:
-  /// **'Underline selection'**
+  /// **'Underline text'**
   String get tbMarkupUnderlineTip;
 
   /// Tooltip for the button opening the full color picker.
@@ -2983,6 +2983,12 @@ abstract class DartPdfEditorLocalizations {
   /// In en, this message translates to:
   /// **'Erase ink strokes'**
   String get tbNameEraser;
+
+  /// Name of the default page-navigation mode, which pans the document by dragging.
+  ///
+  /// In en, this message translates to:
+  /// **'Hand'**
+  String get tbNameHand;
 
   /// Tool name: freehand highlighter.
   ///
@@ -3224,10 +3230,10 @@ abstract class DartPdfEditorLocalizations {
   /// **'Scale'**
   String get tbScale;
 
-  /// Hint shown when the markup tools are open but no text is selected.
+  /// Hint explaining the arm-first text-markup workflow.
   ///
   /// In en, this message translates to:
-  /// **'Select text to use markup'**
+  /// **'Choose a markup, then select text'**
   String get tbSelectTextForMarkup;
 
   /// Strip label for one or more selected annotations.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -1631,6 +1631,9 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'محو خطوط الحبر';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'تمييز';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -1631,7 +1631,7 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'محو خطوط الحبر';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'أداة اليد';
 
   @override
   String get tbNameHighlight => 'تمييز';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -1606,6 +1606,9 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Freihandstriche löschen';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Hervorheben';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -1606,7 +1606,7 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Freihandstriche löschen';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Hand-Werkzeug';
 
   @override
   String get tbNameHighlight => 'Hervorheben';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -1551,25 +1551,25 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get tbMarkupHighlight => 'Highlight';
 
   @override
-  String get tbMarkupHighlightTip => 'Highlight selection';
+  String get tbMarkupHighlightTip => 'Highlight text';
 
   @override
   String get tbMarkupSquiggly => 'Squiggly-underline';
 
   @override
-  String get tbMarkupSquigglyTip => 'Squiggly-underline selection';
+  String get tbMarkupSquigglyTip => 'Squiggly-underline text';
 
   @override
   String get tbMarkupStrikeOut => 'Strike out';
 
   @override
-  String get tbMarkupStrikeOutTip => 'Strike out selection';
+  String get tbMarkupStrikeOutTip => 'Strike out text';
 
   @override
   String get tbMarkupUnderline => 'Underline';
 
   @override
-  String get tbMarkupUnderlineTip => 'Underline selection';
+  String get tbMarkupUnderlineTip => 'Underline text';
 
   @override
   String get tbMoreColors => 'More colors…';
@@ -1597,6 +1597,9 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get tbNameEraser => 'Erase ink strokes';
+
+  @override
+  String get tbNameHand => 'Hand';
 
   @override
   String get tbNameHighlight => 'Highlight';
@@ -1720,7 +1723,7 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get tbScale => 'Scale';
 
   @override
-  String get tbSelectTextForMarkup => 'Select text to use markup';
+  String get tbSelectTextForMarkup => 'Choose a markup, then select text';
 
   @override
   String tbSelectionCount(int count) {

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -1605,6 +1605,9 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Borrar trazos';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Resaltar';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -1605,7 +1605,7 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Borrar trazos';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Mano';
 
   @override
   String get tbNameHighlight => 'Resaltar';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -1610,7 +1610,7 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Effacer les traits d\'encre';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Main';
 
   @override
   String get tbNameHighlight => 'Surlignage';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -1610,6 +1610,9 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Effacer les traits d\'encre';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Surlignage';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -1601,7 +1601,7 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'इंक स्ट्रोक मिटाएँ';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'हाथ';
 
   @override
   String get tbNameHighlight => 'हाइलाइट';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -1601,6 +1601,9 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'इंक स्ट्रोक मिटाएँ';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'हाइलाइट';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -1605,7 +1605,7 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Hapus goresan tinta';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Tangan';
 
   @override
   String get tbNameHighlight => 'Sorot';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -1605,6 +1605,9 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Hapus goresan tinta';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Sorot';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -1606,6 +1606,9 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Cancella tratti a inchiostro';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Evidenzia';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -1606,7 +1606,7 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Cancella tratti a inchiostro';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Mano';
 
   @override
   String get tbNameHighlight => 'Evidenzia';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -1590,7 +1590,7 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get tbNameEraser => '手書きストロークを消去';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => '手のひらツール';
 
   @override
   String get tbNameHighlight => 'ハイライト';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -1590,6 +1590,9 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get tbNameEraser => '手書きストロークを消去';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'ハイライト';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -1591,7 +1591,7 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get tbNameEraser => '잉크 획 지우기';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => '손 도구';
 
   @override
   String get tbNameHighlight => '형광펜';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -1591,6 +1591,9 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get tbNameEraser => '잉크 획 지우기';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => '형광펜';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -1606,6 +1606,9 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Inktstreken wissen';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Markeren';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -1627,7 +1627,7 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Wymaż linie odręczne';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Rączka';
 
   @override
   String get tbNameHighlight => 'Zakreślacz';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -1627,6 +1627,9 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Wymaż linie odręczne';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Zakreślacz';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -1605,6 +1605,9 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Apagar traços';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Destacar';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -1605,7 +1605,7 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Apagar traços';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Mão';
 
   @override
   String get tbNameHighlight => 'Destacar';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -1628,7 +1628,7 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Стереть рукописные штрихи';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Рука';
 
   @override
   String get tbNameHighlight => 'Выделение';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -1628,6 +1628,9 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Стереть рукописные штрихи';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Выделение';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -1597,6 +1597,9 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'ลบเส้นหมึก';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'ไฮไลต์';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -1597,7 +1597,7 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'ลบเส้นหมึก';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'มือ';
 
   @override
   String get tbNameHighlight => 'ไฮไลต์';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -1601,7 +1601,7 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Kalem çizgilerini sil';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'El';
 
   @override
   String get tbNameHighlight => 'Vurgu';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -1601,6 +1601,9 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Kalem çizgilerini sil';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Vurgu';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -1626,6 +1626,9 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Стерти штрихи малюнка';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Виділення';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -1626,7 +1626,7 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Стерти штрихи малюнка';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Рука';
 
   @override
   String get tbNameHighlight => 'Виділення';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -1602,7 +1602,7 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Tẩy nét mực';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => 'Bàn tay';
 
   @override
   String get tbNameHighlight => 'Tô sáng';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -1602,6 +1602,9 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get tbNameEraser => 'Tẩy nét mực';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => 'Tô sáng';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -1587,7 +1587,7 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get tbNameEraser => '擦除手绘笔迹';
 
   @override
-  String get tbNameHand => 'Hand';
+  String get tbNameHand => '抓手工具';
 
   @override
   String get tbNameHighlight => '高亮';
@@ -3608,6 +3608,9 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get tbNameEraser => '擦除手繪筆畫';
+
+  @override
+  String get tbNameHand => '手形工具';
 
   @override
   String get tbNameHighlight => '醒目提示';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -1587,6 +1587,9 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get tbNameEraser => '擦除手绘笔迹';
 
   @override
+  String get tbNameHand => 'Hand';
+
+  @override
   String get tbNameHighlight => '高亮';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Tekenen",
   "tbNameEllipse": "Ellips",
   "tbNameEraser": "Inktstreken wissen",
+  "tbNameHand": "Hand",
   "tbNameHighlight": "Markeren",
   "tbNameImage": "Afbeelding",
   "tbNameLine": "Lijn",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Rysowanie",
   "tbNameEllipse": "Elipsa",
   "tbNameEraser": "Wymaż linie odręczne",
+  "tbNameHand": "Rączka",
   "tbNameHighlight": "Zakreślacz",
   "tbNameImage": "Obraz",
   "tbNameLine": "Linia",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Desenhar",
   "tbNameEllipse": "Elipse",
   "tbNameEraser": "Apagar traços",
+  "tbNameHand": "Mão",
   "tbNameHighlight": "Destacar",
   "tbNameImage": "Imagem",
   "tbNameLine": "Linha",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Рисование",
   "tbNameEllipse": "Эллипс",
   "tbNameEraser": "Стереть рукописные штрихи",
+  "tbNameHand": "Рука",
   "tbNameHighlight": "Выделение",
   "tbNameImage": "Изображение",
   "tbNameLine": "Линия",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "วาด",
   "tbNameEllipse": "วงรี",
   "tbNameEraser": "ลบเส้นหมึก",
+  "tbNameHand": "มือ",
   "tbNameHighlight": "ไฮไลต์",
   "tbNameImage": "รูปภาพ",
   "tbNameLine": "เส้น",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Çiz",
   "tbNameEllipse": "Elips",
   "tbNameEraser": "Kalem çizgilerini sil",
+  "tbNameHand": "El",
   "tbNameHighlight": "Vurgu",
   "tbNameImage": "Görsel",
   "tbNameLine": "Çizgi",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Малювати",
   "tbNameEllipse": "Еліпс",
   "tbNameEraser": "Стерти штрихи малюнка",
+  "tbNameHand": "Рука",
   "tbNameHighlight": "Виділення",
   "tbNameImage": "Зображення",
   "tbNameLine": "Лінія",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "Vẽ",
   "tbNameEllipse": "Hình elip",
   "tbNameEraser": "Tẩy nét mực",
+  "tbNameHand": "Bàn tay",
   "tbNameHighlight": "Tô sáng",
   "tbNameImage": "Hình ảnh",
   "tbNameLine": "Đường thẳng",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "绘制",
   "tbNameEllipse": "椭圆",
   "tbNameEraser": "擦除手绘笔迹",
+  "tbNameHand": "抓手工具",
   "tbNameHighlight": "高亮",
   "tbNameImage": "图像",
   "tbNameLine": "直线",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -475,6 +475,7 @@
   "tbNameDraw": "繪製",
   "tbNameEllipse": "橢圓形",
   "tbNameEraser": "擦除手繪筆畫",
+  "tbNameHand": "手形工具",
   "tbNameHighlight": "醒目提示",
   "tbNameImage": "影像",
   "tbNameLine": "線條",

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -231,7 +231,8 @@ enum PdfEditTool {
   link,
 }
 
-/// Text-markup kinds for [PdfEditingController.addMarkup].
+/// Text-markup tools for [PdfEditingController.markupTool] and
+/// [PdfEditingController.addMarkup].
 enum PdfMarkupKind { highlight, underline, strikeOut, squiggly }
 
 /// Where a hyperlink created by the link tool points: either an external
@@ -1424,15 +1425,21 @@ class PdfEditingController extends ChangeNotifier {
   // tool state
 
   PdfEditTool? _tool;
+  PdfMarkupKind? _markupTool;
   bool _colorLocked = false;
 
   static const Set<String> _colorLockedFields = {'color'};
 
   /// The armed tool, or null when the viewer behaves as a plain reader.
+  ///
+  /// Text-markup tools are exposed separately through [markupTool]. They
+  /// leave this value null so normal text-selection gestures remain active.
   PdfEditTool? get tool => _tool;
 
   set tool(PdfEditTool? value) {
-    if (value == _tool) return;
+    // Assigning null while a markup tool is armed is an intentional clear
+    // (Escape and the mobile tool switcher's Clear both use this path).
+    if (value == _tool && _markupTool == null) return;
     preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
     // leaving an ink-like tool commits the drawing, like lifting the pen.
     //
@@ -1453,6 +1460,7 @@ class PdfEditingController extends ChangeNotifier {
     // is only valid while the eraser stays the toggled-on partner
     if (value != PdfEditTool.eraser) _eraserToggledOn = false;
     _tool = value;
+    _markupTool = null;
     if (value != PdfEditTool.select) _selected.clear();
     if (value != PdfEditTool.content) _selectedElement = null;
     _cropModeArmed = false;
@@ -1470,6 +1478,43 @@ class PdfEditingController extends ChangeNotifier {
     if (deferInkCommit) Timer.run(finishInk);
   }
 
+  /// The armed text-markup tool, or null when text selections should remain
+  /// ordinary selections.
+  ///
+  /// Markup is kept separate from [tool] because it uses the viewer's native
+  /// text-selection gestures. Once armed, completing a mouse drag, mouse
+  /// double-click, or touch long-press selection creates the corresponding
+  /// markup and leaves the tool armed for the next selection.
+  PdfMarkupKind? get markupTool => _markupTool;
+
+  set markupTool(PdfMarkupKind? value) {
+    if (value == _markupTool) return;
+    if (value == null) {
+      preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
+      _markupTool = null;
+      preferences.beginStyleScope(
+        _styleScopeKey(_tool),
+        _styleScopeFields(_tool),
+        defaults: _styleScopeDefaults(_tool),
+        lockedFields: _lockedStyleFields,
+      );
+      notifyListeners();
+      return;
+    }
+
+    // Text markup needs reader-mode selection gestures. Going through the
+    // normal setter also commits a pending ink stroke before switching.
+    if (_tool != null) tool = null;
+    preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
+    _markupTool = value;
+    _selected.clear();
+    _selectedElement = null;
+    _cropModeArmed = false;
+    _cropDraft = null;
+    useMarkupStyleScope();
+    notifyListeners();
+  }
+
   Set<String> get _lockedStyleFields =>
       _colorLocked ? _colorLockedFields : const {};
 
@@ -1485,13 +1530,17 @@ class PdfEditingController extends ChangeNotifier {
     if (value == _colorLocked) return;
     preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
     _colorLocked = value;
-    preferences.beginStyleScope(
-      _styleScopeKey(_tool),
-      _styleScopeFields(_tool),
-      defaults: _styleScopeDefaults(_tool),
-      lockedFields: _lockedStyleFields,
-      forceRestore: true,
-    );
+    if (_markupTool != null) {
+      useMarkupStyleScope(forceRestore: true);
+    } else {
+      preferences.beginStyleScope(
+        _styleScopeKey(_tool),
+        _styleScopeFields(_tool),
+        defaults: _styleScopeDefaults(_tool),
+        lockedFields: _lockedStyleFields,
+        forceRestore: true,
+      );
+    }
     notifyListeners();
   }
 
@@ -1545,23 +1594,25 @@ class PdfEditingController extends ChangeNotifier {
       PdfEditToolBehavior.maybeOf(tool)?.styleScopeDefaults ?? const {};
 
   /// Activates the text-markup style scope (highlight / underline / strike
-  /// out / squiggly) - they act on the text selection rather than arming a
-  /// tool, so the toolbar calls this when its Markup strip opens, giving
-  /// markup its own remembered colour and opacity (the classic yellow
-  /// highlighter that stays yellow). See [preferences].
-  void useMarkupStyleScope() => preferences.beginStyleScope(
-      'markup',
-      const {
-        'color',
-        'opacity',
-      },
-      lockedFields: _lockedStyleFields);
+  /// out / squiggly), giving markup its own remembered colour and opacity
+  /// (the classic yellow highlighter that stays yellow). See [preferences].
+  void useMarkupStyleScope({bool forceRestore = false}) =>
+      preferences.beginStyleScope(
+        'markup',
+        const {
+          'color',
+          'opacity',
+        },
+        lockedFields: _lockedStyleFields,
+        forceRestore: forceRestore,
+      );
 
   /// Whether the armed [tool] creates annotations that carry a colour the
   /// toolbar can offer - i.e. the tool's style scope remembers `color`.
   /// False for tools that ignore colour (select, eraser, content, form,
   /// redact, signature), so the colour swatches aren't shown beside them.
-  bool get toolUsesColor => _styleScopeFields(tool).contains('color');
+  bool get toolUsesColor =>
+      markupTool != null || _styleScopeFields(tool).contains('color');
 
   /// The color new annotations are created with. Persisted in [preferences].
   ///

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1426,6 +1426,7 @@ class PdfEditingController extends ChangeNotifier {
 
   PdfEditTool? _tool;
   PdfMarkupKind? _markupTool;
+  bool _handMode = false;
   bool _colorLocked = false;
 
   static const Set<String> _colorLockedFields = {'color'};
@@ -1439,7 +1440,7 @@ class PdfEditingController extends ChangeNotifier {
   set tool(PdfEditTool? value) {
     // Assigning null while a markup tool is armed is an intentional clear
     // (Escape and the mobile tool switcher's Clear both use this path).
-    if (value == _tool && _markupTool == null) return;
+    if (value == _tool && _markupTool == null && !_handMode) return;
     preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
     // leaving an ink-like tool commits the drawing, like lifting the pen.
     //
@@ -1461,6 +1462,7 @@ class PdfEditingController extends ChangeNotifier {
     if (value != PdfEditTool.eraser) _eraserToggledOn = false;
     _tool = value;
     _markupTool = null;
+    _handMode = false;
     if (value != PdfEditTool.select) _selected.clear();
     if (value != PdfEditTool.content) _selectedElement = null;
     _cropModeArmed = false;
@@ -1476,6 +1478,22 @@ class PdfEditingController extends ChangeNotifier {
     );
     notifyListeners();
     if (deferInkCommit) Timer.run(finishInk);
+  }
+
+  /// Whether the viewer is in explicit Hand mode.
+  ///
+  /// Hand mode differs from the ordinary tool-free reader state: mouse
+  /// drags always pan and touch long-presses do not select text. Links and
+  /// form controls remain interactive. Assigning [tool] (including null),
+  /// arming a markup, or pressing Escape leaves Hand mode.
+  bool get isHandMode => _handMode;
+
+  /// Disarms editing and markup tools and enters explicit Hand mode.
+  void activateHandMode() {
+    if (_handMode && _tool == null && _markupTool == null) return;
+    tool = null;
+    _handMode = true;
+    notifyListeners();
   }
 
   /// The armed text-markup tool, or null when text selections should remain
@@ -1504,7 +1522,7 @@ class PdfEditingController extends ChangeNotifier {
 
     // Text markup needs reader-mode selection gestures. Going through the
     // normal setter also commits a pending ink stroke before switching.
-    if (_tool != null) tool = null;
+    if (_tool != null || _handMode) tool = null;
     preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
     _markupTool = value;
     _selected.clear();

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -467,6 +467,11 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
                   : TextAlignVertical.center,
               cursorColor: const Color(0xFF000000),
               cursorWidth: 2 * chromeScale,
+              cursorHeight: pdfZoomAwareCursorHeight(
+                context,
+                lineHeight: _editSize * scale * 1.2,
+                chromeScale: chromeScale,
+              ),
               style: TextStyle(
                 color: const Color(0xFF000000),
                 fontSize: _editSize * scale,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -5675,6 +5675,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                     : null,
                                 cursorColor: _textEditColor,
                                 cursorWidth: 2 * _chromeScale,
+                                cursorHeight: pdfZoomAwareCursorHeight(
+                                  context,
+                                  lineHeight:
+                                      _textEditText.maxStyleSize *
+                                          _geometry.scale *
+                                          _textEditLineSpacing,
+                                  chromeScale: _chromeScale,
+                                ),
                                 selectionControls: _ScaledTextSelectionControls(
                                     _chromeScale,
                                     _inlineTextHandleColor(context)),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 /// Places a text field's selection toolbar - the long-press copy/paste
@@ -69,6 +71,27 @@ Widget pdfZoomAwareCaret(BuildContext context,
     data: media.copyWith(devicePixelRatio: media.devicePixelRatio / chromeScale),
     child: child,
   );
+}
+
+/// The [TextField.cursorHeight] that keeps Flutter's Apple-platform caret
+/// overhang constant in screen space inside the viewer's zoom transform.
+///
+/// [RenderEditable] adds two local pixels to every iOS/macOS caret. Left
+/// alone, the outer page transform magnifies that extra height along with the
+/// text, so at deep zoom the caret visibly towers over its line. Subtract the
+/// zoomed portion here; Flutter adds the two local pixels back, leaving the
+/// requested [lineHeight] plus two *screen* pixels after composition.
+double pdfZoomAwareCursorHeight(
+  BuildContext context, {
+  required double lineHeight,
+  required double chromeScale,
+}) {
+  final platform = Theme.of(context).platform;
+  if (platform != TargetPlatform.iOS && platform != TargetPlatform.macOS) {
+    return lineHeight;
+  }
+  if (!chromeScale.isFinite || chromeScale <= 0) return lineHeight;
+  return math.max(0, lineHeight - 2 * (1 - chromeScale));
 }
 
 /// The gutter [RenderEditable] reserves at the end of every editable line

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -44,14 +44,15 @@ typedef PdfEditingToolbarWidgetBuilder = Widget Function(
 
 /// A ready-made toolbar for [PdfEditingController].
 ///
-/// The bar is organised as a **dock** of tool *groups* - Select, Markup,
-/// Draw, Shapes, Insert, Measure and Edit - flanked by the global
-/// undo/redo, flatten and save actions. Tapping a group raises a
-/// **contextual strip** above the dock: the group's tools on the left and
-/// the active tool's live settings (colour, stroke, opacity, font,
-/// scale…) on the right, so each tool shows only the settings it
-/// supports. Selecting an annotation or a page element raises its own
-/// strip with the actions and restyle controls that apply to it.
+/// The bar is organised as a **dock** with a compact Hand / Select navigation
+/// cluster followed by the editing tool *groups* - Markup, Draw, Shapes,
+/// Insert, Measure and Edit - and the global undo/redo, flatten and save
+/// actions. Tapping an editing group raises a **contextual strip** above the
+/// dock: the group's tools on the left and the active tool's live settings
+/// (colour, stroke, opacity, font, scale…) on the right, so each tool shows
+/// only the settings it supports. Selecting an annotation or a page element
+/// raises its own strip with the actions and restyle controls that apply to
+/// it.
 ///
 /// On narrow (phone) widths the dock collapses to an active-tool switcher, a
 /// quick-colour row and a *Tools* handle. The switcher recalls recently used
@@ -632,6 +633,20 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     // null/no-tool state - tapping the active tool off should leave you
     // able to select and move things, not in limbo
     controller.tool = controller.tool == value ? PdfEditTool.select : value;
+    viewerController.clearSelection();
+  }
+
+  void _activateHandMode() {
+    if (controller.isHandMode) return;
+    setState(() => _openGroupId = null);
+    controller.activateHandMode();
+    viewerController.clearSelection();
+  }
+
+  void _activateSelectMode() {
+    if (controller.tool == PdfEditTool.select) return;
+    setState(() => _openGroupId = 'select');
+    controller.tool = PdfEditTool.select;
     viewerController.clearSelection();
   }
 
@@ -1383,6 +1398,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   Widget _dock(BuildContext context) {
     final groups = _visibleGroups;
+    final showNavigationModes = groups.any((group) => group.id == 'select');
+    final editingGroups =
+        groups.where((group) => group.id != 'select').toList(growable: false);
     final row = Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -1404,7 +1422,21 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           ),
           const _DockDivider(),
         ],
-        for (final group in groups)
+        if (showNavigationModes) ...[
+          _NavigationModeGroup(
+            handLabel: pdfL10n(context).tbNameHand,
+            selectLabel: _entryTip(context, _groups.first.tools.single),
+            handActive: controller.isHandMode,
+            selectActive: controller.tool == PdfEditTool.select,
+            onHand: _activateHandMode,
+            onSelect: _activateSelectMode,
+          ),
+          if (editingGroups.isNotEmpty ||
+              widget.onSave != null ||
+              widget.trailing.isNotEmpty)
+            const _DockDivider(),
+        ],
+        for (final group in editingGroups)
           _GroupChip(
             key: ValueKey('pdf-group-${group.id}'),
             group: group,
@@ -2864,6 +2896,84 @@ class _DockDivider extends StatelessWidget {
         margin: const EdgeInsets.symmetric(horizontal: 4),
         color: Theme.of(context).colorScheme.outlineVariant,
       );
+}
+
+/// The two mutually exclusive navigation modes, kept in one compact control
+/// so they read differently from the editing-tool group chips beside them.
+class _NavigationModeGroup extends StatelessWidget {
+  const _NavigationModeGroup({
+    required this.handLabel,
+    required this.selectLabel,
+    required this.handActive,
+    required this.selectActive,
+    required this.onHand,
+    required this.onSelect,
+  });
+
+  final String handLabel;
+  final String selectLabel;
+  final bool handActive;
+  final bool selectActive;
+  final VoidCallback onHand;
+  final VoidCallback onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      key: const ValueKey('pdf-navigation-modes'),
+      color: Colors.transparent,
+      shape: StadiumBorder(side: BorderSide(color: scheme.outline)),
+      clipBehavior: Clip.antiAlias,
+      child: Row(mainAxisSize: MainAxisSize.min, children: [
+        _button(
+          key: const ValueKey('pdf-mode-hand'),
+          icon: Icons.pan_tool_alt,
+          label: handLabel,
+          active: handActive,
+          onPressed: onHand,
+          scheme: scheme,
+        ),
+        Container(width: 1, height: 24, color: scheme.outlineVariant),
+        _button(
+          // Preserve the established key for host and package widget tests.
+          key: const ValueKey('pdf-group-select'),
+          icon: Icons.near_me,
+          label: selectLabel,
+          active: selectActive,
+          onPressed: onSelect,
+          scheme: scheme,
+        ),
+      ]),
+    );
+  }
+
+  Widget _button({
+    required Key key,
+    required IconData icon,
+    required String label,
+    required bool active,
+    required VoidCallback onPressed,
+    required ColorScheme scheme,
+  }) {
+    return IconButton(
+      key: key,
+      icon: Icon(icon, size: 19),
+      tooltip: label,
+      isSelected: active,
+      style: IconButton.styleFrom(
+        foregroundColor: active ? scheme.primary : scheme.onSurfaceVariant,
+        backgroundColor: active
+            ? scheme.primary.withValues(alpha: 0.15)
+            : Colors.transparent,
+        fixedSize: const Size.square(40),
+        padding: EdgeInsets.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: const RoundedRectangleBorder(),
+      ),
+      onPressed: onPressed,
+    );
+  }
 }
 
 /// The full-height divider between a strip's tools and settings segments.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -53,9 +53,10 @@ typedef PdfEditingToolbarWidgetBuilder = Widget Function(
 /// supports. Selecting an annotation or a page element raises its own
 /// strip with the actions and restyle controls that apply to it.
 ///
-/// On narrow (phone) widths the dock collapses to the active tool plus a
-/// quick-colour row and a *Tools* handle; the handle opens a bottom sheet
-/// with group tabs, a tool grid and the active tool's settings.
+/// On narrow (phone) widths the dock collapses to an active-tool switcher, a
+/// quick-colour row and a *Tools* handle. The switcher recalls recently used
+/// tools and clears back to Hand mode; the handle opens a bottom sheet with
+/// group tabs, a tool grid and the active tool's settings.
 ///
 /// Place it in a Scaffold's `bottomNavigationBar` or as the bottom child
 /// of a Column - it sizes to its content. Apps wanting different chrome
@@ -219,9 +220,8 @@ class PdfEditingToolbar extends StatefulWidget {
   State<PdfEditingToolbar> createState() => _PdfEditingToolbarState();
 }
 
-/// One entry in a tool group - either an armable [PdfEditTool] or a
-/// text-markup action ([PdfMarkupKind], which acts on the live text
-/// selection rather than arming a tool).
+/// One entry in a tool group - either an armable [PdfEditTool] or an armable
+/// text-markup tool ([PdfMarkupKind]).
 class _GroupTool {
   const _GroupTool.tool(this.tool, this.icon) : markup = null;
   const _GroupTool.markup(this.markup, this.icon) : tool = null;
@@ -230,6 +230,8 @@ class _GroupTool {
   final PdfMarkupKind? markup;
   final IconData icon;
 }
+
+typedef _ToolChoice = ({PdfEditTool? tool, PdfMarkupKind? markup});
 
 /// A dock group: a labelled chip that raises a contextual strip of
 /// [tools]. [defaultTool] is armed when the group opens, when arming it
@@ -272,6 +274,10 @@ enum _SelectedFormOverflowAction {
 }
 
 class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
+  static const _mobileRecentToolLimit = 4;
+  static const _mobileToolSwitcherMaxWidth = 180.0;
+  static const Object _clearToolMenuChoice = Object();
+
   PdfEditingController get controller => widget.controller;
   PdfViewerController get viewerController => widget.viewerController;
 
@@ -287,6 +293,69 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   bool _replacingElementImage = false;
   bool _exportingElementImage = false;
+
+  /// Most-recently-used armable tools for the mobile quick switcher. This is
+  /// deliberately session state: a host may expose a different tool set in
+  /// each editor, and opening the full sheet remains the discovery path.
+  final List<_ToolChoice> _recentTools = [];
+  _ToolChoice? _lastObservedTool;
+
+  _ToolChoice get _activeToolChoice => controller.markupTool != null
+      ? (tool: null, markup: controller.markupTool)
+      : (tool: controller.tool, markup: null);
+
+  @override
+  void initState() {
+    super.initState();
+    _resetRecentTools();
+    controller.addListener(_trackRecentTool);
+  }
+
+  @override
+  void didUpdateWidget(PdfEditingToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+    oldWidget.controller.removeListener(_trackRecentTool);
+    _resetRecentTools();
+    controller.addListener(_trackRecentTool);
+  }
+
+  @override
+  void dispose() {
+    controller.removeListener(_trackRecentTool);
+    super.dispose();
+  }
+
+  void _resetRecentTools() {
+    _recentTools.clear();
+    _lastObservedTool = _activeToolChoice;
+    final choice = _activeToolChoice;
+    if (choice.tool != null || choice.markup != null) {
+      _recordRecentTool(choice);
+    }
+  }
+
+  void _trackRecentTool() {
+    final choice = _activeToolChoice;
+    if (choice == _lastObservedTool) return;
+    _lastObservedTool = choice;
+    // Null is Hand/reader mode rather than Select. Temporary null transitions
+    // while changing tools must not displace genuine history.
+    if (choice.tool != null || choice.markup != null) {
+      _recordRecentTool(choice);
+    }
+  }
+
+  void _recordRecentTool(_ToolChoice choice) {
+    if (!_toolChoiceIsVisible(choice)) return;
+    _recentTools
+      ..remove(choice)
+      ..insert(0, choice);
+    final keep = _mobileRecentToolLimit + 1; // current + previous tools
+    if (_recentTools.length > keep) {
+      _recentTools.removeRange(keep, _recentTools.length);
+    }
+  }
 
   bool get _showColorProcessingAction =>
       widget.showColorProcessing &&
@@ -431,7 +500,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     };
   }
 
-  /// The bare, localized name of a text-markup action (for mobile tiles).
+  /// The bare, localized name of a text-markup tool (for mobile tiles).
   String _markupName(BuildContext context, PdfMarkupKind markup) {
     final l = pdfL10n(context);
     return switch (markup) {
@@ -442,7 +511,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     };
   }
 
-  /// The full tooltip for a text-markup action.
+  /// The full tooltip for a text-markup tool.
   String _markupTip(BuildContext context, PdfMarkupKind markup) {
     final l = pdfL10n(context);
     return switch (markup) {
@@ -466,6 +535,30 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     }
     if (entry.markup != null) return widget.showMarkup;
     return true;
+  }
+
+  bool _toolIsVisible(PdfEditTool tool) {
+    for (final group in _visibleGroups) {
+      for (final entry in group.tools) {
+        if (entry.tool == tool && _entryVisible(entry)) return true;
+      }
+    }
+    return false;
+  }
+
+  bool _toolChoiceIsVisible(_ToolChoice choice) {
+    final markup = choice.markup;
+    if (markup != null) return widget.showMarkup && _groupVisible(_groups[1]);
+    final tool = choice.tool;
+    return tool != null && _toolIsVisible(tool);
+  }
+
+  List<_ToolChoice> get _previousVisibleTools {
+    final current = _activeToolChoice;
+    return _recentTools
+        .where((choice) => choice != current && _toolChoiceIsVisible(choice))
+        .take(_mobileRecentToolLimit)
+        .toList(growable: false);
   }
 
   /// Whether [group] has any visible entry (the whole group gated by
@@ -495,7 +588,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// The group whose strip is currently shown: an armed tool's group
   /// always wins, otherwise the explicitly opened group.
   _ToolGroup? get _openGroup {
-    final armed = _groupForTool(controller.tool);
+    final armed = controller.markupTool != null
+        ? _groups.firstWhere((group) => group.id == 'markup')
+        : _groupForTool(controller.tool);
     final id = armed?.id ?? _openGroupId;
     for (final group in _visibleGroups) {
       if (group.id == id) return group;
@@ -514,12 +609,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     controller.addMarkup(kind, quadsByPage);
   }
 
-  void _applyMarkup(PdfMarkupKind kind, {bool restoreTool = false}) {
-    final previousTool = controller.tool;
-    if (restoreTool) controller.tool = null;
-    controller.useMarkupStyleScope();
+  void _chooseMarkup(PdfMarkupKind kind) {
+    controller.markupTool = kind;
+    if (!viewerController.hasSelection) return;
     _markup(kind);
-    if (restoreTool && previousTool != null) controller.tool = previousTool;
+    viewerController.clearSelection();
   }
 
   /// Sets the creation colour - and recolours the selected annotations in
@@ -1353,12 +1447,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       if (!_entryVisible(entry)) continue;
       if (entry.markup != null) {
         toolButtons.add(IconButton(
+          key: ValueKey('pdf-markup-${entry.markup!.name}'),
           icon: Icon(entry.icon),
           tooltip: _markupTip(context, entry.markup!),
-          onPressed: hasTextSelection
-              ? () =>
-                  _applyMarkup(entry.markup!, restoreTool: group.id != 'markup')
-              : null,
+          isSelected: controller.markupTool == entry.markup,
+          onPressed: () => _chooseMarkup(entry.markup!),
         ));
       } else if (labelled) {
         final tool = entry.tool!;
@@ -1415,7 +1508,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             child: Row(mainAxisSize: MainAxisSize.min, children: [
               _StripLabel(
                 group.label(context),
-                hint: group.id == 'markup' && !hasTextSelection
+                hint: group.id == 'markup' &&
+                        !hasTextSelection &&
+                        controller.markupTool == null
                     ? pdfL10n(context).tbSelectTextForMarkup
                     : null,
               ),
@@ -1519,8 +1614,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
               ? pdfL10n(context).tbFingerDraws
               : pdfL10n(context).tbFingerScrolls,
           isSelected: controller.preferences.fingerDrawsInk,
-          onPressed: () =>
-              controller.preferences.fingerDrawsInk = !controller.preferences.fingerDrawsInk,
+          onPressed: () => controller.preferences.fingerDrawsInk =
+              !controller.preferences.fingerDrawsInk,
         ),
       if (controller.hasPendingInk && !controller.inkAutoCommits) ...[
         IconButton(
@@ -1780,8 +1875,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       _alignButton(PdfAlignment.bottom, Icons.align_vertical_bottom,
           pdfL10n(context).tbAlignBottom),
       const _MiniDivider(),
-      _alignButton(PdfAlignment.distributeHorizontal,
-          Icons.horizontal_distribute, pdfL10n(context).tbDistributeHorizontally,
+      _alignButton(
+          PdfAlignment.distributeHorizontal,
+          Icons.horizontal_distribute,
+          pdfL10n(context).tbDistributeHorizontally,
           enabled: canDistribute),
       _alignButton(PdfAlignment.distributeVertical, Icons.vertical_distribute,
           pdfL10n(context).tbDistributeVertically,
@@ -1911,16 +2008,15 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             child: InkWell(
               customBorder: const CircleBorder(),
               onTap: () async {
-                final picked =
-                    await pickEditingColor(context, controller, initial: current);
+                final picked = await pickEditingColor(context, controller,
+                    initial: current);
                 if (picked != null) _applyColor(picked);
               },
               child: SizedBox(
                 width: 40,
                 height: 40,
                 child: Center(
-                  child:
-                      Icon(Icons.palette_outlined, color: current, size: 20),
+                  child: Icon(Icons.palette_outlined, color: current, size: 20),
                 ),
               ),
             ),
@@ -2195,7 +2291,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   Widget _buildMobile(BuildContext context, {required double width}) {
     final scheme = Theme.of(context).colorScheme;
-    final tool = controller.tool;
+    final activeChoice = _activeToolChoice;
     final compactToolLabel = controller.selectedElement != null;
     return Container(
       decoration: BoxDecoration(
@@ -2224,34 +2320,80 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             ),
           ],
           Expanded(
-            child: LayoutBuilder(builder: (context, constraints) {
-              // On narrow phones the undo/redo buttons, tool actions, and
-              // Tools handle can leave less than one icon's width here. Keep
-              // the dock usable by progressively dropping this decorative
-              // status label instead of overflowing the Row.
-              if (constraints.maxWidth < 22) return const SizedBox.shrink();
-              final leadingGap = constraints.maxWidth >= 26;
-              final showLabel = !compactToolLabel && constraints.maxWidth >= 56;
-              return Row(children: [
-                if (leadingGap) const SizedBox(width: 4),
-                Icon(_activeToolIcon(tool), size: 22, color: scheme.primary),
-                if (showLabel) ...[
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      _activeToolLabel(context, tool),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      softWrap: false,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: ConstrainedBox(
+                constraints:
+                    const BoxConstraints(maxWidth: _mobileToolSwitcherMaxWidth),
+                child: LayoutBuilder(builder: (context, constraints) {
+                  // On narrow phones the undo/redo buttons, tool actions, and
+                  // Tools handle can leave less than one icon's width here.
+                  // Keep the switcher usable by progressively dropping its
+                  // label and chevron instead of overflowing.
+                  if (constraints.maxWidth < 22) {
+                    return const SizedBox.shrink();
+                  }
+                  final mainWidth = constraints.maxWidth;
+                  final horizontalPadding = mainWidth >= 36
+                      ? 7.0
+                      : ((mainWidth - 22) / 2).clamp(0.0, 7.0).toDouble();
+                  final showLabel = !compactToolLabel && mainWidth >= 100;
+                  final showChevron = mainWidth >= 54;
+                  final recent = _previousVisibleTools;
+                  final activeLabel = _activeToolLabel(context, activeChoice);
+                  final switchLabel = recent.isEmpty
+                      ? '$activeLabel, ${pdfL10n(context).tbTools}'
+                      : '$activeLabel, ${pdfL10n(context).propRecentlyUsed}';
+                  return Material(
+                    key: const ValueKey('pdf-mobile-current-tool-surface'),
+                    color: scheme.primary.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(10),
+                    clipBehavior: Clip.antiAlias,
+                    child: Semantics(
+                      button: true,
+                      label: switchLabel,
+                      child: InkWell(
+                        key: const ValueKey('pdf-mobile-current-tool'),
+                        onTap: () => _openRecentTools(context),
+                        child: SizedBox(
+                          width: double.infinity,
+                          height: 40,
+                          child: ExcludeSemantics(
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(
+                                  horizontal: horizontalPadding),
+                              child: Row(children: [
+                                Icon(_activeToolIcon(activeChoice),
+                                    size: 22, color: scheme.primary),
+                                if (showLabel) ...[
+                                  const SizedBox(width: 7),
+                                  Expanded(
+                                    child: Text(
+                                      activeLabel,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      softWrap: false,
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.w600,
+                                        fontSize: 14,
+                                      ),
+                                    ),
+                                  ),
+                                ] else
+                                  const Spacer(),
+                                if (showChevron)
+                                  Icon(Icons.expand_less,
+                                      size: 17, color: scheme.primary),
+                              ]),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ],
-              ]);
-            }),
+                  );
+                }),
+              ),
+            ),
           ),
           ..._mobileTrailing(context),
           const SizedBox(width: 6),
@@ -2280,8 +2422,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       return [
         IconButton(
           icon: const Icon(Icons.delete_outline),
-          tooltip: pdfL10n(context).tbDeleteAnnotations(
-              controller.selectedAnnotationSlots.length),
+          tooltip: pdfL10n(context)
+              .tbDeleteAnnotations(controller.selectedAnnotationSlots.length),
           visualDensity: VisualDensity.compact,
           onPressed: controller.deleteSelected,
         ),
@@ -2369,7 +2511,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       // The tune popup carries the full palette, so a couple of quick swatches
       // beside it are enough - and dropping the third keeps the whole cluster
       // (swatches + tune) inside the narrow dock without overflowing.
-      return [..._mobileSwatches(context, count: tune.isEmpty ? 3 : 2), ...tune];
+      return [
+        ..._mobileSwatches(context, count: tune.isEmpty ? 3 : 2),
+        ...tune
+      ];
     }
     return tune;
   }
@@ -2379,7 +2524,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// desktop strip's [_tuneTrailing] so the same stroke/opacity/font sliders
   /// are one tap away on a phone.
   List<Widget> _mobileTuneTrailing(BuildContext context) {
-    final group = _groupForTool(controller.tool);
+    final group = controller.markupTool != null
+        ? _groups.firstWhere((group) => group.id == 'markup')
+        : _groupForTool(controller.tool);
     if (group == null) return const [];
     return _tuneTrailing(
       context,
@@ -2418,24 +2565,120 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     ];
   }
 
-  IconData _activeToolIcon(PdfEditTool? tool) {
-    if (tool == null) return Icons.near_me;
+  IconData _activeToolIcon(_ToolChoice choice) {
+    if (choice.tool == null && choice.markup == null) {
+      return Icons.pan_tool_alt;
+    }
     for (final group in _groups) {
       for (final entry in group.tools) {
-        if (entry.tool == tool) return entry.icon;
+        if (entry.tool == choice.tool && entry.markup == choice.markup) {
+          return entry.icon;
+        }
       }
     }
     return Icons.near_me;
   }
 
-  String _activeToolLabel(BuildContext context, PdfEditTool? tool) =>
-      tool == null
-          ? pdfL10n(context).tbNameSelect
-          : _toolName(context, tool);
+  String _activeToolLabel(BuildContext context, _ToolChoice choice) {
+    final markup = choice.markup;
+    if (markup != null) return _markupName(context, markup);
+    final tool = choice.tool;
+    return tool == null
+        ? pdfL10n(context).tbNameHand
+        : _toolName(context, tool);
+  }
+
+  void _clearMobileTool() {
+    if (controller.tool == null && controller.markupTool == null) return;
+    setState(() => _openGroupId = null);
+    controller.tool = null;
+    viewerController.clearSelection();
+  }
+
+  /// Opens the compact MRU menu anchored above the active-tool control. With
+  /// no history in Hand mode, the same tap opens the full tool sheet so the
+  /// control never leads to an empty menu.
+  Future<void> _openRecentTools(BuildContext targetContext) async {
+    final recent = _previousVisibleTools;
+    if (recent.isEmpty &&
+        controller.tool == null &&
+        controller.markupTool == null) {
+      await _openToolSheet(context);
+      return;
+    }
+
+    final overlay = Overlay.of(targetContext).context.findRenderObject();
+    final target = targetContext.findRenderObject();
+    if (overlay is! RenderBox || target is! RenderBox || !target.attached) {
+      await _openToolSheet(context);
+      return;
+    }
+    final targetRect = Rect.fromPoints(
+      overlay.globalToLocal(target.localToGlobal(Offset.zero)),
+      overlay.globalToLocal(
+        target.localToGlobal(target.size.bottomRight(Offset.zero)),
+      ),
+    );
+    final items = <PopupMenuEntry<Object>>[
+      if (controller.tool != null || controller.markupTool != null)
+        PopupMenuItem<Object>(
+          key: const ValueKey('pdf-recent-tool-clear'),
+          value: _clearToolMenuChoice,
+          child: Row(children: [
+            const Icon(Icons.close, size: 20),
+            const SizedBox(width: 12),
+            Text(pdfL10n(targetContext).clear),
+          ]),
+        ),
+      if ((controller.tool != null || controller.markupTool != null) &&
+          recent.isNotEmpty)
+        const PopupMenuDivider(),
+      if (recent.isNotEmpty)
+        PopupMenuItem<Object>(
+          enabled: false,
+          height: 32,
+          child: Text(
+            pdfL10n(targetContext).propRecentlyUsed,
+            style: const TextStyle(fontSize: 12),
+          ),
+        ),
+      for (final choice in recent)
+        PopupMenuItem<Object>(
+          key: ValueKey(choice.markup != null
+              ? 'pdf-recent-markup-${choice.markup!.name}'
+              : 'pdf-recent-tool-${choice.tool!.name}'),
+          value: choice,
+          child: Row(children: [
+            Icon(_activeToolIcon(choice), size: 20),
+            const SizedBox(width: 12),
+            Text(_activeToolLabel(targetContext, choice)),
+          ]),
+        ),
+    ];
+    final picked = await showMenu<Object>(
+      context: targetContext,
+      position: RelativeRect.fromRect(
+        targetRect,
+        Offset.zero & overlay.size,
+      ),
+      items: items,
+    );
+    if (!mounted || picked == null) return;
+    if (identical(picked, _clearToolMenuChoice)) {
+      _clearMobileTool();
+      return;
+    }
+    final choice = picked as _ToolChoice;
+    if (choice.markup != null) {
+      _chooseMarkup(choice.markup!);
+    } else {
+      await _armGroupTool(context, choice.tool!);
+    }
+  }
 
   /// Opens the mobile tools sheet: group tabs, a tool grid, and the active
-  /// tool's settings. The tab state lives in the sheet so switching groups
-  /// doesn't arm anything until a tool is tapped.
+  /// tool's settings. Multi-tool tabs only navigate; Select's one-option tab
+  /// arms it directly and closes the sheet.
   Future<void> _openToolSheet(BuildContext context) async {
     final groups = _visibleGroups;
     var tabId = _openGroup?.id ?? groups.first.id;
@@ -2468,6 +2711,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                               group: g,
                               active: g.id == tabId,
                               onTap: () {
+                                if (g.id == 'select') {
+                                  Navigator.of(sheetContext).pop();
+                                  _toggleTool(PdfEditTool.select);
+                                  return;
+                                }
                                 setSheetState(() => tabId = g.id);
                                 // markup arms no tool - scope it so its
                                 // settings row edits markup's own style
@@ -2482,10 +2730,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                     const SizedBox(height: 14),
                     _SheetSectionLabel(
                       group.label(context),
-                      hint:
-                          group.id == 'markup' && !viewerController.hasSelection
-                              ? pdfL10n(context).tbSelectTextForMarkup
-                              : null,
+                      hint: group.id == 'markup' &&
+                              !viewerController.hasSelection &&
+                              controller.markupTool == null
+                          ? pdfL10n(context).tbSelectTextForMarkup
+                          : null,
                     ),
                     const SizedBox(height: 10),
                     _sheetToolGrid(sheetContext, group),
@@ -2501,7 +2750,6 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   }
 
   Widget _sheetToolGrid(BuildContext context, _ToolGroup group) {
-    final hasTextSelection = viewerController.hasSelection;
     final entries = group.tools.where(_entryVisible).toList();
     return GridView.count(
       crossAxisCount: 4,
@@ -2528,12 +2776,13 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
               label: entry.markup != null
                   ? _markupName(context, entry.markup!)
                   : _entryLabel(context, entry),
-              active: entry.tool != null && controller.tool == entry.tool,
-              enabled: entry.markup == null || hasTextSelection,
+              active: entry.markup != null
+                  ? controller.markupTool == entry.markup
+                  : controller.tool == entry.tool,
+              enabled: true,
               onTap: () async {
                 if (entry.markup != null) {
-                  _applyMarkup(entry.markup!,
-                      restoreTool: group.id != 'markup');
+                  _chooseMarkup(entry.markup!);
                   if (context.mounted) Navigator.of(context).pop();
                 } else {
                   await _armGroupTool(context, entry.tool!);
@@ -3433,7 +3682,8 @@ class _StyleMenuState extends State<_StyleMenu> {
           border: (_rgb(color),),
           // setting a border gives it the current stroke width; clearing
           // one leaves the width field alone
-          borderWidth: color == null ? null : controller.preferences.strokeWidth);
+          borderWidth:
+              color == null ? null : controller.preferences.strokeWidth);
     }
   }
 
@@ -3549,7 +3799,10 @@ class _StyleMenuState extends State<_StyleMenu> {
             final lineEndingTarget = controller.canSetLineEndings;
             final lineEndings = lineEndingTarget
                 ? controller.selectedLineEndings!
-                : (controller.preferences.lineStartEnding, controller.preferences.lineEndEnding);
+                : (
+                    controller.preferences.lineStartEnding,
+                    controller.preferences.lineEndEnding
+                  );
             final restyling = controller.canRestyleSelectedText;
             final boxStyle =
                 restyling ? controller.selectedAnnotation?.freeTextStyle : null;
@@ -3601,8 +3854,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                       fieldMax: kPdfTypedSizeMax,
                       display: (v) => '${v.round()} pt',
                       parse: _parsePoints,
-                      onChanged: (v) =>
-                          controller.preferences.eraserRadius = v.roundToDouble(),
+                      onChanged: (v) => controller.preferences.eraserRadius =
+                          v.roundToDouble(),
                     ),
                   if (fields.stroke)
                     _slider(
@@ -3616,7 +3869,9 @@ class _StyleMenuState extends State<_StyleMenu> {
                       parse: _parsePoints,
                       onChanged: (v) {
                         setState(() => _draggingStroke = v);
-                        if (!restylingAnnotation) controller.preferences.strokeWidth = v;
+                        if (!restylingAnnotation) {
+                          controller.preferences.strokeWidth = v;
+                        }
                       },
                       onChangeEnd: (v) {
                         controller.preferences.strokeWidth = v;
@@ -3644,7 +3899,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                       onChanged: (v) {
                         setState(() => _draggingCornerRadius = v);
                         if (!restylingAnnotation) {
-                          controller.preferences.cornerRadius = v.roundToDouble();
+                          controller.preferences.cornerRadius =
+                              v.roundToDouble();
                         }
                       },
                       onChangeEnd: (v) {
@@ -3670,7 +3926,9 @@ class _StyleMenuState extends State<_StyleMenu> {
                       parse: _parsePercent,
                       onChanged: (v) {
                         setState(() => _draggingOpacity = v);
-                        if (!restylingAnnotation) controller.preferences.opacity = v;
+                        if (!restylingAnnotation) {
+                          controller.preferences.opacity = v;
+                        }
                       },
                       onChangeEnd: (v) {
                         controller.preferences.opacity = v;
@@ -3699,7 +3957,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                                 DropdownMenuItem(
                                   value: style,
                                   key: ValueKey('pdf-line-type-${style.name}'),
-                                  child: Text(pdfLineStyleLabel(context, style)),
+                                  child:
+                                      Text(pdfLineStyleLabel(context, style)),
                                 ),
                             ],
                             onChanged: (value) {
@@ -3728,7 +3987,9 @@ class _StyleMenuState extends State<_StyleMenu> {
                       display: (v) => '${v.toStringAsFixed(1)}×',
                       onChanged: (v) {
                         setState(() => _draggingScale = v);
-                        if (!restylingAnnotation) controller.preferences.lineScale = v;
+                        if (!restylingAnnotation) {
+                          controller.preferences.lineScale = v;
+                        }
                       },
                       onChangeEnd: (v) {
                         controller.preferences.lineScale = v;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5219,6 +5219,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (editing != null &&
         editing.tool == null &&
         editing.markupTool == null &&
+        !editing.isHandMode &&
         !editing.isPickingColor &&
         _lastPointerKind == PointerDeviceKind.mouse) {
       final point = _pagePointAt(details.localPosition);
@@ -5246,6 +5247,10 @@ class _PdfViewerState extends State<PdfViewer>
     final (page, x, y) = point;
     final takeover = !widget.contextMenuEnabled;
     final editing = widget.editing;
+    // Hand is a navigation-only mode. A secondary click must not quietly
+    // turn into the text/annotation selection gesture that ordinary reader
+    // mode offers.
+    if (editing?.isHandMode == true) return;
     if (editing != null && !editing.isPickingColor) {
       // Existing form widgets become the selection in normal/select/form
       // modes. Their actions live in the contextual toolbar/properties
@@ -5755,7 +5760,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// click would select.
   bool _selectableAnnotationAt(Offset local, {(int, double, double)? at}) {
     final editing = widget.editing;
-    if (editing == null || editing.tool != null) return false;
+    if (editing == null || editing.tool != null || editing.isHandMode) {
+      return false;
+    }
     final point = at ?? _pagePointAt(local);
     return point != null &&
         editing.selectableAnnotationAt(point.$1, point.$2, point.$3) != null;
@@ -5766,7 +5773,13 @@ class _PdfViewerState extends State<PdfViewer>
     if (_grabPanning) return; // grabbing keeps its cursor mid-drag
     final editing = widget.editing;
     final MouseCursor cursor;
-    if (editing != null &&
+    if (editing?.isHandMode == true) {
+      final action = _annotationAt(event.localPosition);
+      final notified = widget.onAnnotationTap != null &&
+          _annotationHitAt(event.localPosition, actionsOnly: false) != null;
+      cursor =
+          action != null || notified ? SystemMouseCursors.click : grabCursor;
+    } else if (editing != null &&
         editing.tool == null &&
         !editing.isPickingColor &&
         !editing.hasAnnotationSelection &&
@@ -5916,6 +5929,7 @@ class _PdfViewerState extends State<PdfViewer>
   void _onSelectAll() {
     final page = _controller.currentPage;
     final editing = widget.editing;
+    if (editing?.isHandMode == true) return;
     if (editing != null &&
         (editing.tool == PdfEditTool.select ||
             editing.hasAnnotationSelection)) {
@@ -6048,7 +6062,11 @@ class _PdfViewerState extends State<PdfViewer>
   /// by the disambiguation timeout and claim the second of two rapid
   /// clicks, starving buttons in page overlays.
   void _onPointerUp(PointerUpEvent event) {
-    if (event.kind != PointerDeviceKind.mouse || !_wordDrag) return;
+    if (event.kind != PointerDeviceKind.mouse ||
+        !_wordDrag ||
+        widget.editing?.isHandMode == true) {
+      return;
+    }
     final downLocal = _lastMouseDownLocal;
     if (downLocal == null ||
         (event.localPosition - downLocal).distance >= kTouchSlop) {
@@ -6125,6 +6143,16 @@ class _PdfViewerState extends State<PdfViewer>
     // document out from under its own stroke
     if (_kindDrawsInk(details.kind)) return;
     _focusNode.requestFocus();
+    if (widget.editing?.isHandMode == true) {
+      // Explicit Hand mode is navigation-only. Unlike the tool-free reader
+      // state, a drag that begins over page text must grab the document
+      // instead of creating a text selection.
+      _grabPanning = true;
+      _beginMotionRenderHold();
+      setState(() => _hoverCursor = grabbingCursor);
+      _controller._setSelection('');
+      return;
+    }
     // Shift+drag in default editing mode (no tool armed, nothing
     // selected) rubber-bands a marquee selection - the gesture the
     // select tool offers, without arming it. Shift forces the marquee
@@ -7729,6 +7757,7 @@ class _PdfViewerState extends State<PdfViewer>
                                     ..gestureSettings = gestureSettings
                                     ..isEnabled = (() =>
                                         widget.editing?.tool == null &&
+                                        widget.editing?.isHandMode != true &&
                                         widget.editing?.isPickingColor != true)
                                     ..onLongPressStart = _onLongPressStart
                                     ..onLongPressMoveUpdate = _onLongPressMove

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5218,6 +5218,7 @@ class _PdfViewerState extends State<PdfViewer>
     final editing = widget.editing;
     if (editing != null &&
         editing.tool == null &&
+        editing.markupTool == null &&
         !editing.isPickingColor &&
         _lastPointerKind == PointerDeviceKind.mouse) {
       final point = _pagePointAt(details.localPosition);
@@ -5974,6 +5975,10 @@ class _PdfViewerState extends State<PdfViewer>
         editing.clearElementSelection();
         return;
       }
+      if (editing.markupTool != null) {
+        editing.markupTool = null;
+        return;
+      }
       if (editing.tool != null) {
         editing.tool = null;
         return;
@@ -6056,6 +6061,7 @@ class _PdfViewerState extends State<PdfViewer>
     // would immediately clear the selection made here
     _suppressTap = true;
     _selectWordAt(event.localPosition);
+    _applyArmedMarkup();
   }
 
   /// Whether a default/select-mode mouse click at [local] is over a
@@ -6175,6 +6181,7 @@ class _PdfViewerState extends State<PdfViewer>
     final editing = widget.editing;
     if (editing == null ||
         editing.tool != null ||
+        editing.markupTool != null ||
         editing.isPickingColor ||
         editing.hasAnnotationSelection) {
       return false;
@@ -6234,12 +6241,19 @@ class _PdfViewerState extends State<PdfViewer>
     _controller._setSelection(_selectedText());
   }
 
-  void _onSelectionEnd(DragEndDetails details) {
+  void _onSelectionEnd(DragEndDetails details, {bool cancelled = false}) {
     if (_marqueeStart != null) {
       _commitMarquee();
       return;
     }
-    if (!_grabPanning) return;
+    if (!_grabPanning) {
+      if (cancelled && widget.editing?.markupTool != null) {
+        _clearSelection();
+      } else if (!cancelled) {
+        _applyArmedMarkup();
+      }
+      return;
+    }
     _grabPanning = false;
     _scheduleMotionRenderHoldRelease();
     setState(() => _hoverCursor = grabCursor);
@@ -6387,9 +6401,31 @@ class _PdfViewerState extends State<PdfViewer>
     _extendWordSelection(details.localPosition);
   }
 
-  void _onLongPressEnd() {
+  void _onLongPressEnd({bool cancelled = false}) {
     if (!_touchSelecting) return;
     setState(() => _touchSelecting = false);
+    if (cancelled && widget.editing?.markupTool != null) {
+      _clearSelection();
+    } else if (!cancelled) {
+      _applyArmedMarkup();
+    }
+  }
+
+  /// Applies an armed text-markup tool to the current selection. The tool
+  /// remains armed so several passages can be marked without returning to
+  /// the toolbar between selections.
+  bool _applyArmedMarkup() {
+    final editing = widget.editing;
+    final kind = editing?.markupTool;
+    if (editing == null || kind == null || _selRange == null) return false;
+    final quadsByPage = {
+      for (final page in _controller.selectionPages)
+        page: _selectionRectsOn(page),
+    };
+    if (quadsByPage.values.every((quads) => quads.isEmpty)) return false;
+    editing.addMarkup(kind, quadsByPage);
+    _clearSelection();
+    return true;
   }
 
   /// A handle drag begins: the dragged end becomes the moving focus and
@@ -7677,8 +7713,9 @@ class _PdfViewerState extends State<PdfViewer>
                                     ..onStart = _onSelectionStart
                                     ..onUpdate = _onSelectionUpdate
                                     ..onEnd = _onSelectionEnd
-                                    ..onCancel =
-                                        () => _onSelectionEnd(DragEndDetails()),
+                                    ..onCancel = () => _onSelectionEnd(
+                                        DragEndDetails(),
+                                        cancelled: true),
                                 ),
                                 // touch text selection starts with a long
                                 // press instead; stands aside while an
@@ -7697,7 +7734,8 @@ class _PdfViewerState extends State<PdfViewer>
                                     ..onLongPressMoveUpdate = _onLongPressMove
                                     ..onLongPressEnd =
                                         ((_) => _onLongPressEnd())
-                                    ..onLongPressCancel = _onLongPressEnd,
+                                    ..onLongPressCancel =
+                                        () => _onLongPressEnd(cancelled: true),
                                 ),
                               },
                               child: ColoredBox(

--- a/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
@@ -146,6 +146,8 @@ void main() {
         Ink caretAtStart,
         Ink caretAtEnd,
         Rect textArea,
+        double caretHeight,
+        double lineHeight,
         double dpr,
       })> measure(
     WidgetTester tester, {
@@ -194,10 +196,15 @@ void main() {
             render.localToGlobal(render.size.bottomRight(Offset.zero)))
         .intersect(wash);
 
+    var caretHeight = 0.0;
     Future<(Ink, Ink)> at(int offset) async {
       field.controller!.selection = TextSelection.collapsed(offset: offset);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 16));
+      final caret = render.getLocalRectForCaret(TextPosition(offset: offset));
+      final top = render.localToGlobal(caret.topLeft);
+      final bottom = render.localToGlobal(caret.bottomLeft);
+      caretHeight = (bottom.dy - top.dy).abs();
       return paintedInk(tester, region, wash);
     }
 
@@ -211,6 +218,8 @@ void main() {
       caretAtStart: caretAtStart,
       caretAtEnd: caretAtEnd,
       textArea: textArea,
+      caretHeight: caretHeight,
+      lineHeight: fontSize * 1.2 * perPoint,
       dpr: tester.view.devicePixelRatio,
     );
   }
@@ -237,6 +246,9 @@ void main() {
               reason: 'caret at offset 0 left the first glyph behind');
           expect(shot.caretAtEnd.$2, closeTo(shot.glyphs.$2 + 2 * shot.dpr, 4),
               reason: 'caret at text.length landed inside the last glyph');
+          expect(shot.caretHeight, closeTo(shot.lineHeight + 2, 1.5),
+              reason: 'the Apple caret overhang must stay two screen pixels, '
+                  'not grow with page zoom');
 
           // ...and the line itself is laid out on the appearance's text area,
           // not on what is left of the field after Flutter reserves its caret

--- a/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
+++ b/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
@@ -117,6 +117,8 @@ void main() {
       expect(editor, findsOneWidget);
       final field = tester.widget<TextField>(editor);
       expect(field.cursorWidth, closeTo(1, 0.01));
+      expect(field.cursorHeight,
+          closeTo(field.style!.fontSize! * field.style!.height!, 0.01));
 
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();

--- a/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
@@ -61,6 +61,8 @@ void main() {
     }
     c.tool = null;
     expect(c.toolUsesColor, isFalse, reason: 'select ignores colour');
+    c.markupTool = PdfMarkupKind.highlight;
+    expect(c.toolUsesColor, isTrue, reason: 'text markup paints in colour');
   });
 
   testWidgets('swatches hide for a colourless tool, show for a painter',
@@ -92,9 +94,164 @@ void main() {
     editing.tool = PdfEditTool.note;
     await tester.pump();
 
+    expect(
+        find.byKey(const ValueKey('pdf-mobile-current-tool')), findsOneWidget);
     expect(find.byKey(const ValueKey('pdf-tools-handle')), findsOneWidget);
     expect(tester.takeException(), isNull,
-        reason: 'the status icon and label must not overflow a narrow dock');
+        reason: 'the tool switcher must not overflow a narrow dock');
+  });
+
+  testWidgets('current tool popup recalls previous tools in MRU order',
+      (tester) async {
+    final editing = await pumpToolbar(tester, width: 500);
+
+    editing.tool = PdfEditTool.select;
+    await tester.pump();
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+    editing.tool = PdfEditTool.rectangle;
+    await tester.pump();
+
+    final switcher = find.byKey(const ValueKey('pdf-mobile-current-tool'));
+    final semantics = tester.getSemantics(switcher);
+    expect(semantics.label, contains('Rectangle'));
+    expect(semantics.label, contains('Recently used'));
+
+    await tester.tap(switcher);
+    await tester.pumpAndSettle();
+
+    final ink = find.byKey(const ValueKey('pdf-recent-tool-ink'));
+    final select = find.byKey(const ValueKey('pdf-recent-tool-select'));
+    expect(ink, findsOneWidget);
+    expect(select, findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('pdf-recent-tool-rectangle')), findsNothing,
+        reason: 'the active tool is not repeated in its previous-tool list');
+    expect(tester.getTopLeft(ink).dy, lessThan(tester.getTopLeft(select).dy),
+        reason: 'the most recently used previous tool comes first');
+
+    await tester.tap(ink);
+    await tester.pumpAndSettle();
+    expect(editing.tool, PdfEditTool.ink);
+  });
+
+  testWidgets('armed markup is the current tool and participates in history',
+      (tester) async {
+    final editing = await pumpToolbar(tester, width: 500);
+    editing.markupTool = PdfMarkupKind.highlight;
+    await tester.pump();
+
+    final switcher = find.byKey(const ValueKey('pdf-mobile-current-tool'));
+    expect(tester.getSemantics(switcher).label, contains('Highlight'));
+    expect(editing.tool, isNull,
+        reason: 'markup keeps native text-selection gestures enabled');
+
+    editing.tool = PdfEditTool.note;
+    await tester.pump();
+    await tester.tap(switcher);
+    await tester.pumpAndSettle();
+    final markup = find.byKey(const ValueKey('pdf-recent-markup-highlight'));
+    expect(markup, findsOneWidget);
+
+    await tester.tap(markup);
+    await tester.pumpAndSettle();
+    expect(editing.markupTool, PdfMarkupKind.highlight);
+    expect(tester.getSemantics(switcher).label, contains('Highlight'));
+  });
+
+  testWidgets('tool switcher fills its surface and clears only from popup',
+      (tester) async {
+    final editing = await pumpToolbar(tester, width: 590);
+    final switcher = find.byKey(const ValueKey('pdf-mobile-current-tool'));
+    expect(tester.getSemantics(switcher).label, contains('Hand'));
+    expect(
+        find.descendant(
+            of: switcher, matching: find.byIcon(Icons.pan_tool_alt)),
+        findsOneWidget,
+        reason: 'the Hand navigation mode is visibly distinct from Select');
+
+    editing.tool = PdfEditTool.note;
+    await tester.pump();
+
+    final surface =
+        find.byKey(const ValueKey('pdf-mobile-current-tool-surface'));
+    expect(find.byKey(const ValueKey('pdf-mobile-clear-tool')), findsNothing);
+    expect(tester.getRect(switcher), tester.getRect(surface),
+        reason: 'the popup target fills the entire shaded tool surface');
+    expect(tester.getSize(surface).width, 180,
+        reason: 'the shaded popup button does not consume the whole dock');
+
+    await tester.tap(switcher);
+    await tester.pumpAndSettle();
+    final clear = find.byKey(const ValueKey('pdf-recent-tool-clear'));
+    expect(clear, findsOneWidget);
+    await tester.tap(clear);
+    await tester.pumpAndSettle();
+
+    expect(editing.tool, isNull);
+    expect(tester.getSemantics(switcher).label, contains('Hand'));
+    expect(
+        find.descendant(
+            of: switcher, matching: find.byIcon(Icons.pan_tool_alt)),
+        findsOneWidget);
+    expect(clear, findsNothing,
+        reason: 'clearing closes the popup and returns to Hand mode');
+
+    // Clearing does not erase history: the prior tool remains one tap away.
+    await tester.tap(find.byKey(const ValueKey('pdf-mobile-current-tool')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('pdf-recent-tool-note')), findsOneWidget);
+  });
+
+  testWidgets('clear remains available in the popup on a narrow phone',
+      (tester) async {
+    final editing = await pumpToolbar(tester, width: 320);
+    editing.tool = PdfEditTool.note;
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('pdf-mobile-current-tool')));
+    await tester.pumpAndSettle();
+    final clear = find.byKey(const ValueKey('pdf-recent-tool-clear'));
+    expect(clear, findsOneWidget);
+
+    await tester.tap(clear);
+    await tester.pumpAndSettle();
+    expect(editing.tool, isNull);
+  });
+
+  testWidgets('Select group directly arms Select and closes the tool sheet',
+      (tester) async {
+    final editing = await pumpToolbar(tester);
+
+    Future<void> chooseSelect() async {
+      await tester.tap(find.byKey(const ValueKey('pdf-tools-handle')));
+      await tester.pumpAndSettle();
+      final selectGroup = find.byKey(const ValueKey('pdf-group-tab-select'));
+      expect(selectGroup, findsOneWidget);
+
+      await tester.tap(selectGroup);
+      await tester.pumpAndSettle();
+      expect(editing.tool, PdfEditTool.select);
+      final switcher = find.byKey(const ValueKey('pdf-mobile-current-tool'));
+      expect(tester.getSemantics(switcher).label, contains('Select'));
+      expect(
+          find.descendant(of: switcher, matching: find.byIcon(Icons.near_me)),
+          findsOneWidget,
+          reason: 'Select keeps its arrow instead of looking like Hand');
+      expect(
+          find.descendant(
+              of: switcher, matching: find.byIcon(Icons.pan_tool_alt)),
+          findsNothing);
+      expect(selectGroup, findsNothing,
+          reason: 'choosing the one-option group closes the sheet');
+    }
+
+    expect(editing.tool, isNull);
+    await chooseSelect();
+
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+    await chooseSelect();
   });
 
   testWidgets('a selection surfaces quick actions, not creation swatches',

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -1,5 +1,5 @@
 // Line-type (dash) styles, polygon fill, cross-page annotation moves, the
-// select-tool toggle-off, and the stroke/opacity drag readout.
+// Hand / Select navigation modes, and the stroke/opacity drag readout.
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -257,8 +257,8 @@ void main() {
     });
   });
 
-  group('select tool toggle-off', () {
-    testWidgets('tapping the armed Select chip disarms to reader mode',
+  group('desktop navigation modes', () {
+    testWidgets('Hand and Select are explicit compact sibling buttons',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       final viewer = PdfViewerController();
@@ -272,16 +272,34 @@ void main() {
         ),
       ));
 
+      final modes = find.byKey(const ValueKey('pdf-navigation-modes'));
+      final hand = find.byKey(const ValueKey('pdf-mode-hand'));
+      final select = find.byKey(const ValueKey('pdf-group-select'));
+      expect(modes, findsOneWidget);
+      expect(tester.getSize(modes), const Size(81, 40));
+      // Tool-free reader mode is intentionally distinct from explicit Hand:
+      // it still permits text selection and therefore highlights neither.
+      expect(tester.widget<IconButton>(hand).isSelected, isFalse);
+      expect(tester.widget<IconButton>(select).isSelected, isFalse);
+
       editing.tool = PdfEditTool.select;
       await tester.pump();
-      await tester.tap(find.byKey(const ValueKey('pdf-group-select')));
+      expect(tester.widget<IconButton>(hand).isSelected, isFalse);
+      expect(tester.widget<IconButton>(select).isSelected, isTrue);
+
+      await tester.tap(hand);
       await tester.pump();
       expect(editing.tool, isNull);
+      expect(editing.isHandMode, isTrue);
+      expect(tester.widget<IconButton>(hand).isSelected, isTrue);
+      expect(tester.widget<IconButton>(select).isSelected, isFalse);
 
-      // tapping it again re-arms Select
-      await tester.tap(find.byKey(const ValueKey('pdf-group-select')));
+      await tester.tap(select);
       await tester.pump();
       expect(editing.tool, PdfEditTool.select);
+      expect(editing.isHandMode, isFalse);
+      expect(tester.widget<IconButton>(hand).isSelected, isFalse);
+      expect(tester.widget<IconButton>(select).isSelected, isTrue);
     });
   });
 

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -1099,6 +1099,21 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('escape clears an armed text-markup tool', (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      await tester.tapAt(view(400, 400));
+      await tester.pump();
+      editing.markupTool = PdfMarkupKind.squiggly;
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      expect(editing.markupTool, isNull);
+      expect(editing.tool, isNull);
+      await settle(tester);
+    });
+
     testWidgets('escape commits fresh ink instead of discarding it',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -1561,6 +1561,8 @@ void main() {
 
       final field = tester.widget<TextField>(find.byKey(editorKey));
       expect(field.cursorWidth, closeTo(1, 0.01));
+      expect(field.cursorHeight,
+          closeTo(field.style!.fontSize! * field.style!.height!, 0.01));
       final scaled = field.selectionControls!;
       expect(scaled.getHandleSize(20).width, closeTo(18, 0.01));
       expect(field.contextMenuBuilder, isNotNull);

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -981,7 +981,7 @@ void main() {
       expect(find.byKey(const ValueKey('pdf-shape-fill-none')), findsOneWidget);
     });
 
-    testWidgets('compact markup tools explain that text must be selected',
+    testWidgets('compact markup tools explain the arm-first workflow',
         (tester) async {
       tester.view.physicalSize = const Size(560, 800);
       tester.view.devicePixelRatio = 1;
@@ -995,18 +995,28 @@ void main() {
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
 
-      expect(find.text('Select text to use markup'), findsOneWidget);
+      expect(find.text('Choose a markup, then select text'), findsOneWidget);
     });
 
-    testWidgets('desktop markup tools explain that text must be selected',
+    testWidgets('desktop markup tools explain the arm-first workflow',
         (tester) async {
-      await pump(tester, PdfEditorView(bytes: buildClassicPdf()));
+      final editing = PdfEditingController(buildClassicPdf());
+      addTearDown(editing.dispose);
+      await pump(tester, PdfEditorView(controller: editing));
 
       await tester.tap(find.byKey(const ValueKey('pdf-group-markup')),
           kind: PointerDeviceKind.mouse);
       await tester.pump();
 
-      expect(find.text('Select text to use markup'), findsOneWidget);
+      expect(find.text('Choose a markup, then select text'), findsOneWidget);
+      final highlight = find.byKey(const ValueKey('pdf-markup-highlight'));
+      expect(tester.widget<IconButton>(highlight).onPressed, isNotNull);
+
+      await tester.tap(highlight, kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(editing.markupTool, PdfMarkupKind.highlight);
+      expect(find.text('Choose a markup, then select text'), findsNothing,
+          reason: 'the selected button now communicates the armed state');
     });
 
     testWidgets('toolbar buttons drive the owned session', (tester) async {

--- a/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
@@ -122,6 +122,49 @@ void main() {
     });
   });
 
+  group('armed text markup', () {
+    testWidgets('mouse drag applies markup and leaves the tool armed',
+        (tester) async {
+      final state = await pumpEditor(tester);
+      state.editing.markupTool = PdfMarkupKind.highlight;
+      await tester.pump();
+
+      final gesture = await tester.startGesture(view(158, 720),
+          kind: PointerDeviceKind.mouse);
+      await gesture.moveBy(const Offset(-20, 0));
+      await tester.pump();
+      await gesture.moveTo(view(50, 720));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(state.viewer.hasSelection, isFalse);
+      expect(state.editing.markupTool, PdfMarkupKind.highlight);
+      final annotations = state.editing.document.page(0).annotations;
+      expect(annotations, hasLength(1));
+      expect(annotations.single.subtype, 'Highlight');
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('touch long-press applies the armed markup on lift',
+        (tester) async {
+      final state = await pumpEditor(tester);
+      state.editing.markupTool = PdfMarkupKind.underline;
+      await tester.pump();
+
+      await longPressSelect(tester, view(100, 720));
+
+      expect(state.viewer.hasSelection, isFalse);
+      expect(state.editing.markupTool, PdfMarkupKind.underline);
+      final annotations = state.editing.document.page(0).annotations;
+      expect(annotations, hasLength(1));
+      expect(annotations.single.subtype, 'Underline');
+      expect(
+          find.byKey(const ValueKey('pdf-text-selection-chip')), findsNothing);
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+  });
+
   group('long-press selection', () {
     testWidgets('RTL selection starts on the right edge', (tester) async {
       final controller = await pumpViewer(tester, bytes: buildRtlTextPdf());
@@ -189,8 +232,7 @@ void main() {
     testWidgets(
         'contextMenuEnabled: false hides the chip but keeps the selection, '
         'its handles and word-drag extension', (tester) async {
-      final controller =
-          await pumpViewer(tester, contextMenuEnabled: false);
+      final controller = await pumpViewer(tester, contextMenuEnabled: false);
       final gesture = await tester.startGesture(view(100, 720));
       await tester.pump(const Duration(milliseconds: 600));
       // the press still extends by word while it drags

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -343,6 +343,56 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400));
   });
 
+  testWidgets('explicit Hand mode pans over text instead of selecting it',
+      (tester) async {
+    final bytes = buildMultiPagePdf(5);
+    final editing = PdfEditingController(bytes)..activateHandMode();
+    final controller = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: PdfViewerFit.width,
+          document: editing.document,
+          controller: controller,
+          editing: editing,
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+    MouseRegion region() => tester.widget<MouseRegion>(find
+        .descendant(
+            of: find.byType(PdfViewer), matching: find.byType(MouseRegion))
+        .first);
+
+    final hover =
+        await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 7);
+    await hover.addPointer(location: view(100, 720));
+    await tester.pump();
+    await hover.moveTo(view(101, 720));
+    await tester.pump();
+    expect(region().cursor, SystemMouseCursors.grab);
+    await hover.removePointer();
+    await tester.pump();
+
+    final gesture = await tester.startGesture(view(158, 720),
+        kind: PointerDeviceKind.mouse, pointer: 8);
+    await gesture.moveBy(const Offset(-20, 0));
+    await tester.pump();
+    await gesture.moveTo(view(50, 720));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(controller.hasSelection, isFalse);
+    expect(controller.selectedText, isEmpty);
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
   testWidgets('selection geometry is exposed in PDF page coordinates',
       (tester) async {
     final controller = await pumpViewer(tester);


### PR DESCRIPTION
## Summary

- Add a mobile current-tool switcher that uses the full shaded toolbar slot, constrains its width, exposes recently used tools, and keeps clearing the active tool inside the popup.
- Distinguish Hand navigation from Select editing, and make the single-option mobile Select group arm Select immediately.
- Let users arm a text-markup tool before selecting text while retaining the existing select-first workflow.
- Keep inline text and form cursors visually proportional at deep zoom, and constrain the animated app tab strip during narrow-window resizing.
- Document the repository's UX north star and add UX checks to the contribution and PR guidance.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [ ] `fvm flutter pub get`
- [ ] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Targeted validation was used because the changes are confined to editor chrome and interaction paths:

- `cd packages/dart_pdf_editor && fvm flutter test test/pdf_touch_selection_test.dart test/editing_mobile_toolbar_test.dart test/pdf_shell_test.dart test/editing_test.dart` (177 tests)
- `cd packages/dart_pdf_editor && fvm flutter test test/editing_caret_zoom_test.dart test/editing_text_edit_test.dart test/editing_form_interactive_test.dart` (76 tests)
- Targeted `fvm dart analyze` for the changed editor, viewer, localization, and test files
- `cd app && fvm flutter test test/tabs_sizing_test.dart` (3 tests)
- `cd app && fvm dart analyze lib/editor_screen.dart test/tabs_sizing_test.dart`
- `git diff --cached --check`

Core PDF parsing, rendering, serialization, and corpus behavior are unchanged, so the package-wide core and corpus suites were not run.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

No new PDF fixture is needed; the behavior is covered with programmatic widget fixtures and visual caret assertions at normal and deep zoom.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `Hand` is the user-facing name for grab/pan navigation; `Select` is reserved for editable object selection.
- The new localization key is generated across all locale classes, with the English label used until translations are supplied.
- The unrelated local `app/macos/Podfile.lock` checksum change is intentionally excluded.
