### PR TITLE
ci: publish Patrol performance reports on PRs

### DIFF
--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -168,6 +168,79 @@ jobs:
             packages/dart_pdf_editor/example/playwright-report
           if-no-files-found: ignore
 
+  report:
+    name: Patrol performance report
+    if: >-
+      always() &&
+      needs.build.result != 'cancelled' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download Patrol web results
+        id: patrol-results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: patrol-web-results
+          path: patrol-results
+
+      - name: Comment Patrol performance report
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          PATROL_MARKER: dart-pdf-patrol-performance
+          PATROL_SUMMARY: patrol-results/test-results/perf/patrol-perf.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = `<!-- ${process.env.PATROL_MARKER} -->`;
+            const summaryPath = process.env.PATROL_SUMMARY;
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const summary = fs.existsSync(summaryPath)
+              ? fs.readFileSync(summaryPath, 'utf8').trim()
+              : [
+                  '## Patrol web performance',
+                  '',
+                  'No performance summary artifact was produced. Open the workflow run for the failing step and raw logs.',
+                ].join('\n');
+            const body = [
+              marker,
+              summary,
+              '',
+              `Automated for commit \`${sha}\` · [workflow run and downloadable trace artifact](${runUrl})`,
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   deploy:
     # Fork and Dependabot PRs do not receive repository secrets. Other same-repo
     # PRs deploy only the static build artifact from the build job; this job does

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -106,6 +106,7 @@ class PatrolPerfTrace {
     required this.webWorkerOutcomes,
     required this.workerPhases,
     required this.rasterElapsedMs,
+    required this.tiles,
     required this.scenarioPhases,
     required Map<String, _ScenarioMetrics> scenarioMetrics,
   }) : _scenarioMetrics = scenarioMetrics;
