### PR TITLE
perf(viewer): reconcile dirty pages incrementally

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -321,6 +321,7 @@ class PdfWorkerRevisionDelta {
     required this.baseLength,
     required this.newLength,
     required this.changedPages,
+    this.impact,
   });
 
   /// Byte length of the prefix shared with the previous revision. Revisions are
@@ -335,6 +336,13 @@ class PdfWorkerRevisionDelta {
   /// Pages whose rendering the transition changed, or null when every page may
   /// have (the worker then clears its per-page caches).
   final Set<int>? changedPages;
+
+  /// The semantic invalidation reported by the editor transaction that
+  /// produced this revision. Null only for legacy/external delta producers.
+  ///
+  /// The render worker needs [changedPages] alone; the viewer consumes the
+  /// richer lanes to reconcile page geometry and derived caches incrementally.
+  final PdfEditImpact? impact;
 }
 
 /// An editing session over a PDF document: applies edits through
@@ -611,6 +619,7 @@ class PdfEditingController extends ChangeNotifier {
             baseLength: _revisions[_cursor],
             newLength: _revisions[_cursor],
             changedPages: impact.visualPages,
+            impact: impact,
           );
     _reopen();
     _emitAnnotationChanges(impact.annotationPages);
@@ -631,6 +640,7 @@ class PdfEditingController extends ChangeNotifier {
             baseLength: beforeLength,
             newLength: _revisions[_cursor],
             changedPages: impact.visualPages,
+            impact: impact,
           );
     // redo re-extends to a revision already in the buffer: an append
     _reopen(grew: true);
@@ -823,6 +833,7 @@ class PdfEditingController extends ChangeNotifier {
             baseLength: beforeLength,
             newLength: newLength,
             changedPages: impact.visualPages,
+            impact: impact,
           );
     if (_committingRemoteRevision) _undoFloor = _cursor;
     final selected = List.of(_selected);
@@ -1312,7 +1323,9 @@ class PdfEditingController extends ChangeNotifier {
     _annotationBaseline =
         pages == null ? after : baseline.withPagesReplaced(pages, after);
 
-    if (_applyingRemote) return; // baseline advanced; don't echo the remote edit
+    if (_applyingRemote) {
+      return; // baseline advanced; don't echo the remote edit
+    }
     final changes = pdfDiffAnnotationStates(before, after);
     if (changes.isNotEmpty) feed.add(changes);
   }

