### PR TITLE
perf(web): keep plain JPEGs on browser-native decode

### DIFF
--- a/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/perf_e2e_test.dart
@@ -9,6 +9,7 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor_assets/dart_pdf_editor_assets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
 import 'package:patrol/patrol.dart';
 import 'package:pdf_test_fixtures/cad_image_strip.dart';
 
@@ -549,6 +550,136 @@ void main() {
       store.dispose();
     }
   });
+
+  patrolTest('measures ordinary browser JPEG consumer decode', ($) async {
+    expect($.isWeb, isTrue);
+
+    // Build outside the scenario window: the benchmark is the production
+    // worker -> consumer JPEG decode -> Flutter image path, not the fixture's
+    // pure-Dart JPEG encoder. Two distinct XObjects model #454's page-0 shape
+    // and make the consumer cost large enough to distinguish codec paths.
+    final bytes = _buildJpegPerfDocument();
+    final preferences = PdfEditingPreferences();
+    await preferences.ready;
+    preferences
+      ..showThumbnailSidebar = false
+      ..showBookmarkSidebar = false
+      ..showAnnotationSidebar = false
+      ..showPropertiesPanel = false
+      ..showSearchResultsPanel = false
+      ..showThumbnailView = false
+      ..showReflowView = false;
+    final editing = PdfEditingController(bytes, preferences: preferences);
+    final viewer = PdfViewerController();
+    final lines = <String>[];
+    final previousSink = PdfPerfLog.sink;
+    PdfPerfLog.sink = (line) {
+      lines.add(line);
+      previousSink?.call(line);
+    };
+
+    PdfPerfLog.log(
+      'scenario name=jpeg-consumer-decode phase=start pages=1 '
+      'images=2 sourceMpx=${(2 * 1280 * 1656 / 1e6).toStringAsFixed(1)}',
+    );
+    try {
+      await $.pumpWidget(MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 1080,
+            height: 1400,
+            child: PdfEditorView(
+              controller: editing,
+              viewerController: viewer,
+              initialFit: PdfViewerFit.width,
+              features: const PdfEditorFeatures(
+                headerBar: false,
+                search: false,
+                searchResultsPanel: false,
+                pageNumber: false,
+                author: false,
+                viewOptions: false,
+                reflowView: false,
+                pageColorEditable: false,
+                bookmarks: false,
+                annotationSidebar: false,
+                propertiesPanel: false,
+                toolbar: false,
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      await _waitFor(
+        $,
+        () => viewer.pageCount == 1 && viewer.debugRenderWorkerActive,
+        reason: 'the JPEG page should open on the production worker',
+        attempts: 240,
+      );
+      await _waitFor(
+        $,
+        () => viewer.isPageRasterReady(0),
+        reason: 'the JPEG page should reach the browser compositor',
+        attempts: 300,
+      );
+      await _waitFor(
+        $,
+        () => lines.any((line) =>
+            line.contains('interpret page=0 path=worker FIRST') &&
+            line.contains(' decode=') &&
+            line.contains(' replay=')),
+        reason: 'the JPEG build should report its decode/replay split',
+      );
+
+      final workerTrace = viewer.debugLastRenderTrace;
+      expect(workerTrace, isNotNull);
+      final workerSummary = workerTrace!.imageDecodeSummary ?? '';
+      expect(workerSummary, contains('consumerDct:2'),
+          reason: 'ordinary RGB JPEGs should stay compressed across the '
+              'worker boundary for zero-copy browser upload');
+      final batchLine = lines.lastWhere(
+        (line) => line.contains('image batch requests=2 unique=2'),
+      );
+      expect(batchLine, contains('pending=2'),
+          reason: 'both cold JPEGs should enter the concurrent codec batch');
+      expect(
+        lines.where((line) => line.contains('jpeg rgba-browser')).length,
+        2,
+        reason: 'both JPEGs should stay compressed until createImageBitmap '
+            'hands them to Flutter',
+      );
+      expect(
+          lines.any((line) => line.contains('jpeg rgba-accelerated')), isFalse,
+          reason: 'plain browser JPEGs should not expand through synchronous '
+              'libjpeg-turbo on the consumer isolate');
+
+      final interpretLine = lines.lastWhere(
+        (line) => line.contains('interpret page=0 path=worker FIRST'),
+      );
+      final decodeMs = _perfMs(interpretLine, 'decode');
+      final replayMs = _perfMs(interpretLine, 'replay');
+      final batchMs = _perfMs(batchLine, 'work');
+      final jankFrames = lines.where((line) => line.contains('] JANK ')).length;
+      expect(decodeMs, greaterThan(0));
+      expect(replayMs, greaterThanOrEqualTo(0));
+      expect(batchMs, greaterThan(0));
+
+      PdfPerfLog.log(
+        'scenario name=jpeg-consumer-decode phase=validated '
+        'consumerDct=2 decode=${decodeMs.toStringAsFixed(1)}ms '
+        'batch=${batchMs.toStringAsFixed(1)}ms '
+        'replay=${replayMs.toStringAsFixed(1)}ms jankFrames=$jankFrames',
+      );
+    } finally {
+      PdfPerfLog.sink = previousSink;
+      await $.pumpWidget(const SizedBox());
+      await $.pump(const Duration(milliseconds: 50));
+      viewer.dispose();
+      editing.dispose();
+      preferences.dispose();
+    }
+  }, tags: 'jpeg-consumer');
 }
 
 Future<void> _waitFor(
@@ -561,6 +692,14 @@ Future<void> _waitFor(
     await $.pump(const Duration(milliseconds: 100));
   }
   expect(predicate(), isTrue, reason: reason);
+}
+
+double _perfMs(String line, String field) {
+  final match = RegExp('(?:^| )$field=([0-9.]+)ms(?: |\$)').firstMatch(line);
+  if (match == null) {
+    throw StateError('missing $field timing in: $line');
+  }
+  return double.parse(match.group(1)!);
 }
 
 /// A deterministic, browser-safe six-page drawing.
@@ -647,5 +786,31 @@ Uint8List _buildCadPerfDocument() {
     tiles: tiles,
     ops: 30000,
     streams: 4,
+  );
+}
+
+Uint8List _buildJpegPerfDocument() {
+  final source = img.Image(width: 1280, height: 1656, numChannels: 3);
+  img.fill(source, color: img.ColorRgb8(38, 112, 168));
+  final jpeg = Uint8List.fromList(img.encodeJpg(source, quality: 82));
+  return buildSyntheticCadImageStrip(
+    tiles: [
+      PdfTileSpec(
+        codec: PdfTileCodec.jpeg,
+        width: source.width,
+        height: source.height,
+        payload: jpeg,
+      ),
+      PdfTileSpec(
+        codec: PdfTileCodec.jpeg,
+        width: source.width,
+        height: source.height,
+        payload: jpeg,
+      ),
+    ],
+    ops: 0,
+    streams: 1,
+    pageW: 612,
+    pageH: 792,
   );
 }

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  image: ^4.9.1
   patrol: 4.9.0
   pdf_test_fixtures: ^3.7.0
   shared_preferences: ^2.3.0

--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -813,6 +813,33 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
   if (colorFamily == 'DeviceRGB' &&
       acceleratedRgbRanges == null &&
       acceleratedRgbColorKey == null) {
+    final smask = cos.resolve(dict['SMask']);
+    final mask = cos.resolve(dict['Mask']);
+    // Keep an ordinary RGB JPEG compressed until the browser codec hands its
+    // ImageBitmap directly to Flutter. Running libjpeg-turbo in this isolate
+    // first expands the whole image to RGBA synchronously, then uploads it;
+    // createImageBitmap performs the codec work asynchronously and the bitmap
+    // stays GPU-resident. Masks still use the accelerator path below because
+    // they may need CPU samples or a coordinated base/mask decode.
+    if (smask is! CosStream && mask is! CosStream && mask is! CosArray) {
+      final browserClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
+      final browser = scaled
+          ? await decodeJpegWithBrowser(
+              jpeg,
+              targetWidth: targetWidth,
+              targetHeight: targetHeight,
+            )
+          : await decodeJpegWithBrowser(jpeg);
+      if (browser != null) {
+        if (browserClock != null) {
+          PdfPerfLog.log('jpeg rgba-browser '
+              '${browser.width}x${browser.height} '
+              'ms=${(browserClock.elapsedMicroseconds / 1000).toStringAsFixed(1)}');
+        }
+        return browser;
+      }
+    }
+
     final rgbClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     final accelerated = await _acceleratedDctRgbImage(
       jpeg,
@@ -820,8 +847,6 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
       targetHeight: targetHeight,
     );
     if (accelerated != null) {
-      final smask = cos.resolve(dict['SMask']);
-      final mask = cos.resolve(dict['Mask']);
       if (deferSimpleDctSoftMask && smask is CosStream) {
         final gpuMask = await _decodeSimpleSoftMaskImage(
           cos,
@@ -852,12 +877,13 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
       accelerated.dispose();
     }
   }
-  // On web, decode through the browser's native codec first: it is far faster
-  // than the engine's WASM codec under CanvasKit (a ~640 ms main-thread cost on
-  // the reported doc) and lands a GPU image with no readback. The worker
-  // already does this off-thread; this recovers the win on the main thread when
-  // the worker declined - e.g. its scope lacked OffscreenCanvas. Returns null
-  // off web and on any failure, falling through to the engine codec. #458.
+  // On web, decode residual DCT cases through the browser's native codec first:
+  // it is far faster than the engine's WASM codec under CanvasKit (a ~640 ms
+  // main-thread cost on the reported doc) and lands a GPU image with no
+  // readback. Semantically plain RGB JPEGs already returned through the
+  // earlier fast path; this branch preserves the same preference for masks and
+  // sample transforms that need the generic processing below. Returns null off
+  // web and on any failure, falling through to the engine codec. #458.
   //
   // The platform codec downscales during decode when a target is given -
   // decisive on the web, where the alternative is decoding 100+ MP and reading


### PR DESCRIPTION
## Summary

- prefer createImageBitmap for semantically plain DeviceRGB JPEGs before the synchronous libjpeg-turbo RGBA path
- preserve the existing accelerator and generic correctness paths for masks, Decode transforms, color keys, browser failures, and native platforms
- add a tagged Patrol scenario that exercises the production render worker and asserts the consumer codec path

## Measured result

Same local Chrome/Patrol scenario, two 1280x1656 JPEG XObjects (4.2 source Mpx):

| metric | before | after run 1 | after run 2 |
| --- | ---: | ---: | ---: |
| decode | 114.1 ms | 107.1 ms | 106.4 ms |
| batch work | 77.9 ms | 70.9 ms | 70.3 ms |
| replay | 1.5 ms | 1.6 ms | 1.5 ms |
| observed JANK frames | 8 | 6 | 6 |

The two browser decodes each take about 63-68 ms but complete inside a 70-71 ms batch, while the synchronous jpeg-turbo RGBA expansion is absent. The worker handoff remains a 189-byte command record with consumerDct:2.

## Validation

- fvm dart analyze
- fvm flutter test test/image_decoder_test.dart (44 tests)
- full Patrol perf target in headless Chrome (4 scenarios)
- focused jpeg-consumer Patrol repeat

Addresses #454.