### PR TITLE
perf(web): validate the production worker in Patrol

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -38,6 +38,9 @@ jobs:
           flutter pub get
           dart pub global activate patrol_cli "$PATROL_CLI_VERSION"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+      - name: Build the render worker
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        run: dart run dart_pdf_editor:build_web_worker
       - name: Run Patrol on web
         id: patrol-web
         working-directory: ${{ env.EXAMPLE_DIR }}

--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -56,9 +56,18 @@ covered by Flutter unit/widget tests and the existing build/smoke jobs.
 
 ## Web worker
 
-On web, `dart_pdf_editor` uses its bundled render worker asset automatically.
-No example-app setup is needed. The worker falls back to main-thread rendering
-if the browser cannot load it.
+The repository example self-hosts its render worker at
+`web/pdf_render_worker.dart.js`. Generate it before a local web run:
+
+```sh
+fvm dart run dart_pdf_editor:build_web_worker
+```
+
+`tool/build_web.sh` does this automatically before a production build, as do
+the preview, deploy, and Patrol workflows. The Patrol performance target fails
+unless a real off-thread request completes, so CI cannot silently benchmark the
+main-thread fallback. Published apps may instead use the prebuilt worker from
+`dart_pdf_editor_assets` via `registerBundledEditorAssets()`.
 
 ## OCR
 

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -124,6 +124,11 @@ void main() {
   // fallbacks, off-main-thread web rendering). A viewer-only app would omit the
   // dart_pdf_editor_assets dependency and this call.
   registerBundledEditorAssets();
+  // Repository checkouts intentionally keep only a placeholder in the asset
+  // package; the example's web build compiles the real worker into web/.
+  // Point this app at that self-hosted bundle. Published package consumers can
+  // keep the package-asset URL installed by registerBundledEditorAssets().
+  if (kIsWeb) pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
   // Diagnostics: turn on the in-app performance trace (interpret times,
   // render-hold/scheduler transitions, prerender warms, and frame JANK,
   // streamed to the browser console) without a rebuild by opening the demo

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -1,4 +1,5 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_assets/dart_pdf_editor_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -25,7 +26,15 @@ const _testPreferences = <String, Object>{
 
 void main() {
   // Patrol owns this test entry point, so the example app's main() does not
-  // run. Stamp the shared perf logger here as well as in lib/main.dart so CI
+  // run. Mirror its optional-asset registration so the browser journey
+  // exercises the production render worker instead of silently falling back
+  // to main-thread interpretation.
+  registerBundledEditorAssets();
+  // CI builds the example's self-hosted worker before Patrol. Native backends
+  // ignore this web-only URL and continue to use isolates.
+  pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
+
+  // Stamp the shared perf logger here as well as in lib/main.dart so CI
   // artifacts can always be attributed to the exact revision under test.
   if (_buildCommit.isNotEmpty) {
     PdfPerfLog.buildTag = 'commit=$_buildCommit';

--- a/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
@@ -5,6 +5,7 @@
 import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_assets/dart_pdf_editor_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -13,6 +14,12 @@ const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
 const _mb = 1024 * 1024;
 
 void main() {
+  // Patrol owns the entrypoint, so the example app's main() does not register
+  // its optional assets for us. Keep this benchmark on the production web
+  // path: the bundled worker must open the document and return a real trace.
+  registerBundledEditorAssets();
+  pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
+
   if (_buildCommit.isNotEmpty) {
     PdfPerfLog.buildTag = 'commit=$_buildCommit';
   }
@@ -86,6 +93,22 @@ void main() {
         $,
         () => viewer.pageCount == 6 && viewer.isPageRasterReady(0),
         reason: 'the capped first-page raster should finish',
+      );
+      await _waitFor(
+        $,
+        () => viewer.debugRenderWorkerActive,
+        reason: 'the production web render worker should stay active',
+      );
+      await _waitFor(
+        $,
+        () => viewer.debugLastRenderTrace != null,
+        reason: 'an off-thread page render should complete with phase timings',
+      );
+      final workerTrace = viewer.debugLastRenderTrace!;
+      expect(workerTrace.pageIndex, inInclusiveRange(0, 5));
+      PdfPerfLog.log(
+        'scenario name=web-worker phase=validated '
+        'page=${workerTrace.pageIndex} total=${workerTrace.endToEndUs}us',
       );
       await _waitFor(
         $,

--- a/packages/dart_pdf_editor/example/tool/build_web.sh
+++ b/packages/dart_pdf_editor/example/tool/build_web.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Builds the SDK demo for the web with a freshly regenerated bundled render
+# Builds the SDK demo for the web with a freshly regenerated self-hosted render
 # worker and content-hashed stable resource URLs.
 set -euo pipefail
 
@@ -11,9 +11,8 @@ cd "$EXAMPLE_DIR"
 DART="${DART:-fvm dart}"
 FLUTTER="${FLUTTER:-fvm flutter}"
 
-echo "==> Regenerating the bundled render worker asset"
-$DART run dart_pdf_editor:build_web_worker \
-  --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
+echo "==> Regenerating the self-hosted render worker"
+$DART run dart_pdf_editor:build_web_worker
 
 echo "==> flutter build web $*"
 $FLUTTER build web "$@"

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -42,6 +42,7 @@ import 'preview_cache.dart';
 import 'raster_cache.dart';
 import 'raster_warm.dart';
 import 'render_scheduler.dart';
+import 'render_trace.dart';
 import 'render_worker.dart';
 import 'render_worker_host.dart';
 import 'renderer.dart';
@@ -498,6 +499,20 @@ class PdfViewerController extends ChangeNotifier {
   /// [PdfViewer.pagePreviews]); null when no viewer is attached.
   @visibleForTesting
   PdfPagePreviewCache? get debugPreviewCache => _state?._previews;
+
+  /// Test hook: whether the attached viewer currently has a live render-worker
+  /// backend instead of the main-thread fallback.
+  @visibleForTesting
+  bool get debugRenderWorkerActive =>
+      _state?._effectiveRenderWorker?.isActive ?? false;
+
+  /// Test hook: the most recent completed off-thread render trace.
+  ///
+  /// A non-null value proves more than worker construction: the worker opened
+  /// the document, completed a request, and returned its phase timings.
+  @visibleForTesting
+  PdfRenderTrace? get debugLastRenderTrace =>
+      _state?._effectiveRenderWorker?.lastRenderTrace;
 
   /// Test hook: the namespace isolating this viewer's process-wide LoD tiles.
   @visibleForTesting

--- a/packages/dart_pdf_editor/test/default_worker_test.dart
+++ b/packages/dart_pdf_editor/test/default_worker_test.dart
@@ -2,6 +2,8 @@
 // bare embed gets off-thread interpretation (#396 part 1). These pin the wiring
 // via the host's debug spawn seam - no real isolate - so they assert *whether*
 // a default worker is created, disposed, and sized, not the isolate itself.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -14,9 +16,13 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 class _FakeWorker extends PdfRenderWorker {
   bool disposed = false;
+  PdfRenderTrace? trace;
 
   @override
   bool get isActive => !disposed;
+
+  @override
+  PdfRenderTrace? get lastRenderTrace => trace;
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
@@ -25,7 +31,8 @@ class _FakeWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override
@@ -75,7 +82,8 @@ void main() {
   testWidgets('a bare viewer starts its own single default worker',
       (tester) async {
     await pump(tester, viewer(buildMultiPagePdf(3)));
-    expect(spawned, hasLength(1), reason: 'the viewer must own a default worker');
+    expect(spawned, hasLength(1),
+        reason: 'the viewer must own a default worker');
     expect(spawnedCounts.single, 1, reason: 'the default is a single worker');
   });
 
@@ -85,11 +93,36 @@ void main() {
     expect(spawned, isEmpty);
   });
 
-  testWidgets('an explicit renderWorker suppresses the default', (tester) async {
+  testWidgets('an explicit renderWorker suppresses the default',
+      (tester) async {
     final host = _FakeWorker();
     await pump(tester, viewer(buildMultiPagePdf(3), renderWorker: host));
-    expect(spawned, isEmpty, reason: 'the host worker is used, none is spawned');
-    expect(host.disposed, isFalse, reason: 'the viewer does not own the host worker');
+    expect(spawned, isEmpty,
+        reason: 'the host worker is used, none is spawned');
+    expect(host.disposed, isFalse,
+        reason: 'the viewer does not own the host worker');
+  });
+
+  testWidgets('controller diagnostics expose the effective worker and trace',
+      (tester) async {
+    final controller = PdfViewerController();
+    final host = _FakeWorker()..trace = PdfRenderTrace(pageIndex: 2);
+
+    expect(controller.debugRenderWorkerActive, isFalse);
+    expect(controller.debugLastRenderTrace, isNull);
+
+    await pump(
+      tester,
+      PdfViewer(
+        document: PdfDocument.open(buildMultiPagePdf(3)),
+        controller: controller,
+        initialFit: PdfViewerFit.width,
+        renderWorker: host,
+      ),
+    );
+
+    expect(controller.debugRenderWorkerActive, isTrue);
+    expect(controller.debugLastRenderTrace, same(host.trace));
   });
 
   testWidgets('the default worker is disposed with the viewer', (tester) async {

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -101,6 +101,7 @@ class PatrolPerfTrace {
     required this.reconcileFallbackReasons,
     required this.thumbnailPaths,
     required this.pageRasterOutcomes,
+    required this.webWorkerOutcomes,
     required this.rasterElapsedMs,
     required this.scenarioPhases,
   });
@@ -121,6 +122,7 @@ class PatrolPerfTrace {
     final fallbackReasons = <String, int>{};
     final thumbnailPaths = <String, int>{};
     final pageRasterOutcomes = <String, int>{};
+    final webWorkerOutcomes = <String, int>{};
     final rasterElapsed = <double>[];
     final scenarioPhases = <String, int>{};
 
@@ -172,6 +174,9 @@ class PatrolPerfTrace {
         }
       } else if (event == 'page-raster') {
         _increment(pageRasterOutcomes, _secondWord(message));
+      } else if (event == 'webworker') {
+        final outcome = _webWorkerOutcome(message);
+        if (outcome != null) _increment(webWorkerOutcomes, outcome);
       } else if (event == 'raster') {
         _addMilliseconds(rasterElapsed, fields['ms']);
       } else if (event == 'scenario') {
@@ -196,6 +201,7 @@ class PatrolPerfTrace {
       reconcileFallbackReasons: fallbackReasons,
       thumbnailPaths: thumbnailPaths,
       pageRasterOutcomes: pageRasterOutcomes,
+      webWorkerOutcomes: webWorkerOutcomes,
       rasterElapsedMs: rasterElapsed,
       scenarioPhases: scenarioPhases,
     );
@@ -215,11 +221,12 @@ class PatrolPerfTrace {
   final Map<String, int> reconcileFallbackReasons;
   final Map<String, int> thumbnailPaths;
   final Map<String, int> pageRasterOutcomes;
+  final Map<String, int> webWorkerOutcomes;
   final List<double> rasterElapsedMs;
   final Map<String, int> scenarioPhases;
 
   Map<String, Object?> toJson() => {
-        'schema': 2,
+        'schema': 3,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -245,6 +252,10 @@ class PatrolPerfTrace {
         'pageRasters': {
           'events': eventCounts['page-raster'] ?? 0,
           'outcomes': _sortedMap(pageRasterOutcomes),
+        },
+        'webWorker': {
+          'events': eventCounts['webworker'] ?? 0,
+          'outcomes': _sortedMap(webWorkerOutcomes),
         },
         'rasters': {
           'count': eventCounts['raster'] ?? 0,
@@ -284,6 +295,7 @@ class PatrolPerfTrace {
           '| Reconcile fallbacks | ${_mapText(reconcileFallbackReasons)} |')
       ..writeln('| Thumbnail paths | ${_mapText(thumbnailPaths)} |')
       ..writeln('| Page-raster outcomes | ${_mapText(pageRasterOutcomes)} |')
+      ..writeln('| Web-worker outcomes | ${_mapText(webWorkerOutcomes)} |')
       ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
@@ -366,6 +378,18 @@ class PatrolPerfComparison {
       const ['pageRasters', 'outcomes', 'reject'],
       absentIsZero: true,
     );
+    countRow(
+      'Web-worker ready',
+      const ['webWorker', 'outcomes', 'ready'],
+    );
+    countRow(
+      'Web-worker null starts',
+      const ['webWorker', 'outcomes', 'start-null'],
+    );
+    countRow(
+      'Web-worker fatal fallbacks',
+      const ['webWorker', 'outcomes', 'fallback'],
+    );
     timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
 
     buffer
@@ -382,6 +406,8 @@ class PatrolPerfComparison {
           'Thumbnail paths', const ['thumbnails', 'paths'], baseline, current))
       ..writeln(_mapComparisonRow('Page-raster outcomes',
           const ['pageRasters', 'outcomes'], baseline, current))
+      ..writeln(_mapComparisonRow('Web-worker outcomes',
+          const ['webWorker', 'outcomes'], baseline, current))
       ..writeln()
       ..writeln(
           'Baseline build: ${_code('${baseline['build'] ?? 'unstamped'}')}.')
@@ -406,6 +432,25 @@ String _secondWord(String message) {
   if (words.length < 2) return 'unknown';
   final separator = words[1].indexOf('=');
   return separator < 0 ? words[1] : words[1].substring(0, separator);
+}
+
+String? _webWorkerOutcome(String message) {
+  if (message.startsWith('webworker startRenderWorker')) {
+    return message.contains('url=null') ? 'start-null' : 'start-configured';
+  }
+  if (message.startsWith('webworker ready ')) return 'ready';
+  if (message.startsWith('webworker result ')) {
+    if (message.contains('→ worker')) return 'result-worker';
+    // Some individual pages deliberately decline when their image mix cannot
+    // travel through the worker. Keep that ordinary per-record local path
+    // distinct from a dead worker falling back for the whole session.
+    if (message.contains('→ local')) return 'result-local';
+  }
+  if (message.contains('falling back to local') ||
+      message.contains('watchdog fired')) {
+    return 'fallback';
+  }
+  return null;
 }
 
 void _increment(Map<String, int> values, String key) {


### PR DESCRIPTION
## Summary

- point the repository example and Patrol entrypoints at the generated self-hosted web worker
- build the worker in standalone main Patrol runs and fail the perf scenario unless a real off-thread trace completes
- report configured starts, readiness, worker results, per-page local declines, and fatal fallbacks in Patrol artifacts

## Why

The first merged #722 main artifact was structurally complete, but all 20 worker starts logged url=null. The example build generated web/pdf_render_worker.dart.js while startup still selected the repository placeholder package asset.

## Validation

- workspace dart analyze
- focused worker/shell and example widget tests
- Patrol web perf target: passed with worker ready and web-worker:validated
- Patrol web demo target: 5/5 passed with real worker results
- release web build plus cache-bust: 1.3 MB worker packaged and hashed URL referenced