### PR TITLE
perf: stop edge pages consuming detail work

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1166,6 +1166,23 @@ class _PdfPageViewState extends State<PdfPageView>
     final settleChanged = oldWidget.settleGeneration != widget.settleGeneration;
     final tileShareChanged =
         oldWidget.qualityPageCount != widget.qualityPageCount;
+    final leftQualityForeground = oldWidget.onScreen &&
+        oldWidget.qualityVisible &&
+        (!widget.onScreen || !widget.qualityVisible);
+    if (leftQualityForeground) {
+      // The page can remain geometrically on screen as a narrow edge sliver
+      // after another page becomes the sole foreground-quality claimant. A
+      // render queued while this page was meaningful may otherwise be granted
+      // after that hand-off and launch a full visible-region detail record.
+      // Keep already-painted base/detail pixels as the sliver's fallback, but
+      // withdraw work that has not started and reject any detail result which
+      // was already in flight. Re-entry consumes the deferred refresh below.
+      _renderSession.invalidateDetail();
+      _deferredOffscreenRasterRefresh = true;
+      _awaitingExactDetailPaint = false;
+      _cancelTilePanAhead();
+      widget.renderScheduler?.cancel(this);
+    }
     final enteredDeepForeground = widget.onScreen &&
         widget.qualityVisible &&
         _detailRequiredAt(widget.scale) &&
@@ -3976,6 +3993,10 @@ class _PdfPageViewState extends State<PdfPageView>
       _dropDetail();
       return true;
     }
+    // A narrow edge sliver may keep presenting an already-painted exact patch,
+    // just as the tile layer keeps retained tiles, but it must not schedule a
+    // fresh region record/raster until it becomes foreground-quality again.
+    if (!widget.qualityVisible) return true;
 
     // A retained/direct picture keeps vector and text commands live under the
     // viewer transform. When its decoded images already have at least one
@@ -4132,6 +4153,7 @@ class _PdfPageViewState extends State<PdfPageView>
             region,
             ratio,
             widget.previewIndex,
+            generation,
             priority: progressivePriority,
           )
         : Future<ui.Picture?>.value();
@@ -4145,9 +4167,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // worker pass was started to replace it.
     if (retainedCoversRegion) {
       final cachedPicture = await _picture;
-      if (!mounted ||
-          !_renderSession.acceptsDetail(generation) ||
-          _renderPaused) {
+      if (!_acceptsForegroundDetail(generation)) {
         return false;
       }
       final retainedImage = await PdfRasterProbe.measure(
@@ -4159,9 +4179,7 @@ class _PdfPageViewState extends State<PdfPageView>
             ? heldScene.rasterizeRegion(region, pixelRatio: ratio)
             : PdfPageRenderer.rasterizeRegion(cachedPicture, region, ratio),
       );
-      if (!mounted ||
-          !_renderSession.acceptsDetail(generation) ||
-          _renderPaused) {
+      if (!_acceptsForegroundDetail(generation)) {
         retainedImage.dispose();
         return false;
       }
@@ -4188,9 +4206,7 @@ class _PdfPageViewState extends State<PdfPageView>
       'elapsed=${detailClock.elapsedMilliseconds}ms '
       'stripImage=${workerStripImage != null} picture=${workerPicture != null}',
     );
-    if (!mounted ||
-        !_renderSession.acceptsDetail(generation) ||
-        _renderPaused) {
+    if (!_acceptsForegroundDetail(generation)) {
       workerStripImage?.dispose();
       workerPicture?.dispose();
       return false;
@@ -4217,9 +4233,7 @@ class _PdfPageViewState extends State<PdfPageView>
             PdfPageRenderer.rasterizeRegion(workerPicture, region, ratio),
       );
       workerPicture.dispose();
-      if (!mounted ||
-          !_renderSession.acceptsDetail(generation) ||
-          _renderPaused) {
+      if (!_acceptsForegroundDetail(generation)) {
         image.dispose();
         return false;
       }
@@ -4266,9 +4280,7 @@ class _PdfPageViewState extends State<PdfPageView>
       widget.page,
       _renderPlan,
     ));
-    if (!mounted ||
-        !_renderSession.acceptsDetail(generation) ||
-        _renderPaused) {
+    if (!_acceptsForegroundDetail(generation)) {
       return false;
     }
     // Same replay-over-nested-raster swap as the full-page path: the deep-
@@ -4289,9 +4301,7 @@ class _PdfPageViewState extends State<PdfPageView>
         pixelRatio: ratio,
         region: region,
       );
-      if (!mounted ||
-          !_renderSession.acceptsDetail(generation) ||
-          _renderPaused) {
+      if (!_acceptsForegroundDetail(generation)) {
         return false;
       }
       rasterize = () => scene.rasterizeRegionStrips(
@@ -4317,9 +4327,7 @@ class _PdfPageViewState extends State<PdfPageView>
       region: (width: region.width, height: region.height),
       rasterize: rasterize,
     );
-    if (!mounted ||
-        !_renderSession.acceptsDetail(generation) ||
-        _renderPaused) {
+    if (!_acceptsForegroundDetail(generation)) {
       image.dispose();
       return false;
     }
@@ -4337,7 +4345,7 @@ class _PdfPageViewState extends State<PdfPageView>
     required String source,
   }) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_renderSession.acceptsDetail(generation)) return;
+      if (!_acceptsForegroundDetail(generation)) return;
       if (PdfPerfLog.enabled) {
         PdfPerfLog.log(
           'detail paint page=${widget.previewIndex} pass=visible '
@@ -4350,6 +4358,13 @@ class _PdfPageViewState extends State<PdfPageView>
       _activateTilePanAhead();
     });
   }
