### PR TITLE
perf: stabilize web caches and reconcile page reorders

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -39,16 +39,31 @@ jobs:
           dart pub global activate patrol_cli "$PATROL_CLI_VERSION"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
       - name: Run Patrol on web
+        id: patrol-web
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        shell: bash
+        run: |
+          set -o pipefail
+          patrol test \
+            --device chrome \
+            --target patrol_test/demo_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ github.sha }} \
+            --show-flutter-logs \
+            --web-headless \
+            --web-locale en-US \
+            --web-workers 1 \
+            --web-video retain-on-failure \
+            --verbose \
+            2>&1 | tee "$RUNNER_TEMP/patrol-web.log"
+      - name: Collect Patrol performance trace
+        if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}
         run: >-
-          patrol test
-          --device chrome
-          --target patrol_test/demo_e2e_test.dart
-          --web-headless
-          --web-locale en-US
-          --web-workers 1
-          --web-video retain-on-failure
-          --verbose
+          dart ../../../tool/patrol_perf_summary.dart
+          "$RUNNER_TEMP/patrol-web.log"
+          --output test-results/perf
+          --markdown "$GITHUB_STEP_SUMMARY"
       - name: Upload Patrol web results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -70,16 +70,32 @@ jobs:
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
 
       - name: Run Patrol on web
+        id: patrol-web
+        working-directory: packages/dart_pdf_editor/example
+        shell: bash
+        run: |
+          set -o pipefail
+          patrol test \
+            --device chrome \
+            --target patrol_test/demo_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ github.event.pull_request.head.sha }} \
+            --show-flutter-logs \
+            --web-headless \
+            --web-locale en-US \
+            --web-workers 1 \
+            --web-video retain-on-failure \
+            --verbose \
+            2>&1 | tee "$RUNNER_TEMP/patrol-web.log"
+
+      - name: Collect Patrol performance trace
+        if: always()
         working-directory: packages/dart_pdf_editor/example
         run: >-
-          patrol test
-          --device chrome
-          --target patrol_test/demo_e2e_test.dart
-          --web-headless
-          --web-locale en-US
-          --web-workers 1
-          --web-video retain-on-failure
-          --verbose
+          dart ../../../tool/patrol_perf_summary.dart
+          "$RUNNER_TEMP/patrol-web.log"
+          --output test-results/perf
+          --markdown "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Patrol web results
         if: always()

--- a/app/lib/adaptive_memory.dart
+++ b/app/lib/adaptive_memory.dart
@@ -39,10 +39,18 @@ int pdfWarmPageRasterFloorBytes(PdfPerformancePlatform platform) =>
 
 /// Per-page admission floor while a warm policy is active.
 ///
-/// The derived limit is `pageBytes ~/ 8` with an 8 MB floor off-desktop, so a
-/// page budget under 64 MB admits nothing bigger than 8 MB - and a letter page
-/// at DPR 2 is ~10 MB. Raising the *total* without raising this buys nothing.
+/// The derived limit is `pageBytes ~/ 8`, with a 16 MB floor on desktop/web
+/// and 8 MB elsewhere. A web fit raster can easily reach 15-16 MB on a normal
+/// high-DPI display; pricing it below the floor makes an otherwise healthy
+/// 100+ MB page budget retain zero pages.
 const pdfWarmPageRasterEntryFloorBytes = 24 * _mb;
+
+int _pageRasterEntryFloor(PdfPerformancePlatform platform) =>
+    switch (platform) {
+      PdfPerformancePlatform.desktop || PdfPerformancePlatform.web =>
+        16 * _mb,
+      PdfPerformancePlatform.mobile || PdfPerformancePlatform.other => 8 * _mb,
+    };
 
 typedef AppMemoryProbe = Future<AppMemorySnapshot?> Function();
 
