### PR TITLE
perf(raster): cull offscreen shapes before flattening

### DIFF
--- a/packages/pdf_graphics/lib/src/raster/strip_generator.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_generator.dart
@@ -239,15 +239,14 @@ class StripGenerator {
   /// Cached like [fillPath] when a [shapeCache] is attached; stroke
   /// parameters (device width, caps, joins, dashes - quantized to 1/64 px)
   /// join the content key.
-  void strokePath(
-      PdfPath path, PdfMatrix transform, PdfStroke stroke, int rgba,
+  void strokePath(PdfPath path, PdfMatrix transform, PdfStroke stroke, int rgba,
       {double tolerance = 0.25}) {
     if (path.isEmpty || _rowCount == 0) return;
     final cache = shapeCache;
     if (cache != null &&
         path.segments.length <= ShapeStripCache.maxSegments &&
-        _shapeCached(cache, path, transform, PdfFillRule.nonzero, stroke,
-            rgba, tolerance)) {
+        _shapeCached(cache, path, transform, PdfFillRule.nonzero, stroke, rgba,
+            tolerance)) {
       return;
     }
     _strokePathDirect(path, transform, stroke, rgba, tolerance);
@@ -258,8 +257,7 @@ class StripGenerator {
     final sf = transform.scaleFactor;
     var subs = flattenPath(path, transform, tolerance: tolerance);
     if (subs.isEmpty) return;
-    if (stroke.dashArray.isNotEmpty &&
-        stroke.dashArray.any((d) => d > 0)) {
+    if (stroke.dashArray.isNotEmpty && stroke.dashArray.any((d) => d > 0)) {
       subs = dashSubpaths(subs, [for (final d in stroke.dashArray) d * sf],
           stroke.dashPhase * sf);
     }
@@ -508,8 +506,8 @@ class StripGenerator {
       _shapePush(qCap);
       _shapePush(qJoin);
       _shapePush(qMiter);
-      _shapePush((stroke.dashPhase * sf * 64).round().clamp(-(1 << 26),
-          1 << 26));
+      _shapePush(
+          (stroke.dashPhase * sf * 64).round().clamp(-(1 << 26), 1 << 26));
       _shapePush(stroke.dashArray.length);
       for (final d in stroke.dashArray) {
         _shapePush((d * sf * 64).round().clamp(-(1 << 26), 1 << 26));
@@ -619,12 +617,22 @@ class StripGenerator {
     final w = maxX.ceil() - sx + 1;
     final h = maxY.ceil() - sy + 1;
     final dx = ix + sx, dy = iy + sy; // replay translate (dy multiple of 4)
+    final viewportHeight = _rowCount * 4;
+    if (dx + w <= 0 || dy + h <= 0 || dx >= _width || dy >= viewportHeight) {
+      // The cache probe already paid the transformed-bounds walk. Treat a
+      // wholly offscreen shape as handled here instead of reporting a cache
+      // bypass and walking/flattening it all over again in the direct path.
+      // This is the dominant deep-zoom CAD shape: tens of thousands of tiny
+      // strokes spread across a wide sheet, with only one viewport visible.
+      cache.viewportCulls++;
+      return true;
+    }
     if (w > ShapeStripCache.maxShapeSide ||
         h > ShapeStripCache.maxShapeSide ||
         dx < 0 ||
         dy < 0 ||
         dx + w > _width ||
-        dy + h > _rowCount * 4) {
+        dy + h > viewportHeight) {
       cache.bypasses++;
       return false;
     }
@@ -642,16 +650,16 @@ class StripGenerator {
       // 32-bit hash collision between distinct shapes: never replay - render
       // this draw from its own quantized content. The stored entry stays.
       cache.collisions++;
-      _rasterShapeContent(_shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(),
-          rgba);
+      _rasterShapeContent(
+          _shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(), rgba);
       return true;
     }
     if (!cache._secondSight(hash)) {
       // First sight renders directly - but from the same quantized content,
       // so this draw is byte-identical to the replays that follow once the
       // key recurs (cache state never shifts pixels between renders).
-      _rasterShapeContent(_shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(),
-          rgba);
+      _rasterShapeContent(
+          _shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(), rgba);
       return true;
     }
     final built = cache._build(_shapeBuf, _shapeLen, hash, sx, sy, w, h);
@@ -693,8 +701,8 @@ class StripGenerator {
   /// anchor's integer device position, the cache build passes the local
   /// frame shift. Mirrors the direct paths' semantics exactly (fill: pen
   /// survives a close; stroke: flattenPath's close-is-final rule).
-  void _rasterShapeContent(Int32List c, int len, double ox, double oy,
-      int rgba) {
+  void _rasterShapeContent(
+      Int32List c, int len, double ox, double oy, int rgba) {
     final flags = c[0];
     final tolerance = c[1] / 1024.0;
     final bx = ox + c[2] * 0.125;
@@ -738,8 +746,7 @@ class StripGenerator {
   /// [flattenPath] semantics over a content record (device-space quantized
   /// points, already transformed).
   List<FlatSubpath> _flattenShapeContent(
-      Int32List c, int start, int len, double bx, double by,
-      double tolerance) {
+      Int32List c, int start, int len, double bx, double by, double tolerance) {
     final out = <FlatSubpath>[];
     DoubleBuilder? current;
     var closed = false;
@@ -776,8 +783,7 @@ class StripGenerator {
         if (cur == null) continue;
         final d1 =
             math.max((lastX - 2 * x1 + x2).abs(), (lastY - 2 * y1 + y2).abs());
-        final d2 =
-            math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+        final d2 = math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
         final d = math.max(d1, d2);
         final n = d <= tolerance
             ? 1
@@ -810,8 +816,8 @@ class StripGenerator {
   }
 
   /// [_flattenEdges] semantics over a content record.
-  void _edgesFromShapeContent(Int32List c, int start, int len, double bx,
-      double by, double tolerance) {
+  void _edgesFromShapeContent(
+      Int32List c, int start, int len, double bx, double by, double tolerance) {
     _subpathOpen = false;
     var p = start;
     while (p < len) {
@@ -832,10 +838,9 @@ class StripGenerator {
         final x2 = bx + c[p++] / 64.0, y2 = by + c[p++] / 64.0;
         final x3 = bx + c[p++] / 64.0, y3 = by + c[p++] / 64.0;
         if (!_subpathOpen) continue;
-        final d1 = math.max(
-            (_penX - 2 * x1 + x2).abs(), (_penY - 2 * y1 + y2).abs());
-        final d2 =
-            math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+        final d1 =
+            math.max((_penX - 2 * x1 + x2).abs(), (_penY - 2 * y1 + y2).abs());
+        final d2 = math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
         final d = math.max(d1, d2);
         final n = d <= tolerance
             ? 1
@@ -929,8 +934,8 @@ class StripGenerator {
           final y2 = m.transformY(segment.x2, segment.y2);
           final x3 = m.transformX(segment.x3, segment.y3);
           final y3 = m.transformY(segment.x3, segment.y3);
-          final d1 = math.max((_penX - 2 * x1 + x2).abs(),
-              (_penY - 2 * y1 + y2).abs());
+          final d1 = math.max(
+              (_penX - 2 * x1 + x2).abs(), (_penY - 2 * y1 + y2).abs());
           final d2 =
               math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
           final d = math.max(d1, d2);
@@ -941,9 +946,7 @@ class StripGenerator {
           for (var i = 1; i <= n; i++) {
             final t = i / n;
             final mt = 1 - t;
-            final ba = mt * mt * mt,
-                bb = 3 * mt * mt * t,
-                bc = 3 * mt * t * t;
+            final ba = mt * mt * mt, bb = 3 * mt * mt * t, bc = 3 * mt * t * t;
             final be = t * t * t;
             final qx = ba * _penX + bb * x1 + bc * x2 + be * x3;
             final qy = ba * _penY + bb * y1 + bc * y2 + be * y3;
@@ -1114,8 +1117,7 @@ class StripGenerator {
     var nc = _nodeCount;
     if (4 * nc + 4 > _nodes.length) {
       _nodes = Float32List(_nodes.length * 2)..setRange(0, 4 * nc, _nodes);
-      _nodeNext = Int32List(_nodeNext.length * 2)
-        ..setRange(0, nc, _nodeNext);
+      _nodeNext = Int32List(_nodeNext.length * 2)..setRange(0, nc, _nodeNext);
     }
     final base = 4 * nc;
     _nodes[base] = x0;
@@ -1536,8 +1538,8 @@ class GlyphStripCache {
 /// content before replaying (a collision falls back to direct raster, never
 /// to the wrong pixels).
 class CachedShapeStrips {
-  CachedShapeStrips(this.data, this.stripCount, this.alphaTexelCount,
-      this.content);
+  CachedShapeStrips(
+      this.data, this.stripCount, this.alphaTexelCount, this.content);
 
   final Uint32List data;
   final int stripCount;
@@ -1618,6 +1620,11 @@ class ShapeStripCache {
   int misses = 0;
   int bypasses = 0;
 
+  /// Small shapes rejected by the cache probe because their padded device
+  /// bounds lie wholly outside the current viewport. These draws are complete
+  /// no-ops and do not fall through to the direct flatten/raster path.
+  int viewportCulls = 0;
+
   /// First-sight draws that rendered directly (cache-on-second-sight gate).
   int firstSights = 0;
 
@@ -1632,6 +1639,7 @@ class ShapeStripCache {
     hits = 0;
     misses = 0;
     bypasses = 0;
+    viewportCulls = 0;
     firstSights = 0;
     collisions = 0;
   }

--- a/packages/pdf_graphics/test/raster/shape_cache_test.dart
+++ b/packages/pdf_graphics/test/raster/shape_cache_test.dart
@@ -94,10 +94,10 @@ void main() {
     // same shape content at integer translations: one key
     gen.fillPath(arrow(10, 20), PdfMatrix.identity, PdfFillRule.nonzero,
         black); // first sight
-    gen.fillPath(arrow(30, 24), PdfMatrix.identity, PdfFillRule.nonzero,
-        black); // build
-    gen.fillPath(arrow(51, 12), PdfMatrix.identity, PdfFillRule.nonzero,
-        black); // hit
+    gen.fillPath(
+        arrow(30, 24), PdfMatrix.identity, PdfFillRule.nonzero, black); // build
+    gen.fillPath(
+        arrow(51, 12), PdfMatrix.identity, PdfFillRule.nonzero, black); // hit
     expect(cache.firstSights, 1);
     expect(cache.misses, 1);
     expect(cache.hits, 1);
@@ -116,7 +116,8 @@ void main() {
     expect(meanAbsDiff(a, b), lessThanOrEqualTo(1.0));
   });
 
-  test('grid-aligned draws replay identically across generators sharing a '
+  test(
+      'grid-aligned draws replay identically across generators sharing a '
       'cache', () {
     final cache = ShapeStripCache();
     final g0 = (StripGenerator()..shapeCache = cache)..begin(64, 64);
@@ -127,8 +128,8 @@ void main() {
         black); // 1st sight
     g1.fillPath(knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero,
         black); // build
-    g2.fillPath(knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero,
-        black); // hit
+    g2.fillPath(
+        knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero, black); // hit
     expect(decodeStripCoverage(g2.strips, 64, 64),
         decodeStripCoverage(g1.strips, 64, 64));
     expect(decodeStripCoverage(g0.strips, 64, 64),
@@ -184,6 +185,22 @@ void main() {
         decodeStripCoverage(direct.strips, 40, 40));
   });
 
+  test('wholly offscreen small shapes stop at the cache bounds probe', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(40, 40);
+
+    gen.fillPath(
+        arrow(-30, 20), PdfMatrix.identity, PdfFillRule.nonzero, black);
+    gen.strokePath(tick(60, 20), PdfMatrix.identity, thinStroke, black);
+
+    expect(gen.strips.length, 0);
+    expect(cache.viewportCulls, 2);
+    expect(cache.bypasses, 0,
+        reason: 'a full offscreen reject must not fall through and flatten');
+    expect(cache.firstSights, 0,
+        reason: 'offscreen shapes must not pollute the content cache');
+  });
+
   test('oversized paths skip the cache entirely', () {
     final cache = ShapeStripCache();
     final gen = (StripGenerator()..shapeCache = cache)..begin(64, 64);
@@ -192,8 +209,7 @@ void main() {
     for (var i = 0; i < ShapeStripCache.maxSegments + 8; i++) {
       segs.add(PdfLineTo(2.0 + (i % 50), 3.0 + i * 0.7));
     }
-    gen.fillPath(PdfPath(segs), PdfMatrix.identity, PdfFillRule.nonzero,
-        black);
+    gen.fillPath(PdfPath(segs), PdfMatrix.identity, PdfFillRule.nonzero, black);
     expect(cache.bypasses, 0);
     expect(cache.firstSights, 0);
     expect(cache.entryCount, 0);
@@ -227,18 +243,15 @@ void main() {
   test('cache accounting tracks alpha bytes', () {
     final cache = ShapeStripCache();
     final gen = (StripGenerator()..shapeCache = cache)..begin(64, 64);
-    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero,
-        black);
-    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero,
-        black);
+    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero, black);
+    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero, black);
     expect(cache.dataBytes, greaterThan(0));
     cache.clear();
     expect(cache.dataBytes, 0);
     expect(cache.entryCount, 0);
   });
 
-  test('dashed cached stroke matches the direct dashed raster on the grid',
-      () {
+  test('dashed cached stroke matches the direct dashed raster on the grid', () {
     const stroke = PdfStroke(width: 2, dashArray: [5, 3], cap: 1);
     final cache = ShapeStripCache();
     final cached = (StripGenerator()..shapeCache = cache)..begin(64, 32);


### PR DESCRIPTION
## Summary

- treat wholly offscreen small fills and strokes as handled after the shape cache has already computed their conservative padded device bounds
- keep partially visible and oversized shapes on the existing direct unquantized fallback
- expose a viewport-cull counter and cover the no-fallthrough/cache-pollution behavior

This targets the deep-zoom CAD shape from #726: tens of thousands of tiny strokes distributed across a very wide page, with only one viewport visible. Previously each offscreen cache probe transformed the path, classified it as a bypass, then transformed and flattened it again in the direct path even though it emitted no strips.

## Performance evidence

- focused 30k-command CAD-shaped bin probe: median 68.7 ms -> 25.8 ms (62% lower), with identical emitted strip count
- local 2600x2600 Chrome Patrol performance target: both journeys passed; the final successful CAD detail bin was 190 ms
- #726 hosted-main evidence saw successful CAD detail bins at 568-842 ms; runner variance makes this PR hosted Patrol run the authoritative comparison

## Validation

- fvm dart analyze
- full pdf_graphics suite: 1,040 tests passed
- shape-cache + strip-plan focused tests: 24 passed
- render_worker_strips_test.dart, strip_plan_device_test.dart, tile_image_detail_test.dart, cad_wide_region_replay_test.dart: 31 passed
- production worker compiled with dart2js
- headless Chrome Patrol perf_e2e_test.dart at 2600x2600: 2 journeys passed