### PR TITLE
feat(editor): make multi-edit properties permissive

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -5304,11 +5304,14 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // restyle
 
-  /// Whether [restyleSelected] can recolor everything selected in place
-  /// (see [pdfCanRestyleAnnotation] for the per-subtype conditions).
+  /// Whether [restyleSelected] can restyle at least one selected annotation
+  /// in place (see [pdfCanRestyleAnnotation] for the per-subtype conditions).
+  ///
+  /// A mixed selection is intentionally permissive: each property applies to
+  /// the compatible annotations and leaves the rest untouched.
   bool get canRestyleSelected =>
       _selected.isNotEmpty &&
-      _selected.every((slot) {
+      _selected.any((slot) {
         final annotation = _annotationAt(slot);
         return annotation?.behavior.canRestyle == true;
       });
@@ -5344,12 +5347,13 @@ class PdfEditingController extends ChangeNotifier {
     return rgb == null ? color : Color(0xFF000000 | rgb);
   }
 
-  /// Whether [restyleSelected]'s `fill` parameter applies to every selected
-  /// annotation (shapes and FreeText boxes).
+  /// Whether [restyleSelected]'s `fill` parameter applies to at least one
+  /// selected annotation (shapes and FreeText boxes).
   bool get canFillSelected =>
       canRestyleSelected &&
-      _selected.every((slot) {
-        return _annotationAt(slot)?.behavior.supportsFill == true;
+      _selected.any((slot) {
+        final behavior = _annotationAt(slot)?.behavior;
+        return behavior?.canRestyle == true && behavior?.supportsFill == true;
       });
 
   /// The primary selected annotation's interior/background fill, or null
@@ -5359,12 +5363,14 @@ class PdfEditingController extends ChangeNotifier {
     return rgb == null ? null : Color(0xFF000000 | rgb);
   }
 
-  /// Whether every selected annotation takes a border line style - shapes
-  /// and the line family - so [restyleSelected]'s `lineStyle` applies.
+  /// Whether at least one selected annotation takes a border line style -
+  /// shapes and the line family - so [restyleSelected]'s `lineStyle` applies.
   bool get canSetLineStyleSelected =>
       canRestyleSelected &&
-      _selected.every((slot) {
-        return _annotationAt(slot)?.behavior.supportsLineStyle == true;
+      _selected.any((slot) {
+        final behavior = _annotationAt(slot)?.behavior;
+        return behavior?.canRestyle == true &&
+            behavior?.supportsLineStyle == true;
       });
 
   /// The primary selected annotation's border line style (for the line-type
@@ -5510,13 +5516,13 @@ class PdfEditingController extends ChangeNotifier {
     return true;
   }
 
-  /// Restyles every selected annotation in place - one revision, one
-  /// undo, and the selection survives (annotations keep their /Annots
-  /// slots). Parameters follow [PdfEditor.restyleAnnotation]: [color]
-  /// is the stroke/tint (free text's *text* color), [fill] the shape
-  /// interior or text-box background (`(null,)` clears it), and
-  /// parameters a subtype doesn't have are ignored for it. Returns
-  /// whether anything changed.
+  /// Restyles every compatible selected annotation in place - one revision,
+  /// one undo, and the selection survives (annotations keep their /Annots
+  /// slots). Parameters follow [PdfEditor.restyleAnnotation]: [color] is the
+  /// stroke/tint (free text's *text* color), [fill] the shape interior or
+  /// text-box background (`(null,)` clears it). In a mixed selection each
+  /// property applies only to subtypes that support it. Returns whether
+  /// anything changed.
   bool restyleSelected({
     Color? color,
     (Color?,)? fill,
@@ -5536,9 +5542,22 @@ class PdfEditingController extends ChangeNotifier {
       return false;
     }
     if (!canRestyleSelected) return false;
+    bool applies(PdfAnnotation annotation) {
+      final behavior = annotation.behavior;
+      if (!behavior.canRestyle) return false;
+      return (color != null && behavior.supportsColor) ||
+          (fill != null && behavior.supportsFill) ||
+          (strokeWidth != null && behavior.supportsStrokeWidth) ||
+          (opacity != null && behavior.supportsOpacity) ||
+          (lineStyle != null && behavior.supportsLineStyle) ||
+          (scale != null && behavior.supportsLineStyle) ||
+          (cornerRadius != null && annotation.subtype == 'Square');
+    }
+
     final targets = <(int, PdfAnnotation)>[
       for (final slot in _selected)
-        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
+        if (_annotationAt(slot) case final annotation?)
+          if (applies(annotation)) (slot.$1, annotation),
     ];
     if (targets.isEmpty) return false;
     return apply(
@@ -5573,12 +5592,16 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
-  /// Whether [restyleSelected]'s `cornerRadius` applies - every selected
-  /// annotation is a restylable /Square rectangle (the only subtype that
-  /// rounds its corners). Gates the selection corner-radius control.
+  /// Whether [restyleSelected]'s `cornerRadius` applies to at least one
+  /// selected restylable /Square rectangle (the only subtype that rounds its
+  /// corners). Other selected annotations are left untouched.
   bool get canRoundSelectedCorners =>
       canRestyleSelected &&
-      _selected.every((slot) => _annotationAt(slot)?.subtype == 'Square');
+      _selected.any((slot) {
+        final annotation = _annotationAt(slot);
+        return annotation?.subtype == 'Square' &&
+            annotation?.behavior.canRestyle == true;
+      });
 
   /// The primary selected rectangle's current corner radius (page points),
   /// or null when the selection isn't a roundable /Square - for the corner
@@ -6174,11 +6197,12 @@ class PdfEditingController extends ChangeNotifier {
     return dx * dx + dy * dy;
   }
 
-  /// Whether every selected annotation is a /Line or /PolyLine whose endings
-  /// can be set together ([setSelectedLineEndings]).
+  /// Whether at least one selected annotation is a /Line or /PolyLine whose
+  /// endings can be set ([setSelectedLineEndings]). Other selected subtypes
+  /// are ignored.
   bool get canSetLineEndings {
     return _selected.isNotEmpty &&
-        _selected.every((slot) {
+        _selected.any((slot) {
           final annotation = _annotationAt(slot);
           return annotation != null &&
               annotation.behavior.supportsLineEndings &&
@@ -6186,11 +6210,24 @@ class PdfEditingController extends ChangeNotifier {
         });
   }
 
-  /// The primary selected /Line or /PolyLine's start/end line endings, or
-  /// null when the selection cannot edit line endings. Multi-selection UIs
-  /// may compare each annotation when they need a mixed-value indicator.
+  PdfAnnotation? get _selectedLineEndingAnnotation {
+    for (final slot in _selected.reversed) {
+      final annotation = _annotationAt(slot);
+      if (annotation != null &&
+          annotation.behavior.supportsLineEndings &&
+          annotation.normalAppearance != null) {
+        return annotation;
+      }
+    }
+    return null;
+  }
+
+  /// The most recently selected compatible /Line or /PolyLine's start/end
+  /// endings, or null when the selection cannot edit line endings.
+  /// Multi-selection UIs may compare each compatible annotation when they
+  /// need a mixed-value indicator.
   (PdfLineEnding, PdfLineEnding)? get selectedLineEndings {
-    final annotation = selectedAnnotation;
+    final annotation = _selectedLineEndingAnnotation;
     if (annotation == null || !canSetLineEndings) return null;
     return pdfLineEndings(annotation);
   }
@@ -6203,7 +6240,10 @@ class PdfEditingController extends ChangeNotifier {
     if (!canSetLineEndings) return;
     final targets = <(int, PdfAnnotation)>[
       for (final slot in _selected)
-        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
+        if (_annotationAt(slot) case final annotation?)
+          if (annotation.behavior.supportsLineEndings &&
+              annotation.normalAppearance != null)
+            (slot.$1, annotation),
     ];
     apply((e) {
       for (final (page, annotation) in targets) {
@@ -6330,17 +6370,35 @@ class PdfEditingController extends ChangeNotifier {
     return (font: embedded ?? standard.font, size: standard.size);
   }
 
-  /// Whether the selection is a single free-text annotation whose font
-  /// and size [restyleSelectedText] can change.
-  bool get canRestyleSelectedText =>
-      _selected.length == 1 && selectedAnnotation?.subtype == 'FreeText';
+  PdfAnnotation? get _selectedFreeTextAnnotation {
+    for (final slot in _selected.reversed) {
+      final annotation = _annotationAt(slot);
+      if (annotation?.subtype == 'FreeText') return annotation;
+    }
+    return null;
+  }
+
+  List<({int page, int slot, PdfAnnotation annotation})>
+      get _selectedFreeTextAnnotations => [
+            for (final slot in _selected)
+              if (_annotationAt(slot) case final annotation?)
+                if (annotation.subtype == 'FreeText')
+                  (page: slot.$1, slot: slot.$2, annotation: annotation),
+          ];
+
+  /// Whether at least one selected free-text annotation can have its font,
+  /// size, alignment, or box text style changed.
+  ///
+  /// Mixed selections are supported: text properties apply to every selected
+  /// free-text box and leave lines, shapes, and other annotations untouched.
+  bool get canRestyleSelectedText => _selectedFreeTextAnnotation != null;
 
   /// The selected free-text annotation's font and size (parsed from its
-  /// /DA), or null when the selection isn't free text.
+  /// /DA), or null when the selection contains no free text. With a mixed
+  /// selection this is the most recently selected free-text box.
   ({PdfStandardFont font, double size})? get selectedTextStyle {
-    final annotation = selectedAnnotation;
-    if (annotation?.subtype != 'FreeText') return null;
-    return _freeTextStyleOf(annotation!);
+    final annotation = _selectedFreeTextAnnotation;
+    return annotation == null ? null : _freeTextStyleOf(annotation);
   }
 
   /// The selected free-text annotation's per-run rich styling, parsed
@@ -6352,6 +6410,10 @@ class PdfEditingController extends ChangeNotifier {
   List<PdfFreeTextRun>? get selectedRichRuns {
     final annotation = selectedAnnotation;
     if (annotation == null || annotation.subtype != 'FreeText') return null;
+    return _richRunsOf(annotation);
+  }
+
+  List<PdfFreeTextRun>? _richRunsOf(PdfAnnotation annotation) {
     final rc = annotation.richContent;
     if (rc == null) return null;
     final style = _freeTextStyleOf(annotation);
@@ -6364,10 +6426,11 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// The selected free-text annotation's horizontal alignment (its /Q
-  /// quadding), or null when the selection isn't a single free-text box.
+  /// quadding), or null when the selection contains no free-text box.
   PdfTextAlign? get selectedTextAlign {
-    if (!canRestyleSelectedText) return null;
-    return selectedAnnotation?.freeTextStyle?.alignment ?? PdfTextAlign.left;
+    final annotation = _selectedFreeTextAnnotation;
+    if (annotation == null) return null;
+    return annotation.freeTextStyle?.alignment ?? PdfTextAlign.left;
   }
 
   /// The actual font of the selected free-text box - its embedded font
@@ -6376,16 +6439,17 @@ class PdfEditingController extends ChangeNotifier {
   /// this reports the real face, so the font picker shows a bundled/custom
   /// font's own name instead of collapsing to "Sans".
   PdfTextFont? get selectedTextFont {
-    final annotation = selectedAnnotation;
-    if (annotation == null || annotation.subtype != 'FreeText') return null;
+    final annotation = _selectedFreeTextAnnotation;
+    if (annotation == null) return null;
     return _freeTextFontOf(annotation).font;
   }
 
   /// The selected free-text box's full parsed style (spacing, underline,
-  /// alignment, colours), or null when the selection isn't a free-text box.
+  /// alignment, colours), or null when the selection contains no free-text
+  /// box. With a mixed selection this is the most recently selected box.
   PdfFreeTextStyle? get selectedFreeTextStyle {
-    final annotation = selectedAnnotation;
-    if (annotation == null || annotation.subtype != 'FreeText') return null;
+    final annotation = _selectedFreeTextAnnotation;
+    if (annotation == null) return null;
     return annotation.freeTextStyle;
   }
 
@@ -6393,7 +6457,8 @@ class PdfEditingController extends ChangeNotifier {
   /// horizontal glyph width, whole-box underline) on the selected box,
   /// regenerating its appearance and preserving any per-run styling. Each
   /// value also becomes the creation default. Omitted values are left as-is.
-  /// A no-op when the selection isn't a single free-text box.
+  /// In a mixed selection this updates every selected free-text box and leaves
+  /// the other annotations untouched.
   void setSelectedTextBoxStyle({
     double? lineSpacing,
     double? charSpacing,
@@ -6408,34 +6473,12 @@ class PdfEditingController extends ChangeNotifier {
     // swap the document under it - the change rides the creation defaults
     // and lands when the edit commits instead
     if (isEditingText) return;
-    final annotation = selectedAnnotation;
-    if (annotation == null || !canRestyleSelectedText) return;
-    final richRuns = selectedRichRuns;
-    if (richRuns != null && richRuns.isNotEmpty) {
-      final runs = underline == null
-          ? richRuns
-          : [
-              for (final r in richRuns)
-                PdfFreeTextRun(r.text,
-                    font: r.font,
-                    fontSize: r.fontSize,
-                    color: r.color,
-                    underline: underline)
-            ];
-      _rewriteSelectedRich(annotation, runs,
-          lineSpacing: lineSpacing,
-          charSpacing: charSpacing,
-          fontWidth: fontWidth);
-    } else {
-      _rewriteSelected(
-        annotation,
-        annotation.contents ?? '',
-        lineSpacing: lineSpacing,
-        charSpacing: charSpacing,
-        fontWidth: fontWidth,
-        underline: underline,
-      );
-    }
+    _restyleSelectedFreeText(
+      lineSpacing: lineSpacing,
+      charSpacing: charSpacing,
+      fontWidth: fontWidth,
+      underline: underline,
+    );
   }
 
   PdfRect _autosizeTextRect(
@@ -6467,7 +6510,11 @@ class PdfEditingController extends ChangeNotifier {
   /// rather than sliding inward to fit.
   void autosizeSelectedTextBox() {
     final annotation = selectedAnnotation;
-    if (annotation == null || !canRestyleSelectedText) return;
+    if (_selected.length != 1 ||
+        annotation == null ||
+        annotation.subtype != 'FreeText') {
+      return;
+    }
     final style = _freeTextStyleOf(annotation);
     final rect = _autosizeTextRect(
       annotation,
@@ -6478,9 +6525,10 @@ class PdfEditingController extends ChangeNotifier {
     resizeSelected(rect);
   }
 
-  /// Rewrites the selected free-text annotation with a new [font] and/or
-  /// [size], keeping its text, place, color, and author. The selection
-  /// survives (the annotation keeps its /Annots slot).
+  /// Rewrites every selected free-text annotation with a new [font] and/or
+  /// [size], keeping each box's text, place, color, and author. Other selected
+  /// annotation subtypes are left untouched. The whole change is one undo
+  /// step and the selection survives.
   ///
   /// [fill] and [border] change the box's background and border color:
   /// the single-field record distinguishes "set to this RGB" - including
@@ -6496,17 +6544,9 @@ class PdfEditingController extends ChangeNotifier {
     (int?,)? border,
     double? borderWidth,
   }) {
-    final annotation = selectedAnnotation;
-    if (annotation == null || !canRestyleSelectedText) return;
-    // Default to the box's own (possibly embedded) font, so changing only
-    // the size never silently converts an embedded font to Helvetica; an
-    // explicit [font] (the family picker) still wins.
-    final style = _freeTextFontOf(annotation);
-    _rewriteSelected(
-      annotation,
-      annotation.contents ?? '',
-      font: font ?? style.font,
-      size: size ?? style.size,
+    _restyleSelectedFreeText(
+      font: font,
+      size: size,
       align: align,
       fill: fill,
       border: border,
@@ -6514,29 +6554,197 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
+  bool _restyleSelectedFreeText({
+    PdfTextFont? font,
+    double? size,
+    PdfTextAlign? align,
+    (int?,)? fill,
+    (int?,)? border,
+    double? borderWidth,
+    double? lineSpacing,
+    double? charSpacing,
+    double? fontWidth,
+    bool? underline,
+  }) {
+    if (font == null &&
+        size == null &&
+        align == null &&
+        fill == null &&
+        border == null &&
+        borderWidth == null &&
+        lineSpacing == null &&
+        charSpacing == null &&
+        fontWidth == null &&
+        underline == null) {
+      return false;
+    }
+    final targets = _selectedFreeTextAnnotations;
+    if (targets.isEmpty) return false;
+
+    // Capture every source before the editor mutates /Annots. Text rewrites
+    // remove and re-add their annotation so a newly chosen embedded font can
+    // install its own resources; remap the complete mixed selection to the
+    // survivor slots and appended replacement slots up front.
+    final specs = [
+      for (final target in targets)
+        (
+          page: target.page,
+          slot: target.slot,
+          annotation: target.annotation,
+          rect: _appearanceRotationOf(target.annotation) == 0
+              ? target.annotation.rect
+              : _localFrameOf(target.annotation),
+          rotation: _appearanceRotationOf(target.annotation),
+          pageRotation: _page(target.page).rotation,
+          textFont: _freeTextFontOf(target.annotation),
+          parsed: target.annotation.freeTextStyle,
+          richRuns: _richRunsOf(target.annotation),
+        ),
+    ];
+    final removedByPage = <int, List<int>>{};
+    final pageCounts = <int, int>{};
+    for (final spec in specs) {
+      (removedByPage[spec.page] ??= []).add(spec.slot);
+      pageCounts.putIfAbsent(
+          spec.page, () => _page(spec.page).annotations.length);
+    }
+    for (final slots in removedByPage.values) {
+      slots.sort();
+    }
+    final replacementSlots = <(int, int), (int, int)>{};
+    final pageOrdinals = <int, int>{};
+    for (final spec in specs) {
+      final ordinal = pageOrdinals[spec.page] ?? 0;
+      pageOrdinals[spec.page] = ordinal + 1;
+      final survivorCount =
+          pageCounts[spec.page]! - removedByPage[spec.page]!.length;
+      replacementSlots[(spec.page, spec.slot)] =
+          (spec.page, survivorCount + ordinal);
+    }
+    final oldSelection = List<(int, int)>.of(_selected);
+    final nextSelection = <(int, int)>[];
+    for (final slot in oldSelection) {
+      final replacement = replacementSlots[slot];
+      if (replacement != null) {
+        nextSelection.add(replacement);
+        continue;
+      }
+      final removed = removedByPage[slot.$1];
+      if (removed == null) {
+        nextSelection.add(slot);
+        continue;
+      }
+      final shift = removed.where((index) => index < slot.$2).length;
+      nextSelection.add((slot.$1, slot.$2 - shift));
+    }
+    _selected
+      ..clear()
+      ..addAll(nextSelection);
+
+    final changed = apply((e) {
+      for (final spec in specs) {
+        e.removeAnnotation(spec.page, spec.annotation);
+      }
+      for (final spec in specs) {
+        final annotation = spec.annotation;
+        final parsed = spec.parsed;
+        final effectiveFill = fill != null ? fill.$1 : parsed?.fillColor;
+        final effectiveBorder =
+            border != null ? border.$1 : parsed?.borderColor;
+        final effectiveBorderWidth = borderWidth ??
+            ((parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1);
+        final effectiveAlign = align ?? parsed?.alignment ?? PdfTextAlign.left;
+        final effectiveLineSpacing = lineSpacing ??
+            parsed?.lineSpacing ??
+            kPdfFreeTextDefaultLineSpacing;
+        final effectiveCharSpacing = charSpacing ?? parsed?.charSpacing ?? 0;
+        final effectiveFontWidth = fontWidth ??
+            parsed?.horizontalScale ??
+            kPdfFreeTextDefaultHorizontalScale;
+        final runs = spec.richRuns;
+        if (runs != null && runs.isNotEmpty) {
+          e.addFreeTextRich(
+            spec.page,
+            spec.rect,
+            [
+              for (final run in runs)
+                PdfFreeTextRun(
+                  run.text,
+                  font: font ?? run.font,
+                  fontSize: size ?? run.fontSize,
+                  color: run.color,
+                  underline: underline ?? run.underline,
+                ),
+            ],
+            align: effectiveAlign,
+            fillColor: effectiveFill,
+            borderColor: effectiveBorder,
+            borderWidth: effectiveBorderWidth,
+            opacity: annotation.appearanceOpacity,
+            lineSpacing: effectiveLineSpacing,
+            charSpacing: effectiveCharSpacing,
+            horizontalScale: effectiveFontWidth,
+            pageRotation: spec.pageRotation,
+            author: annotation.author,
+            name: annotation.name,
+          );
+        } else {
+          e.addFreeText(
+            spec.page,
+            spec.rect,
+            annotation.contents ?? '',
+            fontSize: size ?? spec.textFont.size,
+            font: font ?? spec.textFont.font,
+            align: effectiveAlign,
+            color: parsed?.color ?? annotation.color ?? 0x000000,
+            fillColor: effectiveFill,
+            borderColor: effectiveBorder,
+            borderWidth: effectiveBorderWidth,
+            opacity: annotation.appearanceOpacity,
+            lineSpacing: effectiveLineSpacing,
+            charSpacing: effectiveCharSpacing,
+            horizontalScale: effectiveFontWidth,
+            underline: underline ?? parsed?.underline ?? false,
+            pageRotation: spec.pageRotation,
+            author: annotation.author,
+            name: annotation.name,
+          );
+        }
+        if (spec.rotation != 0) {
+          final annotations = _document.page(spec.page).annotations;
+          if (annotations.isNotEmpty) {
+            e.rotateAnnotation(
+              spec.page,
+              annotations.last,
+              spec.rotation * 180 / math.pi,
+            );
+          }
+        }
+      }
+    });
+    if (!changed) {
+      _selected
+        ..clear()
+        ..addAll(oldSelection);
+    }
+    return changed;
+  }
+
   /// Sets the horizontal alignment of the selected free-text box (its /Q
   /// quadding), regenerating its appearance, and makes it the default for
-  /// new boxes. A no-op when the selection isn't a single free-text box.
+  /// new boxes. In a mixed selection every free-text box is updated.
   void setSelectedTextAlign(PdfTextAlign align) {
     preferences.textAlign = align; // the new default either way
     if (canRestyleSelectedText) restyleSelectedText(align: align);
   }
 
-  /// Rewrites the selected free-text annotation in [font] - a base-14
-  /// face or an embedded TrueType/OpenType font - keeping its text, size,
-  /// place, color, and author. Unlike [restyleSelectedText] (which only
-  /// takes the standard families) this can switch a box to any embedded
-  /// font.
+  /// Rewrites every selected free-text annotation in [font] - a base-14 face
+  /// or an embedded TrueType/OpenType font - keeping its text, size, place,
+  /// color, and author. Other selected subtypes are ignored. Unlike
+  /// [restyleSelectedText] (which only takes the standard families) this can
+  /// switch boxes to any embedded font.
   void restyleSelectedFont(PdfTextFont font) {
-    final annotation = selectedAnnotation;
-    if (annotation == null || !canRestyleSelectedText) return;
-    final style = _freeTextFontOf(annotation);
-    _rewriteSelected(
-      annotation,
-      annotation.contents ?? '',
-      font: font,
-      size: style.size,
-    );
+    _restyleSelectedFreeText(font: font);
   }
 
   /// Applies font, size, and/or text color to a substring of the selected
@@ -6551,7 +6759,11 @@ class PdfEditingController extends ChangeNotifier {
     int? color,
   }) {
     final annotation = selectedAnnotation;
-    if (annotation == null || !canRestyleSelectedText) return false;
+    if (_selected.length != 1 ||
+        annotation == null ||
+        annotation.subtype != 'FreeText') {
+      return false;
+    }
     final text = annotation.contents ?? '';
     final from = math.max(0, math.min(start, end)).clamp(0, text.length);
     final to = math.min(text.length, math.max(start, end));

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -134,8 +134,8 @@ Future<List<PdfEmbeddedFont>> loadFallbackFonts() async {
 
 /// Applies [font] to [controller]: it becomes the font new free text is
 /// written in (an embedded font sets [PdfEditingController.activeFont]; a
-/// standard family sets [PdfEditingController.fontFamily]) and, when a
-/// single free-text box is selected, restyles it in place too.
+/// standard family sets [PdfEditingController.fontFamily]) and restyles every
+/// selected free-text box too. Other selected annotation subtypes are ignored.
 void pdfApplyFont(PdfEditingController controller, PdfTextFont font) {
   if (font is PdfStandardFont) {
     controller.fontFamily = font;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -535,34 +535,31 @@ class _PdfAnnotationPropertiesPanelState
     );
   }
 
-  /// Whether every selected annotation satisfies a shared semantic
-  /// capability. The subtype matrix lives in pdf_document.
-  bool _allSelected(bool Function(PdfAnnotationBehavior) test) {
-    final slots = _controller.selectedAnnotationSlots;
-    if (slots.isEmpty) return false;
-    for (final (page, index) in slots) {
-      final annotation = _controller.annotationAt(page, index);
-      if (annotation == null || !test(annotation.behavior)) {
-        return false;
-      }
-    }
-    return true;
-  }
+  /// The selected annotations that satisfy one semantic capability. Property
+  /// controls operate on this compatible subset instead of disappearing just
+  /// because the mixed selection also contains another subtype.
+  List<PdfAnnotation> _compatible(
+    bool Function(PdfAnnotationBehavior) test,
+  ) =>
+      [
+        for (final annotation in _selectedAnnotations)
+          if (annotation.behavior.canRestyle && test(annotation.behavior))
+            annotation,
+      ];
 
   List<Widget> _styleControls() {
     final children = <Widget>[];
     if (!_controller.canRestyleSelected) return children;
     final annotations = _selectedAnnotations;
     if (annotations.isEmpty) return children;
-    final styles = [
-      for (final annotation in annotations) annotation.behavior.style
-    ];
-    final style = _controller.selectedAnnotationStyle;
-    if (style == null) return children;
     // An image stamp (a pasted picture) has no tintable colour - only its
     // opacity applies - so the swatch is hidden for it while opacity stays.
-    if (_allSelected((behavior) => behavior.supportsColor)) {
-      final colors = _common<int?>([for (final style in styles) style.color]);
+    final colorAnnotations = _compatible((behavior) => behavior.supportsColor);
+    if (colorAnnotations.isNotEmpty) {
+      final colors = _common<int?>([
+        for (final annotation in colorAnnotations)
+          annotation.behavior.style.color,
+      ]);
       children.add(_swatchRow(
         pdfL10n(context).propColor,
         Color(0xFF000000 | (colors.value ?? 0)),
@@ -571,9 +568,11 @@ class _PdfAnnotationPropertiesPanelState
         varies: colors.varies,
       ));
     }
-    if (_allSelected((behavior) => behavior.supportsFill)) {
+    final fillAnnotations = _compatible((behavior) => behavior.supportsFill);
+    if (fillAnnotations.isNotEmpty) {
       final fills = _common<int?>([
-        for (final style in styles) style.fillColor,
+        for (final annotation in fillAnnotations)
+          annotation.behavior.style.fillColor,
       ]);
       final fillColor =
           fills.value == null ? null : Color(0xFF000000 | fills.value!);
@@ -583,9 +582,12 @@ class _PdfAnnotationPropertiesPanelState
           onClear: () => _controller.restyleSelected(fill: (null,)),
           varies: fills.varies));
     }
-    if (_allSelected((behavior) => behavior.supportsStrokeWidth)) {
+    final strokeAnnotations =
+        _compatible((behavior) => behavior.supportsStrokeWidth);
+    if (strokeAnnotations.isNotEmpty) {
       final widths = _common<double?>([
-        for (final style in styles) style.strokeWidth,
+        for (final annotation in strokeAnnotations)
+          annotation.behavior.style.strokeWidth,
       ]);
       children.add(_sliderRow(
         pdfL10n(context).propStroke,
@@ -607,7 +609,10 @@ class _PdfAnnotationPropertiesPanelState
     // off circles, polygons and everything else
     if (_controller.canRoundSelectedCorners) {
       final radii = _common<double>([
-        for (final annotation in annotations) annotation.cornerRadius,
+        for (final annotation in annotations)
+          if (annotation.subtype == 'Square' &&
+              annotation.behavior.canRestyle)
+            annotation.cornerRadius,
       ]);
       children.add(_sliderRow(
         pdfL10n(context).propCornerRadius,
@@ -627,10 +632,12 @@ class _PdfAnnotationPropertiesPanelState
         },
       ));
     }
-    if (_allSelected((behavior) => behavior.supportsLineStyle) &&
+    final lineStyleAnnotations =
+        _compatible((behavior) => behavior.supportsLineStyle);
+    if (lineStyleAnnotations.isNotEmpty &&
         _controller.canSetLineStyleSelected) {
       final lineStyles = _common<PdfLineStyle>([
-        for (final annotation in annotations)
+        for (final annotation in lineStyleAnnotations)
           PdfLineStyle.ofDashArray(annotation.borderDash),
       ]);
       children.add(Padding(
@@ -673,11 +680,19 @@ class _PdfAnnotationPropertiesPanelState
       ));
     }
     if (_controller.canSetLineEndings) {
+      final lineEndingAnnotations = [
+        for (final annotation in annotations)
+          if (annotation.behavior.supportsLineEndings &&
+              annotation.normalAppearance != null)
+            annotation,
+      ];
       final starts = _common<PdfLineEnding>([
-        for (final annotation in annotations) pdfLineEndings(annotation)!.$1,
+        for (final annotation in lineEndingAnnotations)
+          pdfLineEndings(annotation)!.$1,
       ]);
       final ends = _common<PdfLineEnding>([
-        for (final annotation in annotations) pdfLineEndings(annotation)!.$2,
+        for (final annotation in lineEndingAnnotations)
+          pdfLineEndings(annotation)!.$2,
       ]);
       children
         ..add(_lineEndingRow(
@@ -695,9 +710,12 @@ class _PdfAnnotationPropertiesPanelState
               _controller.setSelectedLineEndings(end: ending),
         ));
     }
-    if (_allSelected((behavior) => behavior.supportsOpacity)) {
+    final opacityAnnotations =
+        _compatible((behavior) => behavior.supportsOpacity);
+    if (opacityAnnotations.isNotEmpty) {
       final opacities = _common<double>([
-        for (final style in styles) style.opacity,
+        for (final annotation in opacityAnnotations)
+          annotation.behavior.style.opacity,
       ]);
       children.add(_sliderRow(
         pdfL10n(context).propOpacity,
@@ -724,12 +742,44 @@ class _PdfAnnotationPropertiesPanelState
     return children;
   }
 
-  List<Widget> _textStyleControls(PdfAnnotation annotation) {
+  List<Widget> _textStyleControls() {
     if (!_controller.canRestyleSelectedText) return const [];
+    final annotations = [
+      for (final annotation in _selectedAnnotations)
+        if (annotation.subtype == 'FreeText') annotation,
+    ];
+    if (annotations.isEmpty) return const [];
     final style = _controller.selectedTextStyle;
     if (style == null) return const [];
-    final border = annotation.behavior.style.borderColor;
-    final borderColor = border == null ? null : Color(0xFF000000 | border);
+    final sizes = _common<double>([
+      for (final annotation in annotations)
+        annotation.freeTextStyle?.fontSize ?? style.size,
+    ]);
+    final freeStyles = [
+      for (final annotation in annotations)
+        annotation.freeTextStyle ??
+            PdfFreeTextStyle(
+              fontName: style.font.resourceName,
+              fontSize: style.size,
+              color: annotation.color ?? 0,
+            ),
+    ];
+    final alignments =
+        _common<PdfTextAlign>([for (final value in freeStyles) value.alignment]);
+    final underlines =
+        _common<bool>([for (final value in freeStyles) value.underline]);
+    final lineSpacings =
+        _common<double>([for (final value in freeStyles) value.lineSpacing]);
+    final charSpacings =
+        _common<double>([for (final value in freeStyles) value.charSpacing]);
+    final fontWidths = _common<double>([
+      for (final value in freeStyles) value.horizontalScale,
+    ]);
+    final borders =
+        _common<int?>([for (final value in freeStyles) value.borderColor]);
+    final borderColor = borders.value == null
+        ? null
+        : Color(0xFF000000 | borders.value!);
     return [
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -761,98 +811,97 @@ class _PdfAnnotationPropertiesPanelState
           Expanded(child: Text(pdfL10n(context).propAlign)),
           TextAlignToggles(
             keyPrefix: 'pdf-prop-text-align',
-            align: _controller.selectedTextAlign ?? PdfTextAlign.left,
+            align: alignments.value,
             onChanged: (align) => _controller.restyleSelectedText(align: align),
           ),
         ]),
       ),
       _sliderRow(
         pdfL10n(context).propSize,
-        _draggingFontSize ?? style.size,
+        _draggingFontSize ?? sizes.value,
         key: const ValueKey('pdf-prop-font-size'),
         min: 6,
         max: 72,
         fieldMin: 1,
         fieldMax: kPdfTypedSizeMax,
+        varies: _draggingFontSize == null && sizes.varies,
         onChanged: (v) => setState(() => _draggingFontSize = v),
         onChangeEnd: (v) {
           _controller.restyleSelectedText(size: v.roundToDouble());
           setState(() => _draggingFontSize = null);
         },
       ),
-      if (annotation.subtype == 'FreeText') ...[
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-          child: Row(children: [
-            Expanded(child: Text(pdfL10n(context).propUnderline)),
-            IconButton(
-              key: const ValueKey('pdf-prop-text-underline'),
-              icon: const Icon(Icons.format_underlined, size: 18),
-              tooltip: pdfL10n(context).propUnderline,
-              isSelected: _controller.selectedFreeTextStyle?.underline ?? false,
-              onPressed: () => _controller.setSelectedTextBoxStyle(
-                  underline:
-                      !(_controller.selectedFreeTextStyle?.underline ?? false)),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: Row(children: [
+          Expanded(child: Text(pdfL10n(context).propUnderline)),
+          IconButton(
+            key: const ValueKey('pdf-prop-text-underline'),
+            icon: const Icon(Icons.format_underlined, size: 18),
+            tooltip: underlines.varies
+                ? pdfL10n(context).propVaries
+                : pdfL10n(context).propUnderline,
+            isSelected: !underlines.varies && underlines.value,
+            onPressed: () => _controller.setSelectedTextBoxStyle(
+              underline: underlines.varies || !underlines.value,
             ),
-          ]),
-        ),
-        _sliderRow(
-          pdfL10n(context).propLineSpacing,
-          _draggingLineSpacing ??
-              _controller.selectedFreeTextStyle?.lineSpacing ??
-              kPdfFreeTextDefaultLineSpacing,
-          key: const ValueKey('pdf-prop-line-spacing'),
-          min: 0.8,
-          max: 3,
-          fieldMin: 0.1,
-          fieldMax: 100,
-          display: (v) => '${v.toStringAsFixed(1)}×',
-          onChanged: (v) => setState(() => _draggingLineSpacing = v),
-          onChangeEnd: (v) {
-            _controller.setSelectedTextBoxStyle(lineSpacing: v);
-            setState(() => _draggingLineSpacing = null);
-          },
-        ),
-        _sliderRow(
-          pdfL10n(context).propCharSpacing,
-          _draggingCharSpacing ??
-              _controller.selectedFreeTextStyle?.charSpacing ??
-              0,
-          key: const ValueKey('pdf-prop-char-spacing'),
-          min: -2,
-          max: 10,
-          fieldMin: -kPdfTypedSizeMax,
-          fieldMax: kPdfTypedSizeMax,
-          display: (v) => '${v.toStringAsFixed(1)} pt',
-          onChanged: (v) => setState(() => _draggingCharSpacing = v),
-          onChangeEnd: (v) {
-            _controller.setSelectedTextBoxStyle(charSpacing: v);
-            setState(() => _draggingCharSpacing = null);
-          },
-        ),
-        _sliderRow(
-          pdfL10n(context).propFontWidth,
-          _draggingFontWidth ??
-              _controller.selectedFreeTextStyle?.horizontalScale ??
-              kPdfFreeTextDefaultHorizontalScale,
-          key: const ValueKey('pdf-prop-font-width'),
-          min: 50,
-          max: 200,
-          fieldMin: 1,
-          fieldMax: kPdfTypedSizeMax,
-          display: (v) => '${v.round()}%',
-          onChanged: (v) => setState(() => _draggingFontWidth = v),
-          onChangeEnd: (v) {
-            _controller.setSelectedTextBoxStyle(fontWidth: v);
-            setState(() => _draggingFontWidth = null);
-          },
-        ),
-        _swatchRow(pdfL10n(context).propOutline, borderColor,
-            key: const ValueKey('pdf-prop-text-border'),
-            onTap: () => _pickTextBorder(borderColor),
-            onClear: () => _controller.restyleSelectedText(border: (null,)),
-            clearTooltip: pdfL10n(context).propNoOutline),
-      ],
+          ),
+        ]),
+      ),
+      _sliderRow(
+        pdfL10n(context).propLineSpacing,
+        _draggingLineSpacing ?? lineSpacings.value,
+        key: const ValueKey('pdf-prop-line-spacing'),
+        min: 0.8,
+        max: 3,
+        fieldMin: 0.1,
+        fieldMax: 100,
+        varies: _draggingLineSpacing == null && lineSpacings.varies,
+        display: (v) => '${v.toStringAsFixed(1)}×',
+        onChanged: (v) => setState(() => _draggingLineSpacing = v),
+        onChangeEnd: (v) {
+          _controller.setSelectedTextBoxStyle(lineSpacing: v);
+          setState(() => _draggingLineSpacing = null);
+        },
+      ),
+      _sliderRow(
+        pdfL10n(context).propCharSpacing,
+        _draggingCharSpacing ?? charSpacings.value,
+        key: const ValueKey('pdf-prop-char-spacing'),
+        min: -2,
+        max: 10,
+        fieldMin: -kPdfTypedSizeMax,
+        fieldMax: kPdfTypedSizeMax,
+        varies: _draggingCharSpacing == null && charSpacings.varies,
+        display: (v) => '${v.toStringAsFixed(1)} pt',
+        onChanged: (v) => setState(() => _draggingCharSpacing = v),
+        onChangeEnd: (v) {
+          _controller.setSelectedTextBoxStyle(charSpacing: v);
+          setState(() => _draggingCharSpacing = null);
+        },
+      ),
+      _sliderRow(
+        pdfL10n(context).propFontWidth,
+        _draggingFontWidth ?? fontWidths.value,
+        key: const ValueKey('pdf-prop-font-width'),
+        min: 50,
+        max: 200,
+        fieldMin: 1,
+        fieldMax: kPdfTypedSizeMax,
+        varies: _draggingFontWidth == null && fontWidths.varies,
+        display: (v) => '${v.round()}%',
+        onChanged: (v) => setState(() => _draggingFontWidth = v),
+        onChangeEnd: (v) {
+          _controller.setSelectedTextBoxStyle(fontWidth: v);
+          setState(() => _draggingFontWidth = null);
+        },
+      ),
+      _swatchRow(pdfL10n(context).propOutline, borderColor,
+          key: const ValueKey('pdf-prop-text-border'),
+          onTap: () => _pickTextBorder(borderColor),
+          onClear: () => _controller.restyleSelectedText(border: (null,)),
+          clearTooltip: pdfL10n(context).propNoOutline,
+          varies: borders.varies),
     ];
   }
 
@@ -966,7 +1015,7 @@ class _PdfAnnotationPropertiesPanelState
     }
 
     addGroup('appearance', l.propSectionAppearance, _styleControls());
-    addGroup('text', l.propSectionText, _textStyleControls(annotation));
+    addGroup('text', l.propSectionText, _textStyleControls());
     // a form widget's /T is its field name, not an author, and /V (not
     // /Contents) is its value - so widgets get a "Field name" group instead
     // of the generic Contents/Author group
@@ -1067,6 +1116,7 @@ class _PdfAnnotationPropertiesPanelState
       ),
     ]);
     addGroup('appearance', l.propSectionAppearance, _styleControls());
+    addGroup('text', l.propSectionText, _textStyleControls());
     if (!hasWidget) {
       addGroup('content', l.propSectionContent, [
         _textRow(

--- a/packages/dart_pdf_editor/test/editing_line_endings_test.dart
+++ b/packages/dart_pdf_editor/test/editing_line_endings_test.dart
@@ -67,7 +67,7 @@ void main() {
           (PdfLineEnding.none, PdfLineEnding.none));
     });
 
-    test('canSetLineEndings is false for shapes and multi-selection', () {
+    test('mixed selections expose endings for their compatible lines', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addRectangle(0, const PdfRect(100, 100, 200, 200))
         ..addLine(0, (100, 240), (220, 300))
@@ -78,8 +78,13 @@ void main() {
       expect(editing.canSetLineEndings, isFalse);
       expect(editing.selectedLineEndings, isNull);
 
-      editing.selectAllAnnotationsOn(0); // both
-      expect(editing.canSetLineEndings, isFalse);
+      editing.selectAllAnnotationsOn(0); // square + line
+      expect(editing.canSetLineEndings, isTrue);
+      editing.setSelectedLineEndings(end: PdfLineEnding.circle);
+      final annotations = editing.document.page(0).annotations;
+      expect(annotations[0].subtype, 'Square');
+      expect(pdfLineEndings(annotations[1]),
+          (PdfLineEnding.none, PdfLineEnding.circle));
     });
   });
 

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -113,6 +113,46 @@ void main() {
         everyElement(isNull),
       );
     });
+
+    test('mixed selections bulk-restyle only their free-text boxes', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, const PdfRect(80, 620, 240, 680), 'First')
+        ..addFreeText(0, const PdfRect(280, 620, 440, 680), 'Second')
+        ..addLine(0, (80, 560), (440, 560));
+      addTearDown(editing.dispose);
+      editing.selectAllAnnotationsOn(0);
+      final originalSizes = editing.document
+          .page(0)
+          .annotations
+          .where((a) => a.subtype == 'FreeText')
+          .map((a) => a.freeTextStyle?.fontSize)
+          .toList();
+
+      expect(editing.canRestyleSelectedText, isTrue);
+      editing.restyleSelectedText(
+        font: PdfStandardFont.timesBold,
+        size: 24,
+      );
+
+      final after = editing.document.page(0).annotations;
+      final text = after.where((a) => a.subtype == 'FreeText').toList();
+      expect(text, hasLength(2));
+      expect(
+        text.map((a) => a.freeTextStyle?.fontName),
+        everyElement(PdfStandardFont.timesBold.resourceName),
+      );
+      expect(text.map((a) => a.freeTextStyle?.fontSize), everyElement(24));
+      expect(after.where((a) => a.subtype == 'Line'), hasLength(1));
+      expect(editing.selectedAnnotationSlots, hasLength(3));
+
+      // Both text boxes were one transaction; a single undo restores them.
+      editing.undo();
+      final restored = editing.document
+          .page(0)
+          .annotations
+          .where((a) => a.subtype == 'FreeText');
+      expect(restored.map((a) => a.freeTextStyle?.fontSize), originalSizes);
+    });
   });
 
   group('properties panel', () {
@@ -310,7 +350,8 @@ void main() {
       await tester.pump();
 
       expect(find.byKey(const ValueKey('pdf-prop-stroke')), findsOneWidget);
-      expect(find.byKey(const ValueKey('pdf-prop-corner-radius')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-prop-corner-radius')), findsNothing);
     });
 
     testWidgets('a placed image gets a working opacity slider, no colour',
@@ -323,8 +364,7 @@ void main() {
               0,
               300,
               400,
-              base64.decode(
-                  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
+              base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
                   'AAAAGUlEQVR4nGP4z8DwHwgbWBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==')),
           isTrue);
       await pumpPanel(tester, editing);
@@ -342,8 +382,8 @@ void main() {
       expect(stamp.appearanceOpacity, lessThan(1));
       expect(stamp.appearanceOpacity, greaterThan(0));
       // the picture survived the restyle
-      final content = latin1
-          .decode(editing.document.cos.decodeStreamData(stamp.normalAppearance!));
+      final content = latin1.decode(
+          editing.document.cos.decodeStreamData(stamp.normalAppearance!));
       expect(content, contains('/Img0 Do'));
     });
 
@@ -410,8 +450,7 @@ void main() {
       await tester.enterText(opacity, '150');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
-      expect(
-          editing.selectedAnnotation!.appearanceOpacity, closeTo(1, 0.001));
+      expect(editing.selectedAnnotation!.appearanceOpacity, closeTo(1, 0.001));
     });
 
     testWidgets('the fill clear button removes a shape fill', (tester) async {
@@ -580,6 +619,40 @@ void main() {
           closeTo(annotations[1].appearanceOpacity, 1e-6));
     });
 
+    testWidgets(
+        'mixed text boxes and a line keep all compatible property controls',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, const PdfRect(80, 620, 240, 680), 'First')
+        ..addFreeText(0, const PdfRect(280, 620, 440, 680), 'Second')
+        ..addLine(0, (80, 560), (440, 560));
+      addTearDown(editing.dispose);
+      editing.selectAllAnnotationsOn(0);
+      await pumpPanel(tester, editing);
+
+      // Text applies to the two boxes; stroke/line endings apply to the line.
+      expect(find.byKey(const ValueKey('pdf-prop-font')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-font-size')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-stroke')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-line-end-ending')),
+          findsOneWidget);
+
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-prop-font-size-input')), '26');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      final annotations = editing.document.page(0).annotations;
+      expect(
+        annotations
+            .where((a) => a.subtype == 'FreeText')
+            .map((a) => a.freeTextStyle?.fontSize),
+        everyElement(26),
+      );
+      expect(annotations.where((a) => a.subtype == 'Line'), hasLength(1));
+      expect(editing.selectedAnnotationSlots, hasLength(3));
+    });
+
     testWidgets('mixed bulk properties show Varies and accept one value',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
@@ -691,7 +764,8 @@ void main() {
       await tester.pump();
 
       // groups start expanded, so the position rows are visible
-      final header = find.byKey(const ValueKey('pdf-prop-section-position-size'));
+      final header =
+          find.byKey(const ValueKey('pdf-prop-section-position-size'));
       expect(header, findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-prop-x')), findsOneWidget);
 


### PR DESCRIPTION
## Summary

- show property controls when any selected annotation supports them
- apply bulk text styling to selected text boxes while leaving incompatible annotations untouched
- preserve mixed selections and commit compatible bulk text changes as one undo step
- expose mixed line and appearance controls using compatible-subset semantics

## Testing

- fvm dart analyze
- fvm flutter test test/editing_properties_test.dart test/editing_line_endings_test.dart test/editing_shape_styles_test.dart test/editing_text_edit_test.dart test/editing_text_style_test.dart
