### PR TITLE
Collect Patrol performance baselines for PRs

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -23,7 +23,7 @@ jobs:
     # Keep this standalone lane for main/deploy pushes and manual runs.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
@@ -56,6 +56,24 @@ jobs:
             --web-video retain-on-failure \
             --verbose \
             2>&1 | tee "$RUNNER_TEMP/patrol-web.log"
+      - name: Run Patrol performance scenario
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        shell: bash
+        run: |
+          set -o pipefail
+          patrol test \
+            --device chrome \
+            --target patrol_test/perf_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ github.sha }} \
+            --show-flutter-logs \
+            --web-headless \
+            --web-locale en-US \
+            --web-workers 1 \
+            --web-viewport '{"width":2600,"height":2600}' \
+            --web-video retain-on-failure \
+            --verbose \
+            2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
       - name: Collect Patrol performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -9,6 +9,7 @@ on:
       - packages/pdf_document/**
       - packages/pdf_graphics/**
       - packages/dart_pdf_editor/**
+      - tool/patrol_perf_summary.dart
 
 concurrency:
   group: demo-web-preview-${{ github.event.pull_request.number }}
@@ -23,6 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
 
     steps:
@@ -88,14 +90,73 @@ jobs:
             --verbose \
             2>&1 | tee "$RUNNER_TEMP/patrol-web.log"
 
+      - name: Run Patrol performance scenario
+        id: patrol-perf
+        working-directory: packages/dart_pdf_editor/example
+        shell: bash
+        run: |
+          set -o pipefail
+          patrol test \
+            --device chrome \
+            --target patrol_test/perf_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ github.event.pull_request.head.sha }} \
+            --show-flutter-logs \
+            --web-headless \
+            --web-locale en-US \
+            --web-workers 1 \
+            --web-viewport '{"width":2600,"height":2600}' \
+            --web-video retain-on-failure \
+            --verbose \
+            2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
+
+      - name: Download latest main Patrol web baseline
+        id: patrol-baseline
+        if: always()
+        working-directory: packages/dart_pdf_editor/example
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t baseline_runs < <(gh run list \
+            --workflow patrol-e2e.yml \
+            --branch main \
+            --event push \
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId')
+          for baseline_run in "${baseline_runs[@]}"; do
+            destination="$RUNNER_TEMP/patrol-baseline/$baseline_run"
+            if gh run download "$baseline_run" \
+              --name patrol-web-results \
+              --dir "$destination"; then
+              json="$destination/test-results/perf/patrol-perf.json"
+              if [[ -f "$json" ]]; then
+                echo "json=$json" >> "$GITHUB_OUTPUT"
+                echo "Using Patrol web baseline from run $baseline_run"
+                exit 0
+              fi
+            fi
+          done
+          echo "::notice::No usable main Patrol web artifact is available yet"
+
       - name: Collect Patrol performance trace
         if: always()
         working-directory: packages/dart_pdf_editor/example
-        run: >-
-          dart ../../../tool/patrol_perf_summary.dart
-          "$RUNNER_TEMP/patrol-web.log"
-          --output test-results/perf
-          --markdown "$GITHUB_STEP_SUMMARY"
+        shell: bash
+        run: |
+          set -euo pipefail
+          arguments=(
+            "$RUNNER_TEMP/patrol-web.log"
+            --output test-results/perf
+            --markdown "$GITHUB_STEP_SUMMARY"
+          )
+          baseline="${{ steps.patrol-baseline.outputs.json }}"
+          if [[ -f "$baseline" ]]; then
+            arguments+=(--baseline "$baseline")
+          fi
+          dart ../../../tool/patrol_perf_summary.dart "${arguments[@]}"
 
       - name: Upload Patrol web results
         if: always()

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -280,16 +280,16 @@ void main() {
       expect(field('name').value, 'Grace Hopper');
 
       expect(field('newsletter').isChecked, isTrue);
-      await demo.tapFormField('newsletter');
-      await demo.waitFor(
+      await demo.tapFormFieldUntil(
+        'newsletter',
         () => !field('newsletter').isChecked,
         reason: 'the checkbox revision should finish before validation',
       );
       expect(field('newsletter').isChecked, isFalse);
 
       expect(field('color').value, 'Blue');
-      await demo.tapFormField('color');
-      await demo.waitFor(
+      await demo.tapFormFieldUntil(
+        'color',
         () => field('color').value == 'Red',
         reason: 'the radio revision should finish before validation',
       );
@@ -417,6 +417,29 @@ class _DemoHarness {
     await waitForFinder(target);
     await tester.tap(target);
     await $.pump(const Duration(milliseconds: 400));
+  }
+
+  /// Taps a button-like form widget, retrying one physical tap when a slow
+  /// Android emulator loses the first gesture during a page/raster handoff.
+  ///
+  /// This does not fall back to the controller API: both attempts still go
+  /// through the live overlay, so the journey continues to validate the real
+  /// reader interaction path. Text and choice fields use [tapFormField]
+  /// directly because a successful first tap opens stateful chrome.
+  Future<void> tapFormFieldUntil(
+    String name,
+    bool Function() changed, {
+    required String reason,
+    int widgetIndex = 0,
+  }) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      await tapFormField(name, widgetIndex: widgetIndex);
+      for (var i = 0; i < 20 && !changed(); i++) {
+        await $.pump(const Duration(milliseconds: 100));
+      }
+      if (changed()) return;
+    }
+    expect(changed(), isTrue, reason: reason);
   }
 
   Future<void> goToPage(int pageNumber) async {

--- a/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
@@ -1,0 +1,327 @@
+// Patrol targets live outside Flutter's conventional test/ directory, but
+// this is still test code and deliberately exercises the diagnostic seams.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
+const _mb = 1024 * 1024;
+
+void main() {
+  if (_buildCommit.isNotEmpty) {
+    PdfPerfLog.buildTag = 'commit=$_buildCommit';
+  }
+
+  patrolTest(
+      'retains capped rasters, reuses previews, and keys pure page reorders',
+      ($) async {
+    // This target is deliberately run only by the web lane with a 2600px
+    // viewport. At that width a letter page reaches the whole-page pixel cap,
+    // producing the ~16.01 MiB RGBA raster that exposed the admission-floor
+    // bug. A normal phone-sized native viewport would not exercise that seam.
+    expect($.isWeb, isTrue);
+
+    final preferences = PdfEditingPreferences();
+    await preferences.ready;
+    preferences
+      ..showThumbnailSidebar = false
+      ..showBookmarkSidebar = false
+      ..showAnnotationSidebar = false
+      ..showPropertiesPanel = false
+      ..showSearchResultsPanel = false
+      ..showThumbnailView = false
+      ..showReflowView = false;
+    final editing = PdfEditingController(
+      _buildPerfDocument(),
+      preferences: preferences,
+    );
+    final viewer = PdfViewerController();
+    PdfThumbnailSidebar.debugRasterizations = 0;
+
+    PdfPerfLog.log(
+      'scenario name=heavy-document phase=start pages=${editing.document.pageCount}',
+    );
+    try {
+      await $.pumpWidget(MaterialApp(
+        home: PdfEditorView(
+          controller: editing,
+          viewerController: viewer,
+          initialFit: PdfViewerFit.width,
+          features: const PdfEditorFeatures(
+            headerBar: false,
+            search: false,
+            searchResultsPanel: false,
+            pageNumber: false,
+            author: false,
+            viewOptions: false,
+            reflowView: false,
+            pageColorEditable: false,
+            bookmarks: false,
+            annotationSidebar: false,
+            propertiesPanel: false,
+            toolbar: false,
+          ),
+          // Mirrors the app's admission policy while idle warming is active.
+          // The entry floor intentionally sits above the renderer's capped
+          // image after independent edge rounding.
+          pageRasterCachePolicy: const PdfPageRasterCachePolicy(
+            maxBytes: 64 * _mb,
+            maxEntryBytes: 24 * _mb,
+          ),
+          pageRasterWarmPolicy: const PdfPageRasterWarmPolicy.nearby(
+            window: 3,
+            // The test invokes the pass explicitly after foreground work is
+            // quiet; a long automatic delay removes timer races from CI.
+            idleDelay: Duration(hours: 1),
+          ),
+        ),
+      ));
+
+      await _waitFor(
+        $,
+        () => viewer.pageCount == 6 && viewer.isPageRasterReady(0),
+        reason: 'the capped first-page raster should finish',
+      );
+      await _waitFor(
+        $,
+        () => !viewer.isPageRenderBusy,
+        reason: 'foreground rendering should settle before idle warming',
+      );
+      await _waitFor(
+        $,
+        () => (viewer.pageRasterWarmStats?.entries ?? 0) > 0,
+        reason: 'the completed display raster should enter the exact cache',
+      );
+      await $.pump(const Duration(milliseconds: 350));
+
+      var stats = viewer.pageRasterWarmStats!;
+      expect(
+        stats.retainedBytes ~/ stats.entries,
+        greaterThan(16 * _mb),
+        reason: 'each capped fit-width raster should cross the historical '
+            '16 MiB admission boundary',
+      );
+
+      // Web intentionally avoids a second readback of the just-painted page.
+      // Wait for the idle offscreen prerender to seed the shared low-res tier
+      // that the thumbnail panel is expected to consume.
+      int? previewPage;
+      await _waitFor(
+        $,
+        () {
+          final cache = viewer.pagePreviewCache;
+          if (cache == null) return false;
+          for (var page = 1; page < editing.document.pageCount; page++) {
+            if (cache.isFresh(
+              page,
+              editing.pageAt(page),
+              requireImages: true,
+            )) {
+              previewPage = page;
+              return true;
+            }
+          }
+          return false;
+        },
+        reason: 'idle prerender should seed an offscreen web preview',
+      );
+
+      final warm = viewer.debugWarmFullRasters();
+      for (var i = 0; i < 80 && viewer.debugRasterWarming; i++) {
+        await $.pump(const Duration(milliseconds: 100));
+      }
+      await warm.timeout(const Duration(seconds: 30));
+      stats = viewer.pageRasterWarmStats!;
+      expect(stats.attempts, greaterThan(0));
+      expect(stats.completions, greaterThan(0));
+      expect(stats.rejected, 0,
+          reason: 'the 24 MiB warm entry floor must admit capped pages');
+
+      // Prove the viewer's complete preview is large enough for the sidebar's
+      // web softness allowance before mounting the panel that consumes it.
+      final previewCache = viewer.pagePreviewCache!;
+      previewPage = null;
+      for (var page = 1; page < editing.document.pageCount; page++) {
+        if (previewCache.isFresh(
+          page,
+          editing.pageAt(page),
+          requireImages: true,
+          targetLongestSide: 400,
+        )) {
+          previewPage = page;
+          break;
+        }
+      }
+      expect(previewPage, isNotNull,
+          reason: 'a complete 400px preview should survive exact warming');
+      final reusable = previewCache.thumbnailImageFor(
+        previewPage!,
+        editing.pageAt(previewPage!),
+        width: 192,
+        height: 249,
+        minimumScale: 0.75,
+      );
+      expect(reusable, isNotNull);
+      reusable!.dispose();
+
+      preferences.showThumbnailSidebar = true;
+      await _waitFor(
+        $,
+        () => find.byType(PdfThumbnailSidebar).evaluate().isNotEmpty,
+        reason: 'the thumbnail panel should mount from preferences',
+      );
+      await _waitFor(
+        $,
+        () => find
+            .descendant(
+              of: find.byType(PdfThumbnailSidebar),
+              matching: find.byType(RawImage),
+            )
+            .evaluate()
+            .isNotEmpty,
+        reason: 'the panel should paint a preview-backed thumbnail',
+      );
+
+      final originalFirst = viewer.debugPageIdentity(0);
+      final originalState = $.tester.state(find.byWidgetPredicate(
+        (widget) =>
+            widget is PdfPageView && identical(widget.page, originalFirst),
+      ));
+      final presentationEpoch = viewer.pagePresentationEpoch;
+      final tileNamespace = viewer.debugTileCacheNamespace;
+      final keyedBefore = viewer.debugKeyedPageReconciliations;
+      editing.movePage(0, editing.document.pageCount - 1);
+      await _waitFor(
+        $,
+        () => viewer.debugKeyedPageReconciliations == keyedBefore + 1,
+        reason: 'a pure move must use stable page identities',
+      );
+      expect(
+        viewer.debugPageReconciliationDiagnostics!.mode,
+        PdfPageReconciliationMode.keyedStructure,
+      );
+      expect(
+        viewer.debugPageIdentity(editing.document.pageCount - 1),
+        isNot(same(originalFirst)),
+        reason: 'the page wrapper must belong to the current revision',
+      );
+      final reorderedFirst = viewer.debugPageIdentity(
+        editing.document.pageCount - 1,
+      );
+      final reorderedFirstView = find.byWidgetPredicate(
+        (widget) =>
+            widget is PdfPageView && identical(widget.page, reorderedFirst),
+      );
+      await _waitFor(
+        $,
+        () => reorderedFirstView.evaluate().isNotEmpty,
+        reason: 'the remapped viewport should build the moved page',
+      );
+      expect(
+        $.tester.state(reorderedFirstView),
+        same(originalState),
+        reason: 'the moved page State should follow its stable page key',
+      );
+      expect(viewer.pagePresentationEpoch, presentationEpoch);
+      expect(viewer.debugTileCacheNamespace, same(tileNamespace));
+
+      PdfPerfLog.log(
+        'scenario name=heavy-document phase=validated '
+        'rasterBytes=${stats.retainedBytes} rasterEntries=${stats.entries} '
+        'warmCompletions=${stats.completions} '
+        'thumbnailRasters=${PdfThumbnailSidebar.debugRasterizations} '
+        'keyed=${viewer.debugKeyedPageReconciliations}',
+      );
+    } finally {
+      await $.pumpWidget(const SizedBox());
+      await $.pump(const Duration(milliseconds: 50));
+      viewer.dispose();
+      editing.dispose();
+      preferences.dispose();
+    }
+  });
+}
+
+Future<void> _waitFor(
+  PatrolIntegrationTester $,
+  bool Function() predicate, {
+  required String reason,
+  int attempts = 120,
+}) async {
+  for (var i = 0; i < attempts && !predicate(); i++) {
+    await $.pump(const Duration(milliseconds: 100));
+  }
+  expect(predicate(), isTrue, reason: reason);
+}
+
+/// A deterministic, browser-safe six-page drawing.
+///
+/// The repeated linework gives the render and preview paths meaningful work
+/// without depending on a corpus file or network fetch. All arithmetic stays
+/// comfortably inside JavaScript's exact integer range, unlike the VM-only
+/// 64-bit CAD fixture generator used by the benchmark suite.
+Uint8List _buildPerfDocument() {
+  const pageCount = 6;
+  final objects = <String>[];
+  final kids = [
+    for (var i = 0; i < pageCount; i++) '${3 + i * 2} 0 R',
+  ].join(' ');
+  final fontNumber = 3 + pageCount * 2;
+  objects
+    ..add('<< /Type /Catalog /Pages 2 0 R >>')
+    ..add('<< /Type /Pages /Kids [$kids] /Count $pageCount >>');
+
+  for (var page = 0; page < pageCount; page++) {
+    final content = StringBuffer()
+      ..writeln('q 0.35 w 0.12 0.18 0.24 RG')
+      ..writeln('24 24 564 744 re S');
+    // Stay over PdfPageView's 5k-command direct-picture threshold: the
+    // scenario must produce a whole-page raster, not retain a display list.
+    for (var i = 0; i < 6000; i++) {
+      final x = 30 + ((i * 37 + page * 19) % 540);
+      final y = 34 + ((i * 53 + page * 23) % 710);
+      final dx = 8 + (i % 37);
+      final dy = (i % 9) - 4;
+      content.writeln('$x $y m ${x + dx} ${y + dy} l S');
+      if (i % 80 == 0) {
+        content.writeln(
+          '0.88 g ${36 + (i % 480)} ${48 + (i % 660)} 24 12 re f '
+          '0.12 0.18 0.24 RG',
+        );
+      }
+    }
+    content
+      ..writeln('BT /F1 20 Tf 42 744 Td (Patrol perf page ${page + 1}) Tj ET')
+      ..writeln('Q');
+    final body = content.toString();
+    objects
+      ..add('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+          '/Contents ${4 + page * 2} 0 R '
+          '/Resources << /Font << /F1 $fontNumber 0 R >> >> >>')
+      ..add('<< /Length ${body.length} >>\nstream\n$body\nendstream');
+  }
+  objects.add('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+
+  final output = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(output.length);
+    output.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = output.length;
+  output
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    output.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  output
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(output.toString().codeUnits);
+}

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -687,7 +687,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
   }) {
     _IntermediatePreviewKey? bestIntermediate;
     var bestIsBase = false;
-    var bestPixels = 1 << 62;
+    int? bestPixels;
 
     void consider(_PreviewEntry? entry, {_IntermediatePreviewKey? key}) {
       if (entry == null ||
@@ -695,7 +695,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
           !entry.includesImages ||
           entry.image.width < width ||
           entry.image.height < height ||
-          entry.pixels >= bestPixels) {
+          (bestPixels != null && entry.pixels >= bestPixels!)) {
         return;
       }
       bestPixels = entry.pixels;
@@ -1477,7 +1477,8 @@ class PdfPagePreviewCache extends ChangeNotifier {
             page, commands, plan,
             includeImages: decodeImages, maxImagePixelRatio: buildRatio);
       } else {
-        picture = await PdfPageRenderer.renderPictureRecordedWithPlan(page, plan,
+        picture = await PdfPageRenderer.renderPictureRecordedWithPlan(
+            page, plan,
             maxImagePixelRatio: buildRatio);
       }
       try {

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -767,10 +767,10 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
     }
 
     var best = -1;
-    var bestLoad = 1 << 62;
+    int? bestLoad;
     for (final i in eligible) {
       final load = _loads[i];
-      if (load < bestLoad) {
+      if (bestLoad == null || load < bestLoad) {
         best = i;
         bestLoad = load;
       }
@@ -847,16 +847,14 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
       // has strictly lower load. Equal load keeps the sticky worker: a
       // transcript miss is never worth paying to break a tie.
       var alternative = -1;
-      var alternativeLoad = 1 << 62;
       for (var i = 0; i < _workers.length; i++) {
         if (i == existing || !_workers[i].isActive) continue;
         final load = _loads[i];
-        if (load < alternativeLoad) {
+        if (alternative < 0 || load < _loads[alternative]) {
           alternative = i;
-          alternativeLoad = load;
         }
       }
-      if (alternative >= 0 && alternativeLoad < _loads[existing]) {
+      if (alternative >= 0 && _loads[alternative] < _loads[existing]) {
         _pageWorkers[pageIndex] = alternative;
         return alternative;
       }
@@ -907,13 +905,13 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
             !_workers[worker].supportsPageSurfaces)) {
       worker = -1;
     }
-    var bestLoad = 1 << 62;
+    int? bestLoad;
     if (worker < 0) {
       for (var i = 0; i < _workers.length; i++) {
         final candidate = _workers[i];
         if (!candidate.isActive || !candidate.supportsPageSurfaces) continue;
         final load = _loads[i] + _surfaceLoads[i];
-        if (load < bestLoad) {
+        if (bestLoad == null || load < bestLoad) {
           worker = i;
           bestLoad = load;
         }

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -154,6 +154,17 @@ void main() {
     final image = sufficient!;
     expect(math.max(image.width, image.height), 400);
     image.dispose();
+
+    final thumbnail = cache.thumbnailImageFor(
+      0,
+      page,
+      width: 192,
+      height: 249,
+      minimumScale: 0.75,
+    );
+    expect(thumbnail, isNotNull,
+        reason: 'the sidebar should reuse the complete 400px tier');
+    thumbnail!.dispose();
   });
 
   testWidgets('a sufficient preview bypasses first-render hold',
@@ -551,8 +562,10 @@ void main() {
       3,
       reason: 'every rung still reports its own cost',
     );
-    expect(logs.every((line) => !line.contains('prerender page=0') ||
-        line.contains('retained ')), isTrue);
+    expect(
+        logs.every((line) =>
+            !line.contains('prerender page=0') || line.contains('retained ')),
+        isTrue);
     final sharpest = cache.previewFor(0)!;
     expect(sharpest.targetLongestSide, levels[1]);
     expect(math.max(sharpest.image.width, sharpest.image.height),
@@ -1750,8 +1763,7 @@ void main() {
     // warm order happens to reach first.
     for (var i = 0;
         i < 150 &&
-            !(cache.hasIntermediate(2, targetLongestSide: 800) &&
-                cache.has(4));
+            !(cache.hasIntermediate(2, targetLongestSide: 800) && cache.has(4));
         i++) {
       await settle(tester);
     }

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -9,7 +9,7 @@ void main(List<String> arguments) {
   if (arguments.isEmpty || arguments.contains('--help')) {
     stdout.writeln(
       'Usage: dart tool/patrol_perf_summary.dart <patrol-log> '
-      '--output <directory> [--markdown <file>]',
+      '--output <directory> [--markdown <file>] [--baseline <json>]',
     );
     exit(arguments.contains('--help') ? 0 : 64);
   }
@@ -17,12 +17,15 @@ void main(List<String> arguments) {
   final input = arguments.first;
   String? output;
   String? markdownOutput;
+  String? baselineInput;
   for (var i = 1; i < arguments.length; i++) {
     switch (arguments[i]) {
       case '--output':
         output = _nextArgument(arguments, ++i, '--output');
       case '--markdown':
         markdownOutput = _nextArgument(arguments, ++i, '--markdown');
+      case '--baseline':
+        baselineInput = _nextArgument(arguments, ++i, '--baseline');
       default:
         stderr.writeln('Unknown argument: ${arguments[i]}');
         exit(64);
@@ -47,7 +50,23 @@ void main(List<String> arguments) {
   File('${directory.path}/patrol-perf.json').writeAsStringSync(
     '${const JsonEncoder.withIndent('  ').convert(trace.toJson())}\n',
   );
-  final markdown = trace.toMarkdown();
+  var markdown = trace.toMarkdown();
+  if (baselineInput != null) {
+    final baselineFile = File(baselineInput);
+    if (!baselineFile.existsSync()) {
+      stderr.writeln('Patrol baseline does not exist: $baselineInput');
+      exit(66);
+    }
+    final decoded = jsonDecode(baselineFile.readAsStringSync());
+    if (decoded is! Map<String, dynamic>) {
+      stderr.writeln('Patrol baseline is not a JSON object: $baselineInput');
+      exit(65);
+    }
+    markdown += PatrolPerfComparison(
+      baseline: decoded,
+      current: trace.toJson(),
+    ).toMarkdown();
+  }
   File('${directory.path}/patrol-perf.md').writeAsStringSync(markdown);
   if (markdownOutput != null) {
     File(markdownOutput).writeAsStringSync(markdown, mode: FileMode.append);
@@ -70,6 +89,8 @@ class PatrolPerfTrace {
   PatrolPerfTrace._({
     required this.lines,
     required this.timestampsMs,
+    required this.durationMs,
+    required this.journeys,
     required this.buildTag,
     required this.eventCounts,
     required this.jankBuildMs,
@@ -81,11 +102,15 @@ class PatrolPerfTrace {
     required this.thumbnailPaths,
     required this.pageRasterOutcomes,
     required this.rasterElapsedMs,
+    required this.scenarioPhases,
   });
 
   factory PatrolPerfTrace.parse(Iterable<String> sourceLines) {
     final lines = <String>[];
     final timestamps = <int>[];
+    var durationMs = 0;
+    var journeys = 0;
+    int? previousTimestamp;
     String? buildTag;
     final eventCounts = <String, int>{};
     final jankBuild = <double>[];
@@ -97,6 +122,7 @@ class PatrolPerfTrace {
     final thumbnailPaths = <String, int>{};
     final pageRasterOutcomes = <String, int>{};
     final rasterElapsed = <double>[];
+    final scenarioPhases = <String, int>{};
 
     for (final sourceLine in sourceLines) {
       final clean = sourceLine.replaceAll(_ansiEscape, '');
@@ -114,6 +140,20 @@ class PatrolPerfTrace {
         for (final field in _field.allMatches(message))
           field.group(1)!: field.group(2)!,
       };
+
+      // Separate Patrol targets (and app restarts within one target) reset the
+      // perf stopwatch. A `build` stamp is an explicit segment boundary; a
+      // decreasing timestamp is the fallback for unstamped traces. Summing
+      // monotonic segments avoids a negative or invented cross-process span.
+      final startsSegment = event == 'build' ||
+          previousTimestamp == null ||
+          timestamp < previousTimestamp;
+      if (startsSegment) {
+        journeys++;
+      } else {
+        durationMs += timestamp - previousTimestamp;
+      }
+      previousTimestamp = timestamp;
 
       if (event == 'build') {
         buildTag = message.substring('build'.length).trim();
@@ -134,12 +174,18 @@ class PatrolPerfTrace {
         _increment(pageRasterOutcomes, _secondWord(message));
       } else if (event == 'raster') {
         _addMilliseconds(rasterElapsed, fields['ms']);
+      } else if (event == 'scenario') {
+        final name = fields['name'] ?? 'unknown';
+        final phase = fields['phase'] ?? 'event';
+        _increment(scenarioPhases, '$name:$phase');
       }
     }
 
     return PatrolPerfTrace._(
       lines: lines,
       timestampsMs: timestamps,
+      durationMs: durationMs,
+      journeys: journeys,
       buildTag: buildTag,
       eventCounts: eventCounts,
       jankBuildMs: jankBuild,
@@ -151,11 +197,14 @@ class PatrolPerfTrace {
       thumbnailPaths: thumbnailPaths,
       pageRasterOutcomes: pageRasterOutcomes,
       rasterElapsedMs: rasterElapsed,
+      scenarioPhases: scenarioPhases,
     );
   }
 
   final List<String> lines;
   final List<int> timestampsMs;
+  final int durationMs;
+  final int journeys;
   final String? buildTag;
   final Map<String, int> eventCounts;
   final List<double> jankBuildMs;
@@ -167,14 +216,13 @@ class PatrolPerfTrace {
   final Map<String, int> thumbnailPaths;
   final Map<String, int> pageRasterOutcomes;
   final List<double> rasterElapsedMs;
-
-  int get durationMs =>
-      timestampsMs.length < 2 ? 0 : timestampsMs.last - timestampsMs.first;
+  final Map<String, int> scenarioPhases;
 
   Map<String, Object?> toJson() => {
-        'schema': 1,
+        'schema': 2,
         'build': buildTag,
         'events': lines.length,
+        'journeys': journeys,
         'durationMs': durationMs,
         'eventCounts': _sortedMap(eventCounts),
         'jank': {
@@ -202,6 +250,7 @@ class PatrolPerfTrace {
           'count': eventCounts['raster'] ?? 0,
           'elapsedMs': _distribution(rasterElapsedMs),
         },
+        'scenarios': _sortedMap(scenarioPhases),
       };
 
   String toMarkdown() {
@@ -219,6 +268,7 @@ class PatrolPerfTrace {
       ..writeln('| Signal | Result |')
       ..writeln('| --- | ---: |')
       ..writeln('| Build | ${_code(buildTag ?? 'unstamped')} |')
+      ..writeln('| Journey segments | $journeys |')
       ..writeln('| Perf events | ${lines.length} |')
       ..writeln('| Trace span | ${_formatMs(durationMs.toDouble())} |')
       ..writeln('| Jank frames | ${jankTotalMs.length} |')
@@ -234,6 +284,7 @@ class PatrolPerfTrace {
           '| Reconcile fallbacks | ${_mapText(reconcileFallbackReasons)} |')
       ..writeln('| Thumbnail paths | ${_mapText(thumbnailPaths)} |')
       ..writeln('| Page-raster outcomes | ${_mapText(pageRasterOutcomes)} |')
+      ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
       ..writeln()
@@ -241,6 +292,99 @@ class PatrolPerfTrace {
         'Artifacts: `patrol-perf.log` (normalized raw trace), '
         '`patrol-perf.json` (machine comparison), and this Markdown summary.',
       )
+      ..writeln();
+    return buffer.toString();
+  }
+}
+
+/// Advisory comparison with the most recent successful `main` web artifact.
+///
+/// Browser timings are intentionally never a pass/fail gate: shared runners,
+/// CanvasKit startup, and headless Chrome all add noise. Structural paths and
+/// outcomes sit beside the timings so a reviewer can distinguish a genuinely
+/// different render/reconcile route from ordinary wall-clock variance.
+class PatrolPerfComparison {
+  const PatrolPerfComparison({required this.baseline, required this.current});
+
+  final Map<String, dynamic> baseline;
+  final Map<String, Object?> current;
+
+  String toMarkdown() {
+    final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
+    final currentScenarios = _jsonCountMap(current, const ['scenarios']);
+    final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
+    final buffer = StringBuffer()
+      ..writeln('## Patrol comparison with `main`')
+      ..writeln()
+      ..writeln(
+        'Advisory only: timing changes do not fail CI. The baseline is the '
+        'newest usable web artifact from `Patrol E2E` on `main`.',
+      )
+      ..write(
+        sameCoverage
+            ? ''
+            : '\nCoverage differs between the artifacts; timing deltas are '
+                'not like-for-like until `main` contains the same scenarios.\n',
+      )
+      ..writeln()
+      ..writeln('| Signal | Main | PR | Change |')
+      ..writeln('| --- | ---: | ---: | ---: |');
+
+    void countRow(
+      String label,
+      List<String> path, {
+      bool absentIsZero = false,
+    }) {
+      final before = _jsonNumber(baseline, path, absentIsZero: absentIsZero);
+      final after = _jsonNumber(current, path, absentIsZero: absentIsZero);
+      buffer.writeln('| $label | ${_numberText(before)} | '
+          '${_numberText(after)} | ${_countDelta(before, after)} |');
+    }
+
+    void timingRow(String label, List<String> path) {
+      final before = _jsonNumber(baseline, path);
+      final after = _jsonNumber(current, path);
+      buffer.writeln('| $label | ${_timingText(before)} | '
+          '${_timingText(after)} | ${_percentDelta(before, after)} |');
+    }
+
+    countRow('Journey segments', const ['journeys']);
+    countRow('Perf events', const ['events']);
+    countRow('Jank frames', const ['jank', 'count']);
+    timingRow('Jank total p95', const ['jank', 'totalMs', 'p95']);
+    timingRow('Reconcile p95', const ['reconciliation', 'elapsedMs', 'p95']);
+    countRow(
+        'Reconcile fallbacks', const ['reconciliation', 'fallbackReasons', '*'],
+        absentIsZero: true);
+    countRow(
+      'Thumbnail preview hits',
+      const ['thumbnails', 'paths', 'preview-hit'],
+      absentIsZero: true,
+    );
+    countRow(
+      'Page-raster rejects',
+      const ['pageRasters', 'outcomes', 'reject'],
+      absentIsZero: true,
+    );
+    timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
+
+    buffer
+      ..writeln()
+      ..writeln('| Structural signal | Main | PR |')
+      ..writeln('| --- | --- | --- |')
+      ..writeln(_mapComparisonRow(
+          'Scenarios', const ['scenarios'], baseline, current))
+      ..writeln(_mapComparisonRow('Reconcile modes',
+          const ['reconciliation', 'modes'], baseline, current))
+      ..writeln(_mapComparisonRow('Fallback reasons',
+          const ['reconciliation', 'fallbackReasons'], baseline, current))
+      ..writeln(_mapComparisonRow(
+          'Thumbnail paths', const ['thumbnails', 'paths'], baseline, current))
+      ..writeln(_mapComparisonRow('Page-raster outcomes',
+          const ['pageRasters', 'outcomes'], baseline, current))
+      ..writeln()
+      ..writeln(
+          'Baseline build: ${_code('${baseline['build'] ?? 'unstamped'}')}.')
       ..writeln();
     return buffer.toString();
   }
@@ -311,6 +455,83 @@ String _mapText(Map<String, int> values) {
   return entries
       .map((entry) => '${_code(entry.key)} ${entry.value}')
       .join(', ');
+}
+
+num? _jsonNumber(
+  Object? root,
+  List<String> path, {
+  bool absentIsZero = false,
+}) {
+  Object? value = root;
+  for (var i = 0; i < path.length; i++) {
+    final part = path[i];
+    if (part == '*') {
+      if (value is! Map) return null;
+      var total = 0.0;
+      for (final item in value.values) {
+        if (item is num) {
+          total += item;
+        }
+      }
+      return total;
+    }
+    if (value is! Map) return null;
+    if (!value.containsKey(part)) {
+      return absentIsZero && i == path.length - 1 ? 0 : null;
+    }
+    value = value[part];
+  }
+  return value is num ? value : null;
+}
+
+Map<String, int> _jsonCountMap(Object? root, List<String> path) {
+  Object? value = root;
+  for (final part in path) {
+    if (value is! Map || !value.containsKey(part)) return const {};
+    value = value[part];
+  }
+  if (value is! Map) return const {};
+  return {
+    for (final entry in value.entries)
+      if (entry.value is num) '${entry.key}': (entry.value as num).round(),
+  };
+}
+
+bool _sameCountMap(Map<String, int> a, Map<String, int> b) =>
+    a.length == b.length &&
+    a.entries.every((entry) => b[entry.key] == entry.value);
+
+String _mapComparisonRow(
+  String label,
+  List<String> path,
+  Object? baseline,
+  Object? current,
+) =>
+    '| $label | ${_mapText(_jsonCountMap(baseline, path))} | '
+    '${_mapText(_jsonCountMap(current, path))} |';
+
+String _numberText(num? value) {
+  if (value == null) return 'n/a';
+  return value == value.roundToDouble()
+      ? value.round().toString()
+      : value.toStringAsFixed(1);
+}
+
+String _timingText(num? value) =>
+    value == null ? 'n/a' : _formatMs(value.toDouble());
+
+String _countDelta(num? before, num? after) {
+  if (before == null || after == null) return 'n/a';
+  final delta = after - before;
+  if (delta == 0) return '—';
+  return '${delta > 0 ? '+' : ''}${_numberText(delta)}';
+}
+
+String _percentDelta(num? before, num? after) {
+  if (before == null || after == null || before == 0) return 'n/a';
+  final percent = (after / before - 1) * 100;
+  if (percent.abs() < 0.05) return '—';
+  return '${percent > 0 ? '+' : ''}${percent.toStringAsFixed(1)}%';
 }
 
 String _formatMs(double value) => '${value.toStringAsFixed(1)} ms';


### PR DESCRIPTION
## Summary

- add a deterministic large-viewport Patrol journey that exercises the >16 MiB full-raster admission seam, idle raster warming, preview-backed thumbnails, and keyed pure page reorders
- collect both Patrol targets into one normalized JSON/Markdown artifact and add an advisory comparison with the newest usable `main` web artifact
- fix a web-only `1 << 62` sentinel overflow that prevented preview selection, including the same sentinel pattern in pooled worker routing
- make the Android checkbox/radio E2E path tolerate one lost emulator tap while still retrying through the real UI

The first PR run will report that baseline coverage differs because `main` does not yet contain the new heavy-document scenario. After this lands, later PRs compare the same journeys and structural paths; timings remain informational rather than a flaky CI gate.

## Local validation

- `fvm dart analyze`
- `fvm flutter test test/page_preview_test.dart` (50 tests)
- `fvm flutter test test/render_worker_test.dart` (75 tests)
- web Patrol demo journey (5/5)
- web Patrol performance journey at 2600x2600 (1/1)

The performance journey retained 16,785,320-byte rasters, completed three warm renders with zero rejections, logged thumbnail `preview-hit` reuse, and reconciled the page move through `keyedStructure` while preserving the keyed Flutter page state.
