### PR TITLE
Fix nested-overlay popup positioning and formatter drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
           flutter-version: 3.47.0
           channel: stable
           cache: true
+      # Run before pub get on purpose: the formatter wrapper must preserve the
+      # workspace's Dart 3.5 style even when package_config.json does not exist.
+      - name: Check fresh-worktree formatter contract
+        run: dart tool/format.dart --output=none --set-exit-if-changed tool/format.dart
       - run: flutter pub get
       - run: dart analyze --fatal-infos
       # Enforce the lockstep versioning invariant: every workspace package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Monorepo using **pub workspaces** (root `pubspec.yaml` lists members under
 ## Commands
 
 - `fvm flutter pub get` (at repo root - resolves every workspace package)
+- `fvm dart tool/format.dart <files...>` (format changed files; do not invoke
+  `dart format` directly because a fresh worktree has no package config yet)
 - `fvm dart analyze` (at root)
 - `cd packages/<pkg> && fvm dart test` (pure-Dart packages)
 - `cd packages/dart_pdf_editor && fvm flutter test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ Monorepo using **pub workspaces** (root `pubspec.yaml` lists members under
 ## Commands
 
 - `fvm flutter pub get` (at repo root - resolves every workspace package)
+- `fvm dart tool/format.dart <files...>` (format changed files; do not invoke
+  `dart format` directly because a fresh worktree has no package config yet)
 - `fvm dart analyze` (at root)
 - `cd packages/<pkg> && fvm dart test` (pure-Dart packages)
 - `cd packages/dart_pdf_editor && fvm flutter test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,10 @@ fvm flutter pub get    # at the repo root, resolves every workspace package
 Mirror what CI runs (`.github/workflows/ci.yml`):
 
 ```bash
+# Format only the files you changed. This wrapper pins the workspace language
+# version even before pub get has generated a package config.
+fvm dart tool/format.dart path/to/changed_file.dart [...]
+
 # Static analysis (whole workspace, from the repo root)
 fvm dart analyze --fatal-infos
 
@@ -73,6 +77,12 @@ cd packages/pdf_graphics && fvm dart test
 # Flutter package
 cd packages/dart_pdf_editor && fvm flutter test
 ```
+
+Use `tool/format.dart` rather than calling `dart format` directly. In a fresh
+worktree, the generated package config does not exist yet; the bare SDK command
+then assumes its latest language version and can rewrite the Dart 3.5 codebase
+into a different formatting style. The wrapper reads the workspace SDK lower
+bound from the root `pubspec.yaml` and passes it explicitly.
 
 `dart analyze` must be clean with `--fatal-infos`; CI fails on any info,
 warning, or error.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Anchor thumbnail context menus to the correct position when the editor is
   hosted inside an offset nested navigator.
+- Anchor viewer text, annotation, and form popups in that same nested-navigator
+  configuration instead of shifting them by the overlay origin.
 - Render ordinary pages *through* a scroll instead of waiting it out.
   `PdfPageRenderScheduler` gains a motion lane: a request declares a
   `PdfRenderMotionClass`, evaluated at grant time rather than baked in, so a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
@@ -8,6 +8,7 @@ import 'editing_fonts.dart';
 import 'editing_value_field.dart';
 import 'text_prompt.dart';
 import '../l10n/pdf_l10n.dart';
+import '../popup_position.dart';
 
 /// A field-type menu for the single selected form widget.
 ///