--- a/packages/dart_pdf_editor/lib/src/page_object_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/page_object_cache.dart
@@ -76,6 +76,14 @@ class PdfPageObjectCache<V> {
   /// Drops every entry - a document or revision swap invalidates them all.
   void clear() => _entries.clear();
 
+  /// Drops the cached values for [pages], preserving every clean page's LRU
+  /// value and relative recency.
+  void removeAll(Iterable<int> pages) {
+    for (final page in pages) {
+      _entries.remove(page);
+    }
+  }
+
   /// The number of retained entries. Bounded by the configured cap.
   @visibleForTesting
   int get length => _entries.length;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -440,6 +441,29 @@ class PdfViewerController extends ChangeNotifier {
   /// Test hook: the namespace isolating this viewer's process-wide LoD tiles.
   @visibleForTesting
   Object? get debugTileCacheNamespace => _state?._tileCacheNamespace;
+
+  /// Number of revision swaps reconciled from their dirty-page impact without
+  /// walking/reloading the complete page list.
+  @visibleForTesting
+  int get debugIncrementalPageReconciliations =>
+      _state?._incrementalPageReconciliations ?? 0;
+
+  /// Pages inspected by the most recent successful incremental reconcile.
+  /// Null when the latest document transition used the full fallback.
+  @visibleForTesting
+  Set<int>? get debugLastIncrementallyReconciledPages =>
+      _state?._lastIncrementallyReconciledPages;
+
+  /// Opaque identity of the attached viewer's page presentation object.
+  /// Clean pages retain this across an incremental revision; dirty pages do
+  /// not, which also fences their stale asynchronous render completions.
+  @visibleForTesting
+  Object? debugPageIdentity(int index) {
+    final pages = _state?._pages;
+    return pages == null || index < 0 || index >= pages.length
+        ? null
+        : pages[index];
+  }
 
   /// Opaque identity matching this viewer to [PdfTileRasterDiagnostics].
   ///
@@ -1765,6 +1789,8 @@ class _PdfViewerState extends State<PdfViewer>
   late List<PdfPage> _pages;
   late List<(int, int)?> _pageRefs;
   late List<double> _aspects; // height / width, after /Rotate
+  int _incrementalPageReconciliations = 0;
+  Set<int>? _lastIncrementallyReconciledPages;
 
   /// The controller that owns the document revisions for a given viewer
   /// configuration, if any: the editing controller, or - when interactive
@@ -1832,7 +1858,16 @@ class _PdfViewerState extends State<PdfViewer>
       host.sync(
         document: controller.document,
         bytes: controller.bytes,
-        pageCount: controller.document.pageCount,
+        // A reported revision is non-structural, so the already-loaded count
+        // is authoritative. Asking the fresh PdfDocument wrapper for
+        // pageCount here would walk the complete page tree before the viewer's
+        // dirty-page reconciler gets a chance to bail out.
+        pageCount: delta?.impact != null &&
+                !delta!.impact!.pageStructureChanged &&
+                _loadedDocument != null &&
+                identical(_loadedDocument!.cos, controller.document.cos)
+            ? _pages.length
+            : controller.document.pageCount,
         revision: delta == null
             ? null
             : (
@@ -3588,6 +3623,11 @@ class _PdfViewerState extends State<PdfViewer>
   /// revision with no host rebuild).
   void _swapDocument({bool preserveRevisionViewport = false}) {
     final document = _document;
+    if (preserveRevisionViewport &&
+        _tryReconcileIncrementalRevision(document)) {
+      return;
+    }
+    _lastIncrementallyReconciledPages = null;
     final sameGeometry = _sameGeometryAs(document);
     if (!preserveRevisionViewport) {
       // The old namespace cannot be reached after an unrelated document swap.
@@ -3715,6 +3755,146 @@ class _PdfViewerState extends State<PdfViewer>
     setState(() {});
   }
 
+  /// Applies a non-structural append-only revision by touching only the pages
+  /// named by its [PdfEditImpact]. False selects [_swapDocument]'s existing
+  /// correctness-first full reconciliation.
+  ///
+  /// The fast path is deliberately narrow:
+  ///
+  ///  * the old and new wrappers must share one incrementally advanced COS
+  ///    graph;
+  ///  * every invalidation lane must be known (null means "all/unknown");
+  ///  * every dirty page must retain a resolvable indirect-object identity;
+  ///
+  /// Ordinary annotation edits, form fills, content stamps, metadata changes,
+  /// and page rotations satisfy those rules. A dirty page receives a fresh
+  /// [PdfPage] wrapper while clean pages retain identity, mirroring keyed child
+  /// reconciliation: clean render/cache state bails out and stale async work
+  /// for dirty pages can no longer pass identity guards.
+  bool _tryReconcileIncrementalRevision(PdfDocument document) {
+    final loaded = _loadedDocument;
+    final delta = _revisionController?.lastRevisionDelta;
+    final impact = delta?.impact;
+    if (loaded == null ||
+        impact == null ||
+        impact.pageStructureChanged ||
+        !identical(loaded.cos, document.cos)) {
+      return false;
+    }
+    final visualPages = impact.visualPages;
+    final contentPages = impact.contentPages;
+    final annotationPages = impact.annotationPages;
+    if (visualPages == null ||
+        contentPages == null ||
+        annotationPages == null) {
+      return false;
+    }
+
+    final dirtyPages = <int>{
+      ...visualPages,
+      ...contentPages,
+      ...annotationPages,
+    };
+    if (dirtyPages.any((page) => page < 0 || page >= _pages.length)) {
+      return false;
+    }
+
+    final replacements = <int, PdfPage>{};
+    final geometry = <int, (double aspect, double pointWidth)>{};
+    var geometryChanged = false;
+    for (final index in dirtyPages) {
+      final key = _pageRefs[index];
+      if (key == null) return false;
+      final resolved = document.cos.resolve(CosReference(key.$1, key.$2));
+      if (resolved is! CosDictionary) return false;
+      final page = _pages[index].forIncrementalRevision(document, resolved);
+      // Geometry is calculated only for pages the transaction dirtied. Most
+      // revisions land here: annotation/content pixels changed while the page
+      // box did not. Rotations/crop changes update their one cached record;
+      // the following pages' offsets derive from that record at layout time.
+      final nextGeometry = (_pageAspect(page), _pagePointWidth(page));
+      geometryChanged |= (nextGeometry.$1 - _aspects[index]).abs() > 1e-6 ||
+          (nextGeometry.$2 - _pointWidths[index]).abs() > 1e-6;
+      replacements[index] = page;
+      geometry[index] = nextGeometry;
+    }
+
+    final preservedViewport = geometryChanged && _pages.isNotEmpty
+        ? _pendingViewport ??
+            _captureViewport() ??
+            PdfViewport(
+              page: _controller.currentPage.clamp(0, _pages.length - 1),
+              zoom: _currentZoom,
+            )
+        : null;
+
+    _controller.clearSearch();
+    _clearSelection();
+    _pageLabels = null;
+    _outline = null;
+
+    // Invalidate only the derived lane whose inputs changed. Text extraction
+    // follows base content; annotation/action/form caches follow /Annots.
+    _textCache.removeAll(contentPages);
+    _annotCache.removeAll(annotationPages);
+    _visibleAnnotCache.removeAll(annotationPages);
+    _fieldRectCache.removeAll(annotationPages);
+
+    for (final entry in replacements.entries) {
+      final oldPage = _pages[entry.key];
+      _previewAttempts.remove(oldPage);
+      _previewVectorAttempts.remove(oldPage);
+      for (final attempted in _intermediatePreviewAttempts.values) {
+        attempted.remove(oldPage);
+      }
+      _rasterWarmAttempts.remove(oldPage);
+      _commandWarmAttempts.remove(oldPage);
+      _pages[entry.key] = entry.value;
+      final nextGeometry = geometry[entry.key]!;
+      _aspects[entry.key] = nextGeometry.$1;
+      _pointWidths[entry.key] = nextGeometry.$2;
+    }
+    if (geometryChanged) {
+      // No page is reparsed here: these reductions use the cached per-page
+      // numbers. If the dirty page became (or ceased to be) the fit reference,
+      // every item's layout scale changes naturally on the next build.
+      _maxPointWidth = _pointWidths.isEmpty ? 0 : _pointWidths.reduce(math.max);
+      _maxPointHeight = _pages.isEmpty
+          ? 0
+          : [
+              for (var i = 0; i < _pages.length; i++)
+                _aspects[i] * _pointWidths[i],
+            ].reduce(math.max);
+      _pendingViewport = preservedViewport;
+    }
+
+    _loadedDocument = document;
+    _rasteredPages.removeAll(contentPages);
+    if (dirtyPages.isEmpty) {
+      _previews.bindPages(_pages);
+    } else {
+      _previews.rebind(
+        _pages,
+        changed: contentPages.contains,
+      );
+    }
+    for (final page in contentPages) {
+      _contentStamps[page] = _contentStamp(page);
+    }
+
+    // Fence background loops started against a dirty page. Clean-page cache
+    // entries and attempt state remain warm; their page identities survived.
+    _commandWarmAnchor = null;
+    _commandWarmGeneration++;
+    _bindRasterCache(prime: false);
+    _incrementalPageReconciliations++;
+    _lastIncrementallyReconciledPages = Set<int>.unmodifiable(dirtyPages);
+    _schedulePreviewPrerender();
+    _scheduleRasterWarm();
+    setState(() {});
+    return true;
+  }
+
   /// The stable identity of a page across incremental revisions. Structural
   /// edits rewrite the page tree but retain every surviving leaf's indirect
   /// object number; newly inserted pages receive new numbers. These keys are
@@ -3758,6 +3938,28 @@ class _PdfViewerState extends State<PdfViewer>
       if ((aspect - _aspects[i]).abs() > 1e-6) return false;
     }
     return true;
+  }
+
+  int _effectiveRotationFor(PdfPage page) =>
+      ((page.rotation + _controller._viewRotation) % 360 + 360) % 360;
+
+  double _pageAspect(PdfPage page) {
+    final box = page.cropBox;
+    final sideways = switch (_effectiveRotationFor(page)) {
+      90 || 270 => true,
+      _ => false,
+    };
+    return sideways
+        ? box.width / math.max(1e-6, box.height)
+        : box.height / math.max(1e-6, box.width);
+  }
+
+  double _pagePointWidth(PdfPage page) {
+    final box = page.cropBox;
+    return switch (_effectiveRotationFor(page)) {
+      90 || 270 => math.max(1e-6, box.height),
+      _ => math.max(1e-6, box.width),
+    };
   }
 
   /// The effective display rotation of page [index], combining the page's
@@ -3927,19 +4129,8 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   void _recomputeAspects() {
-    _aspects = [
-      for (var i = 0; i < _pages.length; i++)
-        _isEffectivelySideways(i)
-            ? _pages[i].cropBox.width / math.max(1e-6, _pages[i].cropBox.height)
-            : _pages[i].cropBox.height /
-                math.max(1e-6, _pages[i].cropBox.width),
-    ];
-    _pointWidths = [
-      for (var i = 0; i < _pages.length; i++)
-        _isEffectivelySideways(i)
-            ? math.max(1e-6, _pages[i].cropBox.height)
-            : math.max(1e-6, _pages[i].cropBox.width),
-    ];
+    _aspects = [for (final page in _pages) _pageAspect(page)];
+    _pointWidths = [for (final page in _pages) _pagePointWidth(page)];
     _maxPointWidth = _pointWidths.isEmpty ? 0 : _pointWidths.reduce(math.max);
     _maxPointHeight = _pages.isEmpty
         ? 0
@@ -4011,11 +4202,6 @@ class _PdfViewerState extends State<PdfViewer>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) unawaited(_previews.loadFromDisk(pages));
     });
-  }
-
-  bool _isEffectivelySideways(int index) {
-    final r = _effectiveRotation(index);
-    return r == 90 || r == 270;
   }
 
   @override
