### PR TITLE
perf: cull worker detail transcripts by viewport

### DIFF
--- a/packages/dart_pdf_editor/lib/src/region_replay_index.dart
+++ b/packages/dart_pdf_editor/lib/src/region_replay_index.dart
@@ -8,6 +8,17 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 /// shipped together, so a mismatch is a programming error (asserted on read).
 const int _regionIndexFormatVersion = 1;
 
+/// Region-index policy for worker detail transcripts.
+///
+/// A detail response is transient, but the worker's page transcript is reused
+/// across every deep-zoom pan. Keeping one index beside that transcript lets a
+/// viewport select its paint units before image decoding, command
+/// serialization, and strip binning. The limits mirror [PdfRetainedScene]'s
+/// ordinary linear/grid escalation without importing the Flutter-facing scene
+/// into worker code.
+const int pdfDetailRegionLinearMaxCommands = 250000;
+const int pdfDetailRegionGridMaxCommands = 4000000;
+
 /// Bounded, painter-order-preserving index for retained region replay.
 ///
 /// Each entry is one independent paint operation plus a persistent snapshot
@@ -77,6 +88,16 @@ class PdfRegionReplayIndex {
           clipNodes++;
         case PdfSetBlendModeCommand(:final mode):
           blendMode = mode;
+        case PdfSetOverprintCommand():
+          // Unlike blend mode, the region index does not yet snapshot the
+          // three overprint fields on each unit. Selective replay would lose
+          // that persistent device state, so keep these pages on the exact
+          // full-transcript fallback.
+          return PdfRegionReplayIndex._(
+            supported: false,
+            units: const [],
+            clipNodeCount: clipNodes,
+          );
         case PdfBeginGroupCommand() ||
               PdfEndGroupCommand() ||
               PdfBeginSoftMaskedCommand() ||
@@ -229,6 +250,42 @@ class PdfRegionReplayIndex {
       for (final unit in units)
         if (_intersects(unit.bounds, region)) unit,
     ];
+  }
+
+  /// Materializes a self-contained transcript for the paint units intersecting
+  /// [region].
+  ///
+  /// Each selected paint is wrapped in its captured save/blend/clip state, the
+  /// same sequence [replay] issues directly to a device. This lets a render
+  /// worker serialize and strip-bin only the visible slice while the consumer
+  /// replays the returned command list normally. [commands] may be a
+  /// document-backed twin of the list this index was built from (the worker's
+  /// source/wire transcript pair), but its top-level command ordering must
+  /// match.
+  ///
+  /// Unsupported indices, mismatched command lists, and selections whose
+  /// state wrappers would be no smaller than the original return [commands]
+  /// unchanged. The last guard keeps broad/full-page details from turning one
+  /// command per paint into four or more commands for no benefit.
+  List<PdfRenderCommand> commandsForRegion(
+    PdfRect region,
+    List<PdfRenderCommand> commands,
+  ) {
+    if (!supported) return commands;
+    final selected = select(region);
+    if (selected.isNotEmpty && selected.last.commandIndex >= commands.length) {
+      return commands;
+    }
+    final out = <PdfRenderCommand>[];
+    for (final unit in selected) {
+      out.add(const PdfSaveCommand());
+      out.add(PdfSetBlendModeCommand(unit.blendMode));
+      unit.clips?.appendCommands(out);
+      out.add(commands[unit.commandIndex]);
+      out.add(const PdfRestoreCommand());
+      if (out.length >= commands.length) return commands;
+    }
+    return List<PdfRenderCommand>.unmodifiable(out);
   }
 }
 
