### PR TITLE
perf(web): expose worker image-cache request deltas

### DIFF
--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -50,10 +50,11 @@ These wall-clock measurements are review evidence rather than a pass/fail gate;
 compare the JSON with a recent `main` run from the same hosted-runner lane. The
 summary keeps global aggregates for continuity and a scenario breakdown for
 elapsed time, jank, reconciliation, raster work, worker phases, decoded-image
-cache pressure, and worker outcomes, so a slow heavy-document journey is not
-hidden inside the other browser journeys. The performance target includes an
-image-heavy, ultra-wide CAD scenario that deep-zooms and pans through distant
-regions, verifying worker-backed image detail and reusable tile delivery.
+cache pressure and per-request hit/miss deltas, and worker outcomes, so a slow
+heavy-document journey is not hidden inside the other browser journeys. The
+performance target includes an image-heavy, ultra-wide CAD scenario that
+deep-zooms and pans through distant regions, verifying worker-backed image
+detail and reusable tile delivery.
 
 When using this repository's FVM SDK, prefix the commands with
 `PATROL_FLUTTER_COMMAND="fvm flutter"`. Patrol supports Android, iOS, macOS,

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -437,6 +437,9 @@ void runPdfRenderWorker() {
                         (pageWidth > 0 && pageHeight > 0
                             ? (width / pageWidth + height / pageHeight) / 2
                             : null);
+                    final imageCacheBefore = timings == null
+                        ? null
+                        : _snapshotImageCache(imageCache);
                     final grayFrames = await _browserGrayFlateFrames(
                       doc.cos,
                       commands,
@@ -477,11 +480,12 @@ void runPdfRenderWorker() {
                       decodeClock.stop();
                       timings!.decodeUs += decodeClock.elapsedMicroseconds;
                       timings.imageDecodeSummary = grayFrames == null
-                          ? '${tally!.format()} '
-                              'cache=${imageCache.hits}h/'
-                              '${imageCache.misses}m/${imageCache.length}e/'
-                              '${imageCache.bytes}B '
-                              'flateSamples=${flateSampleCache.bytes}B'
+                          ? _formatImageDecodeSummary(
+                              tally!,
+                              imageCache,
+                              imageCacheBefore!,
+                              flateSampleBytes: flateSampleCache.bytes,
+                            )
                           : 'videoGray=${grayFrames.frames.length}';
                     }
                   }
@@ -1050,9 +1054,13 @@ Future<Uint8List?> _recordPageAsync(
     );
     if (vector != null) onPartial(vector);
   }
