### PR TITLE
perf(web): trace image-heavy CAD deep zoom

### DIFF
--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -49,8 +49,11 @@ artifact. Pull requests also show the Markdown summary in the Actions run.
 These wall-clock measurements are review evidence rather than a pass/fail gate;
 compare the JSON with a recent `main` run from the same hosted-runner lane. The
 summary keeps global aggregates for continuity and a scenario breakdown for
-elapsed time, jank, reconciliation, raster work, and worker outcomes, so a slow
-heavy-document journey is not hidden inside the other browser journeys.
+elapsed time, jank, reconciliation, raster work, worker phases, decoded-image
+cache pressure, and worker outcomes, so a slow heavy-document journey is not
+hidden inside the other browser journeys. The performance target includes an
+image-heavy, ultra-wide CAD scenario that deep-zooms and pans through distant
+regions, verifying worker-backed image detail and reusable tile delivery.
 
 When using this repository's FVM SDK, prefix the commands with
 `PATROL_FLUTTER_COMMAND="fvm flutter"`. Patrol supports Android, iOS, macOS,

--- a/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
@@ -9,6 +9,7 @@ import 'package:dart_pdf_editor_assets/dart_pdf_editor_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
+import 'package:pdf_test_fixtures/cad_image_strip.dart';
 
 const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
 const _mb = 1024 * 1024;
@@ -271,6 +272,174 @@ void main() {
       preferences.dispose();
     }
   });
