### PR TITLE
fix(viewer): keep large annotation-heavy PDFs responsive on open

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -7871,14 +7871,25 @@ class _MoveDragPreviewPainter extends CustomPainter {
 class _AnnotationAppearanceLayer extends StatefulWidget {
   const _AnnotationAppearanceLayer({
     required this.page,
+    required this.pageIndex,
+    required this.focusDistance,
     required this.rotation,
     required this.pageEpoch,
+    required this.active,
+    required this.renderScheduler,
     required this.onReady,
   });
 
   final PdfPage page;
+  final int pageIndex;
+  final int focusDistance;
   final int rotation;
   final int pageEpoch;
+
+  /// Cold layers farther than one page from the reading position stay idle.
+  /// Their cache remains mounted and resumes when navigation approaches.
+  final bool active;
+  final PdfPageRenderScheduler renderScheduler;
   final VoidCallback onReady;
 
   @override
@@ -7889,6 +7900,7 @@ class _AnnotationAppearanceLayer extends StatefulWidget {
 class _AnnotationAppearanceLayerState
     extends State<_AnnotationAppearanceLayer> {
   var _generation = 0;
+  final Object _scheduleToken = Object();
   List<ui.Picture> _pictures = const [];
   Size? _picturePageSize;
 
@@ -7933,15 +7945,21 @@ class _AnnotationAppearanceLayerState
   @override
   void initState() {
     super.initState();
-    _render();
+    if (widget.active) _render();
   }
 
   @override
   void didUpdateWidget(_AnnotationAppearanceLayer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.page, widget.page) ||
+    final schedulerChanged =
+        !identical(oldWidget.renderScheduler, widget.renderScheduler);
+    if (schedulerChanged) {
+      oldWidget.renderScheduler.cancel(_scheduleToken);
+    }
+    final pageChanged = !identical(oldWidget.page, widget.page) ||
         oldWidget.rotation != widget.rotation ||
-        oldWidget.pageEpoch != widget.pageEpoch) {
+        oldWidget.pageEpoch != widget.pageEpoch;
+    if (pageChanged) {
       final oldSize = PdfPageRenderer.pageSize(oldWidget.page,
           rotation: oldWidget.rotation);
       final newSize =
@@ -7950,12 +7968,25 @@ class _AnnotationAppearanceLayerState
           oldWidget.rotation == widget.rotation &&
           oldSize == newSize;
       _render(keepCurrent: keepCurrent);
+    } else if (schedulerChanged) {
+      _render(keepCurrent: true);
+    } else if (!oldWidget.active && widget.active) {
+      _render(keepCurrent: true);
+    } else if (oldWidget.active && !widget.active) {
+      _generation++;
+      widget.renderScheduler.cancel(_scheduleToken);
+    } else if (oldWidget.focusDistance != widget.focusDistance &&
+        widget.active) {
+      // Refresh a pending request so the newly-current page moves to the head
+      // of the shared annotation queue.
+      _render(keepCurrent: true);
     }
   }
 
   @override
   void dispose() {
     _generation++;
+    widget.renderScheduler.cancel(_scheduleToken);
     _disposePictures();
     _disposeCache();
     super.dispose();
@@ -7994,7 +8025,26 @@ class _AnnotationAppearanceLayerState
 
   void _render({bool keepCurrent = false}) {
     final generation = ++_generation;
+    widget.renderScheduler.cancel(_scheduleToken);
     if (!keepCurrent) _disposePictures();
+    if (!widget.active) return;
+    unawaited(_renderScheduled(generation));
+  }
+
+  /// Resolving a page's annotation array can itself be substantial work.
+  /// Keep the whole cold-layer preparation out of initState's build frame,
+  /// not only the later appearance-stream interpretation.
+  Future<void> _renderScheduled(int generation) async {
+    final permitted = await widget.renderScheduler.paceUiWork(
+      _scheduleToken,
+      widget.pageIndex,
+      motion: PdfRenderMotionClass.quiet,
+      focusDistance: widget.focusDistance,
+    );
+    if (!permitted || !mounted || generation != _generation || !widget.active) {
+      return;
+    }
+
     final page = widget.page;
     final pageSize =
         PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
@@ -8038,35 +8088,85 @@ class _AnnotationAppearanceLayerState
       _publish(generation, annotations, pageSize);
       return;
     }
-    unawaited(Future.wait([
-      for (final annotation in missing)
-        _renderAnnotation(page, annotation, widget.rotation)
-            .then((picture) => (_appearanceKey(annotation), picture)),
-    ]).then((rendered) {
-      if (!mounted || generation != _generation) {
-        for (final (_, picture) in rendered) {
+    await _renderMissing(
+      generation,
+      page,
+      annotations,
+      missing,
+      pageSize,
+      widget.rotation,
+    );
+  }
+
+  /// Renders cold appearances incrementally instead of starting every
+  /// interpreter walk from the layer's build stack.
+  ///
+  /// [PdfPageRenderer.renderAnnotationPicture] performs a synchronous scan
+  /// before its first await. A `Future.wait` comprehension therefore ran that
+  /// scan for *every* annotation during the opening frame; 740 annotations in
+  /// one real-world engineering pack produced a half-second build. The
+  /// viewer's shared render scheduler starts one appearance per engine frame
+  /// across *all* mounted pages, giving input and painting a turn between
+  /// scans while [_publish] exposes each completed appearance progressively.
+  Future<void> _renderMissing(
+    int generation,
+    PdfPage page,
+    List<PdfAnnotation> annotations,
+    List<PdfAnnotation> missing,
+    Size pageSize,
+    int rotation,
+  ) async {
+    for (var i = 0; i < missing.length; i++) {
+      // The preparation pass already owns the first frame's grant. Every
+      // subsequent annotation queues behind the shared next-frame gate.
+      if (i > 0) {
+        final permitted = await widget.renderScheduler.paceUiWork(
+          _scheduleToken,
+          widget.pageIndex,
+          motion: PdfRenderMotionClass.quiet,
+          focusDistance: widget.focusDistance,
+        );
+        if (!permitted ||
+            !mounted ||
+            generation != _generation ||
+            !widget.active) {
+          return;
+        }
+      }
+
+      final annotation = missing[i];
+      final source = _appearanceKey(annotation);
+      if (!_cache.containsKey(source)) {
+        final picture = await _renderAnnotation(page, annotation, rotation);
+        if (!mounted || generation != _generation || !widget.active) {
           if (picture != null) _disposePicture(picture);
+          return;
         }
-        return;
-      }
-      for (final (source, picture) in rendered) {
-        if (picture == null) continue;
-        // A concurrent render may have filled this slot; keep one owner.
-        final existing = _cache[source];
-        if (existing != null) {
-          _disposePicture(picture);
-          continue;
+        if (picture != null) {
+          // A newer overlapping generation may have filled this slot while
+          // the decoder was awaiting. Keep one owner of the native picture.
+          final existing = _cache[source];
+          if (existing != null) {
+            _disposePicture(picture);
+          } else {
+            _cache[source] = picture;
+          }
         }
-        _cache[source] = picture;
       }
-      _publish(generation, annotations, pageSize);
-    }));
+
+      final last = i == missing.length - 1;
+      _publish(generation, annotations, pageSize, ready: last);
+    }
   }
 
   /// Rebuilds the ordered picture list from [_cache] and repaints, then frees
   /// anything retired by the render that produced it.
   void _publish(
-      int generation, List<PdfAnnotation> annotations, Size pageSize) {
+    int generation,
+    List<PdfAnnotation> annotations,
+    Size pageSize, {
+    bool ready = true,
+  }) {
     if (!mounted || generation != _generation) return;
     final next = [
       for (final annotation in annotations)
@@ -8077,7 +8177,7 @@ class _AnnotationAppearanceLayerState
       _picturePageSize = pageSize;
     });
     _flushRetired();
-    _notifyReady(generation);
+    if (ready) _notifyReady(generation);
   }
 
   /// Pictures dropped from [_cache] but possibly still referenced by the
@@ -8500,8 +8600,12 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         Positioned.fill(
           child: _AnnotationAppearanceLayer(
             page: widget.page,
+            pageIndex: widget.index,
+            focusDistance: widget.focusDistance,
             rotation: widget.effectiveRotation,
             pageEpoch: widget.pageEpoch,
+            active: widget.focusDistance <= 1 || widget.forceForeground,
+            renderScheduler: widget.renderScheduler,
             onReady: _onAnnotationLayerReady,
           ),
         ),

--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -370,7 +370,14 @@ class PdfPerformancePolicy {
       PdfPerformancePlatform.other => 2,
     };
     var count = math.min(platformBase, math.min(available, mode.maxWorkers));
-    if (env.documentBytes >= (256 << 20)) {
+    // Every native worker materializes its own full document image.  Once the
+    // source itself is this large, a second worker adds hundreds of MiB before
+    // first paint and lets two cold records land on the UI thread together.
+    // That startup burst is markedly worse than the extra record throughput
+    // on large local PDFs, so cap their auto pool at two here. This matches the
+    // byte threshold that selects the conservative tier above; the controller
+    // then starts that tier with one worker before first paint.
+    if (env.documentBytes >= (192 << 20)) {
       count = math.min(
           count, env.platform == PdfPerformancePlatform.mobile ? 1 : 2);
     }

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -318,12 +318,16 @@ class PdfPageRenderScheduler {
   /// isolate. Several workers finishing together used to put all of those
   /// builds in one frame. This grants one completion per frame, nearest
   /// [focus] first, and waits through a fast-scroll [holding] interval.
+  /// [focusDistance] lets a caller with newer viewport state supply that
+  /// ordering directly; otherwise distance is derived from [priority] and the
+  /// scheduler's current [focus].
   /// Returns false when [token] was cancelled or the scheduler was disposed.
   Future<bool> paceUiWork(
     Object token,
     int priority, {
     bool replacePending = false,
     PdfRenderMotionClass motion = PdfRenderMotionClass.held,
+    int? focusDistance,
   }) {
     if (_disposed) return Future<bool>.value(false);
     // Progressive worker replies are cumulative snapshots. If five prefixes
@@ -341,7 +345,12 @@ class PdfPageRenderScheduler {
         if (!pending.ready.isCompleted) pending.ready.complete(false);
       }
     }
-    final request = _UiWorkRequest(token, priority, motion: motion);
+    final request = _UiWorkRequest(
+      token,
+      priority,
+      motion: motion,
+      focusDistance: focusDistance,
+    );
     _uiPending.add(request);
     _scheduleUiDrain();
     return request.ready.future;
@@ -502,7 +511,8 @@ class PdfPageRenderScheduler {
     var best = 0;
     for (var i = 0; i < _uiPending.length; i++) {
       if (_holding && !_motionPermits(_uiPending[i].motion)) continue;
-      final distance = (_uiPending[i].priority - _focus).abs();
+      final distance = _uiPending[i].focusDistance ??
+          (_uiPending[i].priority - _focus).abs();
       if (pick == null || distance < best) {
         best = distance;
         pick = i;
@@ -595,10 +605,11 @@ class _RenderRequest {
 
 class _UiWorkRequest {
   _UiWorkRequest(this.token, this.priority,
-      {this.motion = PdfRenderMotionClass.held});
+      {this.motion = PdfRenderMotionClass.held, this.focusDistance});
 
   final Object token;
   final int priority;
   final PdfRenderMotionClass motion;
+  final int? focusDistance;
   final Completer<bool> ready = Completer<bool>();
 }

--- a/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
+++ b/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
@@ -72,6 +72,46 @@ void main() {
     expect(editing.document.page(0).annotations, hasLength(6));
   });
 
+  testWidgets('cold annotation appearances are paced across frames',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    for (var i = 0; i < 6; i++) {
+      editing.addRectangle(
+        0,
+        PdfRect(50.0 + i * 20, 600, 65.0 + i * 20, 620),
+      );
+    }
+
+    var renders = 0;
+    PdfViewer.debugAnnotationAppearanceRendererOverride = (_, __, ___) async {
+      renders++;
+      final recorder = ui.PictureRecorder();
+      Canvas(recorder).drawRect(
+        const Rect.fromLTWH(0, 0, 1, 1),
+        Paint()..color = const Color(0xFF000000),
+      );
+      return recorder.endRecording();
+    };
+    addTearDown(
+        () => PdfViewer.debugAnnotationAppearanceRendererOverride = null);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: PdfViewerFit.width,
+          document: editing.document,
+          editing: editing,
+        ),
+      ),
+    ));
+
+    expect(renders, lessThan(6),
+        reason: 'the opening frame must not synchronously start every scan');
+    await tester.pumpAndSettle();
+    expect(renders, 6);
+  });
+
   testWidgets('restyling one annotation keeps the other on screen',
       (tester) async {
     final editing = await pumpViewer(tester);
@@ -130,6 +170,7 @@ void main() {
     expect(editing.selectAnnotation(0, 0), isTrue);
     expect(editing.restyleSelected(color: const Color(0xFF00FF00)), isTrue);
     await tester.pump();
+    await tester.pump();
     expect(delayedRenders, 1);
 
     await tester.pumpWidget(const SizedBox.shrink());
@@ -158,56 +199,56 @@ void main() {
   // layer was rebuilt (a tab switch). The /Rect must be part of the key.
   testWidgets('moving an annotation repaints it at the new /Rect',
       (tester) async {
-    await tester.runAsync(() async {
-      tester.view.devicePixelRatio = 1.0;
-      tester.view.physicalSize = const Size(300, 460);
-      addTearDown(tester.view.reset);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(300, 460);
+    addTearDown(tester.view.reset);
 
-      final editing = PdfEditingController(buildMultiPagePdf(1));
-      addTearDown(editing.dispose);
-      editing.preferences
-        ..shapeFillColor = const Color(0xFFFF0000)
-        ..opacity = 1.0;
-      editing.color = const Color(0xFFFF0000);
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    editing.preferences
+      ..shapeFillColor = const Color(0xFFFF0000)
+      ..opacity = 1.0;
+    editing.color = const Color(0xFFFF0000);
 
-      final boundaryKey = GlobalKey();
-      await tester.pumpWidget(RepaintBoundary(
-        key: boundaryKey,
-        child: MaterialApp(
-          home: Scaffold(
-            body: ListenableBuilder(
-              listenable: editing,
-              builder: (context, _) => PdfViewer(
-                initialFit: PdfViewerFit.width,
-                document: editing.document,
-                editing: editing,
-              ),
+    final boundaryKey = GlobalKey();
+    await tester.pumpWidget(RepaintBoundary(
+      key: boundaryKey,
+      child: MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              editing: editing,
             ),
           ),
         ),
-      ));
-      await tester.pumpAndSettle();
+      ),
+    ));
+    await tester.pumpAndSettle();
 
-      // A solid-red box near the top of the page, then the same box slid far
-      // down (same appearance stream, new /Rect).
-      const oldRect = PdfRect(120, 620, 260, 700);
-      const newRect = PdfRect(120, 120, 260, 200);
-      editing.addRectangle(0, oldRect);
-      await tester.pumpAndSettle();
+    // A solid-red box near the top of the page, then the same box slid far
+    // down (same appearance stream, new /Rect).
+    const oldRect = PdfRect(120, 620, 260, 700);
+    const newRect = PdfRect(120, 120, 260, 200);
+    editing.addRectangle(0, oldRect);
+    await tester.pumpAndSettle();
 
-      final pageRect = tester.getRect(find.byType(PdfPageView).first);
-      final geometry = PdfPageGeometry(
-        cropBox: editing.document.page(0).cropBox,
-        rotation: 0,
-        viewSize: pageRect.size,
-      );
-      Offset centerOf(PdfRect r) =>
-          pageRect.topLeft + geometry.toViewRect(r).center;
-      final oldCenter = centerOf(oldRect);
-      final newCenter = centerOf(newRect);
+    final pageRect = tester.getRect(find.byType(PdfPageView).first);
+    final geometry = PdfPageGeometry(
+      cropBox: editing.document.page(0).cropBox,
+      rotation: 0,
+      viewSize: pageRect.size,
+    );
+    Offset centerOf(PdfRect r) =>
+        pageRect.topLeft + geometry.toViewRect(r).center;
+    final oldCenter = centerOf(oldRect);
+    final newCenter = centerOf(newRect);
 
-      // Count red pixels in an 11×11 window around a boundary-local point.
-      Future<int> reds(Offset at) async {
+    // Count red pixels in an 11×11 window around a boundary-local point.
+    Future<int> reds(Offset at) async {
+      return (await tester.runAsync(() async {
         final boundary =
             tester.renderObject<RenderRepaintBoundary>(find.byKey(boundaryKey));
         final image = await boundary.toImage();
@@ -230,29 +271,29 @@ void main() {
           }
         }
         return count;
-      }
+      }))!;
+    }
 
-      // The box paints where it was added and nowhere it wasn't.
-      expect(await reds(oldCenter), greaterThan(20),
-          reason: 'the added box should paint at its /Rect');
-      expect(await reds(newCenter), 0,
-          reason: 'nothing painted at the destination yet');
+    // The box paints where it was added and nowhere it wasn't.
+    expect(await reds(oldCenter), greaterThan(20),
+        reason: 'the added box should paint at its /Rect');
+    expect(await reds(newCenter), 0,
+        reason: 'nothing painted at the destination yet');
 
-      // Slide it down by 500pt and let the appearance layer re-render.
-      editing
-        ..tool = PdfEditTool.select
-        ..selectAnnotation(0, 0);
-      editing.moveSelected(0, newRect.bottom - oldRect.bottom);
-      await tester.pumpAndSettle();
-      expect(editing.document.page(0).annotations.single.rect, newRect);
+    // Slide it down by 500pt and let the appearance layer re-render.
+    editing
+      ..tool = PdfEditTool.select
+      ..selectAnnotation(0, 0);
+    editing.moveSelected(0, newRect.bottom - oldRect.bottom);
+    await tester.pumpAndSettle();
+    expect(editing.document.page(0).annotations.single.rect, newRect);
 
-      // The picture must follow the box: red at the new spot, gone from the
-      // old one. Before the fix the stale cached picture stayed put and the
-      // old spot was still red.
-      expect(await reds(newCenter), greaterThan(20),
-          reason: 'the moved box must repaint at its new /Rect');
-      expect(await reds(oldCenter), 0,
-          reason: 'the stale picture must not linger at the old /Rect');
-    });
+    // The picture must follow the box: red at the new spot, gone from the
+    // old one. Before the fix the stale cached picture stayed put and the
+    // old spot was still red.
+    expect(await reds(newCenter), greaterThan(20),
+        reason: 'the moved box must repaint at its new /Rect');
+    expect(await reds(oldCenter), 0,
+        reason: 'the stale picture must not linger at the old /Rect');
   });
 }

--- a/packages/dart_pdf_editor/test/performance_policy_test.dart
+++ b/packages/dart_pdf_editor/test/performance_policy_test.dart
@@ -40,6 +40,9 @@ void main() {
         PdfPerformancePolicy.initialWorkerCount(env(bytes: 600 << 20), auto), 1,
         reason: 'each worker holds its own document/decode working set');
     expect(
+        PdfPerformancePolicy.initialWorkerCount(env(bytes: 219314443), auto), 2,
+        reason: 'large sources cap the base count before conservative tuning');
+    expect(
         PdfPerformancePolicy.initialWorkerCount(
             env(cores: 32), const PdfPerformanceMode.auto(maxWorkers: 2)),
         2);
@@ -150,6 +153,15 @@ void main() {
     expect(controller.tuning.previewWindow, 2);
     expect(controller.tuning.vectorFirstPreviews, isTrue);
     expect(controller.beginWorkerGeneration(), 1);
+  });
+
+  test('large byte buffers start one worker before first paint', () {
+    final controller =
+        PdfPerformanceController(environment: env(pages: 83, bytes: 219314443));
+    addTearDown(controller.dispose);
+    expect(controller.tuning.tier, PdfPerformanceTier.conservative);
+    expect(controller.beginWorkerGeneration(), 1,
+        reason: 'a second worker would materialize another 219 MiB source');
   });
 
   group('pdfDefaultTileStoreDetail (issue #314/#360 rollout)', () {

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -306,6 +306,27 @@ void main() {
     expect(order, [5, 6, 8, 0]);
   });
 
+  testWidgets('worker UI work may supply an authoritative focus distance',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler()..focus = 100;
+    addTearDown(scheduler.dispose);
+    final order = <int>[];
+    scheduler
+        .paceUiWork('stale-index', 100, focusDistance: 2)
+        .then((ready) {
+      if (ready) order.add(100);
+    });
+    scheduler.paceUiWork('visible', 5, focusDistance: 0).then((ready) {
+      if (ready) order.add(5);
+    });
+
+    await tester.pump();
+    expect(order, [5],
+        reason: 'a caller with fresher viewport state must win the next frame');
+    await tester.pump();
+    expect(order, [5, 100]);
+  });
+
   testWidgets('worker UI grants use distinct engine frames', (tester) async {
     final scheduler = PdfPageRenderScheduler();
     addTearDown(scheduler.dispose);


### PR DESCRIPTION
## Summary

- pace cold annotation appearance preparation through the shared UI render scheduler
- render appearances progressively and cancel or reprioritize queued work as the viewport moves
- restrict cold appearance work to the current page and its neighbours
- start 192 MiB+ documents in the conservative one-worker tier to avoid duplicating a large source before first paint

The reported 219 MB, 83-page file contains 740 annotations. Document parsing itself completed in about 32 ms; the startup stall came from eagerly scanning hundreds of annotation appearances across mounted page layers on the UI isolate.

## Verification

- `fvm dart analyze`
- `fvm flutter test test/annotation_appearance_cache_test.dart test/render_scheduler_test.dart test/performance_policy_test.dart`
- full `packages/dart_pdf_editor` Flutter suite: 2,399 passed, 36 skipped
- exercised the reported PDF in the macOS example; the shell became interactive in roughly 1.5 seconds and accepted navigation while background appearances continued warming