@@ -275,11 +276,9 @@ Future<void> showPdfFormTextStylePopup({
   PdfFontPicker? fontPicker,
 }) async {
   if (!controller.canStyleSelectedFormField) return;
-  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
   await showMenu<void>(
     context: context,
-    position:
-        RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
+    position: pdfPopupPosition(context, position),
     items: [
       PopupMenuItem<void>(
         key: const ValueKey('pdf-form-style-popup'),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
@@ -5,6 +5,7 @@ import 'package:pdf_document/pdf_document.dart';
 
 import '../l10n/pdf_l10n.dart';
 import '../page_range_dialog.dart';
+import '../popup_position.dart';
 import 'editing_color_picker.dart';
 import 'editing_controller.dart';
 import 'editing_form_style.dart';
@@ -285,11 +286,9 @@ Future<void> showPdfAnnotationMenu({
   final custom =
       customActions?.call(context, request) ?? const <PdfAnnotationMenuItem>[];
 
-  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
   final picked = await showMenu<PdfAnnotationMenuItem>(
     context: context,
-    position:
-        RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
+    position: pdfPopupPosition(context, position),
     items: _menuRowsWithDividers(
         [unlock, clipboard, arrange, nodes, recolor, destructive, custom]),
   );
@@ -366,12 +365,9 @@ Future<void> showPdfFormFieldMenu({
           icon: Icons.list_alt_outlined,
           enabled: enabled && field.options.isNotEmpty,
           onSelected: (_) async {
-            final overlay =
-                Overlay.of(context).context.findRenderObject()! as RenderBox;
             final picked = await showMenu<String>(
               context: context,
-              position: RelativeRect.fromRect(
-                  position & Size.zero, Offset.zero & overlay.size),
+              position: pdfPopupPosition(context, position),
               items: [
                 for (final (export, display) in field.options)
                   PopupMenuItem(
@@ -484,11 +480,9 @@ Future<void> showPdfFormFieldMenu({
     ),
   ];
 
-  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
   final picked = await showMenu<PdfAnnotationMenuItem>(
     context: context,
-    position:
-        RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
+    position: pdfPopupPosition(context, position),
     items: _menuRowsWithDividers([edit, structure, destructive]),
   );
   // the request param is unused by these closures; reuse the row type

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -14,6 +14,7 @@ import '../debug_overlays.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_geometry.dart';
 import '../platform_cursors.dart';
+import '../popup_position.dart';
 import '../renderer.dart';
 import '../theme.dart';
 import 'editing_color_pick.dart';
@@ -4173,12 +4174,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final options = field.options;
     if (options.isEmpty) return;
     final name = field.name;
-    final overlay =
-        Overlay.of(context).context.findRenderObject()! as RenderBox;
     final picked = await showMenu<String>(
       context: context,
-      position: RelativeRect.fromRect(
-          globalPosition & Size.zero, Offset.zero & overlay.size),
+      position: pdfPopupPosition(context, globalPosition),
       items: [
         for (final (export, display) in options)
           PopupMenuItem(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -15,6 +15,7 @@ import '../l10n/pdf_l10n.dart';
 import '../page_range_dialog.dart';
 import '../pdf_page_view.dart';
 import '../pdf_viewer.dart';
+import '../popup_position.dart';
 import '../preview_cache.dart';
 import '../tile_store.dart';
 import '../perf_log.dart';
@@ -2702,14 +2703,9 @@ Future<void> _showPageTileMenu({
   ];
   if (items.isEmpty) return;
 
-  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
-  final overlayPosition = overlay.globalToLocal(position);
   final picked = await showMenu<_PageTileAction>(
     context: context,
-    position: RelativeRect.fromRect(
-      overlayPosition & Size.zero,
-      Offset.zero & overlay.size,
-    ),
+    position: pdfPopupPosition(context, position),
     items: items,
   );
   switch (picked) {

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -35,6 +35,7 @@ import 'page_object_cache.dart';
 import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'platform_cursors.dart';
+import 'popup_position.dart';
 import 'pdf_page_view.dart';
 import 'preview_cache.dart';
 import 'raster_cache.dart';
@@ -5375,12 +5376,9 @@ class _PdfViewerState extends State<PdfViewer>
         editing != null && widget.textSelectionEditing && hasSelection;
     final canMarkup =
         editing != null && widget.textSelectionMarkup && hasSelection;
-    final overlay =
-        Overlay.of(context).context.findRenderObject()! as RenderBox;
     final picked = await showMenu<_TextMenuAction>(
       context: context,
-      position: RelativeRect.fromRect(
-          globalPosition & Size.zero, Offset.zero & overlay.size),
+      position: pdfPopupPosition(context, globalPosition),
       items: [
         if (canEdit)
           PopupMenuItem<_TextMenuAction>(

--- a/packages/dart_pdf_editor/lib/src/popup_position.dart
+++ b/packages/dart_pdf_editor/lib/src/popup_position.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Positions a popup at a pointer location expressed in global coordinates.
+///
+/// [showMenu] interprets its [RelativeRect] in the coordinate system of the
+/// navigator overlay that receives the route. A nested navigator can have a
+/// non-zero global origin, so passing the pointer position through unchanged
+/// shifts the popup by that origin a second time.
+RelativeRect pdfPopupPosition(BuildContext context, Offset globalPosition) {
+  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
+  final overlayPosition = overlay.globalToLocal(globalPosition);
+  return RelativeRect.fromRect(
+    overlayPosition & Size.zero,
+    Offset.zero & overlay.size,
+  );
+}

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -600,6 +600,57 @@ void main() {
       expect(copy.enabled, isTrue);
     });
 
+    testWidgets('the text menu is anchored in an offset navigator overlay',
+        (tester) async {
+      tester.view.physicalSize = const Size(1000, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            const SizedBox(width: 220),
+            Expanded(
+              child: Navigator(
+                onGenerateRoute: (_) => MaterialPageRoute<void>(
+                  builder: (_) => Scaffold(
+                    body: PdfViewer(
+                      initialFit: PdfViewerFit.width,
+                      document: PdfDocument.open(buildMultiPagePdf(1)),
+                      controller: controller,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      const navigatorLeft = 220.0;
+      const nestedScale = (1000 - navigatorLeft) / 612;
+      final clickPosition = Offset(
+        navigatorLeft + 100 * nestedScale,
+        (792 - 720) * nestedScale,
+      );
+      await rightClick(tester, clickPosition);
+
+      final menuPosition = tester.getTopLeft(
+        find.byKey(const ValueKey('pdf-text-menu-copy')),
+      );
+      expect(
+        (menuPosition.dx - clickPosition.dx).abs(),
+        lessThan(100),
+        reason: 'The nested overlay origin must not be added twice.',
+      );
+
+      await tester.tapAt(const Offset(900, 1200));
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('Copy puts the selection on the system clipboard',
         (tester) async {
       await pumpReader(tester);

--- a/tool/format.dart
+++ b/tool/format.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+/// Runs the SDK formatter with the workspace's language version explicitly.
+///
+/// In a fresh checkout, `pub get` may not have created
+/// `.dart_tool/package_config.json` yet. Without that file, `dart format`
+/// assumes the latest language version and can migrate this Dart 3.5 workspace
+/// to the newer tall style. Passing the pubspec's lower bound keeps formatting
+/// stable both before and after dependency resolution.
+Future<void> main(List<String> arguments) async {
+  if (arguments.isEmpty) {
+    stderr.writeln(
+      'Usage: fvm dart tool/format.dart [dart format options] <paths...>',
+    );
+    exitCode = 64;
+    return;
+  }
+  if (arguments.any((argument) =>
+      argument == '--language-version' ||
+      argument.startsWith('--language-version='))) {
+    stderr.writeln(
+      'tool/format.dart owns --language-version; update the root pubspec '
+      'SDK constraint instead.',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final repoRoot = File.fromUri(Platform.script).parent.parent;
+  final pubspec = File('${repoRoot.path}/pubspec.yaml').readAsStringSync();
+  final sdkMatch = RegExp(
+    r'''^\s+sdk:\s*["']?[^\d\r\n]*(\d+)\.(\d+)''',
+    multiLine: true,
+  ).firstMatch(pubspec);
+  if (sdkMatch == null) {
+    stderr.writeln('Could not read the SDK lower bound from pubspec.yaml.');
+    exitCode = 65;
+    return;
+  }
+  final languageVersion = '${sdkMatch[1]}.${sdkMatch[2]}';
+
+  final process = await Process.start(
+    Platform.resolvedExecutable,
+    [
+      'format',
+      '--language-version=$languageVersion',
+      ...arguments,
+    ],
+    mode: ProcessStartMode.inheritStdio,
+  );
+  exitCode = await process.exitCode;
+}


### PR DESCRIPTION
## Summary

- convert global pointer positions into the active navigator overlay coordinate space before opening viewer text, annotation, form, choice, and thumbnail menus
- add nested-navigator regression coverage for the general right-click text menu while retaining the thumbnail-menu coverage from #714
- add a workspace formatter wrapper that pins the root pubspec language version, plus a pre-pub-get CI contract check and contributor guidance

The formatter guard intentionally avoids a repository-wide formatting migration; it keeps changed files on the workspace's existing Dart 3.5 style in fresh worktrees.

## Testing

- `fvm dart analyze --fatal-infos`
- `fvm flutter test test/editing_menu_test.dart`
- `fvm flutter test test/editing_page_ops_test.dart --plain-name 'the menu is anchored in an offset navigator overlay'`
- `fvm dart tool/format.dart --output=none --set-exit-if-changed tool/format.dart packages/dart_pdf_editor/lib/src/popup_position.dart packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart`

Follow-up to #714.