+
+  patrolTest('deep-zooms an image-heavy CAD sheet through worker-backed tiles',
+      ($) async {
+    expect($.isWeb, isTrue);
+
+    // Build before opening the scenario window: this journey measures the
+    // viewer/worker pipeline, not fixture compression. Eighteen 1024x768 image
+    // XObjects represent ~54 MiB if all are decoded to RGBA, while the wide
+    // page and 30k vector operations force the dense-page region/tile route.
+    final bytes = _buildCadPerfDocument();
+    final preferences = PdfEditingPreferences();
+    await preferences.ready;
+    preferences
+      ..showThumbnailSidebar = false
+      ..showBookmarkSidebar = false
+      ..showAnnotationSidebar = false
+      ..showPropertiesPanel = false
+      ..showSearchResultsPanel = false
+      ..showThumbnailView = false
+      ..showReflowView = false;
+    final editing = PdfEditingController(bytes, preferences: preferences);
+    final viewer = PdfViewerController();
+    final tileStore = PdfTileStore.instance;
+    final tilesLandedBefore = tileStore.debugTilesLanded;
+    final imageAdoptionsBefore = PdfPageView.debugTileImageDetailAdoptions;
+
+    PdfPerfLog.log(
+      'scenario name=cad-image-deep-zoom phase=start pages=1 '
+      'images=18 decodedRgbaBytes=${18 * 1024 * 768 * 4} ops=30000',
+    );
+    try {
+      await $.pumpWidget(MaterialApp(
+        home: PdfEditorView(
+          controller: editing,
+          viewerController: viewer,
+          initialFit: PdfViewerFit.width,
+          features: const PdfEditorFeatures(
+            headerBar: false,
+            search: false,
+            searchResultsPanel: false,
+            pageNumber: false,
+            author: false,
+            viewOptions: false,
+            reflowView: false,
+            pageColorEditable: false,
+            bookmarks: false,
+            annotationSidebar: false,
+            propertiesPanel: false,
+            toolbar: false,
+          ),
+        ),
+      ));
+
+      await _waitFor(
+        $,
+        () => viewer.pageCount == 1 && viewer.debugRenderWorkerActive,
+        reason: 'the CAD document should open on the production worker',
+        attempts: 240,
+      );
+      await _waitFor(
+        $,
+        () => viewer.isPageRasterReady(0),
+        reason: 'the CAD fit-width backing raster should finish',
+        attempts: 300,
+      );
+
+      PdfRenderTrace? fitTrace;
+      await _waitFor(
+        $,
+        () {
+          final trace = viewer.debugLastRenderTrace;
+          if (trace == null ||
+              trace.pageIndex != 0 ||
+              trace.decodeUs <= 0 ||
+              trace.imageDecodeSummary == null) {
+            return false;
+          }
+          fitTrace = trace.copy();
+          return true;
+        },
+        reason: 'the worker should report a real browser image decode',
+        attempts: 240,
+      );
+
+      // At 400%, only a window of this 10:1 sheet is visible. The dense scene
+      // must warm its spatial index off-thread, re-decode intersecting images
+      // for that window, and populate reusable fixed-size tiles.
+      // The initial worker decode carries 2x image headroom by design, so 2x
+      // would correctly remain on the whole-page raster without exercising
+      // the incremental detail path this journey is intended to validate.
+      viewer.setZoom(4);
+      final deepZoom = viewer.captureViewport();
+      expect(deepZoom, isNotNull);
+      // setZoom focuses the viewport centre. This ultra-wide page is only
+      // ~258px tall at fit width, so the centre is empty canvas and the page
+      // would otherwise zoom out of view. Re-anchor the completed zoom onto
+      // the sheet; PdfViewport stores the fit-relative multiplier rather than
+      // the controller's public px/pt zoom.
+      viewer.restoreViewport(PdfViewport(
+        page: 0,
+        left: 0.02,
+        zoom: deepZoom!.zoom,
+      ));
+      await $.pump(const Duration(milliseconds: 300));
+      expect(viewer.zoom, closeTo(4, 0.05));
+      PdfPerfLog.log(
+        'scenario name=cad-image-deep-zoom phase=zoom '
+        'display=${viewer.zoom.toStringAsFixed(2)} '
+        'viewport=${deepZoom.zoom.toStringAsFixed(2)}',
+      );
+      await _waitFor(
+        $,
+        () =>
+            PdfPageView.debugTileImageDetailAdoptions > imageAdoptionsBefore &&
+            tileStore.debugTilesLanded > tilesLandedBefore &&
+            find
+                .byKey(const ValueKey('pdf-page-tile-layer'))
+                .evaluate()
+                .isNotEmpty,
+        reason: 'deep zoom should adopt image detail and land CAD tiles',
+        attempts: 360,
+      );
+
+      // Visit three distant windows. Returning to the first one leaves the
+      // cache free to prove reuse in later traces while this journey records
+      // the one-time decode/bin cost and the incremental edge-tile fills.
+      for (final left in const [0.02, 0.48, 0.90, 0.02]) {
+        viewer.restoreViewport(PdfViewport(
+          page: 0,
+          left: left,
+          zoom: deepZoom.zoom,
+        ));
+        await $.pump(const Duration(milliseconds: 400));
+        await $.pump(const Duration(milliseconds: 100));
+      }
+      await _waitFor(
+        $,
+        () => tileStore.inFlightCount == 0,
+        reason: 'CAD tile work should settle after the pan sequence',
+        attempts: 360,
+      );
+
+      final tilesLanded = tileStore.debugTilesLanded - tilesLandedBefore;
+      final imageAdoptions =
+          PdfPageView.debugTileImageDetailAdoptions - imageAdoptionsBefore;
+      final trace = viewer.debugLastRenderTrace ?? fitTrace!;
+      expect(tilesLanded, greaterThan(0));
+      expect(imageAdoptions, greaterThan(0));
+      expect(tileStore.retainedBytes, greaterThan(0));
+      expect(trace.endToEndUs, greaterThan(0));
+
+      PdfPerfLog.log(
+        'scenario name=cad-image-deep-zoom phase=validated '
+        'tilesLanded=$tilesLanded tileCount=${tileStore.tileCount} '
+        'tileBytes=${tileStore.retainedBytes} '
+        'imageAdoptions=$imageAdoptions '
+        'fitTotal=${fitTrace!.endToEndUs}us '
+        'fitWorker=${fitTrace!.workerUs}us fitDecode=${fitTrace!.decodeUs}us '
+        'lastTotal=${trace.endToEndUs}us lastDecode=${trace.decodeUs}us',
+      );
+    } finally {
+      await $.pumpWidget(const SizedBox());
+      await $.pump(const Duration(milliseconds: 50));
+      viewer.dispose();
+      editing.dispose();
+      preferences.dispose();
+    }
+  });
 }
 
 Future<void> _waitFor(
@@ -350,4 +519,24 @@ Uint8List _buildPerfDocument() {
     ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
     ..write('startxref\n$xrefOffset\n%%EOF\n');
   return Uint8List.fromList(output.toString().codeUnits);
+}
+
+Uint8List _buildCadPerfDocument() {
+  final tiles = <PdfTileSpec>[
+    for (var i = 0; i < 18; i++)
+      PdfTileSpec(
+        codec: i == 17
+            ? PdfTileCodec.indexed
+            : i % 3 == 2
+                ? PdfTileCodec.flateRgb
+                : PdfTileCodec.imageMask,
+        width: 1024,
+        height: 768,
+      ),
+  ];
+  return buildSyntheticCadImageStrip(
+    tiles: tiles,
+    ops: 30000,
+    streams: 4,
+  );
 }

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -31,6 +31,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   patrol: 4.9.0
+  pdf_test_fixtures: ^3.7.0
   shared_preferences: ^2.3.0
 
 patrol:

--- a/packages/pdf_test_fixtures/lib/cad_image_strip.dart
+++ b/packages/pdf_test_fixtures/lib/cad_image_strip.dart
@@ -1,0 +1,7 @@
+/// Browser-safe image-heavy CAD fixture builders.
+///
+/// Import this focused library from web tests instead of the package umbrella,
+/// which also exports intentionally VM-only 64-bit fixture generators.
+library;
+
+export 'src/cad_image_strip.dart';

--- a/packages/pdf_test_fixtures/lib/src/cad_image_strip.dart
+++ b/packages/pdf_test_fixtures/lib/src/cad_image_strip.dart
@@ -341,16 +341,23 @@ CosStream _tileStream(
   }
 }
 
