### PR TITLE
ci: publish native Patrol performance traces

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -134,25 +134,7 @@ jobs:
           profile: pixel_6
           disable-animations: true
           working-directory: ${{ env.EXAMPLE_DIR }}
-          script: |
-            bash -o errexit -o pipefail -c '
-              patrol test \
-                --device emulator-5554 \
-                --target patrol_test/demo_e2e_test.dart \
-                --dart-define PDF_PERF_LOG=true \
-                --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
-                --show-flutter-logs \
-                --verbose \
-                2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
-              patrol test \
-                --device emulator-5554 \
-                --target patrol_test/native_perf_e2e_test.dart \
-                --dart-define PDF_PERF_LOG=true \
-                --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
-                --show-flutter-logs \
-                --verbose \
-                2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
-            '
+          script: bash ../../../tool/run_android_patrol_ci.sh
       - name: Collect Patrol Android performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -135,23 +135,24 @@ jobs:
           disable-animations: true
           working-directory: ${{ env.EXAMPLE_DIR }}
           script: |
-            set -o pipefail
-            patrol test \
-              --device emulator-5554 \
-              --target patrol_test/demo_e2e_test.dart \
-              --dart-define PDF_PERF_LOG=true \
-              --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
-              --show-flutter-logs \
-              --verbose \
-              2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
-            patrol test \
-              --device emulator-5554 \
-              --target patrol_test/native_perf_e2e_test.dart \
-              --dart-define PDF_PERF_LOG=true \
-              --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
-              --show-flutter-logs \
-              --verbose \
-              2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
+            bash -o errexit -o pipefail -c '
+              patrol test \
+                --device emulator-5554 \
+                --target patrol_test/demo_e2e_test.dart \
+                --dart-define PDF_PERF_LOG=true \
+                --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+                --show-flutter-logs \
+                --verbose \
+                2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
+              patrol test \
+                --device emulator-5554 \
+                --target patrol_test/native_perf_e2e_test.dart \
+                --dart-define PDF_PERF_LOG=true \
+                --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+                --show-flutter-logs \
+                --verbose \
+                2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
+            '
       - name: Collect Patrol Android performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -15,6 +15,7 @@ env:
   PATROL_CLI_VERSION: 4.7.0
   PATROL_ANALYTICS_ENABLED: "false"
   EXAMPLE_DIR: packages/dart_pdf_editor/example
+  PDF_PATROL_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   web:
@@ -133,16 +134,43 @@ jobs:
           profile: pixel_6
           disable-animations: true
           working-directory: ${{ env.EXAMPLE_DIR }}
-          script: >-
-            patrol test
-            --device emulator-5554
-            --target patrol_test/demo_e2e_test.dart
+          script: |
+            set -o pipefail
+            patrol test \
+              --device emulator-5554 \
+              --target patrol_test/demo_e2e_test.dart \
+              --dart-define PDF_PERF_LOG=true \
+              --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+              --show-flutter-logs \
+              --verbose \
+              2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
+            patrol test \
+              --device emulator-5554 \
+              --target patrol_test/native_perf_e2e_test.dart \
+              --dart-define PDF_PERF_LOG=true \
+              --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+              --show-flutter-logs \
+              --verbose \
+              2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
+      - name: Collect Patrol Android performance trace
+        if: always()
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        shell: bash
+        run: |
+          touch "$RUNNER_TEMP/patrol-android.log"
+          dart ../../../tool/patrol_perf_summary.dart \
+            "$RUNNER_TEMP/patrol-android.log" \
+            --output test-results/perf/android \
+            --markdown "$GITHUB_STEP_SUMMARY" \
+            --label Android
       - name: Upload Patrol Android report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: patrol-android-report
-          path: ${{ env.EXAMPLE_DIR }}/build/app/reports/androidTests
+          path: |
+            ${{ env.EXAMPLE_DIR }}/build/app/reports/androidTests
+            ${{ env.EXAMPLE_DIR }}/test-results/perf/android
           if-no-files-found: ignore
 
   ios:
