### PR TITLE
fix(viewer): keep visible page rasters resident

### DIFF
--- a/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
+++ b/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
@@ -22,14 +22,15 @@ abstract class PdfLiveRasterHolder {
   /// second page - often half the screen - sitting at distance 1. Evicting
   /// *that* is not reclaiming an off-screen prefetch, it is blanking a page the
   /// user is looking at, which re-renders immediately and flickers on the way
-  /// back (#657). On-screen pages are the working set; they are reclaimed only
-  /// when dropping every off-screen page still leaves the total over budget.
+  /// back (#657). On-screen pages are the working set; they are never reclaimed
+  /// by this budget because their next build immediately allocates the same
+  /// raster again.
   bool get liveRasterOnScreen;
 
   /// Drops this page's base + detail rasters (and retained scene) to free
   /// memory. The page keeps its low-res preview up and re-rasterises when it is
-  /// next scrolled back into (or near) the viewport. Called only on a holder
-  /// with [liveRasterDistance] > 0.
+  /// next scrolled back into (or near) the viewport. Called only on an
+  /// off-screen holder with [liveRasterDistance] > 0.
   void evictLiveRaster();
 }
 
@@ -44,9 +45,11 @@ abstract class PdfLiveRasterHolder {
 /// pages' rasters until it fits, never touching the focused page.
 ///
 /// It is a *reclaim* budget, not a reservation: pages rasterise freely and this
-/// trims afterward, so a momentary overshoot is fine and the near-viewport
-/// working set is never evicted (eviction is farthest-first and stops the
-/// moment the total fits).
+/// trims afterward, so a momentary overshoot is fine. The visible working set
+/// may remain over budget: evicting it would not produce lasting headroom,
+/// because a visible page immediately requests its raster again. Off-screen
+/// eviction is farthest-first and stops the moment the total fits or only
+/// visible pages remain.
 class PdfLiveRasterBudget {
   PdfLiveRasterBudget._();
 
@@ -83,12 +86,11 @@ class PdfLiveRasterBudget {
   /// patch lands). Never evicts the focused page (distance 0); stops as soon as
   /// the total fits, so the near-viewport working set is preserved.
   ///
-  /// Off-screen pages go first, in full, before any on-screen page is
-  /// considered ([PdfLiveRasterHolder.liveRasterOnScreen]) - a large-format
-  /// document where two visible pages alone exceed the budget must reclaim the
-  /// prefetch window rather than blank a page under the user's eyes. Only if
-  /// the total is still over after every off-screen page is gone does the
-  /// second pass reach the visible ones, farthest first.
+  /// Off-screen pages go first, in full
+  /// ([PdfLiveRasterHolder.liveRasterOnScreen]). A large-format document where
+  /// two visible pages alone exceed the budget remains temporarily over budget
+  /// rather than blanking one page and immediately allocating it again.
+  /// Per-page caps still bound each member of that unavoidable working set.
   ///
   /// Returns the bytes freed (0 when already within budget).
   int rebalance() {
@@ -100,27 +102,23 @@ class PdfLiveRasterBudget {
     // eviction). A stable order also makes the eviction sequence testable.
     final ordered = _holders.toList()
       ..sort((a, b) {
-        final byDistance =
-            b.liveRasterDistance.compareTo(a.liveRasterDistance);
+        final byDistance = b.liveRasterDistance.compareTo(a.liveRasterDistance);
         return byDistance != 0
             ? byDistance
             : b.liveRasterBytes.compareTo(a.liveRasterBytes);
       });
 
     var freed = 0;
-    // Pass 1 off-screen only, pass 2 the visible remainder (still never the
-    // focused page). Two passes over the same order, not two sorts.
-    for (final onScreenPass in const [false, true]) {
-      for (final holder in ordered) {
-        if (total <= maxBytes) return freed;
-        if (holder.liveRasterDistance <= 0) continue; // never the focused page
-        if (holder.liveRasterOnScreen != onScreenPass) continue;
-        final bytes = holder.liveRasterBytes;
-        if (bytes <= 0) continue;
-        holder.evictLiveRaster();
-        total -= bytes;
-        freed += bytes;
+    for (final holder in ordered) {
+      if (total <= maxBytes) return freed;
+      if (holder.liveRasterDistance <= 0 || holder.liveRasterOnScreen) {
+        continue;
       }
+      final bytes = holder.liveRasterBytes;
+      if (bytes <= 0) continue;
+      holder.evictLiveRaster();
+      total -= bytes;
+      freed += bytes;
     }
     return freed;
   }

--- a/packages/dart_pdf_editor/test/live_raster_budget_test.dart
+++ b/packages/dart_pdf_editor/test/live_raster_budget_test.dart
@@ -157,9 +157,8 @@ void main() {
     });
 
     test('every off-screen page goes before any visible one', () {
-      // Ordering across the two passes, not just the single nearest/farthest
-      // pair: the visible neighbour is farther from focus than both prefetches
-      // and must still outlive them.
+      // The visible neighbour is farther from focus than both prefetches and
+      // must still outlive them: visibility wins over page distance.
       budget.maxBytes = 100;
       final focus = _FakeHolder('focus', bytes: 40, distance: 0);
       final visible =
@@ -178,14 +177,15 @@ void main() {
       expect(budget.totalBytes, 100);
     });
 
-    test('reaches visible pages only once the off-screen ones are gone', () {
-      // The safety valve: zoomed out far enough that the visible pages alone
-      // blow the budget, the reclaim must still make progress rather than
-      // grow without bound.
+    test('keeps the visible working set when it alone exceeds the budget', () {
+      // Field trace: two large CAD pages shared the viewport at deep zoom.
+      // Rebalancing evicted the non-focused visible page a few milliseconds
+      // after every detail raster landed; its next build allocated the same
+      // pixels again, so the safety valve caused a permanent render/evict loop
+      // without producing lasting headroom.
       budget.maxBytes = 100;
       final focus = _FakeHolder('focus', bytes: 60, distance: 0);
-      final near =
-          _FakeHolder('near', bytes: 60, distance: 1, onScreen: true);
+      final near = _FakeHolder('near', bytes: 60, distance: 1, onScreen: true);
       final far = _FakeHolder('far', bytes: 60, distance: 2, onScreen: true);
       final prefetch =
           _FakeHolder('prefetch', bytes: 60, distance: 5, onScreen: false);
@@ -193,14 +193,14 @@ void main() {
       add(near);
       add(far);
       add(prefetch); // total 240 > 100
-      budget.rebalance();
-      // 240 -> prefetch (180) -> then visible, farthest first: far (120),
-      // near (60) -> fits. The focused page is never touched.
+      expect(budget.rebalance(), 60);
+      // The prefetch is genuine reclaimable memory. The remaining 180 bytes
+      // are the visible working set and may exceed the 100-byte target.
       expect(prefetch.evicted, isTrue);
-      expect(far.evicted, isTrue);
-      expect(near.evicted, isTrue);
+      expect(far.evicted, isFalse);
+      expect(near.evicted, isFalse);
       expect(focus.evicted, isFalse);
-      expect(budget.totalBytes, 60);
+      expect(budget.totalBytes, 180);
     });
 
     test('evictReclaimable sheds every non-focused page (pressure path)', () {


### PR DESCRIPTION
## Summary

- keep every page that overlaps the viewport out of live-raster budget eviction
- continue reclaiming off-screen and prefetched page rasters farthest-first
- add a regression test for a visible working set that exceeds the adaptive target

## Trace diagnosis

This is separate from #728. In the supplied trace, zero-based page 1 completes its detail raster at 18:27:00.941, then the global live-raster budget evicts the same page at 18:27:00.954 while onScreen=true. The cycle repeats at 18:27:02.010, 18:27:05.430, and 18:27:06.503.

The evicted page is still visible beside the focused page, so its next build immediately allocates the same raster again. That produces a render/evict loop rather than lasting memory headroom. The visible working set can now temporarily exceed the target; existing per-page caps still bound each page, and off-screen reclaim is unchanged.

## Validation

- fvm dart analyze
- fvm flutter test test/live_raster_budget_test.dart test/page_on_screen_test.dart
- fvm flutter test test/pdf_page_view_test.dart test/page_preview_test.dart test/render_hold_test.dart
- full packages/dart_pdf_editor suite: 2,423 passed, 37 expected skips
- app adaptive_memory_test.dart: 15 passed