+
+  bool _acceptsForegroundDetail(int generation) =>
+      mounted &&
+      widget.onScreen &&
+      widget.qualityVisible &&
+      !_renderPaused &&
+      _renderSession.acceptsDetail(generation);
 
   /// Conservative image-overlap test for the transparent-image progressive
   /// scene. Its local replay is only a visually complete CAD/vector patch
@@ -5545,7 +5560,8 @@ class _PdfPageViewState extends State<PdfPageView>
   Future<ui.Picture?> _detailPictureFromWorker(
     Rect rasterRegion,
     double ratio,
-    int pageIndex, {
+    int pageIndex,
+    int generation, {
     int? priority,
   }) async {
     final worker = widget.renderWorker;
@@ -5558,15 +5574,23 @@ class _PdfPageViewState extends State<PdfPageView>
       imagePixelRatio: ratio,
       imageDecodeRegion: decodeRegion,
     );
-    if (_abandoned(pageIndex) || commands == null) return null;
-    if (_renderPaused) return null;
+    if (_abandoned(pageIndex) ||
+        !_acceptsForegroundDetail(generation) ||
+        commands == null) {
+      return null;
+    }
     _logImageStats(pageIndex, commands);
-    return PdfPageRenderer.pictureFromCommandsWithPlan(
+    final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
       widget.page,
       commands,
       _renderPlan,
       maxImagePixelRatio: ratio,
     );
+    if (!_acceptsForegroundDetail(generation)) {
+      picture.dispose();
+      return null;
+    }
+    return picture;
   }
 
   Future<ui.Image?> _detailStripImageFromWorker(
@@ -5615,8 +5639,7 @@ class _PdfPageViewState extends State<PdfPageView>
       );
     }
     if (_abandoned(pageIndex) ||
-        !_renderSession.acceptsDetail(generation) ||
-        _renderPaused ||
+        !_acceptsForegroundDetail(generation) ||
         detail == null) {
       return null;
     }
@@ -5627,9 +5650,7 @@ class _PdfPageViewState extends State<PdfPageView>
       plan: _renderPlan,
       maxImagePixelRatio: ratio,
     );
-    if (_abandoned(pageIndex) ||
-        !_renderSession.acceptsDetail(generation) ||
-        _renderPaused) {
+    if (_abandoned(pageIndex) || !_acceptsForegroundDetail(generation)) {
       scene.dispose();
       return null;
     }

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -494,6 +494,159 @@ void main() {
     expect(ready, 1);
   });
 