@@ -456,6 +513,11 @@ class PdfRegionClipState {
   void replay(PdfDevice device) {
     parent?.replay(device);
     device.clipPath(command.path, command.rule);
+  }
+
+  void appendCommands(List<PdfRenderCommand> commands) {
+    parent?.appendCommands(commands);
+    commands.add(command);
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -1354,8 +1354,8 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
   PdfRect imageDecodeRegion,
   PdfCancellationToken token,
 ) async {
-  final sourceCommands =
-      await cache.sourceCommandsFor(document, pageIndex, annotations, token);
+  final sourceCommands = await cache.detailCommandsFor(
+      document, pageIndex, annotations, imageDecodeRegion, token);
   if (sourceCommands == null) return null;
   if (token.cancelled) throw const PdfCancelledException();
 
@@ -1404,12 +1404,10 @@ Future<Uint8List?> _buildRegionIndexAsync(
     int maxCommands,
     bool buildGrid,
     PdfCancellationToken token) async {
-  final commands =
-      await cache.commandsFor(document, pageIndex, annotations, token);
-  if (commands == null) return null;
+  final index = await cache.regionIndexFor(
+      document, pageIndex, annotations, maxCommands, buildGrid, token);
+  if (index == null) return null;
   if (token.cancelled) throw const PdfCancelledException();
-  final index = PdfRegionReplayIndex.build(commands,
-      maxCommands: maxCommands, buildGrid: buildGrid);
   return serializeRegionReplayIndex(index);
 }
 
@@ -1453,15 +1451,29 @@ class _BinCommandCache {
           int pageIndex, bool annotations, PdfCancellationToken token) async =>
       (await _entryFor(document, pageIndex, annotations, token))?.wireCommands;
 
-  /// Original document-backed commands for a fresh serialization that must
-  /// resolve/decode image COS streams. The wire-round-tripped commands used by
-  /// [commandsFor] deliberately detach that object graph; feeding those back
-  /// to [serializeCommands] works for vector geometry but can no longer safely
-  /// resolve every image dependency.
-  Future<List<PdfRenderCommand>?> sourceCommandsFor(PdfDocument document,
-          int pageIndex, bool annotations, PdfCancellationToken token) async =>
-      (await _entryFor(document, pageIndex, annotations, token))
-          ?.sourceCommands;
+  Future<List<PdfRenderCommand>?> detailCommandsFor(
+      PdfDocument document,
+      int pageIndex,
+      bool annotations,
+      PdfRect region,
+      PdfCancellationToken token) async {
+    final entry = await _entryFor(document, pageIndex, annotations, token);
+    return entry?.commandsForDetail(region);
+  }
+
+  Future<PdfRegionReplayIndex?> regionIndexFor(
+      PdfDocument document,
+      int pageIndex,
+      bool annotations,
+      int maxCommands,
+      bool buildGrid,
+      PdfCancellationToken token) async {
+    final entry = await _entryFor(document, pageIndex, annotations, token);
+    return entry?.regionIndex(
+      maxCommands: maxCommands,
+      buildGrid: buildGrid,
+    );
+  }
 
   Future<_BinCommandEntry?> _entryFor(PdfDocument document, int pageIndex,
       bool annotations, PdfCancellationToken token) async {
@@ -1514,4 +1526,34 @@ class _BinCommandEntry {
   final List<PdfRenderCommand> sourceCommands;
   final List<PdfRenderCommand> wireCommands;
   final int retainedCommandWeight;
+
+  PdfRegionReplayIndex? _regionIndex;
+  (int, bool)? _regionIndexKey;
+
+  PdfRegionReplayIndex regionIndex({
+    required int maxCommands,
+    required bool buildGrid,
+  }) {
+    final key = (maxCommands, buildGrid);
+    if (_regionIndexKey != key) {
+      _regionIndex = PdfRegionReplayIndex.build(
+        wireCommands,
+        maxCommands: maxCommands,
+        buildGrid: buildGrid,
+      );
+      _regionIndexKey = key;
+    }
+    return _regionIndex!;
+  }
+
+  List<PdfRenderCommand> commandsForDetail(PdfRect region) {
+    final buildGrid = wireCommands.length > pdfDetailRegionLinearMaxCommands;
+    final index = regionIndex(
+      maxCommands: buildGrid
+          ? pdfDetailRegionGridMaxCommands
+          : pdfDetailRegionLinearMaxCommands,
+      buildGrid: buildGrid,
+    );
+    return index.commandsForRegion(region, sourceCommands);
+  }
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -4,6 +4,7 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'budgeted_cache.dart';
+import 'region_replay_index.dart';
 import 'render_trace.dart';
 
 // The worker fills its half of the unified [PdfRenderTrace]; re-exported so
@@ -21,6 +22,38 @@ class PdfWorkerTranscript {
 
   final List<PdfRenderCommand> sourceCommands;
   final List<PdfRenderCommand> wireCommands;
+
+  PdfRegionReplayIndex? _regionIndex;
+  (int, bool)? _regionIndexKey;
+
+  /// Reuses one region index across deep-zoom pans of this transcript.
+  PdfRegionReplayIndex regionIndex({
+    required int maxCommands,
+    required bool buildGrid,
+  }) {
+    final key = (maxCommands, buildGrid);
+    if (_regionIndexKey != key) {
+      _regionIndex = PdfRegionReplayIndex.build(
+        wireCommands,
+        maxCommands: maxCommands,
+        buildGrid: buildGrid,
+      );
+      _regionIndexKey = key;
+    }
+    return _regionIndex!;
+  }
+
+  /// Selects a compact, document-backed transcript for one detail region.
+  List<PdfRenderCommand> commandsForDetail(PdfRect region) {
+    final buildGrid = wireCommands.length > pdfDetailRegionLinearMaxCommands;
+    final index = regionIndex(
+      maxCommands: buildGrid
+          ? pdfDetailRegionGridMaxCommands
+          : pdfDetailRegionLinearMaxCommands,
+      buildGrid: buildGrid,
+    );
+    return index.commandsForRegion(region, sourceCommands);
+  }
 
   /// Command slots retained by this transcript, including commands nested
   /// inside soft-mask groups and both lists when they are distinct.

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -1204,7 +1204,13 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
     timings: timings,
   );
   if (transcript == null) return null;
-  var sourceCommands = transcript.sourceCommands;
+  // The transcript index carries the same conservative paint bounds used by
+  // retained-scene region replay. Select before decoding or serializing so a
+  // narrow CAD viewport does not repeatedly ship and strip-bin the other
+  // tens/hundreds of thousands of offscreen operations.
+  var sourceCommands = transcript.commandsForDetail(imageDecodeRegion);
+  final detailCommandCount = sourceCommands.length;
+  final transcriptCommandCount = transcript.sourceCommands.length;
   if (token.cancelled) throw const PdfCancelledException();
 
   // DCT images use the browser codec on web. Other image formats continue
@@ -1243,12 +1249,12 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
     timings!.serializeUs += serializeClock.elapsedMicroseconds;
   }
   if (tally != null) {
-    timings!.imageDecodeSummary = _formatImageDecodeSummary(
+    timings!.imageDecodeSummary = '${_formatImageDecodeSummary(
       tally,
       imageCache,
       imageCacheBefore!,
       flateSampleBytes: flateSampleCache.bytes,
-    );
+    )} regionCommands=$detailCommandCount/$transcriptCommandCount';
   }
   if (commandBuffer == null) return null;
   if (token.cancelled) throw const PdfCancelledException();
@@ -1345,8 +1351,7 @@ Future<Uint8List?> _buildRegionIndexAsync(
   );
   if (transcript == null) return null;
   if (token.cancelled) throw const PdfCancelledException();
-  final index = PdfRegionReplayIndex.build(
-    transcript.wireCommands,
+  final index = transcript.regionIndex(
     maxCommands: maxCommands,
     buildGrid: buildGrid,
   );

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -17,7 +17,7 @@
 //  - the abstract default (which the unsupported-platform stub inherits)
 //    declines with null.
 import 'dart:typed_data';
-import 'dart:ui' show Rect;
+import 'dart:ui' show Image, ImageByteFormat, Rect;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/region_replay_index.dart';
@@ -33,6 +33,11 @@ import 'render_seam_test.dart' show buildStripsPdf;
 import 'strip_zoom_router_test.dart' show buildVectorPdf;
 
 List<double> _coeffs(PdfMatrix m) => [m.a, m.b, m.c, m.d, m.e, m.f];
+
+Future<Uint8List> _rgba(Image image) async =>
+    (await image.toByteData(format: ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();
 
 /// A one-page PDF dense enough (thousands of interpreter ops) that a bin
 /// job reliably spans several of the worker's cooperative yield points, so
@@ -152,6 +157,70 @@ void main() {
       expect(encodeStripPlan(detail.plan), encodeStripPlan(local.finish()),
           reason: 'the returned plan must describe the returned commands, '
               'not a separate base recording');
+    });
+  });
+
+  testWidgets('isolate detail culls a wide CAD transcript byte-identically',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildSyntheticCadStrip(ops: 6000, streams: 2);
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+
+      final commands = await worker.record(0, decodeImages: false);
+      expect(commands, isNotNull);
+      final fullScene = await PdfRetainedScene.fromCommands(page, commands!);
+      addTearDown(fullScene.dispose);
+
+      const region = Rect.fromLTWH(120, 300, 300, 180);
+      const ratio = 1.5;
+      final geometry = fullScene.stripRegionGeometry(
+        region,
+        pixelRatio: ratio,
+      );
+      final m = geometry.pageToDevice;
+      final size = fullScene.pageSize;
+      final detail = await worker.recordStripDetail(
+        0,
+        annotations: true,
+        pageToDevice: _coeffs(m),
+        deviceWidth: geometry.width,
+        deviceHeight: geometry.height,
+        pixelRatio: ratio,
+        imageDecodeRegion: PdfRect(
+          region.left,
+          size.height - region.bottom,
+          region.right,
+          size.height - region.top,
+        ),
+      );
+      expect(detail, isNotNull);
+      expect(detail!.commands.length, lessThan(commands.length ~/ 2),
+          reason: 'the worker should not transfer the offscreen CAD strokes');
+
+      final detailScene = await PdfRetainedScene.fromCommands(
+        page,
+        detail.commands,
+      );
+      addTearDown(detailScene.dispose);
+      final expected = await fullScene.rasterizeRegionStrips(
+        region,
+        pixelRatio: ratio,
+      );
+      final actual = await detailScene.rasterizeRegionStrips(
+        region,
+        pixelRatio: ratio,
+        stripPlan: detail.plan,
+      );
+      try {
+        expect(await _rgba(actual), await _rgba(expected),
+            reason: 'selective worker detail must preserve region pixels');
+      } finally {
+        actual.dispose();
+        expected.dispose();
+      }
     });
   });
 

