### PR TITLE
perf: stop edge pages refilling tile cache

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -5038,6 +5038,12 @@ class _PdfPageViewState extends State<PdfPageView>
                 (_awaitingExactDetailPaint && !_tilePanAheadActive)
             ? 0
             : null,
+        // A narrow page sliver can keep presenting tiles it already owns, but
+        // it must not refill misses or a pan ring. Once the foreground count
+        // drops back to one, treating every mounted edge page as that sole
+        // claimant lets adjacent pyramids consume the shared LRU in turn and
+        // creates an endless raster/eviction/repaint loop.
+        scheduleMissing: widget.onScreen && widget.qualityVisible,
         // A retained picture keeps vector/text edges transform-sharp. An
         // upscaled coarser raster tile would cover that better base with a
         // visibly blurry square while the exact tile is pending. Coarse tiles

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -36,6 +36,7 @@ class PdfTileLayer extends StatelessWidget {
     this.maxNewTilesPerPaint,
     this.maxInFlightTiles,
     this.prefetchRingOverride,
+    this.scheduleMissing = true,
     this.allowCoarserFallback = true,
     this.fallbackOcclusionFraction,
     this.onExactViewReady,
@@ -89,6 +90,11 @@ class PdfTileLayer extends StatelessWidget {
   /// only the visible tiles; null uses the store's normal pan-ahead ring.
   final int? prefetchRingOverride;
 
+  /// Whether this layer may schedule missing visible tiles and pan-ahead.
+  /// False keeps retained tiles present without letting an edge-sliver page
+  /// compete with the focused page for the shared tile budget.
+  final bool scheduleMissing;
+
   /// Whether a missing exact tile may be covered by an upscaled lower rung.
   /// Disable this when the layer sits over a retained vector picture: the
   /// picture is sharper than that fallback and should remain visible until
@@ -129,6 +135,7 @@ class PdfTileLayer extends StatelessWidget {
           maxNewTilesPerPaint: maxNewTilesPerPaint,
           maxInFlightTiles: maxInFlightTiles,
           prefetchRingOverride: prefetchRingOverride,
+          scheduleMissing: scheduleMissing,
           allowCoarserFallback: allowCoarserFallback,
           fallbackOcclusionFraction: fallbackOcclusionFraction,
           onExactViewReady: onExactViewReady,
@@ -151,6 +158,7 @@ class _TilePagePainter extends CustomPainter {
     required this.maxNewTilesPerPaint,
     required this.maxInFlightTiles,
     required this.prefetchRingOverride,
+    required this.scheduleMissing,
     required this.allowCoarserFallback,
     required this.fallbackOcclusionFraction,
     required this.onExactViewReady,
@@ -171,6 +179,7 @@ class _TilePagePainter extends CustomPainter {
   final int? maxNewTilesPerPaint;
   final int? maxInFlightTiles;
   final int? prefetchRingOverride;
+  final bool scheduleMissing;
   final bool allowCoarserFallback;
   final Rect? fallbackOcclusionFraction;
   final ValueChanged<PdfTileView>? onExactViewReady;
@@ -200,6 +209,7 @@ class _TilePagePainter extends CustomPainter {
       maxNewTiles: maxNewTilesPerPaint,
       maxInFlightTiles: maxInFlightTiles,
       prefetchRingOverride: prefetchRingOverride,
+      scheduleMissing: scheduleMissing,
       allowCoarserFallback: allowCoarserFallback,
     );
     if (view.complete && !view.isEmpty) {
@@ -277,6 +287,7 @@ class _TilePagePainter extends CustomPainter {
       old.maxNewTilesPerPaint != maxNewTilesPerPaint ||
       old.maxInFlightTiles != maxInFlightTiles ||
       old.prefetchRingOverride != prefetchRingOverride ||
+      old.scheduleMissing != scheduleMissing ||
       old.allowCoarserFallback != allowCoarserFallback ||
       old.fallbackOcclusionFraction != fallbackOcclusionFraction ||
       old.filterQuality != filterQuality;

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -616,6 +616,13 @@ class PdfTileStore extends ChangeNotifier {
   /// before spending work on pan headroom, then restore the configured ring on
   /// subsequent pan settles.
   ///
+  /// [scheduleMissing] can make a view presentation-only: retained exact or
+  /// fallback tiles still paint, but neither visible misses nor the prefetch
+  /// ring start new work. The viewer uses this for a narrow page sliver at a
+  /// page boundary. Letting that non-foreground page refill its old pyramid
+  /// makes it compete with the focused page in the shared LRU; both pages then
+  /// evict and immediately re-raster one another's tiles.
+  ///
   /// [allowCoarserFallback] controls presentation only: exact misses are still
   /// scheduled, but a false value leaves their area transparent instead of
   /// upscaling a lower-rung tile. This is useful above a retained vector base,
@@ -639,6 +646,7 @@ class PdfTileStore extends ChangeNotifier {
     int? maxNewTiles,
     int? maxInFlightTiles,
     int? prefetchRingOverride,
+    bool scheduleMissing = true,
     bool allowCoarserFallback = true,
   }) {
     assert(maxNewTiles == null || maxNewTiles > 0);
@@ -726,11 +734,13 @@ class PdfTileStore extends ChangeNotifier {
         ));
       } else {
         complete = false;
-        schedule(
-          key,
-          notifyOnLand: true,
-          inFlightLimit: maxInFlightTiles,
-        );
+        if (scheduleMissing) {
+          schedule(
+            key,
+            notifyOnLand: true,
+            inFlightLimit: maxInFlightTiles,
+          );
+        }
         final fallback = allowCoarserFallback
             ? _coarserFallback(id, rung, tx, ty, span, pageSize)
             : null;
@@ -750,7 +760,7 @@ class PdfTileStore extends ChangeNotifier {
     // A view whose visible set already fills the budget gets no ring; the page
     // view falls back to the single patch before a view gets that dense.
     final requestPrefetchRing = prefetchRingOverride ?? prefetchRing;
-    if (requestPrefetchRing > 0 && complete) {
+    if (scheduleMissing && requestPrefetchRing > 0 && complete) {
       final visibleCount = (tx1 - tx0 + 1) * (ty1 - ty0 + 1);
       var ringHeadroom = budgetTileCapacity - visibleCount;
       if (ringHeadroom > 0) {

--- a/packages/dart_pdf_editor/test/page_on_screen_test.dart
+++ b/packages/dart_pdf_editor/test/page_on_screen_test.dart
@@ -94,6 +94,22 @@ void main() {
     expect(pages[1]!.onScreen, isFalse);
   });
 
+  testWidgets('a narrow edge sliver is presentation-only', (tester) async {
+    await pumpViewer(tester);
+    // Viewport [1000, 1600]. Page 0 contributes only its final 35px, below
+    // the 15% foreground threshold; page 1 occupies the rest. Both page views
+    // stay mounted and page 0 may present retained pixels, but only page 1 may
+    // schedule foreground tile work.
+    await scrollTo(tester, 1000);
+
+    final pages = mountedPages(tester);
+    expect(pages[0]!.onScreen, isTrue);
+    expect(pages[0]!.qualityVisible, isFalse);
+    expect(pages[0]!.qualityPageCount, 1);
+    expect(pages[1]!.qualityVisible, isTrue);
+    expect(pages[1]!.qualityPageCount, 1);
+  });
+
   testWidgets('onScreen tracks the viewer\'s own visibility measurement',
       (tester) async {
     final controller = await pumpViewer(tester, pages: 6);

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -699,6 +699,66 @@ void main() {
         reason: 'combined coarse sets would consume the reserved headroom');
   });
 
+  testWidgets('an edge-sliver page keeps tiles presentation-only',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 512, registerForMemoryPressure: false);
+    final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
+    PdfRetainedScene.spatialRegionReplayMaxCommands = 0;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfRetainedScene.spatialRegionReplayMaxCommands = oldRegionLimit;
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    Widget page({required bool qualityVisible}) => Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: SizedBox(
+              width: 6120,
+              child: PdfPageView(
+                page: doc.page(0),
+                onScreen: true,
+                qualityVisible: qualityVisible,
+                qualityPageCount: 1,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(page(qualityVisible: true));
+    final layer = find.byKey(const ValueKey('pdf-page-tile-layer'));
+    for (var i = 0; i < 300 && layer.evaluate().isEmpty; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(layer, findsOneWidget);
+    expect(
+        (tester.widget<CustomPaint>(layer).painter as dynamic).scheduleMissing,
+        isTrue);
+
+    // This is the page-boundary state from the field trace: the page still
+    // overlaps the viewport, but less than 15% of it is visible and the other
+    // page is the sole foreground-quality claimant.
+    await tester.pumpWidget(page(qualityVisible: false));
+    expect(layer, findsOneWidget,
+        reason: 'retained edge tiles may still contribute pixels');
+    expect(
+      (tester.widget<CustomPaint>(layer).painter as dynamic).scheduleMissing,
+      isFalse,
+      reason: 'the edge page must not refill against the focused page',
+    );
+  });
+
   testWidgets('heavy index warm does not launch an obsolete detail record',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -156,6 +156,64 @@ void main() {
   });
 
   group('PdfTileStore.viewFor', () {
+    testWidgets('presentation-only views never refill misses or a ring',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 1,
+          batchRasters: false,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        addTearDown(store.dispose);
+
+        // Seed only the centre tile, without its ring.
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(48, 48),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(16, 16, 16, 16),
+          rasterize: raster.call,
+          prefetchRingOverride: 0,
+        );
+        await raster.flush();
+        expect(store.debugTilesScheduled, 1);
+
+        // An exact presentation-only view paints the retained tile but does
+        // not use its completeness as permission to start the normal ring.
+        final exact = store.viewFor(
+          id: _id(0),
+          pageSize: const Size(48, 48),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(16, 16, 16, 16),
+          rasterize: raster.call,
+          scheduleMissing: false,
+        );
+        expect(exact.complete, isTrue);
+        expect(exact.placements, hasLength(1));
+        expect(store.debugTilesScheduled, 1,
+            reason: 'an edge page must not start pan-ahead');
+
+        // Moving the edge view across one uncached cell likewise presents the
+        // surviving tile without trying to reclaim the missing one from the
+        // focused page's shared cache budget.
+        final partial = store.viewFor(
+          id: _id(0),
+          pageSize: const Size(48, 48),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(16, 16, 32, 16),
+          rasterize: raster.call,
+          scheduleMissing: false,
+        );
+        expect(partial.complete, isFalse);
+        expect(partial.placements, hasLength(1));
+        expect(store.debugTilesScheduled, 1,
+            reason: 'presentation-only visible misses stay unscheduled');
+        expect(store.inFlightCount, 0);
+      });
+    });
+
     test('raster coverage follows whole cells and includes the prefetch ring',
         () {
       final store = PdfTileStore(


### PR DESCRIPTION
## Summary

- keep a narrow edge-sliver page presentation-only once it falls below the viewer foreground-quality threshold
- let it paint retained exact/fallback tiles while preventing new visible misses and pan-ahead work
- cover the policy at the tile store, page-layer wiring, and real two-page viewer boundary

## Trace evidence

The field trace from merged #730 confirms viewport-culling is working: visible detail completed in roughly 222-323ms and page 2 first painted detail at about 298ms. The remaining tail was tile-cache churn across the page 1/page 2 boundary:

- 191 tile batches total
- 140 prefetch batches / 424 prefetch tiles
- page 1 prefetch: 196 tiles
- page 2 prefetch: 228 tiles
- shared tile cache stayed near its 100MB cap, so the two page pyramids repeatedly evicted and refilled one another

At that boundary page 1 still overlapped the viewport, but occupied less than the 15% foreground threshold. Page 2 was therefore the sole quality page; the old page-local policy still allowed page 1 to schedule because the global quality count was one. This change keys scheduling on the page own quality-visible state as well.

The CI Patrol CAD fixture is single-page, so it cannot reproduce this specific cross-page contention. The deterministic regressions assert the scheduling boundary directly; a future two-page field trace should show no new page 1 prefetch after page 1 becomes an edge sliver.

## Validation

- fvm dart analyze
- focused boundary/tile tests: 61 passed
- adjacent render/page/CAD/worker tests: 121 passed
- full dart_pdf_editor suite: 2,429 passed, 37 expected skips