+  testWidgets('an edge sliver withdraws queued deep-detail work',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final bytes = buildClassicPdf();
+    final document = PdfDocument.open(bytes);
+    final worker = _RatioRecordingWorker(_LocalCommandWorker(bytes));
+    final scheduler = PdfPageRenderScheduler();
+    final oldMotionSafe = PdfPageView.motionSafeRenders;
+    final oldRetained = PdfPageView.retainedZoomReplay;
+    PdfPageView.motionSafeRenders = false;
+    PdfPageView.retainedZoomReplay = false;
+    addTearDown(() {
+      PdfPageView.motionSafeRenders = oldMotionSafe;
+      PdfPageView.retainedZoomReplay = oldRetained;
+      scheduler.dispose();
+      worker.dispose();
+    });
+
+    Widget at(double scale, bool qualityVisible, int settleGeneration) =>
+        Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: document.page(0),
+              baseRasterScale: 1,
+              scale: scale,
+              settleGeneration: settleGeneration,
+              qualityVisible: qualityVisible,
+              renderScheduler: scheduler,
+              renderWorker: worker,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(1, true, 0));
+    for (var i = 0; i < 100 && find.byType(RawImage).evaluate().isEmpty; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byType(RawImage), findsOneWidget);
+    expect(worker.detailRecords, 0);
+
+    scheduler.holding = true;
+    await tester.pumpWidget(at(4, true, 1));
+    await tester.pump();
+    expect(scheduler.hasPending, isTrue);
+
+    // This is the field-trace ordering: a zoom/detail refresh was queued while
+    // the page was meaningful, then the page became a sub-15% edge sliver
+    // before the shared scheduler granted it.
+    await tester.pumpWidget(at(4, false, 1));
+    await tester.pump();
+    scheduler.holding = false;
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+
+    expect(worker.detailRecords, 0,
+        reason: 'an edge page must not enter the worker detail queue');
+    expect(find.byType(RawImage), findsOneWidget,
+        reason: 'the existing fit-size base remains the sliver fallback');
+  });
+
+  testWidgets('an in-flight detail result is discarded after edge hand-off',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final bytes = buildClassicPdf();
+    final document = PdfDocument.open(bytes);
+    final worker = _BlockingDetailWorker(_LocalCommandWorker(bytes));
+    final oldRetained = PdfPageView.retainedZoomReplay;
+    PdfPageView.retainedZoomReplay = false;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplay = oldRetained;
+      worker.releaseFirst();
+      worker.dispose();
+    });
+
+    Widget at(double scale, bool qualityVisible, int settleGeneration) =>
+        Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: document.page(0),
+              baseRasterScale: 1,
+              scale: scale,
+              settleGeneration: settleGeneration,
+              qualityVisible: qualityVisible,
+              renderWorker: worker,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(1, true, 0));
+    for (var i = 0; i < 100 && find.byType(RawImage).evaluate().isEmpty; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byType(RawImage), findsOneWidget);
+
+    await tester.pumpWidget(at(4, true, 1));
+    for (var i = 0; i < 100 && worker.detailRecords == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(worker.detailRecords, 1);
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsNothing);
+
+    await tester.pumpWidget(at(4, false, 1));
+    worker.releaseFirst();
+    for (var i = 0; i < 40; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsNothing,
+        reason: 'a late result must not replay or rasterize over the edge');
+
+    // Becoming meaningful again consumes the deferred refresh and sharpens
+    // without requiring an unrelated scale or settle change.
+    await tester.pumpWidget(at(4, true, 1));
+    for (var i = 0;
+        i < 100 &&
+            find
+                .byKey(const ValueKey('pdf-page-detail-image'))
+                .evaluate()
+                .isEmpty;
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(worker.detailRecords, 2);
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget);
+
+    await tester.pumpWidget(at(4, false, 1));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget,
+        reason: 'the edge can keep presenting already-completed sharp pixels');
+  });
+
   testWidgets('both visible pages sharpen when the viewport spans a boundary',
       (tester) async {
     tester.view.physicalSize = const Size(800, 600);
@@ -1627,6 +1780,7 @@ class _RatioRecordingWorker extends PdfRenderWorker {
 
   final PdfRenderWorker _inner;
   final List<double> imageRatios = [];
+  int detailRecords = 0;
 
   @override
   bool get isActive => _inner.isActive;
@@ -1642,8 +1796,58 @@ class _RatioRecordingWorker extends PdfRenderWorker {
     PdfRect? imageDecodeRegion,
     PdfPartialRecordSink? onPartial,
   }) {
+    if (imageDecodeRegion != null) detailRecords++;
     if (decodeImages && imagePixelRatio != null) {
       imageRatios.add(imagePixelRatio);
+    }
+    return _inner.record(
+      pageIndex,
+      annotations: annotations,
+      priority: priority,
+      imagePixelRatio: imagePixelRatio,
+      decodeImages: decodeImages,
+      commandLimit: commandLimit,
+      imageDecodeRegion: imageDecodeRegion,
+      onPartial: onPartial,
+    );
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      _inner.cancel(pageIndex, priority: priority);
+
+  @override
+  void dispose() => _inner.dispose();
+}
+
+class _BlockingDetailWorker extends PdfRenderWorker {
+  _BlockingDetailWorker(this._inner);
+
+  final PdfRenderWorker _inner;
+  final Completer<void> _firstRelease = Completer<void>();
+  int detailRecords = 0;
+
+  void releaseFirst() {
+    if (!_firstRelease.isCompleted) _firstRelease.complete();
+  }
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async {
+    if (imageDecodeRegion != null) {
+      detailRecords++;
+      if (detailRecords == 1) await _firstRelease.future;
     }
     return _inner.record(
       pageIndex,


### PR DESCRIPTION
## Summary
- withdraw queued detail renders when a page falls below foreground-quality visibility
- reject late worker, strip, and local detail results after that visibility hand-off
- retain completed base/detail pixels as presentation fallback and refresh detail when the page re-enters the foreground

## Why
The field trace after #731 showed that tile churn was fixed, but a sub-15% edge page still launched a roughly 209 ms detail pass ahead of the focused page. That contributed to the focused page's larger detail pass taking roughly 450 ms to arrive.

## Validation
- fvm dart analyze
- focused page-view, tile, scheduler, and visibility suites: 86 passed
- full dart_pdf_editor suite: 2431 passed, 37 expected skips

Regression coverage exercises queued withdrawal, in-flight result rejection, foreground re-entry, and preservation of already-painted fallback pixels.