### PR TITLE
perf(web): break Patrol traces down by scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         run: dart tool/format.dart --output=none --set-exit-if-changed tool/format.dart
       - run: flutter pub get
       - run: dart analyze --fatal-infos
+      - name: Test Patrol performance summarizer
+        run: dart tool/patrol_perf_summary_test.dart
       # Enforce the lockstep versioning invariant: every workspace package
       # must depend on its siblings at the current release version (`^x.y.z`).
       # A stale lower bound makes pub.dev's downgrade analysis fail (0/20 on

--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -47,7 +47,10 @@ The CI web journey enables `PdfPerfLog` and uploads `patrol-perf.log`,
 `patrol-perf.json`, and `patrol-perf.md` inside the `patrol-web-results`
 artifact. Pull requests also show the Markdown summary in the Actions run.
 These wall-clock measurements are review evidence rather than a pass/fail gate;
-compare the JSON with a recent `main` run from the same hosted-runner lane.
+compare the JSON with a recent `main` run from the same hosted-runner lane. The
+summary keeps global aggregates for continuity and a scenario breakdown for
+elapsed time, jank, reconciliation, raster work, and worker outcomes, so a slow
+heavy-document journey is not hidden inside the other browser journeys.
 
 When using this repository's FVM SDK, prefix the commands with
 `PATROL_FLUTTER_COMMAND="fvm flutter"`. Patrol supports Android, iOS, macOS,

