### PR TITLE
feat(viewer): expose showSelectionChip to hide the touch selection chip

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -14,7 +14,6 @@ import '../debug_overlays.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_geometry.dart';
 import '../platform_cursors.dart';
-import '../popup_position.dart';
 import '../renderer.dart';
 import '../theme.dart';
 import 'editing_color_pick.dart';
@@ -510,6 +509,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.onMoveDragPreview,
     this.onTextEditClosed,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
   });
 
   final PdfEditingController controller;
@@ -575,6 +575,15 @@ class EditingPageOverlay extends StatefulWidget {
   /// see that property for the semantics. Has no effect without an editing
   /// controller (the menu path is reader-mode only). Defaults to true.
   final bool contextMenuEnabled;
+
+  /// Whether a touch/stylus selection shows the floating action chip beside
+  /// it (delete, edit-in-place, the context menu) - the affordances mice get
+  /// from hover and right-click. Hosts that provide their own selection
+  /// affordances (a custom context menu via [contextMenuEnabled] false, or a
+  /// note editor on annotation tap) can turn the chip off to avoid doubled
+  /// UI. The selection outline, handles, and move/resize interactions are
+  /// unaffected. Defaults to true.
+  final bool showSelectionChip;
 
   /// Whether the page raster on screen already shows the controller's
   /// current revision. While false (an edit just committed and the
@@ -4174,9 +4183,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final options = field.options;
     if (options.isEmpty) return;
     final name = field.name;
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
     final picked = await showMenu<String>(
       context: context,
-      position: pdfPopupPosition(context, globalPosition),
+      position: RelativeRect.fromRect(
+          globalPosition & Size.zero, Offset.zero & overlay.size),
       items: [
         for (final (export, display) in options)
           PopupMenuItem(
@@ -5673,14 +5685,6 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                     : null,
                                 cursorColor: _textEditColor,
                                 cursorWidth: 2 * _chromeScale,
-                                cursorHeight: pdfZoomAwareCursorHeight(
-                                  context,
-                                  lineHeight:
-                                      _textEditText.maxStyleSize *
-                                          _geometry.scale *
-                                          _textEditLineSpacing,
-                                  chromeScale: _chromeScale,
-                                ),
                                 selectionControls: _ScaledTextSelectionControls(
                                     _chromeScale,
                                     _inlineTextHandleColor(context)),
@@ -5755,7 +5759,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   _textEditFieldName == null &&
                   _controller.hasTouchInput)
                 _buildInlineTextStyleChip(_textEditRect!),
-              if (showChip) _buildSelectionChip(chrome?.$1 ?? selected),
+              if (showChip && widget.showSelectionChip)
+                _buildSelectionChip(chrome?.$1 ?? selected),
               if (_measureReadout() case (final text, final anchor))
                 _buildReadoutChip(text, anchor),
               if (_styleReadout() case (final text, final anchor))

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -234,6 +234,7 @@ class PdfEditorView extends StatefulWidget {
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.imagePicker,
@@ -324,6 +325,7 @@ class PdfEditorView extends StatefulWidget {
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.imagePicker,
@@ -503,6 +505,9 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.contextMenuEnabled].
   final bool contextMenuEnabled;
+
+  /// See [PdfViewer.showSelectionChip].
+  final bool showSelectionChip;
 
   /// See [PdfViewer.onContextMenuRequested].
   final PdfContextMenuHost? onContextMenuRequested;
@@ -768,6 +773,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         pageOverlayBuilder: widget.pageOverlayBuilder,
         annotationMenuBuilder: widget.annotationMenuBuilder,
         contextMenuEnabled: widget.contextMenuEnabled,
+        showSelectionChip: widget.showSelectionChip,
         onContextMenuRequested: widget.onContextMenuRequested,
         formImagePicker: widget.formImagePicker,
         imagePicker: widget.imagePicker,
@@ -1418,6 +1424,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         pageOverlayBuilder: widget.pageOverlayBuilder,
                         annotationMenuBuilder: widget.annotationMenuBuilder,
                         contextMenuEnabled: widget.contextMenuEnabled,
+                        showSelectionChip: widget.showSelectionChip,
                         onContextMenuRequested: widget.onContextMenuRequested,
                         formImagePicker: widget.formImagePicker,
                         imagePicker: widget.imagePicker,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3,13 +3,12 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart'
-    show ValueListenable, immutable, kIsWeb, visibleForTesting;
+    show ValueListenable, kIsWeb, visibleForTesting;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -36,13 +35,11 @@ import 'page_object_cache.dart';
 import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'platform_cursors.dart';
-import 'popup_position.dart';
 import 'pdf_page_view.dart';
 import 'preview_cache.dart';
 import 'raster_cache.dart';
 import 'raster_warm.dart';
 import 'render_scheduler.dart';
-import 'render_trace.dart';
 import 'render_worker.dart';
 import 'render_worker_host.dart';
 import 'renderer.dart';
@@ -59,67 +56,6 @@ export 'annotation_tap.dart'
     show PdfAnnotationTapDetails, PdfAnnotationTapHandler;
 
 const double _defaultMaxZoom = 24;
-
-/// How the viewer reconciled its page presentation across a document change.
-enum PdfPageReconciliationMode {
-  /// Only pages named by the edit impact were re-wrapped.
-  incremental,
-
-  /// Stable page identities were used to reconcile a structural change.
-  keyedStructure,
-
-  /// The complete page list and its presentation state were rebuilt.
-  fullReload,
-}
-
-/// Support snapshot for the most recent page-list reconciliation.
-///
-/// This is deliberately descriptive rather than a performance promise. It is
-/// useful in exported [PdfPerfLog] traces and tests which need to distinguish
-/// a dirty-page bailout from a correctness-first full reload.
-@immutable
-class PdfPageReconciliationDiagnostics {
-  const PdfPageReconciliationDiagnostics({
-    required this.mode,
-    required this.elapsed,
-    required this.pageCount,
-    required this.dirtyPages,
-    required this.retainedPages,
-    required this.geometryPages,
-    required this.walkedPageTree,
-    this.fallbackReason,
-  });
-
-  final PdfPageReconciliationMode mode;
-  final Duration elapsed;
-  final int pageCount;
-
-  /// Pages whose wrappers/presentation inputs were replaced. Null means the
-  /// transition did not have a trustworthy dirty-page boundary.
-  final int? dirtyPages;
-  final int retainedPages;
-  final int geometryPages;
-  final bool walkedPageTree;
-
-  /// Why an incremental candidate selected [PdfPageReconciliationMode.fullReload].
-  final String? fallbackReason;
-}
-
-class _PdfViewerPageKey extends LocalKey {
-  const _PdfViewerPageKey(this.namespace, this.pageIdentity);
-
-  final Object namespace;
-  final Object pageIdentity;
-
-  @override
-  bool operator ==(Object other) =>
-      other is _PdfViewerPageKey &&
-      identical(namespace, other.namespace) &&
-      pageIdentity == other.pageIdentity;
-
-  @override
-  int get hashCode => Object.hash(identityHashCode(namespace), pageIdentity);
-}
 
 /// Page-space distance an arrow-key press slides the selected annotation(s),
 /// and the coarser step Shift+arrow uses. Points, matching the drag move.
@@ -500,56 +436,9 @@ class PdfViewerController extends ChangeNotifier {
   @visibleForTesting
   PdfPagePreviewCache? get debugPreviewCache => _state?._previews;
 
-  /// Test hook: whether the attached viewer currently has a live render-worker
-  /// backend instead of the main-thread fallback.
-  @visibleForTesting
-  bool get debugRenderWorkerActive =>
-      _state?._effectiveRenderWorker?.isActive ?? false;
-
-  /// Test hook: the most recent completed off-thread render trace.
-  ///
-  /// A non-null value proves more than worker construction: the worker opened
-  /// the document, completed a request, and returned its phase timings.
-  @visibleForTesting
-  PdfRenderTrace? get debugLastRenderTrace =>
-      _state?._effectiveRenderWorker?.lastRenderTrace;
-
   /// Test hook: the namespace isolating this viewer's process-wide LoD tiles.
   @visibleForTesting
   Object? get debugTileCacheNamespace => _state?._tileCacheNamespace;
-
-  /// Number of revision swaps reconciled from their dirty-page impact without
-  /// walking/reloading the complete page list.
-  @visibleForTesting
-  int get debugIncrementalPageReconciliations =>
-      _state?._incrementalPageReconciliations ?? 0;
-
-  /// Number of pure page reorders reconciled by stable page identity.
-  @visibleForTesting
-  int get debugKeyedPageReconciliations =>
-      _state?._keyedPageReconciliations ?? 0;
-
-  /// Pages inspected by the most recent successful incremental reconcile.
-  /// Null when the latest document transition used the full fallback.
-  @visibleForTesting
-  Set<int>? get debugLastIncrementallyReconciledPages =>
-      _state?._lastIncrementallyReconciledPages;
-
-  /// Support snapshot for the most recent page-list reconciliation.
-  @visibleForTesting
-  PdfPageReconciliationDiagnostics? get debugPageReconciliationDiagnostics =>
-      _state?._lastPageReconciliation;
-
-  /// Opaque identity of the attached viewer's page presentation object.
-  /// Clean pages retain this across an incremental revision; dirty pages do
-  /// not, which also fences their stale asynchronous render completions.
-  @visibleForTesting
-  Object? debugPageIdentity(int index) {
-    final pages = _state?._pages;
-    return pages == null || index < 0 || index >= pages.length
-        ? null
-        : pages[index];
-  }
 
   /// Opaque identity matching this viewer to [PdfTileRasterDiagnostics].
   ///
@@ -1252,6 +1141,7 @@ class PdfViewer extends StatefulWidget {
     this.textSelectionMarkup = true,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.fontPicker,
@@ -1527,6 +1417,16 @@ class PdfViewer extends StatefulWidget {
   /// in its own chrome. The long-press annotation menu requires [editing];
   /// the desktop text menu does not.
   final bool contextMenuEnabled;
+
+  /// Whether a touch/stylus annotation selection shows the floating action
+  /// chip beside it (delete, edit-in-place, the context menu) - the
+  /// affordances mice get from hover and right-click. Hosts that already
+  /// provide those affordances (their own context menu via
+  /// [onContextMenuRequested], or an editor shown on [onAnnotationTap]) can
+  /// turn the chip off to avoid doubled UI. Selection, handles, move/resize,
+  /// and all pointer interactions are unaffected; mice never see the chip
+  /// either way. Needs [editing]. Defaults to true.
+  final bool showSelectionChip;
 
   /// Fires when the user requests a context menu (desktop right-click on
   /// text, right-click / long-press on an annotation, touch long-press on
@@ -1875,11 +1775,6 @@ class _PdfViewerState extends State<PdfViewer>
   late List<PdfPage> _pages;
   late List<(int, int)?> _pageRefs;
   late List<double> _aspects; // height / width, after /Rotate
-  int _incrementalPageReconciliations = 0;
-  int _keyedPageReconciliations = 0;
-  Set<int>? _lastIncrementallyReconciledPages;
-  PdfPageReconciliationDiagnostics? _lastPageReconciliation;
-  String? _incrementalFallbackReason;
 
   /// The controller that owns the document revisions for a given viewer
   /// configuration, if any: the editing controller, or - when interactive
@@ -1947,16 +1842,7 @@ class _PdfViewerState extends State<PdfViewer>
       host.sync(
         document: controller.document,
         bytes: controller.bytes,
-        // A reported revision is non-structural, so the already-loaded count
-        // is authoritative. Asking the fresh PdfDocument wrapper for
-        // pageCount here would walk the complete page tree before the viewer's
-        // dirty-page reconciler gets a chance to bail out.
-        pageCount: delta?.impact != null &&
-                !delta!.impact!.pageStructureChanged &&
-                _loadedDocument != null &&
-                identical(_loadedDocument!.cos, controller.document.cos)
-            ? _pages.length
-            : controller.document.pageCount,
+        pageCount: controller.document.pageCount,
         revision: delta == null
             ? null
             : (
@@ -3711,16 +3597,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// document/controller) and from [_onRevisionControllerChanged] (a new
   /// revision with no host rebuild).
   void _swapDocument({bool preserveRevisionViewport = false}) {
-    final reconcileClock = Stopwatch()..start();
     final document = _document;
-    if (preserveRevisionViewport &&
-        _tryReconcileIncrementalRevision(document)) {
-      return;
-    }
-    if (!preserveRevisionViewport) {
-      _incrementalFallbackReason = 'unrelated-document-swap';
-    }
-    _lastIncrementallyReconciledPages = null;
     final sameGeometry = _sameGeometryAs(document);
     if (!preserveRevisionViewport) {
       // The old namespace cannot be reached after an unrelated document swap.
@@ -3845,348 +3722,7 @@ class _PdfViewerState extends State<PdfViewer>
       // geometry) keeps the zoom the user chose
       _appliedInitialFit = false;
     }
-    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
-      mode: PdfPageReconciliationMode.fullReload,
-      elapsed: reconcileClock.elapsed,
-      pageCount: _pages.length,
-      dirtyPages: null,
-      retainedPages: 0,
-      geometryPages: _pages.length,
-      walkedPageTree: true,
-      fallbackReason: _incrementalFallbackReason ?? 'full-reload-required',
-    ));
     setState(() {});
-  }
-
-  void _recordPageReconciliation(PdfPageReconciliationDiagnostics diagnostics) {
-    _lastPageReconciliation = diagnostics;
-    final dirty = diagnostics.dirtyPages?.toString() ?? 'unknown';
-    final reason = diagnostics.fallbackReason == null
-        ? ''
-        : ' reason=${diagnostics.fallbackReason}';
-    PdfPerfLog.log('page-reconcile mode=${diagnostics.mode.name} '
-        'pages=${diagnostics.pageCount} dirty=$dirty '
-        'retained=${diagnostics.retainedPages} '
-        'geometry=${diagnostics.geometryPages} '
-        'walk=${diagnostics.walkedPageTree ? 1 : 0} '
-        'elapsed=${(diagnostics.elapsed.inMicroseconds / 1000).toStringAsFixed(2)}ms'
-        '$reason');
-  }
-
-  /// Applies a non-structural append-only revision by touching only the pages
-  /// named by its [PdfEditImpact]. False selects [_swapDocument]'s existing
-  /// correctness-first full reconciliation.
-  ///
-  /// The fast path is deliberately narrow:
-  ///
-  ///  * the old and new wrappers must share one incrementally advanced COS
-  ///    graph;
-  ///  * every invalidation lane must be known (null means "all/unknown");
-  ///  * every dirty page must retain a resolvable indirect-object identity;
-  ///
-  /// Ordinary annotation edits, form fills, content stamps, metadata changes,
-  /// and page rotations satisfy those rules. A dirty page receives a fresh
-  /// [PdfPage] wrapper while clean pages retain identity, mirroring keyed child
-  /// reconciliation: clean render/cache state bails out and stale async work
-  /// for dirty pages can no longer pass identity guards.
-  bool _tryReconcileIncrementalRevision(PdfDocument document) {
-    final reconcileClock = Stopwatch()..start();
-    bool fallback(String reason) {
-      _incrementalFallbackReason = reason;
-      return false;
-    }
-
-    final loaded = _loadedDocument;
-    final delta = _revisionController?.lastRevisionDelta;
-    final impact = _revisionController?.lastRevisionImpact ?? delta?.impact;
-    if (loaded == null) return fallback('no-loaded-document');
-    if (impact == null) return fallback('no-revision-impact');
-    if (impact.pageStructureChanged) {
-      if (!impact.pageOrderOnly) return fallback('page-structure-changed');
-      if (impact.visualPages == null ||
-          impact.contentPages == null ||
-          impact.annotationPages == null ||
-          impact.visualPages!.isNotEmpty ||
-          impact.contentPages!.isNotEmpty ||
-          impact.annotationPages!.isNotEmpty) {
-        return fallback('page-order-mixed-impact');
-      }
-      return _tryReconcileKeyedPageOrder(
-        document,
-        reconcileClock,
-        fallback,
-      );
-    }
-    if (!identical(loaded.cos, document.cos)) return fallback('different-cos');
-    final visualPages = impact.visualPages;
-    final contentPages = impact.contentPages;
-    final annotationPages = impact.annotationPages;
-    if (visualPages == null ||
-        contentPages == null ||
-        annotationPages == null) {
-      return fallback('unknown-impact-pages');
-    }
-
-    final dirtyPages = <int>{
-      ...visualPages,
-      ...contentPages,
-      ...annotationPages,
-    };
-    if (dirtyPages.any((page) => page < 0 || page >= _pages.length)) {
-      return fallback('invalid-dirty-page');
-    }
-
-    final replacements = <int, PdfPage>{};
-    final geometry = <int, (double aspect, double pointWidth)>{};
-    var geometryChanged = false;
-    var geometryPages = 0;
-    for (final index in dirtyPages) {
-      final key = _pageRefs[index];
-      if (key == null) return fallback('missing-stable-page-reference');
-      final resolved = document.cos.resolve(CosReference(key.$1, key.$2));
-      if (resolved is! CosDictionary) return fallback('unresolved-page');
-      final page = _pages[index].forIncrementalRevision(document, resolved);
-      // Geometry is calculated only for pages the transaction dirtied. Most
-      // revisions land here: annotation/content pixels changed while the page
-      // box did not. Rotations/crop changes update their one cached record;
-      // the following pages' offsets derive from that record at layout time.
-      final nextGeometry = (_pageAspect(page), _pagePointWidth(page));
-      final changed = (nextGeometry.$1 - _aspects[index]).abs() > 1e-6 ||
-          (nextGeometry.$2 - _pointWidths[index]).abs() > 1e-6;
-      if (changed) geometryPages++;
-      geometryChanged |= changed;
-      replacements[index] = page;
-      geometry[index] = nextGeometry;
-    }
-
-    final preservedViewport = geometryChanged && _pages.isNotEmpty
-        ? _pendingViewport ??
-            _captureViewport() ??
-            PdfViewport(
-              page: _controller.currentPage.clamp(0, _pages.length - 1),
-              zoom: _currentZoom,
-            )
-        : null;
-
-    _controller.clearSearch();
-    _clearSelection();
-    _pageLabels = null;
-    _outline = null;
-
-    // Invalidate only the derived lane whose inputs changed. Text extraction
-    // follows base content; annotation/action/form caches follow /Annots.
-    _textCache.removeAll(contentPages);
-    _annotCache.removeAll(annotationPages);
-    _visibleAnnotCache.removeAll(annotationPages);
-    _fieldRectCache.removeAll(annotationPages);
-
-    for (final entry in replacements.entries) {
-      final oldPage = _pages[entry.key];
-      _previewAttempts.remove(oldPage);
-      _previewVectorAttempts.remove(oldPage);
-      for (final attempted in _intermediatePreviewAttempts.values) {
-        attempted.remove(oldPage);
-      }
-      _rasterWarmAttempts.remove(oldPage);
-      _commandWarmAttempts.remove(oldPage);
-      _pages[entry.key] = entry.value;
-      final nextGeometry = geometry[entry.key]!;
-      _aspects[entry.key] = nextGeometry.$1;
-      _pointWidths[entry.key] = nextGeometry.$2;
-    }
-    if (geometryChanged) {
-      // No page is reparsed here: these reductions use the cached per-page
-      // numbers. If the dirty page became (or ceased to be) the fit reference,
-      // every item's layout scale changes naturally on the next build.
-      _maxPointWidth = _pointWidths.isEmpty ? 0 : _pointWidths.reduce(math.max);
-      _maxPointHeight = _pages.isEmpty
-          ? 0
-          : [
-              for (var i = 0; i < _pages.length; i++)
-                _aspects[i] * _pointWidths[i],
-            ].reduce(math.max);
-      _pendingViewport = preservedViewport;
-    }
-
-    _loadedDocument = document;
-    _rasteredPages.removeAll(contentPages);
-    if (dirtyPages.isEmpty) {
-      _previews.bindPages(_pages);
-    } else {
-      _previews.rebind(
-        _pages,
-        changed: contentPages.contains,
-      );
-    }
-    for (final page in contentPages) {
-      _contentStamps[page] = _contentStamp(page);
-    }
-
-    // Fence background loops started against a dirty page. Clean-page cache
-    // entries and attempt state remain warm; their page identities survived.
-    _commandWarmAnchor = null;
-    _commandWarmGeneration++;
-    _bindRasterCache(prime: false);
-    _incrementalPageReconciliations++;
-    _lastIncrementallyReconciledPages = Set<int>.unmodifiable(dirtyPages);
-    _incrementalFallbackReason = null;
-    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
-      mode: PdfPageReconciliationMode.incremental,
-      elapsed: reconcileClock.elapsed,
-      pageCount: _pages.length,
-      dirtyPages: dirtyPages.length,
-      retainedPages: _pages.length - dirtyPages.length,
-      geometryPages: geometryPages,
-      walkedPageTree: false,
-    ));
-    _schedulePreviewPrerender();
-    _scheduleRasterWarm();
-    setState(() {});
-    return true;
-  }
-
-  bool _tryReconcileKeyedPageOrder(
-    PdfDocument document,
-    Stopwatch reconcileClock,
-    bool Function(String reason) fallback,
-  ) {
-    final currentPages = document.pages;
-    final count = currentPages.length;
-    if (count != _pages.length) return fallback('page-order-count-changed');
-
-    final oldIndexByRef = <(int, int), int>{};
-    for (var i = 0; i < _pageRefs.length; i++) {
-      final ref = _pageRefs[i];
-      if (ref == null) return fallback('missing-stable-page-reference');
-      if (oldIndexByRef.containsKey(ref)) {
-        return fallback('duplicate-stable-page-reference');
-      }
-      oldIndexByRef[ref] = i;
-    }
-
-    // This is the one unavoidable structural cost: walk the new page tree to
-    // verify its leaf identities and order. The render/presentation objects
-    // themselves are reconciled below instead of being rebuilt by slot.
-    final newPages = <PdfPage>[];
-    final newRefs = <(int, int)>[];
-    final oldIndexForNew = <int>[];
-    for (var i = 0; i < count; i++) {
-      final page = currentPages[i];
-      final ref = _pageReferenceKey(page);
-      if (ref == null) return fallback('missing-new-page-reference');
-      final oldIndex = oldIndexByRef[ref];
-      if (oldIndex == null) return fallback('page-order-identity-changed');
-      final nextAspect = _pageAspect(page);
-      final nextPointWidth = _pagePointWidth(page);
-      if ((nextAspect - _aspects[oldIndex]).abs() > 1e-6 ||
-          (nextPointWidth - _pointWidths[oldIndex]).abs() > 1e-6) {
-        return fallback('page-order-geometry-changed');
-      }
-      newPages.add(page);
-      newRefs.add(ref);
-      oldIndexForNew.add(oldIndex);
-    }
-    if (oldIndexForNew.toSet().length != count) {
-      return fallback('page-order-not-a-permutation');
-    }
-
-    final newIndexForOld = List<int>.filled(count, 0);
-    for (var newIndex = 0; newIndex < count; newIndex++) {
-      newIndexForOld[oldIndexForNew[newIndex]] = newIndex;
-    }
-
-    final oldCurrentPage = _controller.currentPage.clamp(0, count - 1);
-    final oldCurrentRef = _pageRefs[oldCurrentPage];
-    final oldViewport = _pendingViewport ??
-        _captureViewport() ??
-        PdfViewport(page: oldCurrentPage, zoom: _currentZoom);
-    final oldViewportRef = _pageRefs[oldViewport.page.clamp(0, count - 1)];
-
-    _controller.clearSearch();
-    _clearSelection();
-    _pageLabels = null;
-    _outline = null;
-
-    int moved(int oldIndex) => newIndexForOld[oldIndex];
-
-    // These values carry their original page index and/or document wrapper.
-    // They are cheap relative to page rendering and must be rebuilt against
-    // the new order (especially undo, which opens a fresh COS graph).
-    _textCache.clear();
-    _annotCache.clear();
-    _visibleAnnotCache.clear();
-    _fieldRectCache.clear();
-    final oldRastered = _rasteredPages.toList();
-    _rasteredPages
-      ..clear()
-      ..addAll(oldRastered.map(moved));
-    final oldContentStamps = Map<int, int>.of(_contentStamps);
-    _contentStamps
-      ..clear()
-      ..addEntries(oldContentStamps.entries.map(
-        (entry) => MapEntry(moved(entry.key), entry.value),
-      ));
-
-    _pages = newPages;
-    _pageRefs = List<(int, int)?>.of(newRefs, growable: false);
-    _aspects = [for (final oldIndex in oldIndexForNew) _aspects[oldIndex]];
-    _pointWidths = [
-      for (final oldIndex in oldIndexForNew) _pointWidths[oldIndex]
-    ];
-    _loadedDocument = document;
-    _controller._setPageCount(count);
-
-    _previews.reorder(_pages, newIndexForOld);
-    // Tiles are keyed by page slot. Clear them while preserving the page
-    // subtree/base raster itself; old asynchronous tile completions are fenced
-    // by the namespace epoch and cannot land in the reordered slots.
-    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
-        .invalidateNamespace(_tileCacheNamespace);
-
-    final viewportPage = newRefs.indexOf(oldViewportRef!);
-    final remappedViewport = PdfViewport(
-      page: viewportPage < 0 ? oldViewport.page : viewportPage,
-      top: oldViewport.top,
-      left: oldViewport.left,
-      zoom: oldViewport.zoom,
-    );
-    if (_scroll.hasClients && _viewWidth > 0 && _viewHeight > 0) {
-      // The exact total extent is unchanged by a permutation, so the current
-      // ScrollPosition can adopt the remapped offset before the sliver's next
-      // layout. This keeps the viewed keyed child inside the build window while
-      // Flutter moves it; deferring until post-frame would let a long move be
-      // garbage-collected between its old and new slots.
-      _pendingViewport = null;
-      _placeViewport(remappedViewport, remappedViewport.page);
-    } else {
-      _pendingViewport = remappedViewport;
-    }
-    final currentPage = newRefs.indexOf(oldCurrentRef!);
-    _controller._setCurrentPage(
-      currentPage < 0 ? oldCurrentPage : currentPage,
-    );
-
-    _snapshotContentStamps();
-    _commandWarmAttempts.clear();
-    _commandWarmAnchor = null;
-    _commandWarmGeneration++;
-    _bindRasterCache(prime: false);
-    _keyedPageReconciliations++;
-    _lastIncrementallyReconciledPages = const <int>{};
-    _incrementalFallbackReason = null;
-    _recordPageReconciliation(PdfPageReconciliationDiagnostics(
-      mode: PdfPageReconciliationMode.keyedStructure,
-      elapsed: reconcileClock.elapsed,
-      pageCount: count,
-      dirtyPages: 0,
-      retainedPages: count,
-      geometryPages: 0,
-      walkedPageTree: true,
-    ));
-    _schedulePreviewPrerender();
-    _scheduleRasterWarm();
-    setState(() {});
-    return true;
   }
 
   /// The stable identity of a page across incremental revisions. Structural
@@ -4220,11 +3756,10 @@ class _PdfViewerState extends State<PdfViewer>
   /// Whether [document] lays out exactly like the one on screen: same
   /// page count, same aspect ratio per page.
   bool _sameGeometryAs(PdfDocument document) {
-    final pages = document.pages;
-    if (pages.length != _pages.length) return false;
+    if (document.pageCount != _pages.length) return false;
     final vr = _controller._viewRotation;
     for (var i = 0; i < _pages.length; i++) {
-      final page = pages[i];
+      final page = document.page(i);
       final r = ((page.rotation + vr) % 360 + 360) % 360;
       final sideways = r == 90 || r == 270;
       final aspect = sideways
@@ -4235,28 +3770,6 @@ class _PdfViewerState extends State<PdfViewer>
     return true;
   }
 
-  int _effectiveRotationFor(PdfPage page) =>
-      ((page.rotation + _controller._viewRotation) % 360 + 360) % 360;
-
-  double _pageAspect(PdfPage page) {
-    final box = page.cropBox;
-    final sideways = switch (_effectiveRotationFor(page)) {
-      90 || 270 => true,
-      _ => false,
-    };
-    return sideways
-        ? box.width / math.max(1e-6, box.height)
-        : box.height / math.max(1e-6, box.width);
-  }
-
-  double _pagePointWidth(PdfPage page) {
-    final box = page.cropBox;
-    return switch (_effectiveRotationFor(page)) {
-      90 || 270 => math.max(1e-6, box.height),
-      _ => math.max(1e-6, box.width),
-    };
-  }
-
   /// The effective display rotation of page [index], combining the page's
   /// own /Rotate and the controller's view rotation.
   int _effectiveRotation(int index) =>
@@ -4265,8 +3778,8 @@ class _PdfViewerState extends State<PdfViewer>
   void _loadPages() {
     final document = _document;
     _loadedDocument = document;
-    _pages = List<PdfPage>.of(document.pages, growable: true);
-    final count = _pages.length;
+    final count = document.pageCount;
+    _pages = [for (var i = 0; i < count; i++) document.page(i)];
     _pageRefs = [for (final page in _pages) _pageReferenceKey(page)];
     _rasteredPages.clear();
     _commandWarmAttempts.clear();
@@ -4424,8 +3937,19 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   void _recomputeAspects() {
-    _aspects = [for (final page in _pages) _pageAspect(page)];
-    _pointWidths = [for (final page in _pages) _pagePointWidth(page)];
+    _aspects = [
+      for (var i = 0; i < _pages.length; i++)
+        _isEffectivelySideways(i)
+            ? _pages[i].cropBox.width / math.max(1e-6, _pages[i].cropBox.height)
+            : _pages[i].cropBox.height /
+                math.max(1e-6, _pages[i].cropBox.width),
+    ];
+    _pointWidths = [
+      for (var i = 0; i < _pages.length; i++)
+        _isEffectivelySideways(i)
+            ? math.max(1e-6, _pages[i].cropBox.height)
+            : math.max(1e-6, _pages[i].cropBox.width),
+    ];
     _maxPointWidth = _pointWidths.isEmpty ? 0 : _pointWidths.reduce(math.max);
     _maxPointHeight = _pages.isEmpty
         ? 0
@@ -4497,6 +4021,11 @@ class _PdfViewerState extends State<PdfViewer>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) unawaited(_previews.loadFromDisk(pages));
     });
+  }
+
+  bool _isEffectivelySideways(int index) {
+    final r = _effectiveRotation(index);
+    return r == 90 || r == 270;
   }
 
   @override
@@ -5700,8 +5229,6 @@ class _PdfViewerState extends State<PdfViewer>
     final editing = widget.editing;
     if (editing != null &&
         editing.tool == null &&
-        editing.markupTool == null &&
-        !editing.isHandMode &&
         !editing.isPickingColor &&
         _lastPointerKind == PointerDeviceKind.mouse) {
       final point = _pagePointAt(details.localPosition);
@@ -5729,10 +5256,6 @@ class _PdfViewerState extends State<PdfViewer>
     final (page, x, y) = point;
     final takeover = !widget.contextMenuEnabled;
     final editing = widget.editing;
-    // Hand is a navigation-only mode. A secondary click must not quietly
-    // turn into the text/annotation selection gesture that ordinary reader
-    // mode offers.
-    if (editing?.isHandMode == true) return;
     if (editing != null && !editing.isPickingColor) {
       // Existing form widgets become the selection in normal/select/form
       // modes. Their actions live in the contextual toolbar/properties
@@ -5863,9 +5386,12 @@ class _PdfViewerState extends State<PdfViewer>
         editing != null && widget.textSelectionEditing && hasSelection;
     final canMarkup =
         editing != null && widget.textSelectionMarkup && hasSelection;
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
     final picked = await showMenu<_TextMenuAction>(
       context: context,
-      position: pdfPopupPosition(context, globalPosition),
+      position: RelativeRect.fromRect(
+          globalPosition & Size.zero, Offset.zero & overlay.size),
       items: [
         if (canEdit)
           PopupMenuItem<_TextMenuAction>(
@@ -6239,9 +5765,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// click would select.
   bool _selectableAnnotationAt(Offset local, {(int, double, double)? at}) {
     final editing = widget.editing;
-    if (editing == null || editing.tool != null || editing.isHandMode) {
-      return false;
-    }
+    if (editing == null || editing.tool != null) return false;
     final point = at ?? _pagePointAt(local);
     return point != null &&
         editing.selectableAnnotationAt(point.$1, point.$2, point.$3) != null;
@@ -6252,13 +5776,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (_grabPanning) return; // grabbing keeps its cursor mid-drag
     final editing = widget.editing;
     final MouseCursor cursor;
-    if (editing?.isHandMode == true) {
-      final action = _annotationAt(event.localPosition);
-      final notified = widget.onAnnotationTap != null &&
-          _annotationHitAt(event.localPosition, actionsOnly: false) != null;
-      cursor =
-          action != null || notified ? SystemMouseCursors.click : grabCursor;
-    } else if (editing != null &&
+    if (editing != null &&
         editing.tool == null &&
         !editing.isPickingColor &&
         !editing.hasAnnotationSelection &&
@@ -6408,7 +5926,6 @@ class _PdfViewerState extends State<PdfViewer>
   void _onSelectAll() {
     final page = _controller.currentPage;
     final editing = widget.editing;
-    if (editing?.isHandMode == true) return;
     if (editing != null &&
         (editing.tool == PdfEditTool.select ||
             editing.hasAnnotationSelection)) {
@@ -6466,10 +5983,6 @@ class _PdfViewerState extends State<PdfViewer>
       }
       if (editing.selectedElement != null) {
         editing.clearElementSelection();
-        return;
-      }
-      if (editing.markupTool != null) {
-        editing.markupTool = null;
         return;
       }
       if (editing.tool != null) {
@@ -6541,11 +6054,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// by the disambiguation timeout and claim the second of two rapid
   /// clicks, starving buttons in page overlays.
   void _onPointerUp(PointerUpEvent event) {
-    if (event.kind != PointerDeviceKind.mouse ||
-        !_wordDrag ||
-        widget.editing?.isHandMode == true) {
-      return;
-    }
+    if (event.kind != PointerDeviceKind.mouse || !_wordDrag) return;
     final downLocal = _lastMouseDownLocal;
     if (downLocal == null ||
         (event.localPosition - downLocal).distance >= kTouchSlop) {
@@ -6558,7 +6067,6 @@ class _PdfViewerState extends State<PdfViewer>
     // would immediately clear the selection made here
     _suppressTap = true;
     _selectWordAt(event.localPosition);
-    _applyArmedMarkup();
   }
 
   /// Whether a default/select-mode mouse click at [local] is over a
@@ -6622,16 +6130,6 @@ class _PdfViewerState extends State<PdfViewer>
     // document out from under its own stroke
     if (_kindDrawsInk(details.kind)) return;
     _focusNode.requestFocus();
-    if (widget.editing?.isHandMode == true) {
-      // Explicit Hand mode is navigation-only. Unlike the tool-free reader
-      // state, a drag that begins over page text must grab the document
-      // instead of creating a text selection.
-      _grabPanning = true;
-      _beginMotionRenderHold();
-      setState(() => _hoverCursor = grabbingCursor);
-      _controller._setSelection('');
-      return;
-    }
     // Shift+drag in default editing mode (no tool armed, nothing
     // selected) rubber-bands a marquee selection - the gesture the
     // select tool offers, without arming it. Shift forces the marquee
@@ -6688,7 +6186,6 @@ class _PdfViewerState extends State<PdfViewer>
     final editing = widget.editing;
     if (editing == null ||
         editing.tool != null ||
-        editing.markupTool != null ||
         editing.isPickingColor ||
         editing.hasAnnotationSelection) {
       return false;
@@ -6748,19 +6245,12 @@ class _PdfViewerState extends State<PdfViewer>
     _controller._setSelection(_selectedText());
   }
 
-  void _onSelectionEnd(DragEndDetails details, {bool cancelled = false}) {
+  void _onSelectionEnd(DragEndDetails details) {
     if (_marqueeStart != null) {
       _commitMarquee();
       return;
     }
-    if (!_grabPanning) {
-      if (cancelled && widget.editing?.markupTool != null) {
-        _clearSelection();
-      } else if (!cancelled) {
-        _applyArmedMarkup();
-      }
-      return;
-    }
+    if (!_grabPanning) return;
     _grabPanning = false;
     _scheduleMotionRenderHoldRelease();
     setState(() => _hoverCursor = grabCursor);
@@ -6908,31 +6398,9 @@ class _PdfViewerState extends State<PdfViewer>
     _extendWordSelection(details.localPosition);
   }
 
-  void _onLongPressEnd({bool cancelled = false}) {
+  void _onLongPressEnd() {
     if (!_touchSelecting) return;
     setState(() => _touchSelecting = false);
-    if (cancelled && widget.editing?.markupTool != null) {
-      _clearSelection();
-    } else if (!cancelled) {
-      _applyArmedMarkup();
-    }
-  }
-
-  /// Applies an armed text-markup tool to the current selection. The tool
-  /// remains armed so several passages can be marked without returning to
-  /// the toolbar between selections.
-  bool _applyArmedMarkup() {
-    final editing = widget.editing;
-    final kind = editing?.markupTool;
-    if (editing == null || kind == null || _selRange == null) return false;
-    final quadsByPage = {
-      for (final page in _controller.selectionPages)
-        page: _selectionRectsOn(page),
-    };
-    if (quadsByPage.values.every((quads) => quads.isEmpty)) return false;
-    editing.addMarkup(kind, quadsByPage);
-    _clearSelection();
-    return true;
   }
 
   /// A handle drag begins: the dragged end becomes the moving focus and
@@ -7846,12 +7314,6 @@ class _PdfViewerState extends State<PdfViewer>
       // zoom transform - thin, low-contrast, and scaled or translated out
       // of view when zoomed. The viewer paints its own bar outside the
       // transform instead (_PdfScrollbar below).
-      final pageIndexByIdentity = <Object, int>{
-        for (var i = 0; i < _pages.length; i++)
-          _pageRefs[i] ?? ('page-slot', _pageEpoch, i): i,
-      };
-      Object pageIdentity(int index) =>
-          _pageRefs[index] ?? ('page-slot', _pageEpoch, index);
       final list = ExactExtentListView.builder(
         controller: _scroll,
         scrollDirection: widget.pageLayout.scrollAxis,
@@ -7875,29 +7337,20 @@ class _PdfViewerState extends State<PdfViewer>
             ? null
             : _pageMain(index) + (index == 0 ? 0 : widget.pageSpacing),
         itemCount: _pages.length,
-        findChildIndexCallback: (key) {
-          if (key is! _PdfViewerPageKey ||
-              !identical(key.namespace, _tileCacheNamespace)) {
-            return null;
-          }
-          return pageIndexByIdentity[key.pageIdentity];
-        },
         padding: _horizontal
             ? EdgeInsets.only(
                 right: widget.pageSpacing + widget.trailingPadding)
             : EdgeInsets.only(
                 bottom: widget.pageSpacing + widget.trailingPadding),
         itemBuilder: (context, index) => KeyedSubtree(
-          // Stable indirect page identity is the reconciliation key. A pure
-          // reorder can therefore move the already-rastered State with its
-          // page. Insert/remove/import full fallbacks replace the namespace,
-          // so no State can cross a structural boundary that was not verified
-          // as an identity-preserving permutation. Direct/broken page objects
-          // fall back to the slot epoch.
-          key: _PdfViewerPageKey(
-            _tileCacheNamespace,
-            pageIdentity(index),
-          ),
+          // Insert/remove/reorder used to update a slot's existing page State
+          // in place. Its generation guards rejected stale Futures, but native
+          // compositor resources already submitted by the old State could
+          // outlive that Dart Future and paint into a later frame. A structure
+          // epoch therefore owns the complete presentation subtree: changing
+          // it disposes the old raster/scene/tile/annotation layers and mounts
+          // a clean State for the page now occupying this slot.
+          key: ValueKey((_tileCacheNamespace, _pageEpoch, index)),
           child: Padding(
             padding: _horizontal
                 ? EdgeInsets.only(left: index == 0 ? 0 : widget.pageSpacing)
@@ -7966,6 +7419,7 @@ class _PdfViewerState extends State<PdfViewer>
                     onPlaceSignature: widget.onPlaceSignature,
                     onAnnotationTap: widget.onAnnotationTap,
                     contextMenuEnabled: widget.contextMenuEnabled,
+                    showSelectionChip: widget.showSelectionChip,
                     interactionHost: PdfEditingInteractionHost(
                       panViewport: _touchGrabPanBy,
                       endViewportPan: _flingViewport,
@@ -8235,9 +7689,8 @@ class _PdfViewerState extends State<PdfViewer>
                                     ..onStart = _onSelectionStart
                                     ..onUpdate = _onSelectionUpdate
                                     ..onEnd = _onSelectionEnd
-                                    ..onCancel = () => _onSelectionEnd(
-                                        DragEndDetails(),
-                                        cancelled: true),
+                                    ..onCancel =
+                                        () => _onSelectionEnd(DragEndDetails()),
                                 ),
                                 // touch text selection starts with a long
                                 // press instead; stands aside while an
@@ -8251,14 +7704,12 @@ class _PdfViewerState extends State<PdfViewer>
                                     ..gestureSettings = gestureSettings
                                     ..isEnabled = (() =>
                                         widget.editing?.tool == null &&
-                                        widget.editing?.isHandMode != true &&
                                         widget.editing?.isPickingColor != true)
                                     ..onLongPressStart = _onLongPressStart
                                     ..onLongPressMoveUpdate = _onLongPressMove
                                     ..onLongPressEnd =
                                         ((_) => _onLongPressEnd())
-                                    ..onLongPressCancel =
-                                        () => _onLongPressEnd(cancelled: true),
+                                    ..onLongPressCancel = _onLongPressEnd,
                                 ),
                               },
                               child: ColoredBox(
@@ -8432,25 +7883,14 @@ class _MoveDragPreviewPainter extends CustomPainter {
 class _AnnotationAppearanceLayer extends StatefulWidget {
   const _AnnotationAppearanceLayer({
     required this.page,
-    required this.pageIndex,
-    required this.focusDistance,
     required this.rotation,
     required this.pageEpoch,
-    required this.active,
-    required this.renderScheduler,
     required this.onReady,
   });
 
   final PdfPage page;
-  final int pageIndex;
-  final int focusDistance;
   final int rotation;
   final int pageEpoch;
-
-  /// Cold layers farther than one page from the reading position stay idle.
-  /// Their cache remains mounted and resumes when navigation approaches.
-  final bool active;
-  final PdfPageRenderScheduler renderScheduler;
   final VoidCallback onReady;
 
   @override
@@ -8461,7 +7901,6 @@ class _AnnotationAppearanceLayer extends StatefulWidget {
 class _AnnotationAppearanceLayerState
     extends State<_AnnotationAppearanceLayer> {
   var _generation = 0;
-  final Object _scheduleToken = Object();
   List<ui.Picture> _pictures = const [];
   Size? _picturePageSize;
 
@@ -8506,21 +7945,15 @@ class _AnnotationAppearanceLayerState
   @override
   void initState() {
     super.initState();
-    if (widget.active) _render();
+    _render();
   }
 
   @override
   void didUpdateWidget(_AnnotationAppearanceLayer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final schedulerChanged =
-        !identical(oldWidget.renderScheduler, widget.renderScheduler);
-    if (schedulerChanged) {
-      oldWidget.renderScheduler.cancel(_scheduleToken);
-    }
-    final pageChanged = !identical(oldWidget.page, widget.page) ||
+    if (!identical(oldWidget.page, widget.page) ||
         oldWidget.rotation != widget.rotation ||
-        oldWidget.pageEpoch != widget.pageEpoch;
-    if (pageChanged) {
+        oldWidget.pageEpoch != widget.pageEpoch) {
       final oldSize = PdfPageRenderer.pageSize(oldWidget.page,
           rotation: oldWidget.rotation);
       final newSize =
@@ -8529,25 +7962,12 @@ class _AnnotationAppearanceLayerState
           oldWidget.rotation == widget.rotation &&
           oldSize == newSize;
       _render(keepCurrent: keepCurrent);
-    } else if (schedulerChanged) {
-      _render(keepCurrent: true);
-    } else if (!oldWidget.active && widget.active) {
-      _render(keepCurrent: true);
-    } else if (oldWidget.active && !widget.active) {
-      _generation++;
-      widget.renderScheduler.cancel(_scheduleToken);
-    } else if (oldWidget.focusDistance != widget.focusDistance &&
-        widget.active) {
-      // Refresh a pending request so the newly-current page moves to the head
-      // of the shared annotation queue.
-      _render(keepCurrent: true);
     }
   }
 
   @override
   void dispose() {
     _generation++;
-    widget.renderScheduler.cancel(_scheduleToken);
     _disposePictures();
     _disposeCache();
     super.dispose();
@@ -8586,26 +8006,7 @@ class _AnnotationAppearanceLayerState
 
   void _render({bool keepCurrent = false}) {
     final generation = ++_generation;
-    widget.renderScheduler.cancel(_scheduleToken);
     if (!keepCurrent) _disposePictures();
-    if (!widget.active) return;
-    unawaited(_renderScheduled(generation));
-  }
-
-  /// Resolving a page's annotation array can itself be substantial work.
-  /// Keep the whole cold-layer preparation out of initState's build frame,
-  /// not only the later appearance-stream interpretation.
-  Future<void> _renderScheduled(int generation) async {
-    final permitted = await widget.renderScheduler.paceUiWork(
-      _scheduleToken,
-      widget.pageIndex,
-      motion: PdfRenderMotionClass.quiet,
-      focusDistance: widget.focusDistance,
-    );
-    if (!permitted || !mounted || generation != _generation || !widget.active) {
-      return;
-    }
-
     final page = widget.page;
     final pageSize =
         PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
@@ -8649,85 +8050,35 @@ class _AnnotationAppearanceLayerState
       _publish(generation, annotations, pageSize);
       return;
     }
-    await _renderMissing(
-      generation,
-      page,
-      annotations,
-      missing,
-      pageSize,
-      widget.rotation,
-    );
-  }
-
-  /// Renders cold appearances incrementally instead of starting every
-  /// interpreter walk from the layer's build stack.
-  ///
-  /// [PdfPageRenderer.renderAnnotationPicture] performs a synchronous scan
-  /// before its first await. A `Future.wait` comprehension therefore ran that
-  /// scan for *every* annotation during the opening frame; 740 annotations in
-  /// one real-world engineering pack produced a half-second build. The
-  /// viewer's shared render scheduler starts one appearance per engine frame
-  /// across *all* mounted pages, giving input and painting a turn between
-  /// scans while [_publish] exposes each completed appearance progressively.
-  Future<void> _renderMissing(
-    int generation,
-    PdfPage page,
-    List<PdfAnnotation> annotations,
-    List<PdfAnnotation> missing,
-    Size pageSize,
-    int rotation,
-  ) async {
-    for (var i = 0; i < missing.length; i++) {
-      // The preparation pass already owns the first frame's grant. Every
-      // subsequent annotation queues behind the shared next-frame gate.
-      if (i > 0) {
-        final permitted = await widget.renderScheduler.paceUiWork(
-          _scheduleToken,
-          widget.pageIndex,
-          motion: PdfRenderMotionClass.quiet,
-          focusDistance: widget.focusDistance,
-        );
-        if (!permitted ||
-            !mounted ||
-            generation != _generation ||
-            !widget.active) {
-          return;
-        }
-      }
-
-      final annotation = missing[i];
-      final source = _appearanceKey(annotation);
-      if (!_cache.containsKey(source)) {
-        final picture = await _renderAnnotation(page, annotation, rotation);
-        if (!mounted || generation != _generation || !widget.active) {
+    unawaited(Future.wait([
+      for (final annotation in missing)
+        _renderAnnotation(page, annotation, widget.rotation)
+            .then((picture) => (_appearanceKey(annotation), picture)),
+    ]).then((rendered) {
+      if (!mounted || generation != _generation) {
+        for (final (_, picture) in rendered) {
           if (picture != null) _disposePicture(picture);
-          return;
         }
-        if (picture != null) {
-          // A newer overlapping generation may have filled this slot while
-          // the decoder was awaiting. Keep one owner of the native picture.
-          final existing = _cache[source];
-          if (existing != null) {
-            _disposePicture(picture);
-          } else {
-            _cache[source] = picture;
-          }
-        }
+        return;
       }
-
-      final last = i == missing.length - 1;
-      _publish(generation, annotations, pageSize, ready: last);
-    }
+      for (final (source, picture) in rendered) {
+        if (picture == null) continue;
+        // A concurrent render may have filled this slot; keep one owner.
+        final existing = _cache[source];
+        if (existing != null) {
+          _disposePicture(picture);
+          continue;
+        }
+        _cache[source] = picture;
+      }
+      _publish(generation, annotations, pageSize);
+    }));
   }
 
   /// Rebuilds the ordered picture list from [_cache] and repaints, then frees
   /// anything retired by the render that produced it.
   void _publish(
-    int generation,
-    List<PdfAnnotation> annotations,
-    Size pageSize, {
-    bool ready = true,
-  }) {
+      int generation, List<PdfAnnotation> annotations, Size pageSize) {
     if (!mounted || generation != _generation) return;
     final next = [
       for (final annotation in annotations)
@@ -8738,7 +8089,7 @@ class _AnnotationAppearanceLayerState
       _picturePageSize = pageSize;
     });
     _flushRetired();
-    if (ready) _notifyReady(generation);
+    _notifyReady(generation);
   }
 
   /// Pictures dropped from [_cache] but possibly still referenced by the
@@ -8865,6 +8216,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.tileRasterBackend,
     required this.predictStrokes,
     required this.contextMenuEnabled,
+    required this.showSelectionChip,
     required this.onRasterStateChanged,
   });
 
@@ -8983,6 +8335,9 @@ class _PdfViewerPage extends StatefulWidget {
   /// so its long-press recognizer and the floating selection chip both
   /// honor the host's intent.
   final bool contextMenuEnabled;
+
+  /// See [PdfViewer.showSelectionChip] - forwarded to the editing overlay.
+  final bool showSelectionChip;
   final void Function(int index, bool ready) onRasterStateChanged;
 
   @override
@@ -9161,12 +8516,8 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         Positioned.fill(
           child: _AnnotationAppearanceLayer(
             page: widget.page,
-            pageIndex: widget.index,
-            focusDistance: widget.focusDistance,
             rotation: widget.effectiveRotation,
             pageEpoch: widget.pageEpoch,
-            active: widget.focusDistance <= 1 || widget.forceForeground,
-            renderScheduler: widget.renderScheduler,
             onReady: _onAnnotationLayerReady,
           ),
         ),
@@ -9233,13 +8584,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                   builder: (context, _) {
                     final rasterCurrent = _rastered &&
                         _annotationLayerCurrent &&
-                        // Clean page wrappers deliberately survive an
-                        // incremental revision. Their PdfDocument wrapper may
-                        // therefore be older, but it shares the one live COS
-                        // graph and its page-tree caches self-invalidate from
-                        // the COS revision generation.
-                        identical(
-                            widget.page.document.cos, editing.document.cos);
+                        identical(widget.page.document, editing.document);
                     return editing.tool == null &&
                             !editing.isPickingColor &&
                             !editing.hasAnnotationSelection &&
@@ -9267,6 +8612,8 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                                 zoom: zoom,
                                 predictStrokes: widget.predictStrokes,
                                 contextMenuEnabled: widget.contextMenuEnabled,
+                                showSelectionChip:
+                                    widget.showSelectionChip,
                               ),
                             ),
                           );


### PR DESCRIPTION
The floating action chip beside a touch/stylus annotation selection (delete / edit-in-place / context menu) is currently unconditional.

A host that renders its own selection UI on top of the page - e.g. a custom markup toolbar above a text selection, or a note editor opened on annotation tap - gets the chip overlapping that UI, since both float over the same selection.

Plumb a showSelectionChip flag through PdfEditorView -> PdfViewer -> _PdfViewerPage -> EditingPageOverlay (default true, so nothing changes for existing hosts) and gate _buildSelectionChip on it. Selection outline, handles, move/resize, and every pointer interaction are unaffected; mice never see the chip either way.

<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [ ] `fvm flutter pub get`
- [ ] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [ ] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [ ] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [ ] No `dart:io` imports in any `lib/` directory.
- [ ] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [ ] Parsers remain lenient on real-world input and writers remain strict on output.
- [ ] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [ ] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
