### PR TITLE
perf: reuse Flate samples for detail regions

### DIFF
--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -600,6 +600,7 @@ void runPdfRenderWorker() {
               final detail = await _recordStripDetailAsync(
                 doc,
                 imageCache,
+                flateSampleCache,
                 transcriptCache,
                 page,
                 annotations,
@@ -1182,6 +1183,7 @@ Future<Uint8List?> _binStripsAsync(
 Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
   PdfDocument document,
   PdfImageDecodeCache imageCache,
+  _BrowserFlateSampleCache flateSampleCache,
   PdfWorkerTranscriptCache cache,
   int pageIndex,
   bool annotations,
@@ -1218,6 +1220,7 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
     token,
     tally,
     imageDecodeRegion: imageDecodeRegion,
+    flateSampleCache: flateSampleCache,
   );
   if (decodeClock != null) {
     decodeClock.stop();
@@ -1244,6 +1247,7 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
       tally,
       imageCache,
       imageCacheBefore!,
+      flateSampleBytes: flateSampleCache.bytes,
     );
   }
   if (commandBuffer == null) return null;
@@ -1362,6 +1366,11 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
 }) async {
   var changed = false;
   final out = <PdfRenderCommand>[];
+  final regionSampleStreams = imageDecodeRegion != null &&
+          maxImagePixelRatio == null &&
+          flateSampleCache != null
+      ? HashSet<CosStream>.identity()
+      : null;
   for (final command in commands) {
     if (token.cancelled) throw PdfCancelledException();
     switch (command) {
@@ -1385,8 +1394,46 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
           out.add(command);
           continue;
         }
-        PdfDecodedPixels? decoded;
         final filters = pdfImageFilters(cos, request.stream.dictionary);
+        if (regionSampleStreams != null) {
+          // A detail record deliberately leaves Flate/CCITT pixels to
+          // serializeCommands' region-aware decoder. On web, however, that
+          // used to make the serializer reinflate each intersecting Flate
+          // plane with package:archive even when the browser-native full-page
+          // pass had already retained those samples. Re-seed the COS decoded
+          // stream LRU from the worker's bounded sample cache (or populate it
+          // natively on the first region) so the unchanged region decoder can
+          // crop/scale the same bytes without another inflate.
+          //
+          // Include a direct mask stream: Indexed CAD tiles sometimes carry a
+          // separate packed stencil that the region decoder consumes while
+          // decoding the base image.
+          final streams = <CosStream>[request.stream];
+          for (final key in const ['Mask', 'SMask']) {
+            try {
+              final object = cos.resolve(request.stream.dictionary[key]);
+              if (object is CosStream) streams.add(object);
+            } catch (_) {
+              // A broken optional mask remains the image decoder's problem;
+              // sample warming must never make a previously lenient detail
+              // record fail as a whole.
+            }
+          }
+          for (final stream in streams) {
+            if (!regionSampleStreams.add(stream)) continue;
+            final reused = await _seedBrowserFlateRegionSamples(
+              cos,
+              stream,
+              flateSampleCache!,
+            );
+            if (reused == true) {
+              tally?.regionFlateReuse++;
+            } else if (reused == false) {
+              tally?.regionFlate++;
+            }
+          }
+        }
+        PdfDecodedPixels? decoded;
         final hasDctBase =
             filters.contains('DCTDecode') || filters.contains('DCT');
         // A standalone JPEG is cheaper on the consumer: createImageBitmap can
@@ -2002,6 +2049,38 @@ class _BrowserFlateSampleCache {
   }
 }
 
+/// Makes one browser-inflated image plane available to synchronous PDF image
+/// decoding. Returns true for a sample-cache hit, false for a native inflate,
+/// and null when the stream is not a single Flate stream or native inflate is
+/// unavailable/declines.
+Future<bool?> _seedBrowserFlateRegionSamples(
+  CosDocument cos,
+  CosStream stream,
+  _BrowserFlateSampleCache sampleCache,
+) async {
+  final filter = _singleFlateFilter(cos, stream.dictionary);
+  if (filter == null || !globalContext.has('DecompressionStream')) return null;
+  try {
+    final retained = sampleCache[stream];
+    final samples = retained ??
+        await _inflateBrowserFlateSamples(
+          cos,
+          stream,
+          filter,
+          sampleCache,
+        );
+    // This is the exact decrypt + Flate + predictor result decodeStreamData
+    // would produce. The COS cache stores the same Uint8List reference, not a
+    // second sample-plane copy. allowOversize is safe here because its total
+    // LRU remains bounded; the worker sample cache has its own 32 MiB bound.
+    cos.seedDecodedStreamData(stream, samples, allowOversize: true);
+    return retained != null;
+  } catch (_) {
+    // The existing portable, lenient filter path remains the fallback.
+    return null;
+  }
+}
+
 /// Warms the COS decoded-stream cache with the browser's native inflater.
 ///
 /// Dart2JS's portable zlib decoder is a material part of first-stable-paint on
@@ -2510,6 +2589,8 @@ String _formatImageDecodeSummary(
 class _BrowserDecodeTally {
   int codec = 0;
   int flate = 0;
+  int regionFlate = 0;
+  int regionFlateReuse = 0;
   int regionSkipped = 0;
 
   /// Images served from a previous record's decode instead of re-running the
@@ -2529,18 +2610,28 @@ class _BrowserDecodeTally {
     final declined = _declined.values.fold(0, (a, b) => a + b);
     if (codec == 0 &&
         flate == 0 &&
+        regionFlate == 0 &&
+        regionFlateReuse == 0 &&
         declined == 0 &&
         reusedCount == 0 &&
         regionSkipped == 0) {
       return 'none';
     }
     final nativeFlate = flate == 0 ? '' : ' flate=$flate';
+    final nativeRegionFlate =
+        regionFlate == 0 ? '' : ' regionFlate=$regionFlate';
+    final regionFlateHit =
+        regionFlateReuse == 0 ? '' : ' regionFlateReuse=$regionFlateReuse';
     final reuse = reusedCount == 0 ? '' : ' reused=$reusedCount';
     final region = regionSkipped == 0 ? '' : ' regionSkip=$regionSkipped';
-    if (declined == 0) return 'codec=$codec$nativeFlate$reuse$region';
+    if (declined == 0) {
+      return 'codec=$codec$nativeFlate$nativeRegionFlate'
+          '$regionFlateHit$reuse$region';
+    }
     final reasons =
         _declined.entries.map((e) => '${e.key}:${e.value}').join(',');
-    return 'codec=$codec$nativeFlate$reuse$region '
+    return 'codec=$codec$nativeFlate$nativeRegionFlate'
+        '$regionFlateHit$reuse$region '
         'declined=$declined($reasons)';
   }
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -2060,6 +2060,25 @@ Future<bool?> _seedBrowserFlateRegionSamples(
 ) async {
   final filter = _singleFlateFilter(cos, stream.dictionary);
   if (filter == null || !globalContext.has('DecompressionStream')) return null;
+  var isStencil = false;
+  try {
+    isStencil =
+        cos.resolve(stream.dictionary['ImageMask']) == const CosBoolean(true);
+  } catch (_) {
+    // The decoder remains responsible for malformed optional image metadata.
+  }
+  final stencilBytes =
+      isStencil ? _declaredStencilSampleBytes(cos, stream.dictionary) : null;
+  if (stencilBytes != null &&
+      stencilBytes <= CosDocument.decodedStreamCacheItemCapBytes) {
+    // Small planes already enter the ordinary COS cache on first use. In
+    // particular, a 2048x1754 ImageMask is only ~439 KiB; warming and seeding
+    // it buys almost no inflate time and needlessly changes its established
+    // path. Colour planes remain eligible below the cap: an 8-bit Indexed CAD
+    // tile is only 768 KiB but still paid 79 ms to inflate on its first detail
+    // request in the hosted trace.
+    return null;
+  }
   try {
     final retained = sampleCache[stream];
     final samples = retained ??
@@ -2077,6 +2096,29 @@ Future<bool?> _seedBrowserFlateRegionSamples(
     return retained != null;
   } catch (_) {
     // The existing portable, lenient filter path remains the fallback.
+    return null;
+  }
+}
+
+int? _declaredStencilSampleBytes(
+  CosDocument cos,
+  CosDictionary dictionary,
+) {
+  try {
+    final width = cos.resolve(dictionary['Width']);
+    final height = cos.resolve(dictionary['Height']);
+    final bits = cos.resolve(dictionary['BitsPerComponent']);
+    if (width is! CosInteger ||
+        height is! CosInteger ||
+        bits is! CosInteger ||
+        width.value <= 0 ||
+        height.value <= 0 ||
+        bits.value <= 0) {
+      return null;
+    }
+    final rowBytes = (width.value * bits.value + 7) >> 3;
+    return rowBytes * height.value;
+  } catch (_) {
     return null;
   }
 }

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -13,6 +13,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -841,6 +842,61 @@ void main() {
       expect(decoded.width, 1);
       expect(decoded.height, 1);
       expect(decoded.rgba, [40, 100, 7, 255]);
+    });
+
+    test('imageDecodeRegion reuses browser-seeded Flate samples byte-for-byte',
+        () {
+      // Web detail records obtain the post-Flate/post-predictor sample plane
+      // from DecompressionStream, seed it into the COS decoded-stream LRU, and
+      // leave the established region crop/scale path unchanged. Use a plane
+      // above the ordinary 1 MiB per-item cache cap so this only avoids the
+      // inflate when the explicit browser seed is honoured.
+      const width = 1024;
+      const height = 512;
+      final samples = Uint8List(width * height * 3);
+      for (var i = 0; i < samples.length; i++) {
+        samples[i] = (i * 31 + (i >> 9)) & 0xff;
+      }
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(width),
+          'Height': const CosInteger(height),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('FlateDecode'),
+        }),
+        Uint8List.fromList(zlib.encode(samples)),
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(1024, 0, 0, 512, 0, 0),
+      ));
+      final cos = CosDocument.open(buildClassicPdf());
+      Uint8List? record() => serializeCommands(
+            [command],
+            cos: cos,
+            decodeImages: true,
+            maxImagePixelRatio: 4,
+            imageDecodeRegion: const PdfRect(120, 140, 360, 300),
+          );
+
+      final portable = record();
+      expect(portable, isNotNull);
+      cos.seedDecodedStreamData(stream, samples, allowOversize: true);
+
+      final wasEnabled = PdfPerf.enabled;
+      try {
+        PdfPerf.enabled = true;
+        PdfPerf.reset();
+        final seeded = record();
+        expect(seeded, portable,
+            reason: 'native inflation may change only where samples came from');
+        expect(PdfPerf.snapshot().phaseCallCount(PdfPerfPhase.flate), 0,
+            reason: 'serialization must consume the seeded sample plane');
+      } finally {
+        PdfPerf.reset();
+        PdfPerf.enabled = wasEnabled;
+      }
     });
 
     test('imageDecodeRegion reuses a retained native DCT decode', () {


### PR DESCRIPTION
## Summary

- reuse the web worker's bounded browser-inflated Flate color sample planes in deep-zoom detail records
- seed those exact post-Flate/post-predictor bytes into the existing COS decoded-stream LRU, leaving region crop/scale output unchanged
- include direct `/Mask` and `/SMask` streams, but leave small stencils on their existing cheap path; preserve malformed-mask leniency and report native region inflate/reuse in worker traces
- add a regression proving a seeded >1 MiB sample plane produces a byte-identical region record with zero portable Flate calls

## Why

PR #727 removed redundant offscreen geometry flattening and exposed the remaining CAD detail tail. The exact merged-main Patrol baseline had two non-DCT/ImageMask windows at 198 ms and 407 ms serialization, including 79 ms and 336 ms of Flate work. The worker already retained the browser-native decoded sample planes under a 32 MiB LRU, but detail jobs did not receive that cache and reinflated the same planes synchronously inside `serializeCommands`.

The first hosted run also showed why the gate matters: small 1-bit stencils already fit the ordinary COS cache and have negligible inflate cost. The final version keeps those on the old path and seeds only color planes (plus unusually large stencils), including a 768 KiB Indexed tile whose first detail inflate still cost 79 ms.

## Validation

The final hosted Patrol CAD journey passed with all five detail jobs succeeding:

| Signal | Merged #727 hosted | Final PR hosted |
| --- | ---: | ---: |
| Non-DCT detail serialization | 407 ms / 198 ms | 231 ms / 266 ms |
| Portable Flate on those windows | 336 ms / 79 ms | no color-plane Flate (1 ms / 2 ms small-mask work remains) |
| Sample reuse | not visible to detail jobs | exactly one `regionFlateReuse` on each non-DCT window |
| Mask-only reuse | n/a | none on all three windows |
| Flate sample-cache footprint | not reported for detail jobs | stable at 15.2 MB |
| Detail outcomes | 5 ok | 5 ok |

The hosted PR runner was broadly slower than the baseline: unchanged scenario-level signals regressed by roughly 24-57%, and mask-only serialization moved from 60-100 ms to 118-199 ms. Absolute cross-run wall times therefore are not a clean A/B. The reliable evidence is the targeted trace: the 336/79 ms portable color-plane inflate phases disappear, only the intended two requests reuse samples, outputs still validate, and the deterministic codec regression proves byte identity with zero portable Flate calls. A final local production Patrol run was also green (five detail serializations at 41-74 ms, median 54 ms).

Checks run:

- `fvm dart analyze`
- `cd packages/pdf_graphics && fvm dart test test/render_command_codec_test.dart`
- `cd packages/dart_pdf_editor && fvm flutter test test/render_worker_strips_test.dart test/tile_image_detail_test.dart`
- production web worker `dart compile js -O2`
- production Patrol `perf_e2e_test.dart` in headless Chrome (2/2 journeys passed)