@@ -8737,7 +8923,13 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                   builder: (context, _) {
                     final rasterCurrent = _rastered &&
                         _annotationLayerCurrent &&
-                        identical(widget.page.document, editing.document);
+                        // Clean page wrappers deliberately survive an
+                        // incremental revision. Their PdfDocument wrapper may
+                        // therefore be older, but it shares the one live COS
+                        // graph and its page-tree caches self-invalidate from
+                        // the COS revision generation.
+                        identical(
+                            widget.page.document.cos, editing.document.cos);
                     return editing.tool == null &&
                             !editing.isPickingColor &&
                             !editing.hasAnnotationSelection &&

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -1869,11 +1869,20 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// scroll paints blank (then re-renders) instead of flashing now-deleted
   /// content. The rest rebind in place as before.
   void rebind(List<PdfPage> pages, {bool Function(int index)? changed}) {
-    // A retained scene keeps the PdfPage it was recorded from as well as its
-    // command objects. Even an unchanged page in an incremental revision has
-    // a new document graph, so do not rebind these by index the way immutable
-    // raster pixels can be rebound.
-    _retainedScenes.clear();
+    // A retained scene keeps the exact PdfPage it was recorded from as well as
+    // its command objects. The incremental viewer reconciler preserves that
+    // identity for clean pages, so their scenes remain valid; a traditional
+    // full revision swap replaces every page object and naturally evicts all
+    // of them through this same identity check.
+    for (final key in _retainedScenes.keys.toList()) {
+      final index = key.pageIndex;
+      final entry = _retainedScenes.peek(key)!;
+      if (index >= pages.length ||
+          (changed?.call(index) ?? false) ||
+          !identical(entry.page, pages[index])) {
+        _retainedScenes.evict(key);
+      }
+    }
     bindPages(pages);
     var dropped = false;
     for (final index in _entries.keys.toList()) {

--- a/packages/dart_pdf_editor/test/page_object_cache_test.dart
+++ b/packages/dart_pdf_editor/test/page_object_cache_test.dart
@@ -73,6 +73,20 @@ void main() {
       expect(cache[0], isNull);
     });
 
+    test('removeAll invalidates only the named pages', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 5);
+      for (var page = 0; page < 5; page++) {
+        cache.putIfAbsent(page, () => page);
+      }
+
+      cache.removeAll([1, 3, 99]);
+
+      expect(cache.pages.toList(), [0, 2, 4],
+          reason: 'clean entries keep their values and LRU order');
+      expect(cache[1], isNull);
+      expect(cache[3], isNull);
+    });
+
     test('a null maxEntries takes the runtime default', () {
       final previous = pdfViewerPageObjectCacheMaxEntries;
       addTearDown(() => pdfViewerPageObjectCacheMaxEntries = previous);

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -305,6 +305,55 @@ void main() {
     secondLease.dispose();
   });
 
+  testWidgets('rebind preserves retained scenes for identity-stable pages',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final cleanPage = document.page(0);
+    final oldDirtyPage = document.page(1);
+    final newDirtyPage = oldDirtyPage.forIncrementalRevision(
+      document,
+      oldDirtyPage.dict,
+    );
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    for (final (index, page) in [cleanPage, oldDirtyPage].indexed) {
+      late PdfRetainedScene scene;
+      await tester.runAsync(() async {
+        scene = await PdfRetainedScene.record(page);
+      });
+      cache
+          .retainScene(
+            index,
+            page,
+            scene,
+            plan: const PdfPageRenderPlan(),
+            fromWorker: false,
+            estimatedBytes: 1,
+          )
+          .dispose();
+    }
+
+    cache.rebind([cleanPage, newDirtyPage], changed: (index) => index == 1);
+
+    expect(cache.debugRetainedSceneCount, 1);
+    final clean = cache.retainedSceneFor(
+      0,
+      cleanPage,
+      plan: const PdfPageRenderPlan(),
+    );
+    expect(clean, isNotNull);
+    clean!.dispose();
+    expect(
+      cache.retainedSceneFor(
+        1,
+        newDirtyPage,
+        plan: const PdfPageRenderPlan(),
+      ),
+      isNull,
+    );
+  });
+
   testWidgets('cache promotes through a geometric preview ladder',
       (tester) async {
     final document = PdfDocument.open(buildClassicPdf());

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/gestures.dart' show kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_graphics/pdf_graphics.dart' show PdfTextExtractor;
@@ -1486,6 +1487,101 @@ void main() {
   });
 
   group('editing controller drives the document', () {
+    testWidgets('reconciles only dirty pages across annotation revisions',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(12));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            editing: editing,
+            controller: controller,
+            pagePreviews: false,
+            autoRenderWorker: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final cleanPage = controller.debugPageIdentity(0);
+      final dirtyPage = controller.debugPageIdentity(7);
+      final presentationEpoch = controller.pagePresentationEpoch;
+      expect(controller.debugIncrementalPageReconciliations, 0);
+
+      addTearDown(() => PdfPerf.enabled = false);
+      PdfPerf.enabled = true;
+      PdfPerf.reset();
+      editing.addRectangle(7, const PdfRect(100, 100, 200, 200));
+      final revisionPerf = PdfPerf.snapshot();
+      PdfPerf.enabled = false;
+      await tester.pump();
+
+      expect(controller.debugIncrementalPageReconciliations, 1);
+      expect(
+        revisionPerf.phaseCalls[PdfPerfPhase.pageTreeWalk.index],
+        0,
+        reason: 'a dirty-page reconcile must not walk the whole page tree',
+      );
+      expect(controller.debugLastIncrementallyReconciledPages, {7});
+      expect(controller.debugPageIdentity(0), same(cleanPage),
+          reason: 'a clean keyed page must bail out');
+      expect(controller.debugPageIdentity(7), isNot(same(dirtyPage)),
+          reason: 'the dirty page gets a new async-completion fence');
+      expect(controller.pagePresentationEpoch, presentationEpoch,
+          reason: 'a non-structural edit keeps the page-slot lineage');
+
+      final firstDirtyRevision = controller.debugPageIdentity(7);
+      editing.addRectangle(7, const PdfRect(220, 220, 280, 280));
+      await tester.pump();
+
+      expect(controller.debugIncrementalPageReconciliations, 2);
+      expect(controller.debugLastIncrementallyReconciledPages, {7});
+      expect(controller.debugPageIdentity(0), same(cleanPage));
+      expect(controller.debugPageIdentity(7), isNot(same(firstDirtyRevision)));
+      expect(editing.document.page(7).annotations, hasLength(2),
+          reason: 'the second edit resolved the latest page dictionary');
+    });
+
+    testWidgets('reconciles a dirty page geometry change incrementally',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            editing: editing,
+            controller: controller,
+            pagePreviews: false,
+            autoRenderWorker: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final epoch = controller.pagePresentationEpoch;
+      final cleanPage = controller.debugPageIdentity(0);
+      final dirtyPage = controller.debugPageIdentity(1);
+      editing.rotatePages([1], 90);
+      await tester.pump();
+
+      expect(controller.debugIncrementalPageReconciliations, 1);
+      expect(controller.debugLastIncrementallyReconciledPages, {1});
+      expect(controller.debugPageIdentity(0), same(cleanPage));
+      expect(controller.debugPageIdentity(1), isNot(same(dirtyPage)));
+      expect(controller.pagePresentationEpoch, epoch,
+          reason: 'rotation changes geometry, not the page-slot lineage');
+      expect(editing.document.page(1).rotation, 90);
+    });
+
     testWidgets(
         'follows revisions with no host ListenableBuilder and no document',
         (tester) async {

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -33,6 +33,15 @@ class CosDocument {
   /// `startxref` keyword. An incremental update points /Prev here.
   int startXref;
 
+  /// Monotonic generation of this parsed object graph.
+  ///
+  /// It advances when [applyIncrementalUpdate] folds another append-only
+  /// revision into this instance. Higher layers that retain derived state over
+  /// the shared COS document can use it to invalidate that state lazily,
+  /// without making every incremental revision allocate a brand-new graph.
+  int get revision => _revision;
+  int _revision = 0;
+
   // Loaded-object cache keyed by the packed (objectNumber, generation) int
   // (see [_cacheKey]) so [getObject] - the hottest path in the package -
   // resolves a warm object without allocating a CosReference per call (#522).
@@ -198,6 +207,7 @@ class CosDocument {
     });
     _objectStreams.removeWhere((number, _) => changed.contains(number));
     _scannedHeaders = null;
+    _revision++;
     return changed;
   }
 

--- a/packages/pdf_cos/test/incremental_update_test.dart
+++ b/packages/pdf_cos/test/incremental_update_test.dart
@@ -24,6 +24,7 @@ void main() {
         .save();
 
     final doc = CosDocument.open(original);
+    final revision = doc.revision;
     // Warm the cache for the object about to change, so the eviction path runs.
     doc.getObject(5, 0);
     doc.catalog;
@@ -31,6 +32,7 @@ void main() {
     final changed = doc.applyIncrementalUpdate(updated);
 
     expect(changed, contains(5));
+    expect(doc.revision, revision + 1);
     expect(doc.bytes.length, updated.length);
     expect(doc.startXref, greaterThan(0));
     // The redefined object resolves to the appended value (its cache entry was
@@ -80,10 +82,13 @@ void main() {
   test('rejects a buffer that is not an append', () {
     final original = buildClassicPdf();
     final doc = CosDocument.open(original);
+    final revision = doc.revision;
     final shorter = Uint8List.sublistView(original, 0, original.length - 1);
     expect(
       () => doc.applyIncrementalUpdate(shorter),
       throwsA(isA<CosParseException>()),
     );
+    expect(doc.revision, revision,
+        reason: 'a rejected transition did not advance the graph');
   });
 }

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -7,7 +7,8 @@ import 'page.dart';
 
 /// A PDF document with page-level semantics on top of the COS layer.
 class PdfDocument {
-  PdfDocument._(this.cos, [this._sourcePageCountHint]);
+  PdfDocument._(this.cos, [this._sourcePageCountHint])
+      : _pageCacheRevision = cos.revision;
 
   /// The underlying COS-level document, for anything not surfaced here yet.
   final CosDocument cos;
@@ -67,7 +68,10 @@ class PdfDocument {
   /// reference to a stream), and an index below pageCount must never
   /// make [page] throw. The walk caches in [_leafCache]; /Count is still
   /// used as the subtree-skipping hint inside [page].
-  int get pageCount => _sourcePageCountHint ?? _leaves.length;
+  int get pageCount {
+    _refreshPageCacheRevision();
+    return _sourcePageCountHint ?? _leaves.length;
+  }
 
   /// Document information dictionary (/Title, /Author, ...) as text.
   Map<String, String> get info {
@@ -85,6 +89,7 @@ class PdfDocument {
   /// Returns page [index] (zero-based), with inheritable attributes
   /// (Resources, MediaBox, CropBox, Rotate) resolved along the tree path.
   PdfPage page(int index) {
+    _refreshPageCacheRevision();
     if (index < 0) {
       throw RangeError.range(index, 0, null, 'index');
     }
@@ -126,6 +131,23 @@ class PdfDocument {
 
   List<CosDictionary>? _leafCache;
   Map<CosDictionary, int>? _leafIndexCache;
+  int _pageCacheRevision;
+
+  /// Invalidates a wrapper's page-tree caches when another wrapper sharing
+  /// the same [CosDocument] has advanced it to a new incremental revision.
+  ///
+  /// Viewer page objects deliberately survive clean-page revisions. Some of
+  /// them therefore retain an older [PdfDocument] wrapper over the same live
+  /// COS graph; making this check lazy keeps their destination/page-index
+  /// lookups correct without walking the whole page tree on every edit.
+  void _refreshPageCacheRevision() {
+    final revision = cos.revision;
+    if (_pageCacheRevision == revision) return;
+    _leafCache = null;
+    _leafIndexCache = null;
+    _pageCache.clear();
+    _pageCacheRevision = revision;
+  }
 
   /// Identity map from page dictionary to index, built alongside [_leaves].
   ///
@@ -153,6 +175,7 @@ class PdfDocument {
     _leafCache = null;
     _leafIndexCache = null;
     _pageCache.clear();
+    _pageCacheRevision = cos.revision;
   }
 
   /// Feeds an append-only incremental revision into this open document in
@@ -180,8 +203,8 @@ class PdfDocument {
   /// caller depends on the identity, applying the update in place
   /// ([applyIncrementalUpdate]) is a valid drop-in that saves this allocation.
   ///
-  /// The previous wrapper must be discarded: it shares the now-updated
-  /// [CosDocument], so its cached page tree no longer matches.
+  /// Older wrappers share the now-updated [CosDocument]. Their page-tree
+  /// caches notice the COS revision and invalidate lazily if they are retained.
   PdfDocument withIncrementalUpdate(Uint8List newBytes) {
     cos.applyIncrementalUpdate(newBytes);
     return PdfDocument._(cos);
@@ -190,7 +213,10 @@ class PdfDocument {
   /// Zero-based index of a page dictionary, or -1 if it isn't a leaf of
   /// this document's page tree. Resolved objects are cached by reference,
   /// so identity comparison is sound. Used to resolve link destinations.
-  int pageIndexOf(CosDictionary pageDict) => _leafIndex[pageDict] ?? -1;
+  int pageIndexOf(CosDictionary pageDict) {
+    _refreshPageCacheRevision();
+    return _leafIndex[pageDict] ?? -1;
+  }
 
   void _collectLeaves(
       CosDictionary node, List<CosDictionary> out, Set<CosDictionary> visited) {

--- a/packages/pdf_document/lib/src/page.dart
+++ b/packages/pdf_document/lib/src/page.dart
@@ -43,6 +43,28 @@ class PdfPage {
   final CosArray? _inheritedCropBox;
   final int? _inheritedRotate;
 
+  /// Re-wraps this page for a newer incremental revision of the same COS
+  /// document, preserving the inherited attributes resolved from its
+  /// unchanged page-tree path.
+  ///
+  /// [dict] must be the current dictionary resolved for this page's stable
+  /// indirect reference. This is intentionally narrower than constructing an
+  /// arbitrary page: a structural page-tree edit must perform a fresh walk so
+  /// inherited values are resolved from the new ancestry.
+  PdfPage forIncrementalRevision(PdfDocument document, CosDictionary dict) {
+    if (!identical(this.document.cos, document.cos)) {
+      throw ArgumentError('incremental page revision must share the COS graph');
+    }
+    return PdfPage(
+      document: document,
+      dict: dict,
+      inheritedResources: _inheritedResources,
+      inheritedMediaBox: _inheritedMediaBox,
+      inheritedCropBox: _inheritedCropBox,
+      inheritedRotate: _inheritedRotate,
+    );
+  }
+
   /// This page's own entry for [key], or the value inherited from its
   /// ancestors when the page does not carry one.
   T? _own<T extends CosObject>(String key, T? inherited) {

--- a/packages/pdf_document/test/incremental_update_test.dart
+++ b/packages/pdf_document/test/incremental_update_test.dart
@@ -74,6 +74,26 @@ void main() {
     expect(incremental.info['Title'], 'After');
   });
 
+  test('older wrappers lazily invalidate page-tree caches on a shared update',
+      () {
+    final original = buildMultiPagePdf(4);
+    final older = PdfDocument.open(original);
+    final oldThird = older.page(2);
+    expect(older.pageIndexOf(oldThird.dict), 2,
+        reason: 'warms the older wrapper leaf/index caches');
+
+    final editor = PdfEditor(older)
+      ..addSquare(2, const PdfRect(20, 20, 80, 80));
+    final newer = older.withIncrementalUpdate(editor.save());
+    final currentThird = newer.page(2);
+
+    expect(identical(older.cos, newer.cos), isTrue);
+    expect(currentThird.dict, isNot(same(oldThird.dict)),
+        reason: 'the redefined page dictionary was re-read');
+    expect(older.pageIndexOf(currentThird.dict), 2,
+        reason: 'the older wrapper noticed the shared COS revision');
+  });
+
   test('rejects a non-append buffer', () {
     final original = buildMultiPagePdf(2);
     final shorter = Uint8List.sublistView(original, 0, original.length - 1);


### PR DESCRIPTION
## Summary

- carry semantic edit-impact lanes into viewer revision reconciliation
- re-wrap and recalculate only dirty pages while preserving clean page identity, geometry, rasters, previews, and retained render scenes
- keep the existing full reconciliation as the correctness fallback for structural edits, unknown impact, unrelated documents, and unresolved page identities

On the synchronous annotation-revision path, an A/B benchmark against `48cd6a40` produced:

| Pages | HEAD median/edit | This PR median/edit | Improvement |
| ---: | ---: | ---: | ---: |
| 100 | 2.45 ms | 0.99 ms | 2.5x |
| 500 | 27.74 ms | 1.07 ms | 25.9x |
| 1,000 | 102.03 ms | 1.33 ms | 77.0x |

Across 15 revisions, page-tree walks fall from 15 to 0. The regression suite now asserts this structural invariant directly rather than gating on noisy wall time.

## Affected packages

- [x] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [x] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Focused validation run:

- `pdf_cos/test/incremental_update_test.dart`
- `pdf_document/test/incremental_update_test.dart`, page-cache/index, edit-impact, and page-ops tests
- `dart_pdf_editor` viewer, preview-cache, page-object-cache, worker-revision, annotation-cache, and revision-id tests
- updated dirty-page/page-tree-walk regression after the benchmark
- `git diff --check`

The full package suites and platform builds are left to CI. Corpus and screenshot runs are not relevant because this changes revision/cache orchestration, not PDF interpretation or pixels.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

The user-visible change is reduced edit latency on long documents. Input and accessibility behavior are unchanged.

## PDF fixtures and screenshots

The performance comparison uses the programmatic multi-page fixture. There is no visual change to screenshot.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

This intentionally does not attempt structural page-list reconciliation. Page insertion, deletion, and reorder continue through the established full fallback. Geometry changes such as rotation are incremental, with the global fit extrema reduced from already-cached numbers rather than reparsing pages.

Likely follow-ups are structural keyed reconciliation, indexed extent/max structures, and real-corpus edit traces; those should land separately so this PR stays reviewable and its benchmark remains attributable.