--- a/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
@@ -165,6 +165,59 @@ void main() {
     expect(cache.evictions, 2);
   });
 
+  test('detail transcripts select the visible CAD command slice', () async {
+    final document =
+        PdfDocument.open(buildSyntheticCadStrip(ops: 6000, streams: 2));
+    final cache = PdfWorkerTranscriptCache();
+    final transcript = await cache.transcriptFor(
+      document,
+      0,
+      true,
+      PdfCancellationToken(),
+    );
+    expect(transcript, isNotNull);
+
+    final full = transcript!.sourceCommands;
+    final detail = transcript.commandsForDetail(
+      const PdfRect(0, 0, 420, 841.89),
+    );
+    expect(detail, isNotEmpty);
+    expect(detail.length, lessThan(full.length ~/ 2),
+        reason: 'a 5%-wide viewport must not serialize and bin the other '
+            '${full.length} CAD commands');
+    expect(detail.whereType<PdfStrokePathCommand>(), isNotEmpty);
+
+    final again = transcript.commandsForDetail(
+      const PdfRect(8000, 0, 8503.939, 841.89),
+    );
+    expect(again, isNotEmpty,
+        reason: 'the cached index must serve a distant pan too');
+    expect(again.length, lessThan(full.length ~/ 2));
+  });
+
+  test('detail transcript keeps the full fallback for overprint state', () {
+    final commands = <PdfRenderCommand>[
+      const PdfSetOverprintCommand(fill: true, stroke: false, mode: 1),
+      const PdfFillPathCommand(
+        PdfPath([
+          PdfMoveTo(10, 10),
+          PdfLineTo(20, 10),
+          PdfLineTo(20, 20),
+          PdfClosePath(),
+        ]),
+        PdfColor.black,
+        PdfFillRule.nonzero,
+        1,
+      ),
+    ];
+    final transcript = PdfWorkerTranscript(commands, commands);
+    expect(
+      transcript.commandsForDetail(const PdfRect(0, 0, 30, 30)),
+      same(commands),
+      reason: 'state the region index cannot snapshot must never be culled',
+    );
+  });
+
   test('image-bearing transcripts keep the document-backed source graph',
       () async {
     final bytes = PdfImageDocument.fromImageBytes([buildTestJpeg()]);


### PR DESCRIPTION
## Summary
- select the paint units intersecting a deep-zoom viewport before worker image decode, command serialization, and strip binning
- cache the region index with the worker transcript and reuse it across pans on web and native
- retain the full-transcript fallback for unsupported state, broad regions, and selections that would not shrink
- report `regionCommands=selected/total` in web perf traces

## Why
The merged #729 Patrol trace moved reconciliation out of the hot path (2 ms p95). Deep-zoom worker details still spent 289-374 ms binning and 84-214 ms serializing because every viewport replay walked all 30,000 CAD strokes.

## Validation
- `fvm dart analyze`
- web render worker compiles with dart2js
- focused worker/transcript tests
- region replay/grid/worker and detail suites
- all 2,426 `dart_pdf_editor` tests
- new isolate regression proves the selective detail raster is byte-identical to the full-transcript region raster

The Patrol web perf artifact should validate the command-selection ratio and the expected bin/serialize reduction against merged #729.