-/// Deterministic 64-bit LCG (VM-only; see `cad_strip.dart`).
+/// Deterministic Park-Miller generator that is exact on the VM and JavaScript.
+///
+/// The image-heavy fixture is also used by the real-browser Patrol journey, so
+/// keep every multiplication below JavaScript's 53-bit exact-integer ceiling.
+/// The vector-only CAD generator deliberately retains its profiled VM-only
+/// 64-bit sequence; these two fixtures do not promise the same linework.
 class _Lcg {
-  _Lcg(this._state);
+  _Lcg(int seed) : _state = seed % _modulus {
+    if (_state <= 0) _state += _modulus - 1;
+  }
+
+  static const _modulus = 2147483647;
   int _state;
 
-  int _next() =>
-      _state = (_state * 6364136223846793005 + 1442695040888963407) &
-          0x7FFFFFFFFFFFFFFF;
+  int _next() => _state = (_state * 48271) % _modulus;
 
-  double unit() => (_next() >> 11) * (1.0 / (1 << 52));
+  double unit() => (_next() - 1) / (_modulus - 1);
 
   double range(double lo, double hi) => lo + unit() * (hi - lo);
 

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 final _ansiEscape = RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]');
 final _perfLine = RegExp(r'\[perf\s+(\d+)\]\s+(.+)$');
 final _field = RegExp(r'([A-Za-z][A-Za-z0-9_-]*)=([^\s]+)');