+  _BrowserDecodeTally? imageDecodeTally;
+  _ImageCacheSnapshot? imageCacheBefore;
   if (decodeImages) {
     final decodeClock = timings == null ? null : (Stopwatch()..start());
     final tally = timings == null ? null : _BrowserDecodeTally();
+    imageDecodeTally = tally;
+    imageCacheBefore = timings == null ? null : _snapshotImageCache(imageCache);
     final pageRasterPixels = pdfPageRasterPixels(page.cropBox, imagePixelRatio);
     final imageBudgetScale = imagePixelRatio == null
         ? 1.0
@@ -1077,16 +1085,6 @@ Future<Uint8List?> _recordPageAsync(
     if (decodeClock != null) {
       decodeClock.stop();
       timings!.decodeUs += decodeClock.elapsedMicroseconds;
-    }
-    // Report the cache's own state, not just the decode tally: "no reuse" has
-    // two very different causes - nothing was ever stored (entries stays 0), or
-    // entries exist but the key never matches - and the tally alone cannot tell
-    // them apart. #451 burned several device traces on exactly that ambiguity.
-    if (tally != null) {
-      timings!.imageDecodeSummary = '${tally.format()} '
-          'cache=${imageCache.hits}h/${imageCache.misses}m'
-          '/${imageCache.length}e/${imageCache.bytes}B '
-          'flateSamples=${flateSampleCache.bytes}B';
     }
   }
   // Decode the page's images in the worker too: the buffer carries
@@ -1114,6 +1112,20 @@ Future<Uint8List?> _recordPageAsync(
   if (serializeClock != null) {
     serializeClock.stop();
     timings!.serializeUs += serializeClock.elapsedMicroseconds;
+  }
+  // Read the cache after serialization. The pure-Dart decoder runs inside
+  // serializeCommands, so the old pre-serialize snapshot hid precisely the
+  // region/native lookups this diagnostic is meant to distinguish. Report a
+  // per-request delta beside the lifetime total: zero lookups on a detail job
+  // means the format used its direct region decoder, not that a populated key
+  // failed to match.
+  if (imageDecodeTally != null) {
+    timings!.imageDecodeSummary = _formatImageDecodeSummary(
+      imageDecodeTally,
+      imageCache,
+      imageCacheBefore!,
+      flateSampleBytes: flateSampleCache.bytes,
+    );
   }
   return result;
 }
@@ -1197,6 +1209,8 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
   // through serializeCommands' pure-Dart, region-aware decoder.
   final decodeClock = timings == null ? null : (Stopwatch()..start());
   final tally = timings == null ? null : _BrowserDecodeTally();
+  final imageCacheBefore =
+      timings == null ? null : _snapshotImageCache(imageCache);
   sourceCommands = await _withBrowserDecodedImages(
     document.cos,
     imageCache,
@@ -1208,11 +1222,6 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
   if (decodeClock != null) {
     decodeClock.stop();
     timings!.decodeUs += decodeClock.elapsedMicroseconds;
-  }
-  if (tally != null) {
-    timings!.imageDecodeSummary = '${tally.format()} '
-        'cache=${imageCache.hits}h/${imageCache.misses}m'
-        '/${imageCache.length}e/${imageCache.bytes}B';
   }
   if (token.cancelled) throw const PdfCancelledException();
   final serializeClock = timings == null ? null : (Stopwatch()..start());
@@ -1229,6 +1238,13 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
   if (serializeClock != null) {
     serializeClock.stop();
     timings!.serializeUs += serializeClock.elapsedMicroseconds;
+  }
+  if (tally != null) {
+    timings!.imageDecodeSummary = _formatImageDecodeSummary(
+      tally,
+      imageCache,
+      imageCacheBefore!,
+    );
   }
   if (commandBuffer == null) return null;
   if (token.cancelled) throw const PdfCancelledException();
@@ -2447,6 +2463,39 @@ Future<void> _loadWorkerAdventorFonts(
       // Optional enhancement only: a custom worker may not ship these files.
     }
   }
+}
+
+/// Lifetime cache counters captured at one worker-request boundary.
+typedef _ImageCacheSnapshot = ({
+  int hits,
+  int misses,
+  int entries,
+  int bytes,
+});
+
+_ImageCacheSnapshot _snapshotImageCache(PdfImageDecodeCache cache) => (
+      hits: cache.hits,
+      misses: cache.misses,
+      entries: cache.length,
+      bytes: cache.bytes,
+    );
+
+String _formatImageDecodeSummary(
+  _BrowserDecodeTally tally,
+  PdfImageDecodeCache cache,
+  _ImageCacheSnapshot before, {
+  int? flateSampleBytes,
+}) {
+  final deltaHits = cache.hits - before.hits;
+  final deltaMisses = cache.misses - before.misses;
+  final deltaEntries = cache.length - before.entries;
+  final deltaBytes = cache.bytes - before.bytes;
+  return '${tally.format()} '
+      'cache=${cache.hits}h/${cache.misses}m/'
+      '${cache.length}e/${cache.bytes}B '
+      'cacheDelta=${deltaHits}h/${deltaMisses}m/'
+      '${deltaEntries}e/${deltaBytes}B'
+      '${flateSampleBytes == null ? '' : ' flateSamples=${flateSampleBytes}B'}';
 }
 
 /// Per-job tally of how the browser image codec fared, folded into

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -5,6 +5,7 @@ final _ansiEscape = RegExp(r'\x1B\[[0-?]*[ -/]*[@-~]');
 final _perfLine = RegExp(r'\[perf\s+(\d+)\]\s+(.+)$');
 final _field = RegExp(r'([A-Za-z][A-Za-z0-9_-]*)=([^\s]+)');
 final _workerImageCache = RegExp(r'^(\d+)h/(\d+)m/(\d+)e/(\d+)B$');