@@ -129,6 +130,7 @@ class PatrolPerfTrace {
     final webWorkerOutcomes = <String, int>{};
     final workerPhases = _WorkerPhaseMetrics();
     final rasterElapsed = <double>[];
+    final tiles = _TileMetrics();
     final scenarioPhases = <String, int>{};
     final scenarioMetrics = <String, _ScenarioMetrics>{};
     final activeScenarios = <String, _ActiveScenario>{};
@@ -207,6 +209,8 @@ class PatrolPerfTrace {
         }
       } else if (event == 'raster') {
         _addMilliseconds(rasterElapsed, fields['ms']);
+      } else if (event == 'tile') {
+        tiles.record(message, fields);
       }
 
       for (final scenario in activeScenarios.values) {
@@ -242,6 +246,7 @@ class PatrolPerfTrace {
       webWorkerOutcomes: webWorkerOutcomes,
       workerPhases: workerPhases,
       rasterElapsedMs: rasterElapsed,
+      tiles: tiles,
       scenarioPhases: scenarioPhases,
       scenarioMetrics: scenarioMetrics,
     );
@@ -264,11 +269,12 @@ class PatrolPerfTrace {
   final Map<String, int> webWorkerOutcomes;
   final _WorkerPhaseMetrics workerPhases;
   final List<double> rasterElapsedMs;
+  final _TileMetrics tiles;
   final Map<String, int> scenarioPhases;
   final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 6,
+        'schema': 7,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -304,6 +310,7 @@ class PatrolPerfTrace {
           'count': eventCounts['raster'] ?? 0,
           'elapsedMs': _distribution(rasterElapsedMs),
         },
+        'tiles': tiles.toJson(),
         'scenarios': _sortedMap(scenarioPhases),
         'scenarioMetrics': {
           for (final name in _scenarioMetrics.keys.toList()..sort())
@@ -360,6 +367,15 @@ class PatrolPerfTrace {
       ..writeln('| Scenarios | ${_mapText(scenarioPhases)} |')
       ..writeln('| Raster p50 / p95 / max | '
           '${_distributionText(rasterElapsedMs)} |')
+      ..writeln('| Tile replay requests | ${tiles.replayRequests} |')
+      ..writeln('| Tile replay p50 / p95 / max | '
+          '${_distributionText(tiles.replayMs)} |')
+      ..writeln('| Tile replay raster p50 / p95 / max | '
+          '${_distributionText(tiles.rasterMs)} |')
+      ..writeln('| Tile slice classes | ${tiles.sliceClassText} |')
+      ..writeln('| Tile rung/class batches | '
+          '${_mapText(tiles.sliceBatchesByRungClass)} |')
+      ..writeln('| Tile retained peak | ${tiles.retainedPeakText} |')
       ..writeln();
     if (_scenarioMetrics.isNotEmpty) {
       buffer
@@ -368,11 +384,12 @@ class PatrolPerfTrace {
         ..writeln(
           '| Scenario | Runs | Elapsed p50 / p95 / max | Jank p95 | '
           'Reconcile p95 | Raster p95 | Worker total p95 | '
-          'Decode p95 | Cache lookups | Image cache peak | Worker outcomes |',
+          'Decode p95 | Tile replay / prefetch batches | Tile retained peak | '
+          'Cache lookups | Image cache peak | Worker outcomes |',
         )
         ..writeln(
           '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | '
-          '---: | ---: | --- |',
+          '---: | ---: | ---: | ---: | --- |',
         );
       for (final name in _scenarioMetrics.keys.toList()..sort()) {
         final metrics = _scenarioMetrics[name]!;
@@ -384,6 +401,9 @@ class PatrolPerfTrace {
           '${_p95Text(metrics.rasterElapsedMs)} | '
           '${_p95Text(metrics.workerPhases.totalMs)} | '
           '${_p95Text(metrics.workerPhases.decodeMs)} | '
+          '${metrics.tiles.replayRequests} / '
+          '${metrics.tiles.prefetchBatches} | '
+          '${metrics.tiles.retainedPeakText} | '
           '${metrics.workerPhases.cacheLookupText} | '
           '${_formatBytes(metrics.workerPhases.peakImageCacheBytes)} | '
           '${_mapText(metrics.webWorkerOutcomes)} |',
@@ -499,6 +519,17 @@ class PatrolPerfComparison {
       const ['webWorker', 'phases', 'decodeMs', 'p95'],
     );
     timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
+    countRow('Tile replay requests', const ['tiles', 'replayRequests']);
+    countRow(
+      'Tile prefetch batches',
+      const ['tiles', 'sliceBatchesByClass', 'prefetch'],
+    );
+    countRow(
+      'Tile prefetch tiles',
+      const ['tiles', 'slicedTilesByClass', 'prefetch'],
+    );
+    timingRow('Tile replay p95', const ['tiles', 'replayMs', 'p95']);
+    timingRow('Tile replay raster p95', const ['tiles', 'rasterMs', 'p95']);
     for (final scenario in measuredScenarios) {
       countRow(
         'Scenario $scenario runs',
@@ -534,6 +565,20 @@ class PatrolPerfComparison {
         'Scenario $scenario decode p95',
         ['scenarioMetrics', scenario, 'workerPhases', 'decodeMs', 'p95'],
       );
+      countRow(
+        'Scenario $scenario tile replay requests',
+        ['scenarioMetrics', scenario, 'tiles', 'replayRequests'],
+      );
+      countRow(
+        'Scenario $scenario tile prefetch batches',
+        [
+          'scenarioMetrics',
+          scenario,
+          'tiles',
+          'sliceBatchesByClass',
+          'prefetch',
+        ],
+      );
     }
 
     buffer
@@ -558,6 +603,10 @@ class PatrolPerfComparison {
           const ['webWorker', 'phases', 'outcomes'], baseline, current))
       ..writeln(_mapComparisonRow('Worker transcript paths',
           const ['webWorker', 'phases', 'transcripts'], baseline, current))
+      ..writeln(_mapComparisonRow('Tile slice classes',
+          const ['tiles', 'sliceBatchesByClass'], baseline, current))
+      ..writeln(_mapComparisonRow('Tile rung/class batches',
+          const ['tiles', 'sliceBatchesByRungClass'], baseline, current))
       ..writeAll(
         measuredScenarios.map(
           (scenario) => _mapComparisonRow(
@@ -591,6 +640,7 @@ class _ScenarioMetrics {
   final rasterElapsedMs = <double>[];
   final webWorkerOutcomes = <String, int>{};
   final workerPhases = _WorkerPhaseMetrics();
+  final tiles = _TileMetrics();
 
   void record(
     String event,
@@ -609,6 +659,8 @@ class _ScenarioMetrics {
       if (message.startsWith('webworker phase ')) {
         workerPhases.record(fields);
       }
+    } else if (event == 'tile') {
+      tiles.record(message, fields);
     }
   }
 
@@ -628,6 +680,7 @@ class _ScenarioMetrics {
           'elapsedMs': _distribution(rasterElapsedMs),
         },
         'workerPhases': workerPhases.toJson(),
+        'tiles': tiles.toJson(),
         'webWorkerOutcomes': _sortedMap(webWorkerOutcomes),
       };
 }
@@ -726,6 +779,93 @@ class _WorkerPhaseMetrics {
           'noLookupRequests': imageCacheNoLookupRequests,
           'netEntries': netImageCacheEntries,
           'netBytes': netImageCacheBytes,
+        },
+      };
+}
+
+class _TileMetrics {
+  var replayRequests = 0;
+  var sliceBatches = 0;
+  var slicedTiles = 0;
+  final replayMs = <double>[];
+  final rasterMs = <double>[];
+  final sliceElapsedMs = <double>[];
+  final sliceBatchesByClass = <String, int>{};
+  final slicedTilesByClass = <String, int>{};
+  final sliceBatchesByRungClass = <String, int>{};
+  final retainedBytes = <int>[];
+  final retainedEntries = <int>[];
+
+  int get prefetchBatches => sliceBatchesByClass['prefetch'] ?? 0;
+
+  int get peakRetainedBytes =>
+      retainedBytes.isEmpty ? 0 : retainedBytes.reduce((a, b) => a > b ? a : b);
+
+  int get peakRetainedEntries => retainedEntries.isEmpty
+      ? 0
+      : retainedEntries.reduce((a, b) => a > b ? a : b);
+
+  String get sliceClassText {
+    if (sliceBatchesByClass.isEmpty) return 'none';
+    final classes = sliceBatchesByClass.keys.toList()..sort();
+    return classes.map((name) {
+      final batches = sliceBatchesByClass[name]!;
+      final tiles = slicedTilesByClass[name] ?? 0;
+      return '${_code(name)} $batches '
+          '${batches == 1 ? 'batch' : 'batches'} / $tiles '
+          '${tiles == 1 ? 'tile' : 'tiles'}';
+    }).join(', ');
+  }
+
+  String get retainedPeakText {
+    if (retainedBytes.isEmpty && retainedEntries.isEmpty) return 'n/a';
+    return '${_formatBytes(peakRetainedBytes)} / $peakRetainedEntries entries';
+  }
+
+  void record(String message, Map<String, String> fields) {
+    if (message.startsWith('tile replay ')) {
+      replayRequests++;
+      _addMilliseconds(replayMs, fields['replay']);
+      _addMilliseconds(rasterMs, fields['raster']);
+      return;
+    }
+    if (!message.startsWith('tile slice ')) return;
+
+    sliceBatches++;
+    final tileCount = int.tryParse(fields['tiles'] ?? '') ?? 0;
+    slicedTiles += tileCount;
+    final tileClass = fields['class'] ?? 'unknown';
+    sliceBatchesByClass[tileClass] = (sliceBatchesByClass[tileClass] ?? 0) + 1;
+    slicedTilesByClass[tileClass] =
+        (slicedTilesByClass[tileClass] ?? 0) + tileCount;
+    final rung = fields['rung'] ?? 'unknown';
+    final rungClass = 'rung-$rung/$tileClass';
+    sliceBatchesByRungClass[rungClass] =
+        (sliceBatchesByRungClass[rungClass] ?? 0) + 1;
+    _addMilliseconds(sliceElapsedMs, fields['elapsed']);
+    final retained = int.tryParse(fields['retained'] ?? '');
+    if (retained != null) retainedBytes.add(retained);
+    final entries = int.tryParse(fields['entries'] ?? '');
+    if (entries != null) retainedEntries.add(entries);
+  }
+
+  Map<String, Object?> toJson() => {
+        'replayRequests': replayRequests,
+        'replayMs': _distribution(replayMs),
+        'rasterMs': _distribution(rasterMs),
+        'sliceBatches': sliceBatches,
+        'slicedTiles': slicedTiles,
+        'sliceElapsedMs': _distribution(sliceElapsedMs),
+        'sliceBatchesByClass': _sortedMap(sliceBatchesByClass),
+        'slicedTilesByClass': _sortedMap(slicedTilesByClass),
+        'sliceBatchesByRungClass': _sortedMap(sliceBatchesByRungClass),
+        'retainedBytes': {
+          'samples': retainedBytes.length,
+          'max': peakRetainedBytes,
+        },
+        'retainedEntries': {
+          'samples': retainedEntries.length,
+          'max': peakRetainedEntries,
         },
       };
 }

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -22,6 +22,10 @@ void main() {
         'bin=1.0ms transfer=1.0ms deserialize=0.5ms total=9.0ms '
         'transcript=hit imageDecode=none '
         'cache=2h/3m/4e/8388608B cacheDelta=0h/0m/0e/0B',
+    '[perf 38] tile replay page=0 region=256x256pt ratio=2.83 '
+        'selected=40/100 replay=2.0ms raster=5.0ms img=725x725',
+    '[perf 39] tile slice page=0 rung=3 class=prefetch tiles=4 '
+        'elapsed=3.0ms retained=8388608 entries=8',
     '[perf 40] raster page=0 ms=12.5',
     '[perf 45] webworker result kind=record page=0 commands=1 → worker',
     '[perf 47] webworker result kind=record page=1 declined (null) → local',
@@ -30,7 +34,7 @@ void main() {
     '[perf 90] scenario name=heavy-document phase=validated',
   ]);
   final json = trace.toJson();
-  _expectEqual(json['schema'], 6, 'schema');
+  _expectEqual(json['schema'], 7, 'schema');
 
   final workerPhases = _map(_map(json, 'webWorker'), 'phases');
   _expectEqual(workerPhases['count'], 2, 'worker phase count');
@@ -62,6 +66,26 @@ void main() {
       'netBytes': 8388608,
     },
     'worker image cache activity',
+  );
+
+  final tiles = _map(json, 'tiles');
+  _expectEqual(tiles['replayRequests'], 1, 'tile replay requests');
+  _expectEqual(tiles['sliceBatches'], 1, 'tile slice batches');
+  _expectEqual(tiles['slicedTiles'], 4, 'sliced tiles');
+  _expectEqual(
+    _map(tiles, 'sliceBatchesByClass'),
+    const {'prefetch': 1},
+    'tile slice classes',
+  );
+  _expectEqual(
+    _map(tiles, 'sliceBatchesByRungClass'),
+    const {'rung-3/prefetch': 1},
+    'tile rung classes',
+  );
+  _expectEqual(
+    _map(tiles, 'retainedBytes')['max'],
+    8388608,
+    'tile retained bytes',
   );
 
   final scenarios = _map(json, 'scenarioMetrics');
@@ -133,11 +157,28 @@ void main() {
     '| Worker image-cache net growth | 4 entries / +8.0 MiB |',
     'worker cache growth',
   );
+  _expectContains(
+    markdown,
+    '| Tile slice classes | `prefetch` 1 batch / 4 tiles |',
+    'tile class summary',
+  );
+  _expectContains(
+    markdown,
+    '| Tile retained peak | 8.0 MiB / 8 entries |',
+    'tile retained summary',
+  );
 
   final comparison = summary.PatrolPerfComparison(
     baseline: {
       'build': 'commit=main',
       'scenarios': json['scenarios'],
+      'tiles': {
+        'replayRequests': 2,
+        'sliceBatchesByClass': {'prefetch': 2},
+        'slicedTilesByClass': {'prefetch': 8},
+        'replayMs': {'p95': 4.0},
+        'rasterMs': {'p95': 10.0},
+      },
       'scenarioMetrics': {
         'heavy-document': {
           'runs': 1,
@@ -167,6 +208,11 @@ void main() {
     comparison,
     '| Scenario heavy-document worker total p95 | n/a | 12.0 ms | n/a |',
     'scenario worker comparison',
+  );
+  _expectContains(
+    comparison,
+    '| Tile prefetch batches | 2 | 1 | -1 |',
+    'tile prefetch comparison',
   );
 
   final resetTrace = summary.PatrolPerfTrace.parse(const [


### PR DESCRIPTION
## Summary

- publish the Patrol web summary and main comparison as one sticky PR comment
- link the workflow run containing the downloadable raw log and JSON artifact
- add tile replay, prefetch batch/tile, rung/class, and retained-cache metrics to schema 7
- keep reporting independent of Firebase preview deployment and avoid stale cancelled-run comments

## Validation

- fvm dart tool/patrol_perf_summary_test.dart
- fvm dart analyze
- parsed the Preview Demo Web workflow as YAML
- reprocessed the 1,763-event PR #733 artifact and its exact 1,822-event main baseline

The direct #733 comparison shows bounded prefetch activity at 18 batches / 34 tiles, no refill loop, and tile raster p95 improving from 207.5 ms to 178.2 ms.