@@ -189,8 +197,7 @@ AdaptiveMemoryDecision computeAdaptiveMemoryDecision({
   };
   final pageBytes =
       math.min(platformPageCap, (allocatableRegistry * .88).round());
-  final minimumEntry =
-      platform == PdfPerformancePlatform.desktop ? 16 * _mb : 8 * _mb;
+  final minimumEntry = _pageRasterEntryFloor(platform);
   var entryBytes = pageBytes == 0
       ? 0
       : math.min(
@@ -277,6 +284,16 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
   int? _pressureRegistryCap;
   bool _lowMemoryActive = false;
   int? _lastRssBytes;
+
+  // Chrome's `usedJSHeapSize` is sampled before its next GC and includes
+  // short-lived worker transfer/deserialization buffers. A single large-page
+  // open can therefore make the speculative page budget read 110 MB -> 0 and
+  // hold it there under the growth damper, even though the registered caches
+  // themselves occupy only a few MB. The process-wide registry ceiling and
+  // live-raster budget still shrink immediately; only this admission policy
+  // waits for one confirming sample on web, where no OS available-memory
+  // signal exists.
+  PdfPageRasterCachePolicy? _pendingWebPageShrink;
 
   /// Share of process RSS the registered caches must hold before a pressure
   /// event is allowed to shrink their ceiling for [pressureCooldown].
@@ -391,6 +408,23 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
 
     var pagePolicy = decision.pageRasterPolicy;
     final current = tools.pageRasterCachePolicy.value;
+    if (_hasSample &&
+        platform == PdfPerformancePlatform.web &&
+        snapshot.availableBytes == null &&
+        pagePolicy.maxBytes < current.maxBytes) {
+      final pending = _pendingWebPageShrink;
+      final confirmed = pending != null &&
+          pagePolicy.maxBytes <= pending.maxBytes &&
+          pagePolicy.maxEntryBytes <= pending.maxEntryBytes;
+      if (!confirmed) {
+        _pendingWebPageShrink = pagePolicy;
+        pagePolicy = current;
+      } else {
+        _pendingWebPageShrink = null;
+      }
+    } else {
+      _pendingWebPageShrink = null;
+    }
     if (_hasSample && pagePolicy.maxBytes > current.maxBytes) {
       final inCooldown = _lastPressure != null &&
           now.difference(_lastPressure!) < pressureCooldown;
@@ -520,6 +554,6 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
 
 int _entryLimitFor(int bytes, PdfPerformancePlatform platform) {
   if (bytes <= 0) return 0;
-  final floor = platform == PdfPerformancePlatform.desktop ? 16 * _mb : 8 * _mb;
+  final floor = _pageRasterEntryFloor(platform);
   return math.min(bytes, math.min(256 * _mb, math.max(floor, bytes ~/ 8)));
 }

--- a/app/test/adaptive_memory_test.dart
+++ b/app/test/adaptive_memory_test.dart
@@ -177,6 +177,57 @@ void main() {
     expect(decision.pageRasterPolicy.maxBytes, lessThanOrEqualTo(256 * mb));
   });
 
+  test('web page admission keeps a normal high-DPI fit raster cacheable', () {
+    // Field trace 2026-08-22: the total budget still had 110 MB available,
+    // but `pageBytes ~/ 8` priced each entry at 14.47 MB and rejected every
+    // 16.52 MB fit raster. A non-empty cache budget that admits zero pages is
+    // not useful headroom.
+    final decision = computeAdaptiveMemoryDecision(
+      snapshot: const AppMemorySnapshot(
+        physicalBytes: 4 * gb,
+        processRssBytes: 120 * mb,
+      ),
+      platform: PdfPerformancePlatform.web,
+      reclaimableRegistryBytes: 0,
+      liveRasterBytes: 0,
+    );
+
+    expect(decision.pageRasterPolicy.maxBytes, greaterThan(64 * mb));
+    expect(decision.pageRasterPolicy.maxEntryBytes,
+        greaterThanOrEqualTo(16 * mb));
+    expect(decision.pageRasterPolicy.maxEntryBytes,
+        greaterThanOrEqualTo(16515776));
+  });
+
+  test('web transient heap spike needs confirmation before disabling pages',
+      () {
+    final controller = AdaptiveMemoryBudgetController(
+      platform: PdfPerformancePlatform.web,
+    );
+    const roomy = AppMemorySnapshot(
+      physicalBytes: 4 * gb,
+      processRssBytes: 120 * mb,
+    );
+    const transferSpike = AppMemorySnapshot(
+      physicalBytes: 4 * gb,
+      processRssBytes: 300 * mb,
+    );
+
+    controller.applySnapshot(roomy);
+    final before = tools.pageRasterCachePolicy.value;
+    expect(before.maxBytes, greaterThan(0));
+
+    controller.applySnapshot(transferSpike);
+    expect(tools.pageRasterCachePolicy.value, before,
+        reason: 'one pre-GC worker-transfer sample is not sustained pressure');
+    expect(PdfCacheRegistry.instance.maxTotalWeight, 64 * mb,
+        reason: 'the process-wide safety ceiling still shrinks immediately');
+
+    controller.applySnapshot(transferSpike);
+    expect(tools.pageRasterCachePolicy.value.maxBytes, 0,
+        reason: 'a second tight sample confirms the lower admission policy');
+  });
+
   // Gives the process-wide registry real occupancy, so a pressure event is
   // judged against caches that are actually holding something. Without this the
   // registry is empty and the controller (rightly) declines to punish it.

--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -43,6 +43,12 @@ patrol test --device macos
 patrol test --device chrome --web-headless
 ```
 
+The CI web journey enables `PdfPerfLog` and uploads `patrol-perf.log`,
+`patrol-perf.json`, and `patrol-perf.md` inside the `patrol-web-results`
+artifact. Pull requests also show the Markdown summary in the Actions run.
+These wall-clock measurements are review evidence rather than a pass/fail gate;
+compare the JSON with a recent `main` run from the same hosted-runner lane.
+
 When using this repository's FVM SDK, prefix the commands with
 `PATROL_FLUTTER_COMMAND="fvm flutter"`. Patrol supports Android, iOS, macOS,
 and web. Its runner does not support Windows or Linux; those platforms remain

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -31,6 +31,9 @@ final _githubUrl = Uri.parse('https://github.com/ben-milanko/dart-pdf');
 /// The published Flutter package the example is built on.
 final _pubDevUrl = Uri.parse('https://pub.dev/packages/dart_pdf_editor');
 
+/// CI stamps Patrol performance traces with the exact revision under test.
+const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
+
 /// A CORS-enabled, Range-capable sample used to prefill the "Open from a URL"
 /// field - the classic pdf.js test document, served by raw.githubusercontent
 /// with `Access-Control-Allow-Origin: *`.
@@ -113,6 +116,9 @@ String pdfSavePathWithExtension(String path) {
 }
 
 void main() {
+  if (_buildCommit.isNotEmpty) {
+    PdfPerfLog.buildTag = 'commit=$_buildCommit';
+  }
   // Register the optional bundled editor fonts + web render worker so the
   // example keeps the full-featured editor (font menu catalogue, composite-text
   // fallbacks, off-main-thread web rendering). A viewer-only app would omit the

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -7,6 +7,7 @@ import 'package:pdf_viewer_example/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const _preferencePrefix = 'dart_pdf_editor.editing.';
+const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
 const _testPreferences = <String, Object>{
   '${_preferencePrefix}locale': 'en',
   '${_preferencePrefix}showAnnotations': true,
@@ -23,6 +24,13 @@ const _testPreferences = <String, Object>{
 };
 
 void main() {
+  // Patrol owns this test entry point, so the example app's main() does not
+  // run. Stamp the shared perf logger here as well as in lib/main.dart so CI
+  // artifacts can always be attributed to the exact revision under test.
+  if (_buildCommit.isNotEmpty) {
+    PdfPerfLog.buildTag = 'commit=$_buildCommit';
+  }
+
   patrolTest('launches the demo and exercises PDF actions and overlays',
       ($) async {
     final demo = await _DemoHarness.open($);

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -273,6 +273,30 @@ class PdfBudgetedCache<K, V> {
     }
   }
 
+  /// Re-keys retained entries without disposing their values or changing LRU
+  /// order.
+  ///
+  /// Used when an identity-preserving structural edit moves page-indexed
+  /// cache entries to new slots. [keyFor] should normally be one-to-one. If
+  /// two old keys map to one new key, the later (more recently used) entry
+  /// wins and the displaced value is disposed.
+  void remapKeys(K Function(K key) keyFor) {
+    if (_disposed || _entries.isEmpty) return;
+    final remapped = <K, _Entry<V>>{};
+    for (final entry in _entries.entries) {
+      final key = keyFor(entry.key);
+      final displaced = remapped.remove(key);
+      if (displaced != null) {
+        _weight -= displaced.weight;
+        _disposer?.call(displaced.value);
+      }
+      remapped[key] = entry.value;
+    }
+    _entries
+      ..clear()
+      ..addAll(remapped);
+  }
+
   /// Empties the cache, disposing every retained value. Counters survive - a
   /// clear is a cache operation, not a fresh measurement. Any clones already
   /// handed out are unaffected.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -494,17 +494,26 @@ class PdfEditingController extends ChangeNotifier {
   /// Render stamps: how many times each page's rendering has changed.
   /// [_renderStampEpoch] counts the all-pages bumps (structural edits,
   /// unknown-page edits) so they don't iterate a large document.
-  final Map<int, int> _renderStamps = {};
+  final Map<Object, int> _renderStamps = {};
   int _renderStampEpoch = 0;
-  final Map<int, int> _contentRenderStamps = {};
+  final Map<Object, int> _contentRenderStamps = {};
   int _contentRenderStampEpoch = 0;
+
+  Object _pageStampKey(int pageIndex) {
+    final page = _page(pageIndex);
+    final ref = _document.cos.referenceTo(page.dict);
+    return ref == null
+        ? ('page-slot', pageIndex)
+        : (ref.objectNumber, ref.generation);
+  }
 
   void _bumpRenderStamps(Set<int>? pages) {
     if (pages == null) {
       _renderStampEpoch++;
     } else {
       for (final page in pages) {
-        _renderStamps[page] = (_renderStamps[page] ?? 0) + 1;
+        final key = _pageStampKey(page);
+        _renderStamps[key] = (_renderStamps[key] ?? 0) + 1;
       }
     }
   }
@@ -514,7 +523,8 @@ class PdfEditingController extends ChangeNotifier {
       _contentRenderStampEpoch++;
     } else {
       for (final page in pages) {
-        _contentRenderStamps[page] = (_contentRenderStamps[page] ?? 0) + 1;
+        final key = _pageStampKey(page);
+        _contentRenderStamps[key] = (_contentRenderStamps[key] ?? 0) + 1;
       }
     }
   }
@@ -524,13 +534,14 @@ class PdfEditingController extends ChangeNotifier {
   /// other pages only. Thumbnails key their raster caches on it instead
   /// of re-rendering every page on every revision.
   int pageRenderStamp(int pageIndex) =>
-      _renderStampEpoch + (_renderStamps[pageIndex] ?? 0);
+      _renderStampEpoch + (_renderStamps[_pageStampKey(pageIndex)] ?? 0);
 
   /// A value that changes only when [pageIndex]'s base page content image
   /// changed. Annotation-only edits leave it stable: the viewer paints those
   /// appearances in an overlay while thumbnails still use [pageRenderStamp].
   int pageContentRenderStamp(int pageIndex) =>
-      _contentRenderStampEpoch + (_contentRenderStamps[pageIndex] ?? 0);
+      _contentRenderStampEpoch +
+      (_contentRenderStamps[_pageStampKey(pageIndex)] ?? 0);
 
   /// Destructive-render epoch: bumped only by edits that *remove* existing
   /// page content (a redaction burn), as opposed to the additive ones (ink,
@@ -571,6 +582,7 @@ class PdfEditingController extends ChangeNotifier {
   int get revisionId => _revisionId;
 
   PdfWorkerRevisionDelta? _lastRevisionDelta;
+  PdfEditImpact? _lastRevisionImpact;
 
   /// The byte-level shape of the most recent revision transition (edit, undo,
   /// redo) for the render worker's incremental update path, or null when the
@@ -579,6 +591,13 @@ class PdfEditingController extends ChangeNotifier {
   /// meaningful the moment [document]'s identity changes; the shell reads it
   /// then and ignores it otherwise.
   PdfWorkerRevisionDelta? get lastRevisionDelta => _lastRevisionDelta;
+
+  /// The semantic impact of the most recent revision transition.
+  ///
+  /// Unlike [lastRevisionDelta], this remains available for structural edits
+  /// which require a render-worker restart but can still be reconciled by the
+  /// viewer using stable page identities.
+  PdfEditImpact? get lastRevisionImpact => _lastRevisionImpact;
 
   /// The current revision's bytes - what "save to disk" should write.
   Uint8List get bytes => Uint8List.sublistView(_bytes, 0, _revisions[_cursor]);
@@ -612,6 +631,7 @@ class PdfEditingController extends ChangeNotifier {
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);
     _cursor--;
+    _lastRevisionImpact = impact;
     // The worker keeps the shared prefix and re-reads it - no bytes to append.
     _lastRevisionDelta = impact.pageStructureChanged
         ? null
@@ -630,6 +650,7 @@ class PdfEditingController extends ChangeNotifier {
     final beforeLength = _revisions[_cursor];
     _cursor++;
     final impact = _revisionImpacts[_cursor];
+    _lastRevisionImpact = impact;
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);
     // Re-extend to the redone revision - its bytes already sit in the buffer as
@@ -823,6 +844,7 @@ class PdfEditingController extends ChangeNotifier {
     _bumpContentRenderStamps(impact.contentPages);
     if (impact.destructive) _destructiveStampEpoch++;
     _cursor++;
+    _lastRevisionImpact = impact;
     // The incremental save appended to the previous revision, so its bytes are
     // that revision's prefix plus the new tail: the worker keeps the first
     // [beforeLength] bytes and appends the rest. A structural edit can shift
@@ -2420,6 +2442,7 @@ class PdfEditingController extends ChangeNotifier {
     // A burn recompacts the whole file: the new buffer is not a prefix-append
     // of the prior one, so the worker cannot update in place and must restart.
     _lastRevisionDelta = null;
+    _lastRevisionImpact = impact;
     _selected.clear();
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -3037,6 +3037,7 @@ Future<ui.Image?> rasterizeThumbnail({
   String reason = 'tile',
   PdfRasterCache? disk,
   PdfPagePreviewCache? previews,
+  bool? allowSoftPreview,
 }) async {
   final page = controller.pageAt(pageIndex);
   final size = PdfPageRenderer.pageSize(page);
@@ -3068,6 +3069,30 @@ Future<ui.Image?> rasterizeThumbnail({
     });
   final sw = Stopwatch()..start();
   try {
+    // Reuse pixels the viewer already produced before replaying its retained
+    // command scene. Intermediate previews can be sharper than the requested
+    // tile; on web, the base 200 px preview is also accepted for a nearby
+    // 256 px request. That small softness avoids the trace's 223 ms CanvasKit
+    // replay of 39k commands (and the resulting 248 ms raster frame).
+    final preview = previews?.thumbnailImageFor(
+      pageIndex,
+      page,
+      width: pixelWidth,
+      height: math.max(1, (size.height * ratio).ceil()),
+      minimumScale: (allowSoftPreview ?? kIsWeb) ? 0.75 : 1,
+    );
+    if (preview != null) {
+      final previewMs = sw.elapsedMicroseconds / 1000.0;
+      trace.instant('preview hit', arguments: {
+        'ms': previewMs,
+        'width': preview.width,
+        'height': preview.height,
+      });
+      PdfPerfLog.log('thumbnail page=$pageIndex $reason px=$pixelWidth '
+          'preview-hit ${preview.width}x${preview.height} '
+          'lookup=${_traceMs(previewMs)}');
+      return preview;
+    }
     // Cheapest live path first: the page's own retained scene. It is already
     // interpreted and its images are already decoded, so a tile costs a
     // command replay plus its (tiny) raster - no worker round trip, and none

--- a/packages/dart_pdf_editor/lib/src/exact_extent_list.dart
+++ b/packages/dart_pdf_editor/lib/src/exact_extent_list.dart
@@ -23,6 +23,7 @@ class ExactExtentListView extends ListView {
     required ItemExtentBuilder super.itemExtentBuilder,
     required super.itemBuilder,
     required int super.itemCount,
+    super.findChildIndexCallback,
   }) : super.builder();
 
   @override

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart' show SliverMultiBoxAdaptorParentData;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pdf_cos/pdf_cos.dart'
@@ -1423,6 +1424,21 @@ class _PdfPageViewState extends State<PdfPageView>
       // Before layout, trust the viewer's explicit visible-span answer. A
       // standalone PdfPageView defaults to onScreen=true.
       return widget.onScreen;
+    }
+    // A keyed child which moves inside a SliverMultiBoxAdaptor is updated
+    // before the sliver lays it out at its new index. During that narrow
+    // reconciliation window its layoutOffset is null and localToGlobal walks
+    // into RenderSliverMultiBoxAdaptor.childMainAxisPosition's null check.
+    // The viewer already computed [onScreen] for the new slot, so use that
+    // answer until the next layout makes coordinate conversion valid again.
+    RenderObject? ancestor = box;
+    while (ancestor != null) {
+      final parentData = ancestor.parentData;
+      if (parentData is SliverMultiBoxAdaptorParentData &&
+          parentData.layoutOffset == null) {
+        return widget.onScreen;
+      }
+      ancestor = ancestor.parent;
     }
     final pageRect = Rect.fromPoints(
       box.localToGlobal(Offset.zero),

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart'
-    show ValueListenable, kIsWeb, visibleForTesting;
+    show ValueListenable, immutable, kIsWeb, visibleForTesting;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
@@ -58,6 +58,67 @@ export 'annotation_tap.dart'
     show PdfAnnotationTapDetails, PdfAnnotationTapHandler;
 
 const double _defaultMaxZoom = 24;
+
+/// How the viewer reconciled its page presentation across a document change.
+enum PdfPageReconciliationMode {
+  /// Only pages named by the edit impact were re-wrapped.
+  incremental,
+
+  /// Stable page identities were used to reconcile a structural change.
+  keyedStructure,
+
+  /// The complete page list and its presentation state were rebuilt.
+  fullReload,
+}
+
+/// Support snapshot for the most recent page-list reconciliation.
+///
+/// This is deliberately descriptive rather than a performance promise. It is
+/// useful in exported [PdfPerfLog] traces and tests which need to distinguish
+/// a dirty-page bailout from a correctness-first full reload.
+@immutable
+class PdfPageReconciliationDiagnostics {
+  const PdfPageReconciliationDiagnostics({
+    required this.mode,
+    required this.elapsed,
+    required this.pageCount,
+    required this.dirtyPages,
+    required this.retainedPages,
+    required this.geometryPages,
+    required this.walkedPageTree,
+    this.fallbackReason,
+  });
+
+  final PdfPageReconciliationMode mode;
+  final Duration elapsed;
+  final int pageCount;
+
+  /// Pages whose wrappers/presentation inputs were replaced. Null means the
+  /// transition did not have a trustworthy dirty-page boundary.
+  final int? dirtyPages;
+  final int retainedPages;
+  final int geometryPages;
+  final bool walkedPageTree;
+
+  /// Why an incremental candidate selected [PdfPageReconciliationMode.fullReload].
+  final String? fallbackReason;
+}
+
+class _PdfViewerPageKey extends LocalKey {
+  const _PdfViewerPageKey(this.namespace, this.pageIdentity);
+
+  final Object namespace;
+  final Object pageIdentity;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _PdfViewerPageKey &&
+      identical(namespace, other.namespace) &&
+      pageIdentity == other.pageIdentity;
+
+  @override
+  int get hashCode => Object.hash(identityHashCode(namespace), pageIdentity);
+}
 
 /// Page-space distance an arrow-key press slides the selected annotation(s),
 /// and the coarser step Shift+arrow uses. Points, matching the drag move.
@@ -448,11 +509,21 @@ class PdfViewerController extends ChangeNotifier {
   int get debugIncrementalPageReconciliations =>
       _state?._incrementalPageReconciliations ?? 0;
 
+  /// Number of pure page reorders reconciled by stable page identity.
+  @visibleForTesting
+  int get debugKeyedPageReconciliations =>
+      _state?._keyedPageReconciliations ?? 0;
+
   /// Pages inspected by the most recent successful incremental reconcile.
   /// Null when the latest document transition used the full fallback.
   @visibleForTesting
   Set<int>? get debugLastIncrementallyReconciledPages =>
       _state?._lastIncrementallyReconciledPages;
+
+  /// Support snapshot for the most recent page-list reconciliation.
+  @visibleForTesting
+  PdfPageReconciliationDiagnostics? get debugPageReconciliationDiagnostics =>
+      _state?._lastPageReconciliation;
 
   /// Opaque identity of the attached viewer's page presentation object.
   /// Clean pages retain this across an incremental revision; dirty pages do
@@ -1790,7 +1861,10 @@ class _PdfViewerState extends State<PdfViewer>
   late List<(int, int)?> _pageRefs;
   late List<double> _aspects; // height / width, after /Rotate
   int _incrementalPageReconciliations = 0;
+  int _keyedPageReconciliations = 0;
   Set<int>? _lastIncrementallyReconciledPages;
+  PdfPageReconciliationDiagnostics? _lastPageReconciliation;
+  String? _incrementalFallbackReason;
 
   /// The controller that owns the document revisions for a given viewer
   /// configuration, if any: the editing controller, or - when interactive
@@ -3622,10 +3696,14 @@ class _PdfViewerState extends State<PdfViewer>
   /// document/controller) and from [_onRevisionControllerChanged] (a new
   /// revision with no host rebuild).
   void _swapDocument({bool preserveRevisionViewport = false}) {
+    final reconcileClock = Stopwatch()..start();
     final document = _document;
     if (preserveRevisionViewport &&
         _tryReconcileIncrementalRevision(document)) {
       return;
+    }
+    if (!preserveRevisionViewport) {
+      _incrementalFallbackReason = 'unrelated-document-swap';
     }
     _lastIncrementallyReconciledPages = null;
     final sameGeometry = _sameGeometryAs(document);
@@ -3752,7 +3830,32 @@ class _PdfViewerState extends State<PdfViewer>
       // geometry) keeps the zoom the user chose
       _appliedInitialFit = false;
     }
+    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
+      mode: PdfPageReconciliationMode.fullReload,
+      elapsed: reconcileClock.elapsed,
+      pageCount: _pages.length,
+      dirtyPages: null,
+      retainedPages: 0,
+      geometryPages: _pages.length,
+      walkedPageTree: true,
+      fallbackReason: _incrementalFallbackReason ?? 'full-reload-required',
+    ));
     setState(() {});
+  }
+
+  void _recordPageReconciliation(PdfPageReconciliationDiagnostics diagnostics) {
+    _lastPageReconciliation = diagnostics;
+    final dirty = diagnostics.dirtyPages?.toString() ?? 'unknown';
+    final reason = diagnostics.fallbackReason == null
+        ? ''
+        : ' reason=${diagnostics.fallbackReason}';
+    PdfPerfLog.log('page-reconcile mode=${diagnostics.mode.name} '
+        'pages=${diagnostics.pageCount} dirty=$dirty '
+        'retained=${diagnostics.retainedPages} '
+        'geometry=${diagnostics.geometryPages} '
+        'walk=${diagnostics.walkedPageTree ? 1 : 0} '
+        'elapsed=${(diagnostics.elapsed.inMicroseconds / 1000).toStringAsFixed(2)}ms'
+        '$reason');
   }
 
   /// Applies a non-structural append-only revision by touching only the pages
@@ -3772,22 +3875,41 @@ class _PdfViewerState extends State<PdfViewer>
   /// reconciliation: clean render/cache state bails out and stale async work
   /// for dirty pages can no longer pass identity guards.
   bool _tryReconcileIncrementalRevision(PdfDocument document) {
-    final loaded = _loadedDocument;
-    final delta = _revisionController?.lastRevisionDelta;
-    final impact = delta?.impact;
-    if (loaded == null ||
-        impact == null ||
-        impact.pageStructureChanged ||
-        !identical(loaded.cos, document.cos)) {
+    final reconcileClock = Stopwatch()..start();
+    bool fallback(String reason) {
+      _incrementalFallbackReason = reason;
       return false;
     }
+
+    final loaded = _loadedDocument;
+    final delta = _revisionController?.lastRevisionDelta;
+    final impact = _revisionController?.lastRevisionImpact ?? delta?.impact;
+    if (loaded == null) return fallback('no-loaded-document');
+    if (impact == null) return fallback('no-revision-impact');
+    if (impact.pageStructureChanged) {
+      if (!impact.pageOrderOnly) return fallback('page-structure-changed');
+      if (impact.visualPages == null ||
+          impact.contentPages == null ||
+          impact.annotationPages == null ||
+          impact.visualPages!.isNotEmpty ||
+          impact.contentPages!.isNotEmpty ||
+          impact.annotationPages!.isNotEmpty) {
+        return fallback('page-order-mixed-impact');
+      }
+      return _tryReconcileKeyedPageOrder(
+        document,
+        reconcileClock,
+        fallback,
+      );
+    }
+    if (!identical(loaded.cos, document.cos)) return fallback('different-cos');
     final visualPages = impact.visualPages;
     final contentPages = impact.contentPages;
     final annotationPages = impact.annotationPages;
     if (visualPages == null ||
         contentPages == null ||
         annotationPages == null) {
-      return false;
+      return fallback('unknown-impact-pages');
     }
 
     final dirtyPages = <int>{
@@ -3796,25 +3918,28 @@ class _PdfViewerState extends State<PdfViewer>
       ...annotationPages,
     };
     if (dirtyPages.any((page) => page < 0 || page >= _pages.length)) {
-      return false;
+      return fallback('invalid-dirty-page');
     }
 
     final replacements = <int, PdfPage>{};
     final geometry = <int, (double aspect, double pointWidth)>{};
     var geometryChanged = false;
+    var geometryPages = 0;
     for (final index in dirtyPages) {
       final key = _pageRefs[index];
-      if (key == null) return false;
+      if (key == null) return fallback('missing-stable-page-reference');
       final resolved = document.cos.resolve(CosReference(key.$1, key.$2));
-      if (resolved is! CosDictionary) return false;
+      if (resolved is! CosDictionary) return fallback('unresolved-page');
       final page = _pages[index].forIncrementalRevision(document, resolved);
       // Geometry is calculated only for pages the transaction dirtied. Most
       // revisions land here: annotation/content pixels changed while the page
       // box did not. Rotations/crop changes update their one cached record;
       // the following pages' offsets derive from that record at layout time.
       final nextGeometry = (_pageAspect(page), _pagePointWidth(page));
-      geometryChanged |= (nextGeometry.$1 - _aspects[index]).abs() > 1e-6 ||
+      final changed = (nextGeometry.$1 - _aspects[index]).abs() > 1e-6 ||
           (nextGeometry.$2 - _pointWidths[index]).abs() > 1e-6;
+      if (changed) geometryPages++;
+      geometryChanged |= changed;
       replacements[index] = page;
       geometry[index] = nextGeometry;
     }
@@ -3889,6 +4014,160 @@ class _PdfViewerState extends State<PdfViewer>
     _bindRasterCache(prime: false);
     _incrementalPageReconciliations++;
     _lastIncrementallyReconciledPages = Set<int>.unmodifiable(dirtyPages);
+    _incrementalFallbackReason = null;
+    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
+      mode: PdfPageReconciliationMode.incremental,
+      elapsed: reconcileClock.elapsed,
+      pageCount: _pages.length,
+      dirtyPages: dirtyPages.length,
+      retainedPages: _pages.length - dirtyPages.length,
+      geometryPages: geometryPages,
+      walkedPageTree: false,
+    ));
+    _schedulePreviewPrerender();
+    _scheduleRasterWarm();
+    setState(() {});
+    return true;
+  }
+
+  bool _tryReconcileKeyedPageOrder(
+    PdfDocument document,
+    Stopwatch reconcileClock,
+    bool Function(String reason) fallback,
+  ) {
+    final currentPages = document.pages;
+    final count = currentPages.length;
+    if (count != _pages.length) return fallback('page-order-count-changed');
+
+    final oldIndexByRef = <(int, int), int>{};
+    for (var i = 0; i < _pageRefs.length; i++) {
+      final ref = _pageRefs[i];
+      if (ref == null) return fallback('missing-stable-page-reference');
+      if (oldIndexByRef.containsKey(ref)) {
+        return fallback('duplicate-stable-page-reference');
+      }
+      oldIndexByRef[ref] = i;
+    }
+
+    // This is the one unavoidable structural cost: walk the new page tree to
+    // verify its leaf identities and order. The render/presentation objects
+    // themselves are reconciled below instead of being rebuilt by slot.
+    final newPages = <PdfPage>[];
+    final newRefs = <(int, int)>[];
+    final oldIndexForNew = <int>[];
+    for (var i = 0; i < count; i++) {
+      final page = currentPages[i];
+      final ref = _pageReferenceKey(page);
+      if (ref == null) return fallback('missing-new-page-reference');
+      final oldIndex = oldIndexByRef[ref];
+      if (oldIndex == null) return fallback('page-order-identity-changed');
+      final nextAspect = _pageAspect(page);
+      final nextPointWidth = _pagePointWidth(page);
+      if ((nextAspect - _aspects[oldIndex]).abs() > 1e-6 ||
+          (nextPointWidth - _pointWidths[oldIndex]).abs() > 1e-6) {
+        return fallback('page-order-geometry-changed');
+      }
+      newPages.add(page);
+      newRefs.add(ref);
+      oldIndexForNew.add(oldIndex);
+    }
+    if (oldIndexForNew.toSet().length != count) {
+      return fallback('page-order-not-a-permutation');
+    }
+
+    final newIndexForOld = List<int>.filled(count, 0);
+    for (var newIndex = 0; newIndex < count; newIndex++) {
+      newIndexForOld[oldIndexForNew[newIndex]] = newIndex;
+    }
+
+    final oldCurrentPage = _controller.currentPage.clamp(0, count - 1);
+    final oldCurrentRef = _pageRefs[oldCurrentPage];
+    final oldViewport = _pendingViewport ??
+        _captureViewport() ??
+        PdfViewport(page: oldCurrentPage, zoom: _currentZoom);
+    final oldViewportRef = _pageRefs[oldViewport.page.clamp(0, count - 1)];
+
+    _controller.clearSearch();
+    _clearSelection();
+    _pageLabels = null;
+    _outline = null;
+
+    int moved(int oldIndex) => newIndexForOld[oldIndex];
+
+    // These values carry their original page index and/or document wrapper.
+    // They are cheap relative to page rendering and must be rebuilt against
+    // the new order (especially undo, which opens a fresh COS graph).
+    _textCache.clear();
+    _annotCache.clear();
+    _visibleAnnotCache.clear();
+    _fieldRectCache.clear();
+    final oldRastered = _rasteredPages.toList();
+    _rasteredPages
+      ..clear()
+      ..addAll(oldRastered.map(moved));
+    final oldContentStamps = Map<int, int>.of(_contentStamps);
+    _contentStamps
+      ..clear()
+      ..addEntries(oldContentStamps.entries.map(
+        (entry) => MapEntry(moved(entry.key), entry.value),
+      ));
+
+    _pages = newPages;
+    _pageRefs = List<(int, int)?>.of(newRefs, growable: false);
+    _aspects = [for (final oldIndex in oldIndexForNew) _aspects[oldIndex]];
+    _pointWidths = [
+      for (final oldIndex in oldIndexForNew) _pointWidths[oldIndex]
+    ];
+    _loadedDocument = document;
+    _controller._setPageCount(count);
+
+    _previews.reorder(_pages, newIndexForOld);
+    // Tiles are keyed by page slot. Clear them while preserving the page
+    // subtree/base raster itself; old asynchronous tile completions are fenced
+    // by the namespace epoch and cannot land in the reordered slots.
+    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        .invalidateNamespace(_tileCacheNamespace);
+
+    final viewportPage = newRefs.indexOf(oldViewportRef!);
+    final remappedViewport = PdfViewport(
+      page: viewportPage < 0 ? oldViewport.page : viewportPage,
+      top: oldViewport.top,
+      left: oldViewport.left,
+      zoom: oldViewport.zoom,
+    );
+    if (_scroll.hasClients && _viewWidth > 0 && _viewHeight > 0) {
+      // The exact total extent is unchanged by a permutation, so the current
+      // ScrollPosition can adopt the remapped offset before the sliver's next
+      // layout. This keeps the viewed keyed child inside the build window while
+      // Flutter moves it; deferring until post-frame would let a long move be
+      // garbage-collected between its old and new slots.
+      _pendingViewport = null;
+      _placeViewport(remappedViewport, remappedViewport.page);
+    } else {
+      _pendingViewport = remappedViewport;
+    }
+    final currentPage = newRefs.indexOf(oldCurrentRef!);
+    _controller._setCurrentPage(
+      currentPage < 0 ? oldCurrentPage : currentPage,
+    );
+
+    _snapshotContentStamps();
+    _commandWarmAttempts.clear();
+    _commandWarmAnchor = null;
+    _commandWarmGeneration++;
+    _bindRasterCache(prime: false);
+    _keyedPageReconciliations++;
+    _lastIncrementallyReconciledPages = const <int>{};
+    _incrementalFallbackReason = null;
+    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
+      mode: PdfPageReconciliationMode.keyedStructure,
+      elapsed: reconcileClock.elapsed,
+      pageCount: count,
+      dirtyPages: 0,
+      retainedPages: count,
+      geometryPages: 0,
+      walkedPageTree: true,
+    ));
     _schedulePreviewPrerender();
     _scheduleRasterWarm();
     setState(() {});
@@ -3926,10 +4205,11 @@ class _PdfViewerState extends State<PdfViewer>
   /// Whether [document] lays out exactly like the one on screen: same
   /// page count, same aspect ratio per page.
   bool _sameGeometryAs(PdfDocument document) {
-    if (document.pageCount != _pages.length) return false;
+    final pages = document.pages;
+    if (pages.length != _pages.length) return false;
     final vr = _controller._viewRotation;
     for (var i = 0; i < _pages.length; i++) {
-      final page = document.page(i);
+      final page = pages[i];
       final r = ((page.rotation + vr) % 360 + 360) % 360;
       final sideways = r == 90 || r == 270;
       final aspect = sideways
@@ -3970,8 +4250,8 @@ class _PdfViewerState extends State<PdfViewer>
   void _loadPages() {
     final document = _document;
     _loadedDocument = document;
-    final count = document.pageCount;
-    _pages = [for (var i = 0; i < count; i++) document.page(i)];
+    _pages = List<PdfPage>.of(document.pages, growable: true);
+    final count = _pages.length;
     _pageRefs = [for (final page in _pages) _pageReferenceKey(page)];
     _rasteredPages.clear();
     _commandWarmAttempts.clear();
@@ -7551,6 +7831,12 @@ class _PdfViewerState extends State<PdfViewer>
       // zoom transform - thin, low-contrast, and scaled or translated out
       // of view when zoomed. The viewer paints its own bar outside the
       // transform instead (_PdfScrollbar below).
+      final pageIndexByIdentity = <Object, int>{
+        for (var i = 0; i < _pages.length; i++)
+          _pageRefs[i] ?? ('page-slot', _pageEpoch, i): i,
+      };
+      Object pageIdentity(int index) =>
+          _pageRefs[index] ?? ('page-slot', _pageEpoch, index);
       final list = ExactExtentListView.builder(
         controller: _scroll,
         scrollDirection: widget.pageLayout.scrollAxis,
@@ -7574,20 +7860,29 @@ class _PdfViewerState extends State<PdfViewer>
             ? null
             : _pageMain(index) + (index == 0 ? 0 : widget.pageSpacing),
         itemCount: _pages.length,
+        findChildIndexCallback: (key) {
+          if (key is! _PdfViewerPageKey ||
+              !identical(key.namespace, _tileCacheNamespace)) {
+            return null;
+          }
+          return pageIndexByIdentity[key.pageIdentity];
+        },
         padding: _horizontal
             ? EdgeInsets.only(
                 right: widget.pageSpacing + widget.trailingPadding)
             : EdgeInsets.only(
                 bottom: widget.pageSpacing + widget.trailingPadding),
         itemBuilder: (context, index) => KeyedSubtree(
-          // Insert/remove/reorder used to update a slot's existing page State
-          // in place. Its generation guards rejected stale Futures, but native
-          // compositor resources already submitted by the old State could
-          // outlive that Dart Future and paint into a later frame. A structure
-          // epoch therefore owns the complete presentation subtree: changing
-          // it disposes the old raster/scene/tile/annotation layers and mounts
-          // a clean State for the page now occupying this slot.
-          key: ValueKey((_tileCacheNamespace, _pageEpoch, index)),
+          // Stable indirect page identity is the reconciliation key. A pure
+          // reorder can therefore move the already-rastered State with its
+          // page. Insert/remove/import full fallbacks replace the namespace,
+          // so no State can cross a structural boundary that was not verified
+          // as an identity-preserving permutation. Direct/broken page objects
+          // fall back to the slot epoch.
+          key: _PdfViewerPageKey(
+            _tileCacheNamespace,
+            pageIdentity(index),
+          ),
           child: Padding(
             padding: _horizontal
                 ? EdgeInsets.only(left: index == 0 ? 0 : widget.pageSpacing)

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -646,15 +646,76 @@ class PdfPagePreviewCache extends ChangeNotifier {
     required int width,
     required int height,
   }) {
-    final entry = _entries.take(index); // a successful lookup is an LRU use
-    if (entry == null ||
-        !identical(entry.page, page) ||
-        !entry.includesImages ||
-        entry.image.width < width ||
-        entry.image.height < height) {
-      return null;
+    return _completeImageFor(index, page, width: width, height: height);
+  }
+
+  /// Returns complete cached pixels suitable for a thumbnail.
+  ///
+  /// An exact-or-larger base/intermediate preview wins. When none exists,
+  /// [minimumScale] permits a slightly softer complete preview instead. Web
+  /// thumbnail surfaces use 0.75: a 200 px viewer preview is materially better
+  /// than replaying a dense 39k-command scene for a 256 px sidebar tile and
+  /// blocking the platform thread for hundreds of milliseconds. The image is
+  /// still page-identity checked and must include all images.
+  ui.Image? thumbnailImageFor(
+    int index,
+    PdfPage page, {
+    required int width,
+    required int height,
+    double minimumScale = 1,
+  }) {
+    final exact = _completeImageFor(
+      index,
+      page,
+      width: width,
+      height: height,
+    );
+    if (exact != null || minimumScale >= 1) return exact;
+    return _completeImageFor(
+      index,
+      page,
+      width: math.max(1, (width * minimumScale).ceil()),
+      height: math.max(1, (height * minimumScale).ceil()),
+    );
+  }
+
+  ui.Image? _completeImageFor(
+    int index,
+    PdfPage page, {
+    required int width,
+    required int height,
+  }) {
+    _IntermediatePreviewKey? bestIntermediate;
+    var bestIsBase = false;
+    var bestPixels = 1 << 62;
+
+    void consider(_PreviewEntry? entry, {_IntermediatePreviewKey? key}) {
+      if (entry == null ||
+          !identical(entry.page, page) ||
+          !entry.includesImages ||
+          entry.image.width < width ||
+          entry.image.height < height ||
+          entry.pixels >= bestPixels) {
+        return;
+      }
+      bestPixels = entry.pixels;
+      bestIntermediate = key;
+      bestIsBase = key == null;
     }
-    return entry.image.clone();
+
+    consider(_entries.peek(index));
+    for (final key in _intermediateEntries.keys) {
+      if (key.pageIndex == index) {
+        consider(_intermediateEntries.peek(key), key: key);
+      }
+    }
+
+    final entry = bestIsBase
+        ? _entries.take(index)
+        : bestIntermediate == null
+            ? null
+            : _intermediateEntries.take(bestIntermediate!);
+    return entry?.image.clone();
   }
 
   /// Returns a lease on a complete retained scene for this page and display

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -1982,6 +1982,60 @@ class PdfPagePreviewCache extends ChangeNotifier {
     if (dropped && !_disposed) notifyListeners();
   }
 
+  /// Re-keys every in-memory raster/scene tier after a pure page reorder.
+  ///
+  /// [newIndexForOld] must be a complete permutation. Page objects and pixels
+  /// stay the same; only their page slots change. Asynchronous work admitted
+  /// under an old slot is rejected by [bindPages] after this returns.
+  void reorder(List<PdfPage> pages, List<int> newIndexForOld) {
+    if (newIndexForOld.length != pages.length ||
+        newIndexForOld.toSet().length != pages.length ||
+        newIndexForOld.any((index) => index < 0 || index >= pages.length)) {
+      throw ArgumentError.value(
+        newIndexForOld,
+        'newIndexForOld',
+        'must be a permutation matching pages',
+      );
+    }
+
+    int moved(int oldIndex) => newIndexForOld[oldIndex];
+
+    _retainedScenes.remapKeys(
+      (key) => _RetainedSceneKey(moved(key.pageIndex), key.plan),
+    );
+    _entries.remapKeys(moved);
+    _intermediateEntries.remapKeys(
+      (key) => _IntermediatePreviewKey(
+        moved(key.pageIndex),
+        key.longestSide,
+      ),
+    );
+    _fullEntries.remapKeys(
+      (key) => PdfPageRasterSignature(
+        pageIndex: moved(key.pageIndex),
+        width: key.width,
+        height: key.height,
+        pageColor: key.pageColor,
+        annotations: key.annotations,
+        rotation: key.rotation,
+      ),
+    );
+    bindPages(pages);
+    for (final index in _entries.keys) {
+      _entries.peek(index)!.page = pages[index];
+    }
+    for (final key in _intermediateEntries.keys) {
+      _intermediateEntries.peek(key)!.page = pages[key.pageIndex];
+    }
+    for (final key in _fullEntries.keys) {
+      _fullEntries.peek(key)!.page = pages[key.pageIndex];
+    }
+    for (final key in _retainedScenes.keys) {
+      _retainedScenes.peek(key)!.page = pages[key.pageIndex];
+    }
+    if (!_disposed) notifyListeners();
+  }
+
   /// Drops every preview (different document, page color change...).
   void clear() {
     _entries.clear(); // disposes every retained image
@@ -2100,7 +2154,7 @@ class _RetainedSceneEntry {
     required this.estimatedBytes,
   });
 
-  final PdfPage page;
+  PdfPage page;
   final PdfRetainedScene scene;
   final ui.Picture? picture;
   final bool fromWorker;

--- a/packages/dart_pdf_editor/test/benchmark_reconciliation_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_reconciliation_test.dart
@@ -1,0 +1,96 @@
+// Reproducible page-reconciliation control-plane benchmark.
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_RECONCILIATION=1 \
+//   PDF_BENCHMARK_RECONCILIATION_PAGES=10000 \
+//     fvm flutter test test/benchmark_reconciliation_test.dart \
+//       --reporter expanded
+//
+// Measures only PdfViewer's synchronous reconciliation transaction, as
+// reported by PdfPageReconciliationDiagnostics. Document editing/saving and
+// the next frame's rendering are intentionally outside the samples.
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  testWidgets('dirty, geometry, and keyed-structure reconciliation',
+      (tester) async {
+    if (Platform.environment['PDF_BENCHMARK_RECONCILIATION'] != '1') {
+      markTestSkipped('set PDF_BENCHMARK_RECONCILIATION=1');
+      return;
+    }
+    final pageCount = int.tryParse(
+            Platform.environment['PDF_BENCHMARK_RECONCILIATION_PAGES'] ?? '') ??
+        1000;
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(pageCount));
+    addTearDown(editing.dispose);
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      home: PdfViewer(
+        editing: editing,
+        controller: controller,
+        pagePreviews: false,
+        autoRenderWorker: false,
+      ),
+    ));
+    await tester.pump();
+
+    int sample(PdfPageReconciliationMode expected) {
+      final diagnostics = controller.debugPageReconciliationDiagnostics!;
+      expect(diagnostics.mode, expected);
+      return diagnostics.elapsed.inMicroseconds;
+    }
+
+    final dirty = <int>[];
+    for (var i = 0; i < 9; i++) {
+      final page = (i * 997) % pageCount;
+      editing.addRectangle(page, const PdfRect(20, 20, 80, 80));
+      dirty.add(sample(PdfPageReconciliationMode.incremental));
+      await tester.pump();
+    }
+
+    final geometry = <int>[];
+    for (var i = 0; i < 8; i++) {
+      final page = (i * 991) % pageCount;
+      editing.rotatePages([page], 90);
+      geometry.add(sample(PdfPageReconciliationMode.incremental));
+      await tester.pump();
+    }
+
+    final reorder = <int>[];
+    for (var i = 0; i < 5; i++) {
+      editing.movePage(0, pageCount - 1);
+      reorder.add(sample(PdfPageReconciliationMode.keyedStructure));
+      await tester.pump();
+    }
+
+    ({int median, int p95, int max}) summary(List<int> values) {
+      final sorted = List<int>.of(values)..sort();
+      return (
+        median: sorted[sorted.length ~/ 2],
+        p95: sorted[((sorted.length - 1) * 0.95).round()],
+        max: sorted.last,
+      );
+    }
+
+    String report(String name, List<int> values) {
+      final result = summary(values);
+      return '$name-median-us=${result.median} '
+          '$name-p95-us=${result.p95} $name-max-us=${result.max}';
+    }
+
+    // ignore: avoid_print
+    print('RECONCILIATION_BENCH pages=$pageCount '
+        '${report('dirty', dirty)} ${report('geometry', geometry)} '
+        '${report('reorder', reorder)}');
+  });
+}

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -53,6 +53,28 @@ void main() {
       expect(cache.length, 1);
       expect(cache.keys, [1]);
     });
+
+    test('remapKeys preserves values, weight, and LRU order', () {
+      final dropped = <int>[];
+      final cache = PdfBudgetedCache<int, _Res>(
+        weigher: (resource) => resource.weight,
+        maxWeight: 100,
+        maxEntries: 3,
+        disposer: (resource) => dropped.add(resource.id),
+      );
+      cache.put(0, _Res(0, weight: 10));
+      cache.put(1, _Res(1, weight: 20));
+      cache.put(2, _Res(2, weight: 30));
+
+      cache.remapKeys((key) => [2, 0, 1][key]);
+
+      expect(cache.keys, [2, 0, 1]);
+      expect(cache.peek(2)!.id, 0);
+      expect(cache.peek(0)!.id, 1);
+      expect(cache.peek(1)!.id, 2);
+      expect(cache.weight, 60);
+      expect(dropped, isEmpty);
+    });
   });
 
   group('weight budget', () {

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -165,6 +165,23 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 300));
       expectViewport(editing, viewer, page: 3, label: 'Page 4');
     });
+
+    test('render stamps follow stable pages through reorder and undo', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(20, 20, 80, 80));
+      final changedStamp = editing.pageRenderStamp(0);
+      final cleanStamp = editing.pageRenderStamp(1);
+      expect(changedStamp, greaterThan(cleanStamp));
+
+      editing.movePage(0, 1);
+      expect(editing.pageRenderStamp(1), changedStamp);
+      expect(editing.pageRenderStamp(0), cleanStamp);
+
+      editing.undo();
+      expect(editing.pageRenderStamp(0), changedStamp);
+      expect(editing.pageRenderStamp(1), cleanStamp);
+    });
   });
 
   group('duplicatePages', () {

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -64,7 +64,8 @@ void main() {
       expect(editing.pageRenderStamp(2), after[2]);
     });
 
-    test('structural edits bump all; editor-attributed edits stay narrow', () {
+    test('pure reorder preserves stamps; editor-attributed edits stay narrow',
+        () {
       final editing = PdfEditingController(buildMultiPagePdf(3));
       addTearDown(editing.dispose);
       final before = [for (var i = 0; i < 3; i++) editing.pageRenderStamp(i)];
@@ -72,7 +73,8 @@ void main() {
       editing.movePage(0, 2);
       final moved = [for (var i = 0; i < 3; i++) editing.pageRenderStamp(i)];
       for (var i = 0; i < 3; i++) {
-        expect(moved[i], isNot(before[i]));
+        expect(moved[i], before[i],
+            reason: 'a pure permutation does not invalidate page pixels');
       }
 
       // A host edit through public apply gets its impact from PdfEditor;

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -474,6 +475,45 @@ void main() {
   });
 
   group('retained scene reuse', () {
+    testWidgets('web-size tile accepts the complete 200px viewer preview',
+        (tester) async {
+      // 2026-08-22 field trace: replaying the viewer's 39k-command retained
+      // scene for a 256px tile blocked CanvasKit for 223ms. The complete 200px
+      // preview was already on screen and is close enough for the sidebar.
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(controller.dispose);
+      controller.rotatePages([0], 90); // the field page was landscape
+      final previews = PdfPagePreviewCache();
+      addTearDown(previews.dispose);
+      final page = controller.pageAt(0);
+      await tester.runAsync(() => previews.renderPreview(0, page));
+
+      ui.Image? rendered;
+      late final int tileOps;
+      await tester.runAsync(() async {
+        PdfPerf.enabled = true;
+        addTearDown(() => PdfPerf.enabled = false);
+        PdfPerf.reset();
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 256,
+          worker: null,
+          previews: previews,
+          allowSoftPreview: true,
+        );
+        tileOps = PdfPerf.snapshot().count(PdfPerfCount.contentOps);
+      });
+
+      expect(rendered, isNotNull);
+      expect(math.max(rendered!.width, rendered!.height), 200);
+      expect(tileOps, 0,
+          reason: 'the tile claims complete cached pixels without replaying');
+      rendered!.dispose();
+    });
+
     testWidgets('a tile replays the viewer scene instead of re-interpreting',
         (tester) async {
       // #699: with no worker a 128px tile fell through to a full page

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -104,6 +104,31 @@ void main() {
     preview.dispose();
   });
 
+  testWidgets('a complete intermediate preview satisfies a thumbnail',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    await tester.runAsync(() => cache.renderPreview(
+          0,
+          page,
+          targetLongestSide: 400,
+        ));
+
+    final sufficient = cache.completeImageFor(
+      0,
+      page,
+      width: 256,
+      height: 330,
+    );
+    expect(sufficient, isNotNull,
+        reason: 'the sharpest preview tier is not limited to the 200px base');
+    final image = sufficient!;
+    expect(math.max(image.width, image.height), 400);
+    image.dispose();
+  });
+
   testWidgets('a sufficient preview bypasses first-render hold',
       (tester) async {
     final document = PdfDocument.open(buildClassicPdf());

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -75,6 +75,33 @@ void main() {
     clone.dispose();
   });
 
+  testWidgets('pure reorder moves previews to their page identities',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final page0 = document.page(0);
+    final page1 = document.page(1);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    await tester.runAsync(() async {
+      await cache.renderPreview(0, page0);
+      await cache.renderPreview(1, page1, targetLongestSide: 400);
+    });
+
+    cache.reorder([page1, page0], [1, 0]);
+
+    expect(cache.isFresh(1, page0, requireImages: true), isTrue);
+    expect(
+      cache.isFresh(
+        0,
+        page1,
+        requireImages: true,
+        targetLongestSide: 400,
+      ),
+      isTrue,
+    );
+    expect(cache.isFresh(0, page0, requireImages: true), isFalse);
+  });
+
   testWidgets('a complete preview can satisfy a smaller physical raster',
       (tester) async {
     final document = PdfDocument.open(buildClassicPdf());

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1513,15 +1513,35 @@ void main() {
       final presentationEpoch = controller.pagePresentationEpoch;
       expect(controller.debugIncrementalPageReconciliations, 0);
 
-      addTearDown(() => PdfPerf.enabled = false);
-      PdfPerf.enabled = true;
+      final logs = <String>[];
+      addTearDown(() {
+        PdfPerfLog.enabled = false;
+        PdfPerfLog.sink = null;
+      });
+      PdfPerfLog.sink = logs.add;
+      PdfPerfLog.enabled = true;
       PdfPerf.reset();
       editing.addRectangle(7, const PdfRect(100, 100, 200, 200));
       final revisionPerf = PdfPerf.snapshot();
-      PdfPerf.enabled = false;
+      PdfPerfLog.enabled = false;
       await tester.pump();
 
       expect(controller.debugIncrementalPageReconciliations, 1);
+      final diagnostics = controller.debugPageReconciliationDiagnostics!;
+      expect(diagnostics.mode, PdfPageReconciliationMode.incremental);
+      expect(diagnostics.pageCount, 12);
+      expect(diagnostics.dirtyPages, 1);
+      expect(diagnostics.retainedPages, 11);
+      expect(diagnostics.geometryPages, 0);
+      expect(diagnostics.walkedPageTree, isFalse);
+      expect(diagnostics.fallbackReason, isNull);
+      expect(
+        logs,
+        contains(predicate<String>((line) =>
+            line.contains('page-reconcile mode=incremental') &&
+            line.contains('pages=12 dirty=1 retained=11') &&
+            line.contains('walk=0'))),
+      );
       expect(
         revisionPerf.phaseCalls[PdfPerfPhase.pageTreeWalk.index],
         0,
@@ -1580,6 +1600,70 @@ void main() {
       expect(controller.pagePresentationEpoch, epoch,
           reason: 'rotation changes geometry, not the page-slot lineage');
       expect(editing.document.page(1).rotation, 90);
+    });
+
+    testWidgets('moves keyed page state across a pure reorder', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            editing: editing,
+            controller: controller,
+            pagePreviews: false,
+            autoRenderWorker: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final movedPage = controller.debugPageIdentity(0);
+      final movedState = tester.state(find.byWidgetPredicate(
+        (widget) => widget is PdfPageView && identical(widget.page, movedPage),
+      ));
+      final epoch = controller.pagePresentationEpoch;
+      final namespace = controller.debugTileCacheNamespace;
+
+      editing.movePage(0, 1);
+      await tester.pump();
+
+      expect(controller.debugKeyedPageReconciliations, 1);
+      final reorderedPage = controller.debugPageIdentity(1);
+      expect(reorderedPage, isNot(same(movedPage)),
+          reason: 'the page wrapper belongs to the current revision');
+      expect(controller.pagePresentationEpoch, epoch);
+      expect(controller.debugTileCacheNamespace, same(namespace));
+      expect(
+        tester.state(find.byWidgetPredicate(
+          (widget) =>
+              widget is PdfPageView && identical(widget.page, reorderedPage),
+        )),
+        same(movedState),
+        reason: 'the rendered State follows its stable page key',
+      );
+      final diagnostics = controller.debugPageReconciliationDiagnostics!;
+      expect(diagnostics.mode, PdfPageReconciliationMode.keyedStructure);
+      expect(diagnostics.dirtyPages, 0);
+      expect(diagnostics.retainedPages, 4);
+      expect(diagnostics.walkedPageTree, isTrue);
+
+      editing.undo();
+      await tester.pump();
+      expect(controller.debugKeyedPageReconciliations, 2);
+      final restoredPage = controller.debugPageIdentity(0);
+      expect(
+        tester.state(find.byWidgetPredicate(
+          (widget) =>
+              widget is PdfPageView && identical(widget.page, restoredPage),
+        )),
+        same(movedState),
+        reason: 'undo moves the same keyed State back to its original slot',
+      );
     });
 
     testWidgets(
@@ -1644,6 +1728,10 @@ void main() {
       expect(tester.state(find.byType(PdfPageView).first),
           isNot(same(oldPageState)),
           reason: 'a shifted page slot must not inherit native render state');
+      expect(
+        controller.debugPageReconciliationDiagnostics!.fallbackReason,
+        'page-structure-changed',
+      );
     });
 
     testWidgets('a stale standalone document never desyncs the viewer',

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -97,6 +97,13 @@ class PdfDocument {
     if (sourceLimit != null && index >= sourceLimit) {
       throw RangeError.range(index, 0, sourceLimit - 1, 'index');
     }
+    final allPages = _allPagesCache;
+    if (allPages != null) {
+      if (index >= allPages.length) {
+        throw RangeError.range(index, 0, allPages.length - 1, 'index');
+      }
+      return allPages[index];
+    }
     final cached = _pageCache[index];
     if (cached != null) return cached;
     // The fast walk trusts /Count on intermediate nodes to skip whole
@@ -129,8 +136,46 @@ class PdfDocument {
   /// /Annots and rebuilt every PdfAnnotation.
   final Map<int, PdfPage> _pageCache = {};
 
+  /// Every reachable page in document order, resolved in one page-tree walk.
+  ///
+  /// Prefer this when a caller needs the whole document. Repeated [page]
+  /// lookups are optimized for sparse random access using subtree /Count, but
+  /// on a flat tree enumerating `page(0)..page(n)` revisits an ever-longer kid
+  /// prefix and becomes quadratic. This traversal also resolves inherited
+  /// page attributes once and seeds [page]'s cache.
+  List<PdfPage> get pages {
+    _refreshPageCacheRevision();
+    final cached = _allPagesCache;
+    if (cached != null) return cached;
+    final t0 = PdfPerf.begin();
+    final out = <PdfPage>[];
+    final leaves = <CosDictionary>[];
+    _collectPages(
+      _pagesRoot,
+      const _Inherited(),
+      <CosDictionary>{},
+      out,
+      leaves,
+      limit: _sourcePageCountHint,
+    );
+    final result = List<PdfPage>.unmodifiable(out);
+    _allPagesCache = result;
+    _leafCache = leaves;
+    _leafIndexCache = {
+      for (var i = 0; i < leaves.length; i++) leaves[i]: i,
+    };
+    _pageCache
+      ..clear()
+      ..addEntries([
+        for (var i = 0; i < result.length; i++) MapEntry(i, result[i]),
+      ]);
+    PdfPerf.end(PdfPerfPhase.pageTreeWalk, t0);
+    return result;
+  }
+
   List<CosDictionary>? _leafCache;
   Map<CosDictionary, int>? _leafIndexCache;
+  List<PdfPage>? _allPagesCache;
   int _pageCacheRevision;
 
   /// Invalidates a wrapper's page-tree caches when another wrapper sharing
@@ -145,6 +190,7 @@ class PdfDocument {
     if (_pageCacheRevision == revision) return;
     _leafCache = null;
     _leafIndexCache = null;
+    _allPagesCache = null;
     _pageCache.clear();
     _pageCacheRevision = revision;
   }
@@ -174,6 +220,7 @@ class PdfDocument {
   void invalidatePageCache() {
     _leafCache = null;
     _leafIndexCache = null;
+    _allPagesCache = null;
     _pageCache.clear();
     _pageCacheRevision = cos.revision;
   }
@@ -231,6 +278,51 @@ class PdfDocument {
       final child = cos.resolve(kid);
       if (child is CosDictionary) _collectLeaves(child, out, visited);
     }
+  }
+
+  bool _collectPages(
+    CosDictionary node,
+    _Inherited inherited,
+    Set<CosDictionary> visited,
+    List<PdfPage> out,
+    List<CosDictionary> leaves, {
+    int? limit,
+  }) {
+    if (limit != null && out.length >= limit) return true;
+    if (!visited.add(node)) return false;
+    if (_isLeaf(node)) {
+      leaves.add(node);
+      final existing = _pageCache[out.length];
+      out.add(existing != null && identical(existing.dict, node)
+          ? existing
+          : PdfPage(
+              document: this,
+              dict: node,
+              inheritedResources: inherited.resources,
+              inheritedMediaBox: inherited.mediaBox,
+              inheritedCropBox: inherited.cropBox,
+              inheritedRotate: inherited.rotate,
+            ));
+      return limit != null && out.length >= limit;
+    }
+    final merged = inherited.mergedWith(node, cos);
+    final kids = cos.resolve(node['Kids']);
+    if (kids is! CosArray) return false;
+    for (final kid in kids.items) {
+      final child = cos.resolve(kid);
+      if (child is CosDictionary &&
+          _collectPages(
+            child,
+            merged,
+            visited,
+            out,
+            leaves,
+            limit: limit,
+          )) {
+        return true;
+      }
+    }
+    return false;
   }
 
   bool _isLeaf(CosDictionary node) =>

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -68,6 +68,7 @@ class PdfEditImpact {
     required this.contentPages,
     required this.annotationPages,
     required this.pageStructureChanged,
+    required this.pageOrderOnly,
     required this.destructive,
   });
 
@@ -77,6 +78,7 @@ class PdfEditImpact {
     contentPages: <int>{},
     annotationPages: <int>{},
     pageStructureChanged: false,
+    pageOrderOnly: false,
     destructive: false,
   );
 
@@ -86,6 +88,7 @@ class PdfEditImpact {
     contentPages: null,
     annotationPages: null,
     pageStructureChanged: false,
+    pageOrderOnly: false,
     destructive: false,
   );
 
@@ -107,6 +110,7 @@ class PdfEditImpact {
       contentPages: content,
       annotationPages: annotations,
       pageStructureChanged: false,
+      pageOrderOnly: false,
       destructive: false,
     );
   }
@@ -117,6 +121,7 @@ class PdfEditImpact {
     required Iterable<int>? contentPages,
     required Iterable<int>? annotationPages,
     bool pageStructureChanged = false,
+    bool pageOrderOnly = false,
     bool destructive = false,
   }) =>
       PdfEditImpact._(
@@ -128,6 +133,7 @@ class PdfEditImpact {
             ? null
             : Set<int>.unmodifiable(annotationPages),
         pageStructureChanged: pageStructureChanged,
+        pageOrderOnly: pageOrderOnly,
         destructive: destructive,
       );
 
@@ -143,6 +149,14 @@ class PdfEditImpact {
   /// Whether page indices/geometry may have shifted across the document.
   final bool pageStructureChanged;
 
+  /// Whether the structural change only permutes the existing page leaves.
+  ///
+  /// No page was inserted, removed, or imported by the structural portion of
+  /// the edit. Hosts may reconcile presentation state by stable indirect
+  /// identity after verifying the new tree and that the page impact lanes are
+  /// empty (a transaction may still combine a reorder with another mutation).
+  final bool pageOrderOnly;
+
   /// Whether existing page content was irreversibly removed.
   final bool destructive;
 }
@@ -153,6 +167,7 @@ class _PdfEditImpactBuilder {
   Set<int>? contentPages = <int>{};
   Set<int>? annotationPages = <int>{};
   bool pageStructureChanged = false;
+  bool pageOrderOnly = false;
   bool destructive = false;
 
   Set<int>? _merge(Set<int>? current, Iterable<int>? next) {
@@ -166,13 +181,18 @@ class _PdfEditImpactBuilder {
     Iterable<int>? content = const <int>[],
     Iterable<int>? annotations = const <int>[],
     bool structure = false,
+    bool orderOnly = false,
     bool removesContent = false,
   }) {
     known = true;
     visualPages = _merge(visualPages, visual);
     contentPages = _merge(contentPages, content);
     annotationPages = _merge(annotationPages, annotations);
-    pageStructureChanged |= structure;
+    if (structure) {
+      pageOrderOnly =
+          pageStructureChanged ? pageOrderOnly && orderOnly : orderOnly;
+      pageStructureChanged = true;
+    }
     destructive |= removesContent;
   }
 
@@ -188,6 +208,7 @@ class _PdfEditImpactBuilder {
           ? null
           : Set<int>.unmodifiable(annotationPages!),
       pageStructureChanged: pageStructureChanged,
+      pageOrderOnly: pageOrderOnly,
       destructive: destructive,
     );
   }
@@ -239,12 +260,14 @@ class PdfEditor {
   void _markContent(Iterable<int> pages) =>
       _impact.add(visual: pages, content: pages);
 
-  void _markStructure() => _impact.add(
-        visual: null,
-        content: null,
-        annotations: null,
-        structure: true,
-      );
+  void _markStructure({bool orderOnly = false}) => orderOnly
+      ? _impact.add(structure: true, orderOnly: true)
+      : _impact.add(
+          visual: null,
+          content: null,
+          annotations: null,
+          structure: true,
+        );
 
   void _markDestructive([Iterable<int>? pages]) => _impact.add(
         visual: pages,
@@ -330,12 +353,10 @@ class PdfEditor {
   /// are returned unchanged and [PdfCompressionResult.compacted] is false.
   /// Throws if the document is encrypted (decrypt it first).
   PdfCompressionResult compress({int deflateLevel = 9}) {
-    final current =
-        _updater.hasChanges ? _updater.save() : document.cos.bytes;
+    final current = _updater.hasChanges ? _updater.save() : document.cos.bytes;
     final snapshot =
         _updater.hasChanges ? PdfDocument.open(current).cos : document.cos;
-    final result =
-        CosCompactor(snapshot, deflateLevel: deflateLevel).run();
+    final result = CosCompactor(snapshot, deflateLevel: deflateLevel).run();
     final smaller = result.bytes.length < current.length;
     return PdfCompressionResult(
       bytes: smaller ? result.bytes : Uint8List.fromList(current),

--- a/packages/pdf_document/lib/src/page_editor.dart
+++ b/packages/pdf_document/lib/src/page_editor.dart
@@ -32,7 +32,10 @@ extension PdfPageOperations on PdfEditor {
       );
     }
     final leaves = _materializedLeaves();
-    _rebuildPageTree([for (final i in order) leaves[i]]);
+    _rebuildPageTree(
+      [for (final i in order) leaves[i]],
+      orderOnly: true,
+    );
   }
 
   /// Removes the page at [index].
@@ -177,7 +180,7 @@ extension PdfPageOperations on PdfEditor {
   }
 
   /// Rewrites the root /Pages node as a flat tree over [leaves].
-  void _rebuildPageTree(List<_Leaf> leaves) {
+  void _rebuildPageTree(List<_Leaf> leaves, {bool orderOnly = false}) {
     final cos = document.cos;
     final rootRef = _pagesRootRef();
     final root = cos.resolve(rootRef) as CosDictionary;
@@ -191,7 +194,7 @@ extension PdfPageOperations on PdfEditor {
     root['Count'] = CosInteger(leaves.length);
     _updater.markChanged(root);
     document.invalidatePageCache();
-    _markStructure();
+    _markStructure(orderOnly: orderOnly);
   }
 
   CosReference _pagesRootRef() {

--- a/packages/pdf_document/test/edit_impact_test.dart
+++ b/packages/pdf_document/test/edit_impact_test.dart
@@ -47,14 +47,37 @@ void main() {
       expect(editor.impact.annotationPages, {0, 2});
     });
 
-    test('page-tree edits report document-wide structural impact', () {
+    test('page reorder reports identity-preserving structural impact', () {
       final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
         ..movePage(0, 2);
+
+      expect(editor.impact.visualPages, isEmpty);
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, isEmpty);
+      expect(editor.impact.pageStructureChanged, isTrue);
+      expect(editor.impact.pageOrderOnly, isTrue);
+    });
+
+    test('page insertion keeps conservative document-wide impact', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
+        ..insertBlankPage(at: 1);
 
       expect(editor.impact.visualPages, isNull);
       expect(editor.impact.contentPages, isNull);
       expect(editor.impact.annotationPages, isNull);
       expect(editor.impact.pageStructureChanged, isTrue);
+      expect(editor.impact.pageOrderOnly, isFalse);
+    });
+
+    test('a reorder combined with page editing retains the dirty lane', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
+        ..movePage(0, 2)
+        ..addSquare(0, const PdfRect(20, 20, 80, 80));
+
+      expect(editor.impact.pageStructureChanged, isTrue);
+      expect(editor.impact.pageOrderOnly, isTrue);
+      expect(editor.impact.visualPages, {0});
+      expect(editor.impact.annotationPages, {0});
     });
 
     test('form filling reports widget repaint without content invalidation',

--- a/packages/pdf_document/test/page_cache_test.dart
+++ b/packages/pdf_document/test/page_cache_test.dart
@@ -13,6 +13,19 @@ void main() {
     expect(identical(doc.page(0), doc.page(1)), isFalse);
   });
 
+  test('pages bulk-loads once and seeds indexed lookup', () {
+    final doc = PdfDocument.open(buildNestedPageTreePdf());
+    final previouslyLoaded = doc.page(1);
+    final pages = doc.pages;
+
+    expect(pages, hasLength(3));
+    expect(doc.pages, same(pages));
+    expect(doc.page(1), same(pages[1]));
+    expect(pages[1], same(previouslyLoaded));
+    expect(pages[0].rotation, 90);
+    expect(pages[0].mediaBox, const PdfRect(0, 0, 400, 400));
+  });
+
   test('annotations parse once and are reused', () {
     final doc = PdfDocument.open(buildMultiPagePdf(1));
     final editor = PdfEditor(doc);
@@ -85,5 +98,37 @@ void main() {
     page.dict.entries.remove('MediaBox');
     expect(page.mediaBox.width, greaterThan(0));
     expect(page.mediaBox.height, greaterThan(0));
+  });
+
+  test('incremental re-wrap preserves inherited page-tree values', () {
+    final doc = PdfDocument.open(buildNestedPageTreePdf());
+    final page = doc.page(0);
+    final inheritedBox = page.mediaBox;
+    final inheritedRotation = page.rotation;
+    final inheritedResources = page.resources;
+    final ref = doc.cos.referenceTo(page.dict)!;
+    final editor = PdfEditor(doc)..addSquare(0, const PdfRect(20, 20, 80, 80));
+    final newer = doc.withIncrementalUpdate(editor.save());
+    final currentDict = newer.cos.resolve(ref) as CosDictionary;
+
+    final revised = page.forIncrementalRevision(newer, currentDict);
+
+    expect(revised.mediaBox, inheritedBox);
+    expect(revised.rotation, inheritedRotation);
+    expect(revised.resources, same(inheritedResources));
+    expect(revised.annotations, hasLength(1));
+  });
+
+  test('incremental re-wrap rejects an unrelated COS graph', () {
+    final first = PdfDocument.open(buildMultiPagePdf(1));
+    final second = PdfDocument.open(buildMultiPagePdf(1));
+
+    expect(
+      () => first.page(0).forIncrementalRevision(
+            second,
+            second.page(0).dict,
+          ),
+      throwsArgumentError,
+    );
   });
 }

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -1,0 +1,318 @@
+import 'dart:convert';
+import 'dart:io';
+
+final _ansiEscape = RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]');
+final _perfLine = RegExp(r'\[perf\s+(\d+)\]\s+(.+)$');
+final _field = RegExp(r'([A-Za-z][A-Za-z0-9_-]*)=([^\s]+)');
+
+void main(List<String> arguments) {
+  if (arguments.isEmpty || arguments.contains('--help')) {
+    stdout.writeln(
+      'Usage: dart tool/patrol_perf_summary.dart <patrol-log> '
+      '--output <directory> [--markdown <file>]',
+    );
+    exit(arguments.contains('--help') ? 0 : 64);
+  }
+
+  final input = arguments.first;
+  String? output;
+  String? markdownOutput;
+  for (var i = 1; i < arguments.length; i++) {
+    switch (arguments[i]) {
+      case '--output':
+        output = _nextArgument(arguments, ++i, '--output');
+      case '--markdown':
+        markdownOutput = _nextArgument(arguments, ++i, '--markdown');
+      default:
+        stderr.writeln('Unknown argument: ${arguments[i]}');
+        exit(64);
+    }
+  }
+  if (output == null) {
+    stderr.writeln('--output is required');
+    exit(64);
+  }
+
+  final source = File(input);
+  if (!source.existsSync()) {
+    stderr.writeln('Patrol log does not exist: $input');
+    exit(66);
+  }
+
+  final trace = PatrolPerfTrace.parse(source.readAsLinesSync());
+  final directory = Directory(output)..createSync(recursive: true);
+  File('${directory.path}/patrol-perf.log').writeAsStringSync(
+    trace.lines.isEmpty ? '' : '${trace.lines.join('\n')}\n',
+  );
+  File('${directory.path}/patrol-perf.json').writeAsStringSync(
+    '${const JsonEncoder.withIndent('  ').convert(trace.toJson())}\n',
+  );
+  final markdown = trace.toMarkdown();
+  File('${directory.path}/patrol-perf.md').writeAsStringSync(markdown);
+  if (markdownOutput != null) {
+    File(markdownOutput).writeAsStringSync(markdown, mode: FileMode.append);
+  }
+
+  stdout.writeln(
+    'Collected ${trace.lines.length} Patrol perf events in ${directory.path}',
+  );
+}
+
+String _nextArgument(List<String> arguments, int index, String option) {
+  if (index >= arguments.length) {
+    stderr.writeln('$option requires a value');
+    exit(64);
+  }
+  return arguments[index];
+}
+
+class PatrolPerfTrace {
+  PatrolPerfTrace._({
+    required this.lines,
+    required this.timestampsMs,
+    required this.buildTag,
+    required this.eventCounts,
+    required this.jankBuildMs,
+    required this.jankRasterMs,
+    required this.jankTotalMs,
+    required this.reconcileElapsedMs,
+    required this.reconcileModes,
+    required this.reconcileFallbackReasons,
+    required this.thumbnailPaths,
+    required this.pageRasterOutcomes,
+    required this.rasterElapsedMs,
+  });
+
+  factory PatrolPerfTrace.parse(Iterable<String> sourceLines) {
+    final lines = <String>[];
+    final timestamps = <int>[];
+    String? buildTag;
+    final eventCounts = <String, int>{};
+    final jankBuild = <double>[];
+    final jankRaster = <double>[];
+    final jankTotal = <double>[];
+    final reconcileElapsed = <double>[];
+    final reconcileModes = <String, int>{};
+    final fallbackReasons = <String, int>{};
+    final thumbnailPaths = <String, int>{};
+    final pageRasterOutcomes = <String, int>{};
+    final rasterElapsed = <double>[];
+
+    for (final sourceLine in sourceLines) {
+      final clean = sourceLine.replaceAll(_ansiEscape, '');
+      final match = _perfLine.firstMatch(clean);
+      if (match == null) continue;
+      final timestamp = int.parse(match.group(1)!);
+      final message = match.group(2)!.trim();
+      final normalized = '[perf $timestamp] $message';
+      lines.add(normalized);
+      timestamps.add(timestamp);
+
+      final event = message.split(RegExp(r'\s+')).first;
+      _increment(eventCounts, event);
+      final fields = <String, String>{
+        for (final field in _field.allMatches(message))
+          field.group(1)!: field.group(2)!,
+      };
+
+      if (event == 'build') {
+        buildTag = message.substring('build'.length).trim();
+      } else if (event == 'JANK') {
+        _addMilliseconds(jankBuild, fields['build']);
+        _addMilliseconds(jankRaster, fields['raster']);
+        _addMilliseconds(jankTotal, fields['total']);
+      } else if (event == 'page-reconcile') {
+        _increment(reconcileModes, fields['mode'] ?? 'unknown');
+        _addMilliseconds(reconcileElapsed, fields['elapsed']);
+        final reason = fields['reason'];
+        if (reason != null) _increment(fallbackReasons, reason);
+      } else if (event == 'thumbnail') {
+        if (fields.containsKey('page') && fields.containsKey('px')) {
+          _increment(thumbnailPaths, _thumbnailPath(message));
+        }
+      } else if (event == 'page-raster') {
+        _increment(pageRasterOutcomes, _secondWord(message));
+      } else if (event == 'raster') {
+        _addMilliseconds(rasterElapsed, fields['ms']);
+      }
+    }
+
+    return PatrolPerfTrace._(
+      lines: lines,
+      timestampsMs: timestamps,
+      buildTag: buildTag,
+      eventCounts: eventCounts,
+      jankBuildMs: jankBuild,
+      jankRasterMs: jankRaster,
+      jankTotalMs: jankTotal,
+      reconcileElapsedMs: reconcileElapsed,
+      reconcileModes: reconcileModes,
+      reconcileFallbackReasons: fallbackReasons,
+      thumbnailPaths: thumbnailPaths,
+      pageRasterOutcomes: pageRasterOutcomes,
+      rasterElapsedMs: rasterElapsed,
+    );
+  }
+
+  final List<String> lines;
+  final List<int> timestampsMs;
+  final String? buildTag;
+  final Map<String, int> eventCounts;
+  final List<double> jankBuildMs;
+  final List<double> jankRasterMs;
+  final List<double> jankTotalMs;
+  final List<double> reconcileElapsedMs;
+  final Map<String, int> reconcileModes;
+  final Map<String, int> reconcileFallbackReasons;
+  final Map<String, int> thumbnailPaths;
+  final Map<String, int> pageRasterOutcomes;
+  final List<double> rasterElapsedMs;
+
+  int get durationMs =>
+      timestampsMs.length < 2 ? 0 : timestampsMs.last - timestampsMs.first;
+
+  Map<String, Object?> toJson() => {
+        'schema': 1,
+        'build': buildTag,
+        'events': lines.length,
+        'durationMs': durationMs,
+        'eventCounts': _sortedMap(eventCounts),
+        'jank': {
+          'count': jankTotalMs.length,
+          'buildMs': _distribution(jankBuildMs),
+          'rasterMs': _distribution(jankRasterMs),
+          'totalMs': _distribution(jankTotalMs),
+        },
+        'reconciliation': {
+          'count': reconcileElapsedMs.length,
+          'modes': _sortedMap(reconcileModes),
+          'fallbackReasons': _sortedMap(reconcileFallbackReasons),
+          'elapsedMs': _distribution(reconcileElapsedMs),
+        },
+        'thumbnails': {
+          'events': eventCounts['thumbnail'] ?? 0,
+          'renders': _sum(thumbnailPaths.values),
+          'paths': _sortedMap(thumbnailPaths),
+        },
+        'pageRasters': {
+          'events': eventCounts['page-raster'] ?? 0,
+          'outcomes': _sortedMap(pageRasterOutcomes),
+        },
+        'rasters': {
+          'count': eventCounts['raster'] ?? 0,
+          'elapsedMs': _distribution(rasterElapsedMs),
+        },
+      };
+
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('## Patrol web performance')
+      ..writeln()
+      ..writeln(
+        lines.isEmpty
+            ? 'No `PdfPerfLog` events were captured. The Patrol result '
+                'artifact still contains the empty trace for diagnosis.'
+            : 'Observational trace from the real Patrol browser journey. '
+                'Use it for PR comparisons; wall-clock values are not a CI gate.',
+      )
+      ..writeln()
+      ..writeln('| Signal | Result |')
+      ..writeln('| --- | ---: |')
+      ..writeln('| Build | ${_code(buildTag ?? 'unstamped')} |')
+      ..writeln('| Perf events | ${lines.length} |')
+      ..writeln('| Trace span | ${_formatMs(durationMs.toDouble())} |')
+      ..writeln('| Jank frames | ${jankTotalMs.length} |')
+      ..writeln(
+        '| Jank total p50 / p95 / max | ${_distributionText(jankTotalMs)} |',
+      )
+      ..writeln(
+        '| Reconcile p50 / p95 / max | '
+        '${_distributionText(reconcileElapsedMs)} |',
+      )
+      ..writeln('| Reconcile modes | ${_mapText(reconcileModes)} |')
+      ..writeln(
+          '| Reconcile fallbacks | ${_mapText(reconcileFallbackReasons)} |')
+      ..writeln('| Thumbnail paths | ${_mapText(thumbnailPaths)} |')
+      ..writeln('| Page-raster outcomes | ${_mapText(pageRasterOutcomes)} |')
+      ..writeln('| Raster p50 / p95 / max | '
+          '${_distributionText(rasterElapsedMs)} |')
+      ..writeln()
+      ..writeln(
+        'Artifacts: `patrol-perf.log` (normalized raw trace), '
+        '`patrol-perf.json` (machine comparison), and this Markdown summary.',
+      )
+      ..writeln();
+    return buffer.toString();
+  }
+}
+
+String _thumbnailPath(String message) {
+  if (message.contains('disk-hit')) return 'disk-hit';
+  if (message.contains('preview-hit')) return 'preview-hit';
+  if (message.contains('retained')) return 'retained';
+  if (message.contains('defer')) return 'deferred';
+  if (message.contains('skip')) return 'skipped';
+  if (message.contains('worker')) return 'worker';
+  if (message.contains('local')) return 'local';
+  return 'other';
+}
+
+String _secondWord(String message) {
+  final words = message.split(RegExp(r'\s+'));
+  if (words.length < 2) return 'unknown';
+  final separator = words[1].indexOf('=');
+  return separator < 0 ? words[1] : words[1].substring(0, separator);
+}
+
+void _increment(Map<String, int> values, String key) {
+  values[key] = (values[key] ?? 0) + 1;
+}
+
+void _addMilliseconds(List<double> values, String? raw) {
+  if (raw == null) return;
+  final parsed = double.tryParse(raw.replaceFirst(RegExp(r'ms$'), ''));
+  if (parsed != null) values.add(parsed);
+}
+
+Map<String, int> _sortedMap(Map<String, int> values) => {
+      for (final key in values.keys.toList()..sort()) key: values[key]!,
+    };
+
+int _sum(Iterable<int> values) =>
+    values.fold(0, (total, value) => total + value);
+
+Map<String, double>? _distribution(List<double> values) {
+  if (values.isEmpty) return null;
+  final sorted = List<double>.of(values)..sort();
+  return {
+    'p50': _percentile(sorted, 0.50),
+    'p95': _percentile(sorted, 0.95),
+    'max': sorted.last,
+  };
+}
+
+double _percentile(List<double> sorted, double fraction) {
+  final index = ((sorted.length - 1) * fraction).round();
+  return sorted[index];
+}
+
+String _distributionText(List<double> values) {
+  final distribution = _distribution(values);
+  if (distribution == null) return 'n/a';
+  return '${_formatMs(distribution['p50']!)} / '
+      '${_formatMs(distribution['p95']!)} / '
+      '${_formatMs(distribution['max']!)}';
+}
+
+String _mapText(Map<String, int> values) {
+  if (values.isEmpty) return 'none';
+  final entries = values.entries.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
+  return entries
+      .map((entry) => '${_code(entry.key)} ${entry.value}')
+      .join(', ');
+}
+
+String _formatMs(double value) => '${value.toStringAsFixed(1)} ms';
+
+String _code(String value) => '`$value`';


### PR DESCRIPTION
## Summary

- admit normal high-DPI page rasters on web and require confirmation before a transient heap spike collapses page caches
- reuse complete viewer previews for thumbnail requests, avoiding retained-scene replay on the UI thread
- add reconciliation diagnostics and perf-log events with explicit fallback reasons
- preserve keyed page state and in-memory preview/full-raster/scene caches across verified pure page reorders
- bulk-enumerate PDF pages in one tree walk instead of repeated page(i) traversal
- collect attributed Patrol web perf traces on PRs and main as raw log, schema-v1 JSON, and a GitHub Actions summary

## Measurements

The reproducible benchmark is `test/benchmark_reconciliation_test.dart`.

- 1,000 pages: dirty 0.14 ms median, geometry 0.77 ms, reorder 7.9 ms
- before the bulk walk, the same 1,000-page reorder was about 95 ms median
- 10,000 pages: dirty 0.30 ms median, geometry 1.81 ms, reorder 32.6 ms

The common dirty and geometry paths do not justify a geometry index or cooperative scheduler. The remaining structural cost is a rare verified permutation and is small beside rewriting a 10,000-page PDF tree.

The first attributed PR Patrol artifact (`commit=42cc4e05…`) captured 11 reconciliations: 10 incremental at 0.7 ms median / 1.9 ms p95, plus one expected full reload for a different COS document.

## Validation

- root `fvm dart analyze`
- full `pdf_document` suite: 843 passed, 1 expected skip
- affected Flutter suites: 215 passed
- adaptive memory tests: 15 passed
- 1,000-page and 10,000-page reconciliation benchmarks
- full example suite: 54 passed
- Patrol web collection/upload verified from the PR artifact: 965 perf events, exact commit attribution, raw/JSON/Markdown outputs

## Follow-up investigations

1. Retain several main and PR Patrol artifacts to establish same-runner distributions before adding any regression threshold.
2. Add a dedicated heavy/CAD Patrol journey so page-raster admission and thumbnail reuse are exercised by representative 16+ MB rasters, not only the compact demo document.
3. Compare JSON reconciliation modes and p95 timings automatically against a recent main artifact; keep this advisory until variance is understood.
4. Revisit geometry indexing or cooperative structural work only if real traces show frequent large reorder/full-reload cost. Current common dirty-page work is sub-millisecond.

Follows the incremental dirty-page reconciler merged in #720.