+final _workerImageCacheDelta = RegExp(r'^(\d+)h/(\d+)m/(-?\d+)e/(-?\d+)B$');
 
 void main(List<String> arguments) {
   if (arguments.isEmpty || arguments.contains('--help')) {
@@ -267,7 +268,7 @@ class PatrolPerfTrace {
   final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 5,
+        'schema': 6,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -349,6 +350,13 @@ class PatrolPerfTrace {
           '${_distributionText(workerPhases.decodeMs)} |')
       ..writeln('| Worker image-cache peak | '
           '${_formatBytes(workerPhases.peakImageCacheBytes)} |')
+      ..writeln('| Worker image-cache lookups | '
+          '${workerPhases.cacheLookupText} |')
+      ..writeln('| Worker image-cache request paths | '
+          '${workerPhases.cacheRequestPathText} |')
+      ..writeln('| Worker image-cache net growth | '
+          '${workerPhases.netImageCacheEntries} entries / '
+          '${_formatSignedBytes(workerPhases.netImageCacheBytes)} |')
       ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
@@ -360,11 +368,11 @@ class PatrolPerfTrace {
         ..writeln(
           '| Scenario | Runs | Elapsed p50 / p95 / max | Jank p95 | '
           'Reconcile p95 | Raster p95 | Worker total p95 | '
-          'Decode p95 | Image cache peak | Worker outcomes |',
+          'Decode p95 | Cache lookups | Image cache peak | Worker outcomes |',
         )
         ..writeln(
           '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | '
-          '---: | --- |',
+          '---: | ---: | --- |',
         );
       for (final name in _scenarioMetrics.keys.toList()..sort()) {
         final metrics = _scenarioMetrics[name]!;
@@ -376,6 +384,7 @@ class PatrolPerfTrace {
           '${_p95Text(metrics.rasterElapsedMs)} | '
           '${_p95Text(metrics.workerPhases.totalMs)} | '
           '${_p95Text(metrics.workerPhases.decodeMs)} | '
+          '${metrics.workerPhases.cacheLookupText} | '
           '${_formatBytes(metrics.workerPhases.peakImageCacheBytes)} | '
           '${_mapText(metrics.webWorkerOutcomes)} |',
         );
@@ -634,10 +643,30 @@ class _WorkerPhaseMetrics {
   final outcomes = <String, int>{};
   final transcripts = <String, int>{};
   final imageCacheBytes = <int>[];
+  var imageCacheDeltaSamples = 0;
+  var imageCacheHits = 0;
+  var imageCacheMisses = 0;
+  var imageCacheRequestsWithHits = 0;
+  var imageCacheMissOnlyRequests = 0;
+  var imageCacheNoLookupRequests = 0;
+  var netImageCacheEntries = 0;
+  var netImageCacheBytes = 0;
 
   int get peakImageCacheBytes => imageCacheBytes.isEmpty
       ? 0
       : imageCacheBytes.reduce((a, b) => a > b ? a : b);
+
+  String get cacheLookupText {
+    final lookups = imageCacheHits + imageCacheMisses;
+    final rate = lookups == 0
+        ? 'n/a'
+        : '${(imageCacheHits * 100 / lookups).toStringAsFixed(1)}% hit';
+    return '$imageCacheHits hit / $imageCacheMisses miss ($rate)';
+  }
+
+  String get cacheRequestPathText => '$imageCacheRequestsWithHits reuse / '
+      '$imageCacheMissOnlyRequests miss-only / '
+      '$imageCacheNoLookupRequests no-lookup';
 
   void record(Map<String, String> fields) {
     _addMilliseconds(queueMs, fields['queue']);
@@ -652,6 +681,25 @@ class _WorkerPhaseMetrics {
     final cache = fields['cache'];
     final match = cache == null ? null : _workerImageCache.firstMatch(cache);
     if (match != null) imageCacheBytes.add(int.parse(match.group(4)!));
+    final delta = fields['cacheDelta'];
+    final deltaMatch =
+        delta == null ? null : _workerImageCacheDelta.firstMatch(delta);
+    if (deltaMatch != null) {
+      imageCacheDeltaSamples++;
+      final hits = int.parse(deltaMatch.group(1)!);
+      final misses = int.parse(deltaMatch.group(2)!);
+      imageCacheHits += hits;
+      imageCacheMisses += misses;
+      netImageCacheEntries += int.parse(deltaMatch.group(3)!);
+      netImageCacheBytes += int.parse(deltaMatch.group(4)!);
+      if (hits > 0) {
+        imageCacheRequestsWithHits++;
+      } else if (misses > 0) {
+        imageCacheMissOnlyRequests++;
+      } else {
+        imageCacheNoLookupRequests++;
+      }
+    }
   }
 
   Map<String, Object?> toJson() => {
@@ -668,6 +716,16 @@ class _WorkerPhaseMetrics {
         'imageCacheBytes': {
           'samples': imageCacheBytes.length,
           'max': peakImageCacheBytes,
+        },
+        'imageCacheActivity': {
+          'samples': imageCacheDeltaSamples,
+          'hits': imageCacheHits,
+          'misses': imageCacheMisses,
+          'requestsWithHits': imageCacheRequestsWithHits,
+          'missOnlyRequests': imageCacheMissOnlyRequests,
+          'noLookupRequests': imageCacheNoLookupRequests,
+          'netEntries': netImageCacheEntries,
+          'netBytes': netImageCacheBytes,
         },
       };
 }
@@ -866,6 +924,19 @@ String _formatBytes(int value) {
   }
   if (value >= 1024) return '${(value / 1024).toStringAsFixed(1)} KiB';
   return '$value B';
+}
+
+String _formatSignedBytes(int value) {
+  if (value == 0) return '0 B';
+  final sign = value > 0 ? '+' : '-';
+  final magnitude = value.abs();
+  if (magnitude >= 1024 * 1024) {
+    return '$sign${(magnitude / (1024 * 1024)).toStringAsFixed(1)} MiB';
+  }
+  if (magnitude >= 1024) {
+    return '$sign${(magnitude / 1024).toStringAsFixed(1)} KiB';
+  }
+  return '$sign$magnitude B';
 }
 
 String _code(String value) => '`$value`';

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -14,7 +14,14 @@ void main() {
         'interpret=1.0ms stream=2.0ms decode=4.0ms serialize=0.5ms '
         'bin=0.0ms transfer=2.0ms deserialize=1.0ms total=12.0ms '
         'transcript=miss imageDecode=codec=2 '
-        'cache=2h/3m/4e/8388608B',
+        'cache=2h/3m/4e/8388608B '
+        'cacheDelta=2h/3m/4e/8388608B',
+    '[perf 37] webworker phase worker=0 kind=detail page=0 '
+        'outcome=presented queue=0.5ms worker=7.0ms parse=0.0ms '
+        'interpret=0.0ms stream=0.0ms decode=0.0ms serialize=2.0ms '
+        'bin=1.0ms transfer=1.0ms deserialize=0.5ms total=9.0ms '
+        'transcript=hit imageDecode=none '
+        'cache=2h/3m/4e/8388608B cacheDelta=0h/0m/0e/0B',
     '[perf 40] raster page=0 ms=12.5',
     '[perf 45] webworker result kind=record page=0 commands=1 → worker',
     '[perf 47] webworker result kind=record page=1 declined (null) → local',
@@ -23,10 +30,10 @@ void main() {
     '[perf 90] scenario name=heavy-document phase=validated',
   ]);
   final json = trace.toJson();
-  _expectEqual(json['schema'], 5, 'schema');
+  _expectEqual(json['schema'], 6, 'schema');
 
   final workerPhases = _map(_map(json, 'webWorker'), 'phases');
-  _expectEqual(workerPhases['count'], 1, 'worker phase count');
+  _expectEqual(workerPhases['count'], 2, 'worker phase count');
   _expectEqual(
     _map(workerPhases, 'totalMs')['p95'],
     12.0,
@@ -41,6 +48,20 @@ void main() {
     _map(workerPhases, 'imageCacheBytes')['max'],
     8388608,
     'worker image cache peak',
+  );
+  _expectEqual(
+    _map(workerPhases, 'imageCacheActivity'),
+    const {
+      'samples': 2,
+      'hits': 2,
+      'misses': 3,
+      'requestsWithHits': 1,
+      'missOnlyRequests': 0,
+      'noLookupRequests': 1,
+      'netEntries': 4,
+      'netBytes': 8388608,
+    },
+    'worker image cache activity',
   );
 
   final scenarios = _map(json, 'scenarioMetrics');
@@ -97,6 +118,21 @@ void main() {
   );
   _expectContains(markdown, '| Worker image-cache peak | 8.0 MiB |',
       'worker cache summary');
+  _expectContains(
+    markdown,
+    '| Worker image-cache lookups | 2 hit / 3 miss (40.0% hit) |',
+    'worker cache lookups',
+  );
+  _expectContains(
+    markdown,
+    '| Worker image-cache request paths | 1 reuse / 0 miss-only / 1 no-lookup |',
+    'worker cache request paths',
+  );
+  _expectContains(
+    markdown,
+    '| Worker image-cache net growth | 4 entries / +8.0 MiB |',
+    'worker cache growth',
+  );
 
   final comparison = summary.PatrolPerfComparison(
     baseline: {


### PR DESCRIPTION
## Summary

- capture the decoded-image cache after command serialization, including pure-Dart regional decoder activity that the previous pre-serialize snapshot missed
- add per-request cacheDelta counters beside lifetime cache totals
- aggregate hit/miss request paths and net cache growth in Patrol schema 6, globally and per scenario
- document the expanded Patrol evidence

## Investigation result

The local production Chrome CAD journey passed at 400% zoom with 128 tiles landed and 3 detail-scene adoptions. Corrected detail traces reported 0 hits, 2-3 misses, 0 new entries, and 0 bytes. Those misses line up with the visible ImageMask/non-DCT requests: the browser prepass declines them and serializeCommands performs the intended direct regional decode. Cache growth instead came from fallback full-record requests storing new stream/target-size combinations for previously unseen windows. Returning to the first window reused retained tiles and did not create another worker decode.

This points to expected region/format behavior rather than a broken cache key. Hosted Patrol should confirm the same request-level pattern.

## Validation

- fvm dart analyze
- fvm dart tool/patrol_perf_summary_test.dart
- fvm dart run dart_pdf_editor:build_web_worker --out /private/tmp/pr726-pdf-render-worker.js
- fvm flutter test test/render_worker_test.dart test/tile_image_detail_test.dart test/render_trace_gate_test.dart
- headless Chrome Patrol performance target at 2600x2600: both journeys passed

## Next investigation

Once this measurement lands, inspect detail payload binary packing. Local and hosted traces continue to show serialization/binning as the larger actionable cost; image-mask detail decline/fallback remains the following correctness-safe optimization candidate.