### PR TITLE
perf: lower the default mobile tile budget

### DIFF
--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -34,12 +34,35 @@ PdfPerformancePlatform get detectedPdfPerformancePlatform => kIsWeb
 /// - **Web**: on-device release traces show the pyramid settling *under* budget
 ///   (no longer pinned/evicting), panning at deep zoom reusing cached tiles
 ///   with no green-grid flicker (2026-07-19 dev-log).
-/// - **Mobile**: on for parity, but the least-exercised path - and the 96 MB
-///   pyramid budget is a meaningful slice of a jetsam-limited process. A
-///   memory-pressure regression here surfaces as tile eviction, not a crash;
-///   [PdfTileStore.maxBytes] is live-adjustable if a lower mobile budget proves
-///   necessary.
+/// - **Mobile**: on for parity with a smaller 64 MB default tile ceiling (issue
+///   #374); the budget-vs-demand guard falls back to a detail patch when the
+///   visible set is too dense to fit. [PdfTileStore.maxBytes] remains
+///   live-adjustable for hosts with their own memory policy.
 bool pdfDefaultTileStoreDetail() => true;
+
+/// The default byte budget for the process-wide deep-zoom tile pyramid
+/// ([PdfTileStore]) on this platform.
+///
+/// The budget is a ceiling, not a reservation. At the default 512-pixel tile
+/// size each full RGBA tile costs 1 MB, so these values translate directly to
+/// retained tile capacity. The store's budget-vs-demand guard reserves 25% for
+/// fallback/headroom and uses the single detail-patch path rather than
+/// thrashing when one visible tile set would overrun the remainder.
+///
+/// Desktop and web keep the established 96 MB ceiling. Mobile uses 64 MB:
+/// enough for 48 visible full tiles under that guard, while returning 32 MB of
+/// GPU-resident headroom to a jetsam-limited process (issue #374). Hosts can
+/// still pass an explicit [PdfTileStore.maxBytes] value or adjust it live.
+int pdfDefaultTileBudgetBytes({PdfPerformancePlatform? platform}) {
+  const mb = 1024 * 1024;
+  return switch (platform ?? detectedPdfPerformancePlatform) {
+    PdfPerformancePlatform.mobile => 64 * mb,
+    PdfPerformancePlatform.desktop ||
+    PdfPerformancePlatform.web ||
+    PdfPerformancePlatform.other =>
+      96 * mb,
+  };
+}
 
 /// The default byte budget for the process-wide decoded-image cache
 /// ([PdfImageCache]) on this platform.

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -32,6 +32,7 @@ import 'package:flutter/painting.dart';
 
 import 'budgeted_cache.dart';
 import 'perf_log.dart';
+import 'performance_policy.dart';
 import 'renderer.dart';
 
 /// Rasterizes one tile: [region] is the tile's bounds in page points (the
@@ -291,7 +292,7 @@ class PdfTileStore extends ChangeNotifier {
   PdfTileStore({
     this.tilePixels = 512,
     this.ladder = const PdfTileZoomLadder(),
-    int maxBytes = _defaultMaxBytes,
+    int? maxBytes,
     this.prefetchRing = 1,
     this.maxPrefetchInFlightTiles = 4,
     this.maxFallbackDepth = 4,
@@ -303,15 +304,14 @@ class PdfTileStore extends ChangeNotifier {
             'a batch slab must fit the engine texture limit'),
         _cache = PdfBudgetedCache<PdfTileKey, PdfTile>(
           weigher: (tile) => tile.bytes,
-          maxWeight: math.max(maxBytes, _minBytes),
+          maxWeight: math.max(
+            maxBytes ?? pdfDefaultTileBudgetBytes(),
+            _minBytes,
+          ),
           disposer: (tile) => tile.image.dispose(),
           clearsUnderMemoryPressure: registerForMemoryPressure,
           debugLabel: 'tiles',
         );
-
-  /// ~96 MB: enough for a deep-zoom viewport plus a prefetch ring across a
-  /// couple of buckets, well under the decoded-image budget it sits beside.
-  static const _defaultMaxBytes = 96 << 20;
 
   /// A floor so a viewport's worth of tiles is never evicted out from under the
   /// view that just asked for them (see [viewFor]'s MRU-protection contract).

--- a/packages/dart_pdf_editor/test/performance_policy_test.dart
+++ b/packages/dart_pdf_editor/test/performance_policy_test.dart
@@ -177,4 +177,43 @@ void main() {
       }
     });
   });
+
+  group('pdfDefaultTileBudgetBytes (issue #374)', () {
+    const mb = 1024 * 1024;
+
+    test('mobile uses 64 MB, returning 32 MB to the process', () {
+      expect(
+        pdfDefaultTileBudgetBytes(platform: PdfPerformancePlatform.mobile),
+        64 * mb,
+      );
+    });
+
+    test('established 96 MB ceiling stays on non-mobile platforms', () {
+      for (final platform in [
+        PdfPerformancePlatform.desktop,
+        PdfPerformancePlatform.web,
+        PdfPerformancePlatform.other,
+      ]) {
+        expect(pdfDefaultTileBudgetBytes(platform: platform), 96 * mb,
+            reason: '$platform');
+      }
+    });
+
+    test('a default-constructed store adopts the platform policy', () {
+      final store = PdfTileStore(registerForMemoryPressure: false);
+      addTearDown(store.dispose);
+
+      expect(store.maxBytes, pdfDefaultTileBudgetBytes());
+    });
+
+    test('an explicit store budget still wins', () {
+      final store = PdfTileStore(
+        maxBytes: 12 * mb,
+        registerForMemoryPressure: false,
+      );
+      addTearDown(store.dispose);
+
+      expect(store.maxBytes, 12 * mb);
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -655,8 +655,14 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final store =
-        PdfTileStore(tilePixels: 512, registerForMemoryPressure: false);
+    // This case inspects the admitted tile layer's shared-page presentation
+    // policy. Pin the roomy tier so platform defaults do not turn it into the
+    // shared-budget fallback covered separately below.
+    final store = PdfTileStore(
+      tilePixels: 512,
+      maxBytes: 96 << 20,
+      registerForMemoryPressure: false,
+    );
     final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
     PdfRetainedScene.spatialRegionReplayMaxCommands = 0;
     PdfPageView.tileStoreDetail = true;


### PR DESCRIPTION
## Summary

- add a public pdfDefaultTileBudgetBytes platform policy
- use a 64 MiB default on mobile and preserve the established 96 MiB ceiling on desktop, web, and unknown platforms
- wire default PdfTileStore construction through the policy while preserving explicit construction and live maxBytes overrides

## Why

A full 512 px RGBA tile costs about 1 MiB. The 64 MiB mobile ceiling gives 32 MiB of GPU-resident headroom back to jetsam-limited processes while retaining capacity for 48 visible full tiles under the existing 75% budget-fit guard. Views that exceed it already fall back to the single detail patch rather than thrashing.

## Validation

- fvm flutter test test/performance_policy_test.dart
- fvm flutter test test/tile_store_test.dart
- fvm dart analyze

## Tracking

Advances #374 without closing it. The stale deep-zoom discard cause was fixed by #433; physical iOS deep-zoom validation remains after this policy change.