+final _workerImageCache = RegExp(r'^(\d+)h/(\d+)m/(\d+)e/(\d+)B$');
 
 void main(List<String> arguments) {
   if (arguments.isEmpty || arguments.contains('--help')) {
@@ -102,6 +103,7 @@ class PatrolPerfTrace {
     required this.thumbnailPaths,
     required this.pageRasterOutcomes,
     required this.webWorkerOutcomes,
+    required this.workerPhases,
     required this.rasterElapsedMs,
     required this.scenarioPhases,
     required Map<String, _ScenarioMetrics> scenarioMetrics,
@@ -124,6 +126,7 @@ class PatrolPerfTrace {
     final thumbnailPaths = <String, int>{};
     final pageRasterOutcomes = <String, int>{};
     final webWorkerOutcomes = <String, int>{};
+    final workerPhases = _WorkerPhaseMetrics();
     final rasterElapsed = <double>[];
     final scenarioPhases = <String, int>{};
     final scenarioMetrics = <String, _ScenarioMetrics>{};
@@ -198,6 +201,9 @@ class PatrolPerfTrace {
       } else if (event == 'webworker') {
         final outcome = _webWorkerOutcome(message);
         if (outcome != null) _increment(webWorkerOutcomes, outcome);
+        if (message.startsWith('webworker phase ')) {
+          workerPhases.record(fields);
+        }
       } else if (event == 'raster') {
         _addMilliseconds(rasterElapsed, fields['ms']);
       }
@@ -233,6 +239,7 @@ class PatrolPerfTrace {
       thumbnailPaths: thumbnailPaths,
       pageRasterOutcomes: pageRasterOutcomes,
       webWorkerOutcomes: webWorkerOutcomes,
+      workerPhases: workerPhases,
       rasterElapsedMs: rasterElapsed,
       scenarioPhases: scenarioPhases,
       scenarioMetrics: scenarioMetrics,
@@ -254,12 +261,13 @@ class PatrolPerfTrace {
   final Map<String, int> thumbnailPaths;
   final Map<String, int> pageRasterOutcomes;
   final Map<String, int> webWorkerOutcomes;
+  final _WorkerPhaseMetrics workerPhases;
   final List<double> rasterElapsedMs;
   final Map<String, int> scenarioPhases;
   final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 4,
+        'schema': 5,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -289,6 +297,7 @@ class PatrolPerfTrace {
         'webWorker': {
           'events': eventCounts['webworker'] ?? 0,
           'outcomes': _sortedMap(webWorkerOutcomes),
+          'phases': workerPhases.toJson(),
         },
         'rasters': {
           'count': eventCounts['raster'] ?? 0,
@@ -333,6 +342,13 @@ class PatrolPerfTrace {
       ..writeln('| Thumbnail paths | ${_mapText(thumbnailPaths)} |')
       ..writeln('| Page-raster outcomes | ${_mapText(pageRasterOutcomes)} |')
       ..writeln('| Web-worker outcomes | ${_mapText(webWorkerOutcomes)} |')
+      ..writeln('| Worker phase requests | ${workerPhases.totalMs.length} |')
+      ..writeln('| Worker total p50 / p95 / max | '
+          '${_distributionText(workerPhases.totalMs)} |')
+      ..writeln('| Worker decode p50 / p95 / max | '
+          '${_distributionText(workerPhases.decodeMs)} |')
+      ..writeln('| Worker image-cache peak | '
+          '${_formatBytes(workerPhases.peakImageCacheBytes)} |')
       ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
@@ -343,9 +359,13 @@ class PatrolPerfTrace {
         ..writeln()
         ..writeln(
           '| Scenario | Runs | Elapsed p50 / p95 / max | Jank p95 | '
-          'Reconcile p95 | Raster p95 | Worker outcomes |',
+          'Reconcile p95 | Raster p95 | Worker total p95 | '
+          'Decode p95 | Image cache peak | Worker outcomes |',
         )
-        ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | --- |');
+        ..writeln(
+          '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | '
+          '---: | --- |',
+        );
       for (final name in _scenarioMetrics.keys.toList()..sort()) {
         final metrics = _scenarioMetrics[name]!;
         buffer.writeln(
@@ -354,6 +374,9 @@ class PatrolPerfTrace {
           '${_p95Text(metrics.jankTotalMs)} | '
           '${_p95Text(metrics.reconcileElapsedMs)} | '
           '${_p95Text(metrics.rasterElapsedMs)} | '
+          '${_p95Text(metrics.workerPhases.totalMs)} | '
+          '${_p95Text(metrics.workerPhases.decodeMs)} | '
+          '${_formatBytes(metrics.workerPhases.peakImageCacheBytes)} | '
           '${_mapText(metrics.webWorkerOutcomes)} |',
         );
       }
@@ -457,6 +480,15 @@ class PatrolPerfComparison {
       const ['webWorker', 'outcomes', 'fallback'],
       absentIsZero: true,
     );
+    countRow('Worker phase requests', const ['webWorker', 'phases', 'count']);
+    timingRow(
+      'Worker phase total p95',
+      const ['webWorker', 'phases', 'totalMs', 'p95'],
+    );
+    timingRow(
+      'Worker decode p95',
+      const ['webWorker', 'phases', 'decodeMs', 'p95'],
+    );
     timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
     for (final scenario in measuredScenarios) {
       countRow(
@@ -485,6 +517,14 @@ class PatrolPerfComparison {
         'Scenario $scenario raster p95',
         ['scenarioMetrics', scenario, 'rasters', 'elapsedMs', 'p95'],
       );
+      timingRow(
+        'Scenario $scenario worker total p95',
+        ['scenarioMetrics', scenario, 'workerPhases', 'totalMs', 'p95'],
+      );
+      timingRow(
+        'Scenario $scenario decode p95',
+        ['scenarioMetrics', scenario, 'workerPhases', 'decodeMs', 'p95'],
+      );
     }
 
     buffer
@@ -503,6 +543,12 @@ class PatrolPerfComparison {
           const ['pageRasters', 'outcomes'], baseline, current))
       ..writeln(_mapComparisonRow('Web-worker outcomes',
           const ['webWorker', 'outcomes'], baseline, current))
+      ..writeln(_mapComparisonRow('Worker request kinds',
+          const ['webWorker', 'phases', 'kinds'], baseline, current))
+      ..writeln(_mapComparisonRow('Worker phase outcomes',
+          const ['webWorker', 'phases', 'outcomes'], baseline, current))
+      ..writeln(_mapComparisonRow('Worker transcript paths',
+          const ['webWorker', 'phases', 'transcripts'], baseline, current))
       ..writeAll(
         measuredScenarios.map(
           (scenario) => _mapComparisonRow(
@@ -535,6 +581,7 @@ class _ScenarioMetrics {
   final reconcileElapsedMs = <double>[];
   final rasterElapsedMs = <double>[];
   final webWorkerOutcomes = <String, int>{};
+  final workerPhases = _WorkerPhaseMetrics();
 
   void record(
     String event,
@@ -550,6 +597,9 @@ class _ScenarioMetrics {
     } else if (event == 'webworker') {
       final outcome = _webWorkerOutcome(message);
       if (outcome != null) _increment(webWorkerOutcomes, outcome);
+      if (message.startsWith('webworker phase ')) {
+        workerPhases.record(fields);
+      }
     }
   }
 
@@ -568,7 +618,57 @@ class _ScenarioMetrics {
           'count': rasterElapsedMs.length,
           'elapsedMs': _distribution(rasterElapsedMs),
         },
+        'workerPhases': workerPhases.toJson(),
         'webWorkerOutcomes': _sortedMap(webWorkerOutcomes),
+      };
+}
+
+class _WorkerPhaseMetrics {
+  final queueMs = <double>[];
+  final workerMs = <double>[];
+  final decodeMs = <double>[];
+  final transferMs = <double>[];
+  final deserializeMs = <double>[];
+  final totalMs = <double>[];
+  final kinds = <String, int>{};
+  final outcomes = <String, int>{};
+  final transcripts = <String, int>{};
+  final imageCacheBytes = <int>[];
+
+  int get peakImageCacheBytes => imageCacheBytes.isEmpty
+      ? 0
+      : imageCacheBytes.reduce((a, b) => a > b ? a : b);
+
+  void record(Map<String, String> fields) {
+    _addMilliseconds(queueMs, fields['queue']);
+    _addMilliseconds(workerMs, fields['worker']);
+    _addMilliseconds(decodeMs, fields['decode']);
+    _addMilliseconds(transferMs, fields['transfer']);
+    _addMilliseconds(deserializeMs, fields['deserialize']);
+    _addMilliseconds(totalMs, fields['total']);
+    _increment(kinds, fields['kind'] ?? 'unknown');
+    _increment(outcomes, fields['outcome'] ?? 'unknown');
+    _increment(transcripts, fields['transcript'] ?? 'unknown');
+    final cache = fields['cache'];
+    final match = cache == null ? null : _workerImageCache.firstMatch(cache);
+    if (match != null) imageCacheBytes.add(int.parse(match.group(4)!));
+  }
+
+  Map<String, Object?> toJson() => {
+        'count': totalMs.length,
+        'queueMs': _distribution(queueMs),
+        'workerMs': _distribution(workerMs),
+        'decodeMs': _distribution(decodeMs),
+        'transferMs': _distribution(transferMs),
+        'deserializeMs': _distribution(deserializeMs),
+        'totalMs': _distribution(totalMs),
+        'kinds': _sortedMap(kinds),
+        'outcomes': _sortedMap(outcomes),
+        'transcripts': _sortedMap(transcripts),
+        'imageCacheBytes': {
+          'samples': imageCacheBytes.length,
+          'max': peakImageCacheBytes,
+        },
       };
 }
 
@@ -758,5 +858,14 @@ String _percentDelta(num? before, num? after) {
 }
 
 String _formatMs(double value) => '${value.toStringAsFixed(1)} ms';
+
+String _formatBytes(int value) {
+  if (value <= 0) return 'n/a';
+  if (value >= 1024 * 1024) {
+    return '${(value / (1024 * 1024)).toStringAsFixed(1)} MiB';
+  }
+  if (value >= 1024) return '${(value / 1024).toStringAsFixed(1)} KiB';
+  return '$value B';
+}
 
 String _code(String value) => '`$value`';

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -9,6 +9,12 @@ void main() {
     '[perf 30] webworker startRenderWorker generation=1 '
         'url=pdf_render_worker.dart.js',
     '[perf 35] webworker ready generation=1',
+    '[perf 36] webworker phase worker=0 kind=record page=0 '
+        'outcome=presented queue=1.0ms worker=8.0ms parse=0.5ms '
+        'interpret=1.0ms stream=2.0ms decode=4.0ms serialize=0.5ms '
+        'bin=0.0ms transfer=2.0ms deserialize=1.0ms total=12.0ms '
+        'transcript=miss imageDecode=codec=2 '
+        'cache=2h/3m/4e/8388608B',
     '[perf 40] raster page=0 ms=12.5',
     '[perf 45] webworker result kind=record page=0 commands=1 → worker',
     '[perf 47] webworker result kind=record page=1 declined (null) → local',
@@ -17,7 +23,25 @@ void main() {
     '[perf 90] scenario name=heavy-document phase=validated',
   ]);
   final json = trace.toJson();
-  _expectEqual(json['schema'], 4, 'schema');
+  _expectEqual(json['schema'], 5, 'schema');
+
+  final workerPhases = _map(_map(json, 'webWorker'), 'phases');
+  _expectEqual(workerPhases['count'], 1, 'worker phase count');
+  _expectEqual(
+    _map(workerPhases, 'totalMs')['p95'],
+    12.0,
+    'worker total phase',
+  );
+  _expectEqual(
+    _map(workerPhases, 'decodeMs')['p95'],
+    4.0,
+    'worker decode phase',
+  );
+  _expectEqual(
+    _map(workerPhases, 'imageCacheBytes')['max'],
+    8388608,
+    'worker image cache peak',
+  );
 
   final scenarios = _map(json, 'scenarioMetrics');
   final heavy = _map(scenarios, 'heavy-document');
@@ -48,6 +72,11 @@ void main() {
     },
     'heavy worker outcomes',
   );
+  _expectEqual(
+    _map(_map(heavy, 'workerPhases'), 'totalMs')['p95'],
+    12.0,
+    'heavy worker total phase',
+  );
 
   final worker = _map(scenarios, 'web-worker');
   _expectEqual(worker['runs'], 1, 'worker runs');
@@ -66,6 +95,8 @@ void main() {
     '| `heavy-document` | 1 | 80.0 ms / 80.0 ms / 80.0 ms |',
     'heavy scenario row',
   );
+  _expectContains(markdown, '| Worker image-cache peak | 8.0 MiB |',
+      'worker cache summary');
 
   final comparison = summary.PatrolPerfComparison(
     baseline: {
@@ -95,6 +126,11 @@ void main() {
     comparison,
     '| Web-worker fatal fallbacks | n/a | 0 | n/a |',
     'missing current fallback is zero',
+  );
+  _expectContains(
+    comparison,
+    '| Scenario heavy-document worker total p95 | n/a | 12.0 ms | n/a |',
+    'scenario worker comparison',
   );
 
   final resetTrace = summary.PatrolPerfTrace.parse(const [


### PR DESCRIPTION
## Summary

- add a deterministic browser-safe image-heavy CAD fixture to the Patrol performance target
- validate production-worker image decode, 400% region refinement, and reusable tile delivery across distant windows
- advance the Patrol artifact to schema 5 with worker phase distributions, request paths, and decoded-image cache pressure globally and per scenario

This is test and observability coverage only; it does not change production rendering behavior.

## Validation

- `fvm dart analyze`
- `fvm dart tool/patrol_perf_summary_test.dart`
- `fvm flutter test test/tile_image_detail_test.dart test/cad_wide_region_replay_test.dart`
- headless Chrome Patrol performance target at 2600x2600: 2/2 journeys passed

## Local browser evidence

The CAD journey decoded 18 image XObjects through the production worker, reached a 400% tile rung, adopted 3 region-scoped image-detail records, landed 128 tiles, and settled at the 72-tile / 72 MiB tile-store budget. The initial worker record reported roughly 17 MiB of decoded-image cache and separated queue, worker, decode, transfer, and deserialization time in the artifact.

Hosted timings remain advisory; the PR comparison should be reviewed against the latest main artifact from the same runner lane.

## Follow-up investigations

1. Measure regional image-cache reuse: distant pans currently grow worker cache pressure before later UI-side image batches become all-hit.
2. Break down detail-record payload cost: binary packing, serialization, and transfer dominate some image-heavy detail requests.
3. Review image-mask regional decode declines and the fallback full-record path to avoid duplicate work where correctness allows.
4. Use the new scenario to evaluate tile churn and revisit hit rate before changing the 72 MiB store budget.