--- a/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
@@ -53,6 +53,9 @@ void main() {
     PdfPerfLog.log(
       'scenario name=heavy-document phase=start pages=${editing.document.pageCount}',
     );
+    PdfPerfLog.log(
+      'scenario name=web-worker phase=start backend=production',
+    );
     try {
       await $.pumpWidget(MaterialApp(
         home: PdfEditorView(

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -104,7 +104,8 @@ class PatrolPerfTrace {
     required this.webWorkerOutcomes,
     required this.rasterElapsedMs,
     required this.scenarioPhases,
-  });
+    required Map<String, _ScenarioMetrics> scenarioMetrics,
+  }) : _scenarioMetrics = scenarioMetrics;
 
   factory PatrolPerfTrace.parse(Iterable<String> sourceLines) {
     final lines = <String>[];
@@ -125,6 +126,8 @@ class PatrolPerfTrace {
     final webWorkerOutcomes = <String, int>{};
     final rasterElapsed = <double>[];
     final scenarioPhases = <String, int>{};
+    final scenarioMetrics = <String, _ScenarioMetrics>{};
+    final activeScenarios = <String, _ActiveScenario>{};
 
     for (final sourceLine in sourceLines) {
       final clean = sourceLine.replaceAll(_ansiEscape, '');
@@ -152,10 +155,28 @@ class PatrolPerfTrace {
           timestamp < previousTimestamp;
       if (startsSegment) {
         journeys++;
+        // A Patrol app restart resets the stopwatch. Never pair an unfinished
+        // scenario in the old process with a completion marker in the next.
+        activeScenarios.clear();
       } else {
         durationMs += timestamp - previousTimestamp;
       }
       previousTimestamp = timestamp;
+
+      String? scenarioName;
+      String? scenarioPhase;
+      if (event == 'scenario') {
+        scenarioName = fields['name'] ?? 'unknown';
+        scenarioPhase = fields['phase'] ?? 'event';
+        _increment(scenarioPhases, '$scenarioName:$scenarioPhase');
+        if (scenarioPhase == 'start') {
+          final metrics = scenarioMetrics.putIfAbsent(
+            scenarioName,
+            _ScenarioMetrics.new,
+          );
+          activeScenarios[scenarioName] = _ActiveScenario(timestamp, metrics);
+        }
+      }
 
       if (event == 'build') {
         buildTag = message.substring('build'.length).trim();
@@ -179,10 +200,20 @@ class PatrolPerfTrace {
         if (outcome != null) _increment(webWorkerOutcomes, outcome);
       } else if (event == 'raster') {
         _addMilliseconds(rasterElapsed, fields['ms']);
-      } else if (event == 'scenario') {
-        final name = fields['name'] ?? 'unknown';
-        final phase = fields['phase'] ?? 'event';
-        _increment(scenarioPhases, '$name:$phase');
+      }
+
+      for (final scenario in activeScenarios.values) {
+        scenario.metrics.record(event, message, fields);
+      }
+      if (scenarioName != null &&
+          scenarioPhase != null &&
+          _completesScenario(scenarioPhase)) {
+        final scenario = activeScenarios.remove(scenarioName);
+        if (scenario != null) {
+          scenario.metrics.elapsedMs.add(
+            (timestamp - scenario.startedAtMs).toDouble(),
+          );
+        }
       }
     }
 
@@ -204,6 +235,7 @@ class PatrolPerfTrace {
       webWorkerOutcomes: webWorkerOutcomes,
       rasterElapsedMs: rasterElapsed,
       scenarioPhases: scenarioPhases,
+      scenarioMetrics: scenarioMetrics,
     );
   }
 
@@ -224,9 +256,10 @@ class PatrolPerfTrace {
   final Map<String, int> webWorkerOutcomes;
   final List<double> rasterElapsedMs;
   final Map<String, int> scenarioPhases;
+  final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 3,
+        'schema': 4,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -262,6 +295,10 @@ class PatrolPerfTrace {
           'elapsedMs': _distribution(rasterElapsedMs),
         },
         'scenarios': _sortedMap(scenarioPhases),
+        'scenarioMetrics': {
+          for (final name in _scenarioMetrics.keys.toList()..sort())
+            name: _scenarioMetrics[name]!.toJson(),
+        },
       };
 
   String toMarkdown() {
@@ -299,7 +336,30 @@ class PatrolPerfTrace {
       ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
-      ..writeln()
+      ..writeln();
+    if (_scenarioMetrics.isNotEmpty) {
+      buffer
+        ..writeln('### Scenario breakdown')
+        ..writeln()
+        ..writeln(
+          '| Scenario | Runs | Elapsed p50 / p95 / max | Jank p95 | '
+          'Reconcile p95 | Raster p95 | Worker outcomes |',
+        )
+        ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | --- |');
+      for (final name in _scenarioMetrics.keys.toList()..sort()) {
+        final metrics = _scenarioMetrics[name]!;
+        buffer.writeln(
+          '| ${_code(name)} | ${metrics.elapsedMs.length} | '
+          '${_distributionText(metrics.elapsedMs)} | '
+          '${_p95Text(metrics.jankTotalMs)} | '
+          '${_p95Text(metrics.reconcileElapsedMs)} | '
+          '${_p95Text(metrics.rasterElapsedMs)} | '
+          '${_mapText(metrics.webWorkerOutcomes)} |',
+        );
+      }
+      buffer.writeln();
+    }
+    buffer
       ..writeln(
         'Artifacts: `patrol-perf.log` (normalized raw trace), '
         '`patrol-perf.json` (machine comparison), and this Markdown summary.',
@@ -325,6 +385,11 @@ class PatrolPerfComparison {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
     final currentScenarios = _jsonCountMap(current, const ['scenarios']);
     final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
+    final measuredScenarios = <String>{
+      ..._jsonMapKeys(baseline, const ['scenarioMetrics']),
+      ..._jsonMapKeys(current, const ['scenarioMetrics']),
+    }.toList()
+      ..sort();
     final buffer = StringBuffer()
       ..writeln('## Patrol comparison with `main`')
       ..writeln()
@@ -391,6 +456,34 @@ class PatrolPerfComparison {
       const ['webWorker', 'outcomes', 'fallback'],
     );
     timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
+    for (final scenario in measuredScenarios) {
+      countRow(
+        'Scenario $scenario runs',
+        ['scenarioMetrics', scenario, 'runs'],
+      );
+      timingRow(
+        'Scenario $scenario elapsed p95',
+        ['scenarioMetrics', scenario, 'elapsedMs', 'p95'],
+      );
+      timingRow(
+        'Scenario $scenario jank p95',
+        ['scenarioMetrics', scenario, 'jank', 'totalMs', 'p95'],
+      );
+      timingRow(
+        'Scenario $scenario reconcile p95',
+        [
+          'scenarioMetrics',
+          scenario,
+          'reconciliation',
+          'elapsedMs',
+          'p95',
+        ],
+      );
+      timingRow(
+        'Scenario $scenario raster p95',
+        ['scenarioMetrics', scenario, 'rasters', 'elapsedMs', 'p95'],
+      );
+    }
 
     buffer
       ..writeln()
@@ -408,6 +501,17 @@ class PatrolPerfComparison {
           const ['pageRasters', 'outcomes'], baseline, current))
       ..writeln(_mapComparisonRow('Web-worker outcomes',
           const ['webWorker', 'outcomes'], baseline, current))
+      ..writeAll(
+        measuredScenarios.map(
+          (scenario) => _mapComparisonRow(
+            'Scenario $scenario worker outcomes',
+            ['scenarioMetrics', scenario, 'webWorkerOutcomes'],
+            baseline,
+            current,
+          ),
+        ),
+        '\n',
+      )
       ..writeln()
       ..writeln(
           'Baseline build: ${_code('${baseline['build'] ?? 'unstamped'}')}.')
@@ -415,6 +519,62 @@ class PatrolPerfComparison {
     return buffer.toString();
   }
 }
+
+class _ActiveScenario {
+  const _ActiveScenario(this.startedAtMs, this.metrics);
+
+  final int startedAtMs;
+  final _ScenarioMetrics metrics;
+}
+
+class _ScenarioMetrics {
+  final elapsedMs = <double>[];
+  final jankTotalMs = <double>[];
+  final reconcileElapsedMs = <double>[];
+  final rasterElapsedMs = <double>[];
+  final webWorkerOutcomes = <String, int>{};
+
+  void record(
+    String event,
+    String message,
+    Map<String, String> fields,
+  ) {
+    if (event == 'JANK') {
+      _addMilliseconds(jankTotalMs, fields['total']);
+    } else if (event == 'page-reconcile') {
+      _addMilliseconds(reconcileElapsedMs, fields['elapsed']);
+    } else if (event == 'raster') {
+      _addMilliseconds(rasterElapsedMs, fields['ms']);
+    } else if (event == 'webworker') {
+      final outcome = _webWorkerOutcome(message);
+      if (outcome != null) _increment(webWorkerOutcomes, outcome);
+    }
+  }
+
+  Map<String, Object?> toJson() => {
+        'runs': elapsedMs.length,
+        'elapsedMs': _distribution(elapsedMs),
+        'jank': {
+          'count': jankTotalMs.length,
+          'totalMs': _distribution(jankTotalMs),
+        },
+        'reconciliation': {
+          'count': reconcileElapsedMs.length,
+          'elapsedMs': _distribution(reconcileElapsedMs),
+        },
+        'rasters': {
+          'count': rasterElapsedMs.length,
+          'elapsedMs': _distribution(rasterElapsedMs),
+        },
+        'webWorkerOutcomes': _sortedMap(webWorkerOutcomes),
+      };
+}
+
+bool _completesScenario(String phase) =>
+    phase == 'validated' ||
+    phase == 'complete' ||
+    phase == 'completed' ||
+    phase == 'end';
 
 String _thumbnailPath(String message) {
   if (message.contains('disk-hit')) return 'disk-hit';
@@ -493,6 +653,11 @@ String _distributionText(List<double> values) {
       '${_formatMs(distribution['max']!)}';
 }
 
+String _p95Text(List<double> values) {
+  final distribution = _distribution(values);
+  return distribution == null ? 'n/a' : _formatMs(distribution['p95']!);
+}
+
 String _mapText(Map<String, int> values) {
   if (values.isEmpty) return 'none';
   final entries = values.entries.toList()
@@ -540,6 +705,17 @@ Map<String, int> _jsonCountMap(Object? root, List<String> path) {
     for (final entry in value.entries)
       if (entry.value is num) '${entry.key}': (entry.value as num).round(),
   };
+}
+
+Set<String> _jsonMapKeys(Object? root, List<String> path) {
+  Object? value = root;
+  for (final part in path) {
+    if (value is! Map || !value.containsKey(part)) return const {};
+    value = value[part];
+  }
+  return value is Map
+      ? value.keys.map((key) => key.toString()).toSet()
+      : const {};
 }
 
 bool _sameCountMap(Map<String, int> a, Map<String, int> b) =>

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -450,10 +450,12 @@ class PatrolPerfComparison {
     countRow(
       'Web-worker null starts',
       const ['webWorker', 'outcomes', 'start-null'],
+      absentIsZero: true,
     );
     countRow(
       'Web-worker fatal fallbacks',
       const ['webWorker', 'outcomes', 'fallback'],
+      absentIsZero: true,
     );
     timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
     for (final scenario in measuredScenarios) {

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -91,6 +91,11 @@ void main() {
     '| Scenario heavy-document elapsed p95 | 100.0 ms | 80.0 ms | -20.0% |',
     'scenario comparison',
   );
+  _expectContains(
+    comparison,
+    '| Web-worker fatal fallbacks | n/a | 0 | n/a |',
+    'missing current fallback is zero',
+  );
 
   final resetTrace = summary.PatrolPerfTrace.parse(const [
     '[perf 0] scenario name=orphan phase=start',

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -1,0 +1,131 @@
+import 'patrol_perf_summary.dart' as summary;
+
+void main() {
+  final trace = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] build commit=test',
+    '[perf 10] scenario name=heavy-document phase=start',
+    '[perf 20] JANK build=1ms raster=2ms total=3ms',
+    '[perf 25] scenario name=web-worker phase=start',
+    '[perf 30] webworker startRenderWorker generation=1 '
+        'url=pdf_render_worker.dart.js',
+    '[perf 35] webworker ready generation=1',
+    '[perf 40] raster page=0 ms=12.5',
+    '[perf 45] webworker result kind=record page=0 commands=1 → worker',
+    '[perf 47] webworker result kind=record page=1 declined (null) → local',
+    '[perf 55] scenario name=web-worker phase=validated',
+    '[perf 60] page-reconcile mode=incremental elapsed=1.5ms',
+    '[perf 90] scenario name=heavy-document phase=validated',
+  ]);
+  final json = trace.toJson();
+  _expectEqual(json['schema'], 4, 'schema');
+
+  final scenarios = _map(json, 'scenarioMetrics');
+  final heavy = _map(scenarios, 'heavy-document');
+  _expectEqual(heavy['runs'], 1, 'heavy runs');
+  _expectEqual(_map(heavy, 'elapsedMs')['p95'], 80.0, 'heavy elapsed');
+  _expectEqual(
+    _map(_map(heavy, 'jank'), 'totalMs')['p95'],
+    3.0,
+    'heavy jank',
+  );
+  _expectEqual(
+    _map(_map(heavy, 'reconciliation'), 'elapsedMs')['p95'],
+    1.5,
+    'heavy reconcile',
+  );
+  _expectEqual(
+    _map(_map(heavy, 'rasters'), 'elapsedMs')['p95'],
+    12.5,
+    'heavy raster',
+  );
+  _expectEqual(
+    _map(heavy, 'webWorkerOutcomes'),
+    const {
+      'ready': 1,
+      'result-local': 1,
+      'result-worker': 1,
+      'start-configured': 1,
+    },
+    'heavy worker outcomes',
+  );
+
+  final worker = _map(scenarios, 'web-worker');
+  _expectEqual(worker['runs'], 1, 'worker runs');
+  _expectEqual(_map(worker, 'elapsedMs')['p95'], 30.0, 'worker elapsed');
+  _expectEqual(_map(worker, 'jank')['count'], 0, 'worker jank count');
+  _expectEqual(
+    _map(worker, 'reconciliation')['count'],
+    0,
+    'worker reconcile count',
+  );
+
+  final markdown = trace.toMarkdown();
+  _expectContains(markdown, '### Scenario breakdown', 'scenario heading');
+  _expectContains(
+    markdown,
+    '| `heavy-document` | 1 | 80.0 ms / 80.0 ms / 80.0 ms |',
+    'heavy scenario row',
+  );
+
+  final comparison = summary.PatrolPerfComparison(
+    baseline: {
+      'build': 'commit=main',
+      'scenarios': json['scenarios'],
+      'scenarioMetrics': {
+        'heavy-document': {
+          'runs': 1,
+          'elapsedMs': {'p95': 100.0},
+          'jank': {
+            'totalMs': {'p95': 4.0},
+          },
+          'rasters': {
+            'elapsedMs': {'p95': 10.0},
+          },
+        },
+      },
+    },
+    current: json,
+  ).toMarkdown();
+  _expectContains(
+    comparison,
+    '| Scenario heavy-document elapsed p95 | 100.0 ms | 80.0 ms | -20.0% |',
+    'scenario comparison',
+  );
+
+  final resetTrace = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] scenario name=orphan phase=start',
+    '[perf 5] JANK build=1ms raster=1ms total=2ms',
+    '[perf 0] build commit=next-process',
+    '[perf 10] scenario name=orphan phase=validated',
+  ]).toJson();
+  final orphan = _map(_map(resetTrace, 'scenarioMetrics'), 'orphan');
+  _expectEqual(orphan['runs'], 0, 'cross-process scenario is incomplete');
+  _expectEqual(orphan['elapsedMs'], null, 'cross-process elapsed is absent');
+
+  print('Patrol performance summarizer tests passed');
+}
+
+Map<String, Object?> _map(Object? parent, String key) {
+  if (parent is! Map || parent[key] is! Map) {
+    throw StateError('$key is not a map: $parent');
+  }
+  return Map<String, Object?>.from(parent[key] as Map);
+}
+
+void _expectEqual(Object? actual, Object? expected, String label) {
+  if (actual is Map && expected is Map) {
+    if (actual.length == expected.length &&
+        actual.entries.every((entry) => expected[entry.key] == entry.value)) {
+      return;
+    }
+  } else if (actual == expected) {
+    return;
+  }
+  throw StateError('$label: expected $expected, got $actual');
+}
+
+void _expectContains(String actual, String expected, String label) {
+  if (!actual.contains(expected)) {
+    throw StateError('$label: missing "$expected" in:\n$actual');
+  }
+}


### PR DESCRIPTION
## Summary

- attribute elapsed time, jank, reconciliation, raster work, and worker outcomes to active named Patrol scenarios
- add a complete start/validated pair for production-worker startup and fence unfinished scenarios across Patrol process resets
- emit schema 4 JSON plus scenario rows in Markdown and PR comparisons
- add a deterministic parser test to CI, including expected per-page local declines

## Validation

- `fvm dart analyze`
- `fvm dart tool/patrol_perf_summary_test.dart`
- reparsed the first worker-backed main artifact from merge commit f129f538 (1,387 events)
- post-merge Patrol passed on web, macOS, iOS, and Android

The real main trace now isolates the heavy-document journey at 8.666s elapsed, 26 jank frames (599.9ms p95), one 422.1ms raster, one 10.7ms reconcile, and 13 worker results. The former global jank p95 was 284.0ms across six mixed journeys, which hid that concentration.

The current main baseline is schema 3, so new scenario rows will show `n/a` for main in this PR. Global aggregates remain comparable; after merge, subsequent PRs receive like-for-like schema 4 scenario comparisons.