@@ -172,16 +200,44 @@ jobs:
           echo "device_id=$device_id" >> "$GITHUB_OUTPUT"
       - name: Run Patrol on iOS
         working-directory: ${{ env.EXAMPLE_DIR }}
-        run: >-
-          patrol test
-          --device "${{ steps.simulator.outputs.device_id }}"
-          --target patrol_test/demo_e2e_test.dart
+        shell: bash
+        run: |
+          set -o pipefail
+          patrol test \
+            --device "${{ steps.simulator.outputs.device_id }}" \
+            --target patrol_test/demo_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+            --show-flutter-logs \
+            --verbose \
+            2>&1 | tee "$RUNNER_TEMP/patrol-ios.log"
+          patrol test \
+            --device "${{ steps.simulator.outputs.device_id }}" \
+            --target patrol_test/native_perf_e2e_test.dart \
+            --dart-define PDF_PERF_LOG=true \
+            --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+            --show-flutter-logs \
+            --verbose \
+            2>&1 | tee -a "$RUNNER_TEMP/patrol-ios.log"
+      - name: Collect Patrol iOS performance trace
+        if: always()
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        shell: bash
+        run: |
+          touch "$RUNNER_TEMP/patrol-ios.log"
+          dart ../../../tool/patrol_perf_summary.dart \
+            "$RUNNER_TEMP/patrol-ios.log" \
+            --output test-results/perf/ios \
+            --markdown "$GITHUB_STEP_SUMMARY" \
+            --label "iOS Simulator"
       - name: Upload Patrol iOS result bundle
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: patrol-ios-results
-          path: ${{ env.EXAMPLE_DIR }}/build/*.xcresult
+          path: |
+            ${{ env.EXAMPLE_DIR }}/build/*.xcresult
+            ${{ env.EXAMPLE_DIR }}/test-results/perf/ios
           if-no-files-found: ignore
 
   macos:
@@ -213,3 +269,82 @@ jobs:
           name: patrol-macos-results
           path: ${{ env.EXAMPLE_DIR }}/build/*.xcresult
           if-no-files-found: ignore
+
+  native-performance-report:
+    name: Native Patrol performance report
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: [android, ios]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download Android Patrol results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: patrol-android-report
+          path: patrol-android
+      - name: Download iOS Patrol results
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: patrol-ios-results
+          path: patrol-ios
+      - name: Comment native Patrol performance report
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          PATROL_MARKER: dart-pdf-patrol-native-performance
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = `<!-- ${process.env.PATROL_MARKER} -->`;
+            const summaries = [
+              'patrol-android/test-results/perf/android/patrol-perf.md',
+              'patrol-ios/test-results/perf/ios/patrol-perf.md',
+            ].filter((path) => fs.existsSync(path));
+            const report = summaries.length > 0
+              ? summaries.map((path) => fs.readFileSync(path, 'utf8').trim()).join('\n\n')
+              : [
+                  '## Native Patrol performance',
+                  '',
+                  'No native performance summary artifact was produced. Open the workflow run for the failing step and raw logs.',
+                ].join('\n');
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              report,
+              '',
+              `Automated for commit \`${sha}\` · [workflow run and downloadable native traces](${runUrl})`,
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -304,9 +304,16 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               marker,
-              report,
+              '## Native Patrol performance',
               '',
               `Automated for commit \`${sha}\` · [workflow run and downloadable native traces](${runUrl})`,
+              '',
+              '<details>',
+              '<summary>View Android and iOS performance details</summary>',
+              '',
+              report,
+              '',
+              '</details>',
             ].join('\n');
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -213,9 +213,16 @@ jobs:
                 ].join('\n');
             const body = [
               marker,
-              summary,
+              '## Patrol web performance',
               '',
               `Automated for commit \`${sha}\` · [workflow run and downloadable trace artifact](${runUrl})`,
+              '',
+              '<details>',
+              '<summary>View browser performance details</summary>',
+              '',
+              summary,
+              '',
+              '</details>',
             ].join('\n');
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,

--- a/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
@@ -1,0 +1,216 @@
+// Patrol targets live outside Flutter's conventional test/ directory, but
+// this is still test code and deliberately exercises diagnostic seams.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
+const _mb = 1024 * 1024;
+
+void main() {
+  if (_buildCommit.isNotEmpty) {
+    PdfPerfLog.buildTag = 'commit=$_buildCommit';
+  }
+
+  patrolTest('fills and settles the native mobile tile budget', ($) async {
+    expect($.isWeb, isFalse);
+    await $.pumpWidget(const MaterialApp(home: SizedBox()));
+    await runNativeTilePerfScenario(pump: $.pump);
+    await $.pumpWidget(const SizedBox());
+    await $.pump(const Duration(milliseconds: 50));
+  });
+}
+
+@visibleForTesting
+Future<void> runNativeTilePerfScenario({
+  required Future<void> Function(Duration duration) pump,
+}) async {
+  final platform = switch (defaultTargetPlatform) {
+    TargetPlatform.android => 'android',
+    TargetPlatform.iOS => 'ios',
+    _ => defaultTargetPlatform.name,
+  };
+  final store = PdfTileStore(registerForMemoryPressure: false);
+  final mobile = defaultTargetPlatform == TargetPlatform.android ||
+      defaultTargetPlatform == TargetPlatform.iOS;
+  final identity = PdfTilePageIdentity(
+    cacheNamespace: Object(),
+    pageIndex: 0,
+    pageEpoch: 0,
+    contentStamp: 0,
+    destructiveStamp: 0,
+    plan: const PdfPageRenderPlan(),
+  );
+
+  // Sixteen columns by four rows is exactly 64 MiB at the production
+  // 512px RGBA tile size. Four viewport visits therefore exercise the real
+  // mobile ceiling without relying on a corpus file or network provider.
+  const pageSize = Size(8192, 2048);
+  const windows = <Rect>[
+    Rect.fromLTWH(0, 512, 1536, 1024),
+    Rect.fromLTWH(2560, 512, 1536, 1024),
+    Rect.fromLTWH(5120, 512, 1536, 1024),
+    Rect.fromLTWH(6656, 512, 1536, 1024),
+  ];
+  var rasterCalls = 0;
+
+  Future<ui.Image> rasterize(Rect region, double ratio) async {
+    final clock = Stopwatch()..start();
+    final width = (region.width * ratio).ceil().clamp(1, 1 << 14);
+    final height = (region.height * ratio).ceil().clamp(1, 1 << 14);
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+      Paint()..color = const Color(0xFF102A1F),
+    );
+    final grid = Paint()
+      ..color = const Color(0xFF4ADE80)
+      ..strokeWidth = 2;
+    final xOffset = -(region.left % 64) * ratio;
+    final yOffset = -(region.top % 64) * ratio;
+    for (var x = xOffset; x <= width; x += 64 * ratio) {
+      canvas.drawLine(
+        Offset(x, 0),
+        Offset(x, height.toDouble()),
+        grid,
+      );
+    }
+    for (var y = yOffset; y <= height; y += 64 * ratio) {
+      canvas.drawLine(
+        Offset(0, y),
+        Offset(width.toDouble(), y),
+        grid,
+      );
+    }
+    final picture = recorder.endRecording();
+    try {
+      final image = await picture.toImage(width, height);
+      rasterCalls++;
+      PdfPerfLog.log(
+        'raster page=0 kind=native-tile platform=$platform '
+        'ms=${(clock.elapsedMicroseconds / 1000).toStringAsFixed(1)} '
+        'img=${width}x$height',
+      );
+      return image;
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  PdfPerfLog.log(
+    'scenario name=native-mobile-tiles phase=start platform=$platform '
+    'budgetBytes=${store.maxBytes} tilePixels=${store.tilePixels}',
+  );
+  try {
+    expect(store.maxBytes, mobile ? 64 * _mb : 96 * _mb,
+        reason: 'the native store must use its platform policy ceiling');
+    for (final window in windows) {
+      final status = store.viewBudgetStatus(
+        pageSize: pageSize,
+        desiredRatio: 1,
+        visiblePageRect: window,
+      );
+      expect(status, isNotNull);
+      expect(status!.fits, isTrue,
+          reason: 'each foreground viewport must fit the mobile budget');
+      final view = await _settleWindow(
+        pump,
+        store,
+        identity,
+        pageSize,
+        window,
+        rasterize,
+      );
+      expect(view.complete, isTrue);
+      expect(view.placements, hasLength(status.visibleTiles));
+      expect(view.placements.every((tile) => !tile.isFallback), isTrue);
+    }
+
+    expect(store.inFlightCount, 0);
+    expect(store.retainedBytes, 64 * _mb,
+        reason: 'the journey must fill the mobile policy working set');
+    expect(store.retainedBytes, lessThanOrEqualTo(store.maxBytes));
+    if (mobile) {
+      expect(store.retainedBytes, store.maxBytes,
+          reason: 'the mobile journey must reach, but never exceed, its cap');
+    }
+    expect(store.tileCount, 64);
+    expect(store.debugTilesDiscarded, 0);
+
+    final scheduledBeforeStatic = store.debugTilesScheduled;
+    for (var i = 0; i < 4; i++) {
+      final view = store.viewFor(
+        id: identity,
+        pageSize: pageSize,
+        desiredRatio: 1,
+        visiblePageRect: windows.first,
+        rasterize: rasterize,
+      );
+      expect(view.complete, isTrue);
+      expect(view.placements.every((tile) => !tile.isFallback), isTrue);
+      await pump(const Duration(milliseconds: 100));
+    }
+    final staticRescheduled = store.debugTilesScheduled - scheduledBeforeStatic;
+    expect(staticRescheduled, 0,
+        reason: 'a static sharp viewport must not restart tile work');
+
+    PdfPerfLog.log(
+      'tile stats platform=$platform budget=${store.maxBytes} '
+      'retained=${store.retainedBytes} entries=${store.tileCount} '
+      'scheduled=${store.debugTilesScheduled} '
+      'landed=${store.debugTilesLanded} '
+      'discarded=${store.debugTilesDiscarded} '
+      'staticRescheduled=$staticRescheduled rasterCalls=$rasterCalls',
+    );
+    PdfPerfLog.log(
+      'scenario name=native-mobile-tiles phase=validated '
+      'platform=$platform budgetBytes=${store.maxBytes}',
+    );
+  } finally {
+    store.dispose();
+    await pump(const Duration(milliseconds: 50));
+  }
+}
+
+Future<PdfTileView> _settleWindow(
+  Future<void> Function(Duration duration) pump,
+  PdfTileStore store,
+  PdfTilePageIdentity identity,
+  Size pageSize,
+  Rect window,
+  PdfTileRasterizer rasterize,
+) async {
+  PdfTileView? view;
+  var stablePasses = 0;
+  var previousScheduled = -1;
+  for (var i = 0; i < 240; i++) {
+    view = store.viewFor(
+      id: identity,
+      pageSize: pageSize,
+      desiredRatio: 1,
+      visiblePageRect: window,
+      rasterize: rasterize,
+    );
+    await pump(const Duration(milliseconds: 50));
+    if (view.complete &&
+        store.inFlightCount == 0 &&
+        store.debugTilesScheduled == previousScheduled) {
+      stablePasses++;
+      if (stablePasses == 2) return view;
+    } else {
+      stablePasses = 0;
+    }
+    previousScheduled = store.debugTilesScheduled;
+  }
+  fail(
+    'native tile window did not settle: complete=${view?.complete} '
+    'inFlight=${store.inFlightCount} scheduled=${store.debugTilesScheduled}',
+  );
+}

--- a/packages/dart_pdf_editor/example/test/native_perf_scenario_test.dart
+++ b/packages/dart_pdf_editor/example/test/native_perf_scenario_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../patrol_test/native_perf_e2e_test.dart';
+
+void main() {
+  testWidgets('native tile pressure journey fills once and settles',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.runAsync(() async {
+      await runNativeTilePerfScenario(
+        pump: (duration) => tester.pump(duration),
+      );
+    });
+  });
+}

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -11,7 +11,8 @@ void main(List<String> arguments) {
   if (arguments.isEmpty || arguments.contains('--help')) {
     stdout.writeln(
       'Usage: dart tool/patrol_perf_summary.dart <patrol-log> '
-      '--output <directory> [--markdown <file>] [--baseline <json>]',
+      '--output <directory> [--markdown <file>] [--baseline <json>] '
+      '[--label <platform>]',
     );
     exit(arguments.contains('--help') ? 0 : 64);
   }
@@ -20,6 +21,7 @@ void main(List<String> arguments) {
   String? output;
   String? markdownOutput;
   String? baselineInput;
+  var label = 'web';
   for (var i = 1; i < arguments.length; i++) {
     switch (arguments[i]) {
       case '--output':
@@ -28,6 +30,8 @@ void main(List<String> arguments) {
         markdownOutput = _nextArgument(arguments, ++i, '--markdown');
       case '--baseline':
         baselineInput = _nextArgument(arguments, ++i, '--baseline');
+      case '--label':
+        label = _nextArgument(arguments, ++i, '--label');
       default:
         stderr.writeln('Unknown argument: ${arguments[i]}');
         exit(64);
@@ -52,7 +56,7 @@ void main(List<String> arguments) {
   File('${directory.path}/patrol-perf.json').writeAsStringSync(
     '${const JsonEncoder.withIndent('  ').convert(trace.toJson())}\n',
   );
-  var markdown = trace.toMarkdown();
+  var markdown = trace.toMarkdown(label: label);
   if (baselineInput != null) {
     final baselineFile = File(baselineInput);
     if (!baselineFile.existsSync()) {
@@ -274,7 +278,7 @@ class PatrolPerfTrace {
   final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 7,
+        'schema': 8,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -318,15 +322,16 @@ class PatrolPerfTrace {
         },
       };
 
-  String toMarkdown() {
+  String toMarkdown({String label = 'web'}) {
+    final journeyKind = label.toLowerCase() == 'web' ? 'browser' : 'device';
     final buffer = StringBuffer()
-      ..writeln('## Patrol web performance')
+      ..writeln('## Patrol $label performance')
       ..writeln()
       ..writeln(
         lines.isEmpty
             ? 'No `PdfPerfLog` events were captured. The Patrol result '
                 'artifact still contains the empty trace for diagnosis.'
-            : 'Observational trace from the real Patrol browser journey. '
+            : 'Observational trace from the real Patrol $journeyKind journey. '
                 'Use it for PR comparisons; wall-clock values are not a CI gate.',
       )
       ..writeln()
@@ -375,8 +380,18 @@ class PatrolPerfTrace {
       ..writeln('| Tile slice classes | ${tiles.sliceClassText} |')
       ..writeln('| Tile rung/class batches | '
           '${_mapText(tiles.sliceBatchesByRungClass)} |')
-      ..writeln('| Tile retained peak | ${tiles.retainedPeakText} |')
-      ..writeln();
+      ..writeln('| Tile retained peak | ${tiles.retainedPeakText} |');
+    if (tiles.policySamples > 0) {
+      buffer
+        ..writeln('| Tile policy snapshots | ${tiles.policySamples} |')
+        ..writeln(
+            '| Tile budget peak | ${_formatBytes(tiles.peakBudgetBytes)} |')
+        ..writeln('| Tile scheduled / landed / discarded | '
+            '${tiles.scheduled} / ${tiles.landed} / ${tiles.discarded} |')
+        ..writeln('| Tile discard rate | ${tiles.discardRateText} |')
+        ..writeln('| Static-view reschedules | ${tiles.staticRescheduled} |');
+    }
+    buffer.writeln();
     if (_scenarioMetrics.isNotEmpty) {
       buffer
         ..writeln('### Scenario breakdown')
@@ -795,6 +810,12 @@ class _TileMetrics {
   final sliceBatchesByRungClass = <String, int>{};
   final retainedBytes = <int>[];
   final retainedEntries = <int>[];
+  final budgetBytes = <int>[];
+  var policySamples = 0;
+  var scheduled = 0;
+  var landed = 0;
+  var discarded = 0;
+  var staticRescheduled = 0;
 
   int get prefetchBatches => sliceBatchesByClass['prefetch'] ?? 0;
 
@@ -804,6 +825,13 @@ class _TileMetrics {
   int get peakRetainedEntries => retainedEntries.isEmpty
       ? 0
       : retainedEntries.reduce((a, b) => a > b ? a : b);
+
+  int get peakBudgetBytes =>
+      budgetBytes.isEmpty ? 0 : budgetBytes.reduce((a, b) => a > b ? a : b);
+
+  String get discardRateText => scheduled == 0
+      ? 'n/a'
+      : '${(discarded * 100 / scheduled).toStringAsFixed(1)}%';
 
   String get sliceClassText {
     if (sliceBatchesByClass.isEmpty) return 'none';
@@ -827,6 +855,20 @@ class _TileMetrics {
       replayRequests++;
       _addMilliseconds(replayMs, fields['replay']);
       _addMilliseconds(rasterMs, fields['raster']);
+      return;
+    }
+    if (message.startsWith('tile stats ')) {
+      policySamples++;
+      final budget = int.tryParse(fields['budget'] ?? '');
+      if (budget != null) budgetBytes.add(budget);
+      scheduled += int.tryParse(fields['scheduled'] ?? '') ?? 0;
+      landed += int.tryParse(fields['landed'] ?? '') ?? 0;
+      discarded += int.tryParse(fields['discarded'] ?? '') ?? 0;
+      staticRescheduled += int.tryParse(fields['staticRescheduled'] ?? '') ?? 0;
+      final retained = int.tryParse(fields['retained'] ?? '');
+      if (retained != null) retainedBytes.add(retained);
+      final entries = int.tryParse(fields['entries'] ?? '');
+      if (entries != null) retainedEntries.add(entries);
       return;
     }
     if (!message.startsWith('tile slice ')) return;
@@ -866,6 +908,17 @@ class _TileMetrics {
         'retainedEntries': {
           'samples': retainedEntries.length,
           'max': peakRetainedEntries,
+        },
+        'policy': {
+          'samples': policySamples,
+          'budgetBytes': {
+            'samples': budgetBytes.length,
+            'max': peakBudgetBytes,
+          },
+          'scheduled': scheduled,
+          'landed': landed,
+          'discarded': discarded,
+          'staticRescheduled': staticRescheduled,
         },
       };
 }

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -26,7 +26,10 @@ void main() {
         'selected=40/100 replay=2.0ms raster=5.0ms img=725x725',
     '[perf 39] tile slice page=0 rung=3 class=prefetch tiles=4 '
         'elapsed=3.0ms retained=8388608 entries=8',
-    '[perf 40] raster page=0 ms=12.5',
+    '[perf 40] tile stats platform=android budget=67108864 '
+        'retained=8388608 entries=8 scheduled=12 landed=10 discarded=2 '
+        'staticRescheduled=0',
+    '[perf 41] raster page=0 ms=12.5',
     '[perf 45] webworker result kind=record page=0 commands=1 → worker',
     '[perf 47] webworker result kind=record page=1 declined (null) → local',
     '[perf 55] scenario name=web-worker phase=validated',
@@ -34,7 +37,7 @@ void main() {
     '[perf 90] scenario name=heavy-document phase=validated',
   ]);
   final json = trace.toJson();
-  _expectEqual(json['schema'], 7, 'schema');
+  _expectEqual(json['schema'], 8, 'schema');
 
   final workerPhases = _map(_map(json, 'webWorker'), 'phases');
   _expectEqual(workerPhases['count'], 2, 'worker phase count');
@@ -86,6 +89,21 @@ void main() {
     _map(tiles, 'retainedBytes')['max'],
     8388608,
     'tile retained bytes',
+  );
+  final tilePolicy = _map(tiles, 'policy');
+  _expectEqual(tilePolicy['samples'], 1, 'tile policy samples');
+  _expectEqual(
+    _map(tilePolicy, 'budgetBytes')['max'],
+    67108864,
+    'tile policy budget',
+  );
+  _expectEqual(tilePolicy['scheduled'], 12, 'tile policy scheduled');
+  _expectEqual(tilePolicy['landed'], 10, 'tile policy landed');
+  _expectEqual(tilePolicy['discarded'], 2, 'tile policy discarded');
+  _expectEqual(
+    tilePolicy['staticRescheduled'],
+    0,
+    'tile policy static reschedules',
   );
 
   final scenarios = _map(json, 'scenarioMetrics');
@@ -166,6 +184,21 @@ void main() {
     markdown,
     '| Tile retained peak | 8.0 MiB / 8 entries |',
     'tile retained summary',
+  );
+  _expectContains(
+    markdown,
+    '| Tile budget peak | 64.0 MiB |',
+    'tile budget summary',
+  );
+  _expectContains(
+    markdown,
+    '| Tile discard rate | 16.7% |',
+    'tile discard summary',
+  );
+  _expectContains(
+    trace.toMarkdown(label: 'Android'),
+    '## Patrol Android performance',
+    'platform heading',
   );
 
   final comparison = summary.PatrolPerfComparison(

--- a/tool/run_android_patrol_ci.sh
+++ b/tool/run_android_patrol_ci.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set by GitHub Actions}"
+: "${PDF_PATROL_BUILD_COMMIT:?PDF_PATROL_BUILD_COMMIT must be set}"
+
+patrol test \
+  --device emulator-5554 \
+  --target patrol_test/demo_e2e_test.dart \
+  --dart-define PDF_PERF_LOG=true \
+  --dart-define "PDF_BUILD_COMMIT=$PDF_PATROL_BUILD_COMMIT" \
+  --show-flutter-logs \
+  --verbose \
+  2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
+
+patrol test \
+  --device emulator-5554 \
+  --target patrol_test/native_perf_e2e_test.dart \
+  --dart-define PDF_PERF_LOG=true \
+  --dart-define "PDF_BUILD_COMMIT=$PDF_PATROL_BUILD_COMMIT" \
+  --show-flutter-logs \
+  --verbose \
+  2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"


### PR DESCRIPTION
## Summary

- run a deterministic native tile-pressure journey on Android and iOS Simulator after the existing Patrol smoke suite
- capture normalized raw, JSON, and Markdown performance artifacts with the 64 MiB budget, retained bytes, scheduled/landed/discarded counts, discard rate, and static-view reschedules
- post a sticky native performance report on each PR so mobile policy changes are reviewable without downloading raw runner logs
- keep physical-device iOS validation explicit as the remaining #374 acceptance item

## Validation

- `fvm dart analyze`
- `fvm dart tool/patrol_perf_summary_test.dart`
- `cd packages/dart_pdf_editor/example && fvm flutter test test/native_perf_scenario_test.dart`
- `cd packages/dart_pdf_editor/example && fvm flutter test`
- workflow YAML parse and `git diff --check`

Advances #374 without closing it.