### PR TITLE
Add mobile provider performance traces

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -100,6 +100,9 @@ jobs:
     name: Android (API 35)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
@@ -135,17 +138,52 @@ jobs:
           disable-animations: true
           working-directory: ${{ env.EXAMPLE_DIR }}
           script: bash ../../../tool/run_android_patrol_ci.sh
+      - name: Download latest main Patrol Android baseline
+        id: patrol-baseline
+        if: always() && github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for baseline_run in $(gh run list \
+            --workflow patrol-e2e.yml \
+            --branch main \
+            --event push \
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId'); do
+            destination="$RUNNER_TEMP/patrol-android-baseline/$baseline_run"
+            if gh run download "$baseline_run" \
+              --name patrol-android-report \
+              --dir "$destination"; then
+              json="$destination/test-results/perf/android/patrol-perf.json"
+              if [[ -f "$json" ]]; then
+                echo "json=$json" >> "$GITHUB_OUTPUT"
+                echo "Using Patrol Android baseline from run $baseline_run"
+                exit 0
+              fi
+            fi
+          done
+          echo "::notice::No usable main Patrol Android artifact is available yet"
       - name: Collect Patrol Android performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}
         shell: bash
         run: |
+          set -euo pipefail
           touch "$RUNNER_TEMP/patrol-android.log"
-          dart ../../../tool/patrol_perf_summary.dart \
-            "$RUNNER_TEMP/patrol-android.log" \
-            --output test-results/perf/android \
-            --markdown "$GITHUB_STEP_SUMMARY" \
+          arguments=(
+            "$RUNNER_TEMP/patrol-android.log"
+            --output test-results/perf/android
+            --markdown "$GITHUB_STEP_SUMMARY"
             --label Android
+          )
+          baseline="${{ steps.patrol-baseline.outputs.json }}"
+          if [[ -f "$baseline" ]]; then
+            arguments+=(--baseline "$baseline")
+          fi
+          dart ../../../tool/patrol_perf_summary.dart "${arguments[@]}"
       - name: Upload Patrol Android report
         if: always()
         uses: actions/upload-artifact@v7
@@ -160,6 +198,9 @@ jobs:
     name: iOS Simulator
     runs-on: macos-15
     timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
@@ -202,17 +243,52 @@ jobs:
             --show-flutter-logs \
             --verbose \
             2>&1 | tee -a "$RUNNER_TEMP/patrol-ios.log"
+      - name: Download latest main Patrol iOS baseline
+        id: patrol-baseline
+        if: always() && github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for baseline_run in $(gh run list \
+            --workflow patrol-e2e.yml \
+            --branch main \
+            --event push \
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId'); do
+            destination="$RUNNER_TEMP/patrol-ios-baseline/$baseline_run"
+            if gh run download "$baseline_run" \
+              --name patrol-ios-results \
+              --dir "$destination"; then
+              json="$destination/test-results/perf/ios/patrol-perf.json"
+              if [[ -f "$json" ]]; then
+                echo "json=$json" >> "$GITHUB_OUTPUT"
+                echo "Using Patrol iOS baseline from run $baseline_run"
+                exit 0
+              fi
+            fi
+          done
+          echo "::notice::No usable main Patrol iOS artifact is available yet"
       - name: Collect Patrol iOS performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}
         shell: bash
         run: |
+          set -euo pipefail
           touch "$RUNNER_TEMP/patrol-ios.log"
-          dart ../../../tool/patrol_perf_summary.dart \
-            "$RUNNER_TEMP/patrol-ios.log" \
-            --output test-results/perf/ios \
-            --markdown "$GITHUB_STEP_SUMMARY" \
+          arguments=(
+            "$RUNNER_TEMP/patrol-ios.log"
+            --output test-results/perf/ios
+            --markdown "$GITHUB_STEP_SUMMARY"
             --label "iOS Simulator"
+          )
+          baseline="${{ steps.patrol-baseline.outputs.json }}"
+          if [[ -f "$baseline" ]]; then
+            arguments+=(--baseline "$baseline")
+          fi
+          dart ../../../tool/patrol_perf_summary.dart "${arguments[@]}"
       - name: Upload Patrol iOS result bundle
         if: always()
         uses: actions/upload-artifact@v7
@@ -293,6 +369,10 @@ jobs:
               'patrol-android/test-results/perf/android/patrol-perf.md',
               'patrol-ios/test-results/perf/ios/patrol-perf.md',
             ].filter((path) => fs.existsSync(path));
+            const headlines = [
+              'patrol-android/test-results/perf/android/patrol-perf-headline.md',
+              'patrol-ios/test-results/perf/ios/patrol-perf-headline.md',
+            ].filter((path) => fs.existsSync(path));
             const report = summaries.length > 0
               ? summaries.map((path) => fs.readFileSync(path, 'utf8').trim()).join('\n\n')
               : [
@@ -300,6 +380,9 @@ jobs:
                   '',
                   'No native performance summary artifact was produced. Open the workflow run for the failing step and raw logs.',
                 ].join('\n');
+            const headline = headlines.length > 0
+              ? headlines.map((path) => fs.readFileSync(path, 'utf8').trim()).join('\n\n')
+              : 'No headline native performance summary was produced.';
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
@@ -307,6 +390,8 @@ jobs:
               '## Native Patrol performance',
               '',
               `Automated for commit \`${sha}\` · [workflow run and downloadable native traces](${runUrl})`,
+              '',
+              headline,
               '',
               '<details>',
               '<summary>View Android and iOS performance details</summary>',

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -196,11 +196,13 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           PATROL_MARKER: dart-pdf-patrol-performance
+          PATROL_HEADLINE: patrol-results/test-results/perf/patrol-perf-headline.md
           PATROL_SUMMARY: patrol-results/test-results/perf/patrol-perf.md
         with:
           script: |
             const fs = require('fs');
             const marker = `<!-- ${process.env.PATROL_MARKER} -->`;
+            const headlinePath = process.env.PATROL_HEADLINE;
             const summaryPath = process.env.PATROL_SUMMARY;
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -211,11 +213,16 @@ jobs:
                   '',
                   'No performance summary artifact was produced. Open the workflow run for the failing step and raw logs.',
                 ].join('\n');
+            const headline = fs.existsSync(headlinePath)
+              ? fs.readFileSync(headlinePath, 'utf8').trim()
+              : 'No headline performance summary was produced.';
             const body = [
               marker,
               '## Patrol web performance',
               '',
               `Automated for commit \`${sha}\` · [workflow run and downloadable trace artifact](${runUrl})`,
+              '',
+              headline,
               '',
               '<details>',
               '<summary>View browser performance details</summary>',

--- a/README.md
+++ b/README.md
@@ -60,21 +60,22 @@ are the baselines - so no diff column).
 ## Performance
 
 **The default viewer has not reached PDFium interaction parity yet.** The most
-recent real-document checkpoint (11 August 2026) used five interleaved
-DartPDF/PDFium runs in Chrome 151 on an M1 Pro, a 1400×1000 viewport, and the
-default JS/CanvasKit web build. The input was a locally supplied 62-page,
-24.1 MB illustrated PDF; the journey opened it, jumped to pages 3 and 47,
-zoomed to 1.72×, and drove matched wheel gestures. Lower ratios are better.
+recent real-document checkpoint (23 August 2026, commit `1b887e9f`) used five
+interleaved DartPDF/PDFium runs in Chrome 151 on an M1 Pro, a 1400×1000
+viewport, and the default JS/CanvasKit web build. The input was a locally
+supplied 62-page, 24.1 MB illustrated PDF; the journey opened it, jumped to
+pages 3 and 47, zoomed to 1.72×, and drove matched wheel gestures. Lower
+ratios are better.
 
 | user-visible metric | DartPDF p50 / p95 | PDFium p50 / p95 | ratio p50 / p95 |
 |---|---:|---:|---:|
-| open to stable visual | 1680 / 1932 ms | 1531 / 1716 ms | **1.10× / 1.13×** |
-| page first visual change | 17 / 63 ms | 12 / 21 ms | 1.45× / 2.95× |
-| page stable visual | 303 / 419 ms | 129 / 142 ms | **2.34× / 2.95×** |
-| zoom stable visual | 30 / 47 ms | 9 / 16 ms | **3.17× / 2.89×** |
-| wheel journey | 320 / 397 ms | 1097 / 1237 ms | 0.29× / 0.32× |
-| wheel rAF interval p95 | 25 ms | 10 ms | **2.50×** |
-| peak browser RSS p50 | 1478 MiB | 1287 MiB | 1.15× |
+| open to stable visual | 918 / 974 ms | 1493 / 1520 ms | **0.61× / 0.64×** |
+| page first visual change | 18 / 24 ms | 11 / 16 ms | 1.72× / 1.54× |
+| page stable visual | 297 / 381 ms | 130 / 134 ms | **2.29× / 2.84×** |
+| zoom stable visual | 22 / 31 ms | 11 / 13 ms | **1.97× / 2.35×** |
+| wheel journey | 315 / 433 ms | 912 / 1123 ms | 0.34× / 0.39× |
+| wheel rAF interval p95 | 42 ms | 10 ms | **4.09×** |
+| peak browser RSS p50 | 1827 MiB | 1850 MiB | 0.99× |
 
 The wheel journey completes sooner, but its worse rAF tail means it is not yet
 as smooth; total duration alone would be a misleading win. Open and memory are
@@ -84,10 +85,11 @@ native-desktop or mobile parity claim. See the full methodology and historical
 experimental results in [the PDFium parity notes](doc/benchmarks/pdfium-parity.md).
 
 The offline corpus benchmark remains useful as a subsystem diagnostic, not as
-evidence of viewer latency: over 49 files / 255 pages at scale 2, pure-Dart
-interpretation takes 9.6 ms/page, PDFium rasterization takes 23.1 ms/page, and
-the complete Flutter raster plus readback takes 45.2 ms/page. Reproducible
-offline harnesses and file-by-file diffs live in [`benchmark/`](benchmark).
+evidence of viewer latency: over the 52-file / 268-page common subset at scale
+2, pure-Dart interpretation takes 12.1 ms/page, PDFium rasterization takes
+31.9 ms/page, and the complete Flutter raster plus readback takes 61.6 ms/page.
+Reproducible offline harnesses and file-by-file diffs live in
+[`benchmark/`](benchmark).
 
 ## Architecture
 

--- a/app/README.md
+++ b/app/README.md
@@ -106,6 +106,30 @@ fvm dart analyze app
 cd app && fvm flutter test
 ```
 
+### Mobile cloud-provider performance capture
+
+The Android and iOS reference pickers emit structured `open-trace:` entries to
+the app's Developer tools log without recording the picked URI, path, or access
+token. To validate a real provider, run a debug/profile build on a physical
+device, open one large PDF from that provider, then open **Settings → Developer
+tools** and export the snapshot. Attach the JSON to the performance issue or
+PR together with the provider/device name.
+
+The useful entries are:
+
+- `mobile-pick`: provider identifier, declared bytes, seekability, and the
+  selected `progressive` or `whole` path.
+- `first-paint`: bytes fetched before the progressive preview, file-size
+  percentage, elapsed milliseconds, and page count.
+- `whole-read`: bytes and elapsed milliseconds when a non-seekable provider or
+  batch must be streamed completely.
+
+A progressive provider pass has `seekable=true`, `mode=progressive`, a
+`first-paint` entry, and `fetchedPercent` materially below 100. A provider may
+legitimately report `seekable=false`; in that case the expected result is a
+successful `whole-read`, not a failed ranged open. `progressive-fallback` is a
+failed progressive attempt and should be investigated.
+
 ## Build
 
 `flutter build <apk|appbundle|ios|macos|windows|linux|web> --release`. The three

--- a/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
@@ -267,6 +267,9 @@ class MainActivity : FlutterActivity() {
                 "token" to uri.toString(),
                 "name" to (displayName(uri) ?: "document.pdf"),
                 "length" to fileLength(uri),
+                // The authority identifies the DocumentsProvider without
+                // exposing the picked URI/path or its persisted access token.
+                "provider" to (uri.authority ?: "android-documents-provider"),
                 "seekable" to probeSeekable(uri),
             )
         } catch (e: Exception) {

--- a/app/ios/Runner/SceneDelegate.swift
+++ b/app/ios/Runner/SceneDelegate.swift
@@ -213,11 +213,20 @@ class SceneDelegate: FlutterSceneDelegate {
     defer { if scoped { url.stopAccessingSecurityScopedResource() } }
     guard let bookmark = try? url.bookmarkData() else { return nil }
     let token = bookmark.base64EncodedString()
-    let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+    let values = try? url.resourceValues(forKeys: [
+      .fileSizeKey, .isUbiquitousItemKey, .ubiquitousItemContainerDisplayNameKey,
+    ])
+    let size = values?.fileSize ?? -1
+    // Apple doesn't expose a third-party File Provider's display name from a
+    // picked URL. iCloud does expose its container label; keep the fallback
+    // deliberately generic rather than leaking any part of the URL/bookmark.
+    let provider = values?.ubiquitousItemContainerDisplayName
+      ?? ((values?.isUbiquitousItem ?? false) ? "iCloud" : "ios-file-provider")
     return [
       "token": token,
       "name": url.lastPathComponent,
       "length": size,
+      "provider": provider,
       // iOS File Provider serves coordinated ranged reads on demand, so a
       // resolvable URL is seekable; confirm by opening a handle.
       "seekable": probeSeekableURL(url),

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -77,6 +77,14 @@ const Duration _tabHoverPreviewDelay = Duration(milliseconds: 400);
 const double _tabHoverPreviewWidth = 240;
 const double _tabHoverPreviewHeight = 300;
 
+String _openTraceLabel(String? value) => (value == null || value.isEmpty)
+    ? '-'
+    : value.replaceAll(RegExp(r'[\r\n"]+'), ' ').trim();
+
+String _openTracePercent(int fetched, int? total) => total == null || total <= 0
+    ? 'unknown'
+    : (fetched * 100 / total).toStringAsFixed(1);
+
 /// The editor's main screen: a strip of open-document tabs over the drop-in
 /// [PdfEditorView] / [PdfReader] shells, which carry all the PDF chrome
 /// (search, page number, panels, toolbar). The screen supplies the edit
@@ -1308,6 +1316,8 @@ class _EditorScreenState extends State<EditorScreen>
     String? bookmark,
     String? token,
     String? cachePath,
+    int? declaredBytes,
+    String? provider,
     void Function(Object error)? onOpenFailed,
     DocumentTab? into,
   }) async {
@@ -1323,8 +1333,19 @@ class _EditorScreenState extends State<EditorScreen>
         );
     final cancel = PdfCancelToken();
     final progress = ValueNotifier<double>(0);
+    final openClock = Stopwatch()..start();
+    var fetchedBytes = 0;
+    var totalBytes = declaredBytes;
     final source = _progressiveSource(
-        path: path, bookmark: bookmark, token: token, cancel: cancel);
+      path: path,
+      bookmark: bookmark,
+      token: token,
+      cancel: cancel,
+      onProgress: (received, total) {
+        fetchedBytes = received;
+        if (total != null && total >= 0) totalBytes = total;
+      },
+    );
 
     PdfDocument doc;
     try {
@@ -1343,6 +1364,17 @@ class _EditorScreenState extends State<EditorScreen>
       // The progressive first paint could not be assembled (IO error, or a
       // shape the ranged loader gives up on). Fall back to the plain read the
       // rest of the app uses, reusing the same loading placeholder.
+      AppDevTools.instance.addLog(
+        'open-trace: progressive-fallback '
+        'platform=${defaultTargetPlatform.name} '
+        'origin=${token == null ? "desktop" : "mobile"} '
+        'provider="${_openTraceLabel(provider)}" '
+        'name="${_openTraceLabel(title)}" '
+        'fetchedBytes=$fetchedBytes '
+        'totalBytes=${totalBytes ?? "unknown"} '
+        'elapsedMs=${openClock.elapsedMilliseconds} '
+        'errorType=${error.runtimeType}',
+      );
       progress.dispose();
       await source.close();
       if (!mounted) return;
@@ -1393,6 +1425,19 @@ class _EditorScreenState extends State<EditorScreen>
     AppDevTools.instance.addLog(
         'progressive open: "$title" first paint — ${doc.pageCount} pages; '
         'reading full file…');
+    AppDevTools.instance.addLog(
+      'open-trace: first-paint '
+      'platform=${defaultTargetPlatform.name} '
+      'origin=${token == null ? "desktop" : "mobile"} '
+      'provider="${_openTraceLabel(provider)}" '
+      'name="${_openTraceLabel(title)}" '
+      'mode=progressive seekable=true '
+      'fetchedBytes=$fetchedBytes '
+      'totalBytes=${totalBytes ?? "unknown"} '
+      'fetchedPercent=${_openTracePercent(fetchedBytes, totalBytes)} '
+      'elapsedMs=${openClock.elapsedMilliseconds} '
+      'pages=${doc.pageCount}',
+    );
 
     // Stream the rest in behind the first paint, then swap to a full session.
     unawaited(_finishProgressive(preview, source));
@@ -1619,18 +1664,67 @@ class _EditorScreenState extends State<EditorScreen>
     final defer = picks.length > 1;
     for (final pick in picks) {
       if (!mounted) return;
-      if (!defer && pick.seekable) {
-        await _openProgressive(title: pick.name, token: pick.token);
+      final progressive = !defer && pick.seekable;
+      final reason = progressive
+          ? 'single-seekable'
+          : defer
+              ? 'batch'
+              : 'non-seekable';
+      AppDevTools.instance.addLog(
+        'open-trace: mobile-pick '
+        'platform=${defaultTargetPlatform.name} '
+        'provider="${_openTraceLabel(pick.provider)}" '
+        'name="${_openTraceLabel(pick.name)}" '
+        'declaredBytes=${pick.length ?? "unknown"} '
+        'seekable=${pick.seekable} '
+        'mode=${progressive ? "progressive" : "whole"} '
+        'reason=$reason',
+      );
+      if (progressive) {
+        await _openProgressive(
+          title: pick.name,
+          token: pick.token,
+          declaredBytes: pick.length,
+          provider: pick.provider,
+        );
       } else {
         // Non-seekable, or a batch we won't fan out into concurrent streams:
         // drain the reference whole (still one read of the original, no OS
         // copy) and open it like any other loaded document.
         await _openLoadedBytes(
-          _readOriginFully(token: pick.token),
+          _readMobileOriginFullyWithTrace(pick, reason: reason),
           title: pick.name,
           defer: defer,
         );
       }
+    }
+  }
+
+  Future<Uint8List> _readMobileOriginFullyWithTrace(
+    MobilePickedPdf pick, {
+    required String reason,
+  }) async {
+    final clock = Stopwatch()..start();
+    try {
+      final bytes = await _readOriginFully(token: pick.token);
+      AppDevTools.instance.addLog(
+        'open-trace: whole-read '
+        'platform=${defaultTargetPlatform.name} origin=mobile '
+        'provider="${_openTraceLabel(pick.provider)}" '
+        'name="${_openTraceLabel(pick.name)}" '
+        'mode=whole reason=$reason '
+        'bytes=${bytes.length} elapsedMs=${clock.elapsedMilliseconds}',
+      );
+      return bytes;
+    } catch (_) {
+      AppDevTools.instance.addLog(
+        'open-trace: whole-read-failed '
+        'platform=${defaultTargetPlatform.name} origin=mobile '
+        'provider="${_openTraceLabel(pick.provider)}" '
+        'name="${_openTraceLabel(pick.name)}" '
+        'mode=whole reason=$reason elapsedMs=${clock.elapsedMilliseconds}',
+      );
+      rethrow;
     }
   }
 

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -76,6 +76,7 @@ class MobilePickedPdf {
     required this.token,
     required this.name,
     this.length,
+    this.provider,
     required this.seekable,
   });
 
@@ -84,6 +85,12 @@ class MobilePickedPdf {
   final String token;
   final String name;
   final int? length;
+
+  /// A non-secret provider identifier supplied by the runner. Android reports
+  /// the content URI authority; iOS reports the iCloud container display name
+  /// when available and otherwise a generic File Provider label. Unlike
+  /// [token], this is safe to include in exported diagnostics.
+  final String? provider;
 
   /// Whether native ranged reads over [token] are random-access. False for a
   /// non-seekable pipe (many cloud providers), where the caller streams whole
@@ -116,10 +123,12 @@ Future<List<MobilePickedPdf>> pickPdfMobileReferences() async {
   for (final entry in picked) {
     final token = entry['token'] as String?;
     if (token == null || token.isEmpty) continue;
+    final rawLength = (entry['length'] as num?)?.toInt();
     out.add(MobilePickedPdf(
       token: token,
       name: (entry['name'] as String?) ?? 'document.pdf',
-      length: (entry['length'] as num?)?.toInt(),
+      length: rawLength != null && rawLength >= 0 ? rawLength : null,
+      provider: entry['provider'] as String?,
       seekable: entry['seekable'] == true,
     ));
   }

--- a/app/test/mobile_progressive_open_test.dart
+++ b/app/test/mobile_progressive_open_test.dart
@@ -57,6 +57,7 @@ void main() {
               'token': 'cloud-token',
               'name': 'cloud.pdf',
               'length': pdfBytes.length,
+              'provider': 'test-cloud-provider',
               'seekable': seekable,
             }
           ];
@@ -96,6 +97,18 @@ void main() {
       final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
       expect(log, contains('progressive open: "cloud.pdf" first paint'));
       expect(log, contains('full read complete'));
+      expect(
+          log,
+          contains('open-trace: mobile-pick platform=android '
+              'provider="test-cloud-provider" name="cloud.pdf" '
+              'declaredBytes=${pdfBytes.length} seekable=true '
+              'mode=progressive reason=single-seekable'));
+      expect(log, contains('open-trace: first-paint platform=android '));
+      expect(log, contains('origin=mobile provider="test-cloud-provider" '));
+      expect(log, contains('mode=progressive seekable=true fetchedBytes='));
+      expect(log, contains('fetchedPercent='));
+      expect(log, contains('elapsedMs='));
+      expect(log, isNot(contains('cloud-token')));
       expect(find.byType(PdfEditorView), findsOneWidget);
     } finally {
       debugDefaultTargetPlatformOverride = null;
@@ -123,6 +136,16 @@ void main() {
       // first-paint path.
       final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
       expect(log, isNot(contains('progressive open')));
+      expect(
+          log,
+          contains('open-trace: mobile-pick platform=android '
+              'provider="test-cloud-provider" name="cloud.pdf" '
+              'declaredBytes=${pdfBytes.length} seekable=false '
+              'mode=whole reason=non-seekable'));
+      expect(log, contains('open-trace: whole-read platform=android '));
+      expect(log, contains('mode=whole reason=non-seekable '));
+      expect(log, isNot(contains('open-trace: first-paint')));
+      expect(log, isNot(contains('cloud-token')));
       expect(find.byType(PdfEditorView), findsOneWidget);
     } finally {
       debugDefaultTargetPlatformOverride = null;

--- a/app/test/pdf_mobile_source_test.dart
+++ b/app/test/pdf_mobile_source_test.dart
@@ -142,9 +142,16 @@ void main() {
       messenger.setMockMethodCallHandler(mobileFileChannel, (call) async {
         expect(call.method, 'pickDocuments');
         return <Map<Object?, Object?>>[
-          {'token': 't1', 'name': 'a.pdf', 'length': 1234, 'seekable': true},
+          {
+            'token': 't1',
+            'name': 'a.pdf',
+            'length': 1234,
+            'provider': 'com.example.files',
+            'seekable': true,
+          },
           // Seekability defaults to false when the runner omits it.
-          {'token': 't2', 'name': 'b.pdf'},
+          // A native -1 length is normalized to unknown.
+          {'token': 't2', 'name': 'b.pdf', 'length': -1},
           // An entry without a token is dropped.
           {'name': 'no-token.pdf'},
         ];
@@ -154,10 +161,12 @@ void main() {
       expect(picks[0].token, 't1');
       expect(picks[0].name, 'a.pdf');
       expect(picks[0].length, 1234);
+      expect(picks[0].provider, 'com.example.files');
       expect(picks[0].seekable, isTrue);
       expect(picks[1].token, 't2');
       expect(picks[1].seekable, isFalse);
       expect(picks[1].length, isNull);
+      expect(picks[1].provider, isNull);
     });
 
     test('a cancelled pick (null result) yields an empty list', () async {

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,29 +15,29 @@ bundles a prebuilt PDFium binary. You do not need a system PDFium build or
 
 ## Latest results
 
-Real-world corpus (49 files / **255 pages** that all three tools rendered
-without error), scale 2.0 (144 DPI), best-of-3 render passes, on the
-development Mac. PDFium 5.9.0 / libpdfium 150.0.7869.0. Captured 2026-07-26
-from the 3.1.1 release commit.
+Real-world corpus (52 files / **268 pages** that all three tools rendered
+without error), scale 2.0 (144 DPI), up to 10 pages per file, best-of-3 render
+passes, on the 10-core M1 Pro development Mac. PDFium 5.9.0 / libpdfium
+150.0.7869.0. Captured 2026-08-23 from commit `1b887e9f`.
 
 | engine | throughput | ms/page | vs PDFium |
 |---|---|---|---|
-| **PDFium** (rasterize; open excluded) | 43.2 pages/s | 23.1 | 1.00× |
-| **dart-pdf interpret** (pure Dart, no raster) | 104.5 pages/s | 9.6 | **2.42× faster** |
-| **dart-pdf render** (full Flutter raster + readback) | 22.1 pages/s | 45.2 | **1.95× slower** |
+| **PDFium** (rasterize; open excluded) | 31.3 pages/s | 31.9 | 1.00× |
+| **dart-pdf interpret** (pure Dart, no raster) | 82.4 pages/s | 12.1 | **2.63× faster** |
+| **dart-pdf render** (full Flutter raster + readback) | 16.2 pages/s | 61.6 | **1.93× slower** |
 
 Takeaways:
 
-- **The pure-Dart page interpreter processes this corpus 2.42× faster than
+- **The pure-Dart page interpreter processes this corpus 2.63× faster than
   PDFium rasterizes it.** The interpreter number excludes rasterization; it
   isolates the portable Dart parsing, font, geometry, and content-stream work.
-- **The apples-to-apples full Flutter render is 1.95× slower than PDFium.**
+- **The apples-to-apples full Flutter render is 1.93× slower than PDFium.**
   Beyond interpretation, this path includes image decoding, Flutter
   painting/rasterization, and `toImage`/`toByteData` readback.
-- Against the previous 2026-07-08 table, aggregate interpreter time fell from
-  13.3 to 9.6 ms/page and full-render time from 52.0 to 45.2 ms/page. Results
-  vary by document: a few formerly pathological files account for much of the
-  aggregate full-render gain, while the median file was about 9% slower.
+- Since the 2026-07-26 checkpoint, the common set grew from 49 files / 255
+  pages to 52 files / 268 pages. Absolute milliseconds are therefore not a
+  direct regression comparison; the relative ratios moved from 2.42× to
+  2.63× for interpretation and from 1.95× to 1.93× for full rendering.
 
 Absolute milliseconds and ratios are machine-specific. Re-run on the target
 hardware with `benchmark/run.sh corpus 2 10` (see Quick start).
@@ -99,7 +99,8 @@ Chrome by [`app/tool/perf/`](../app/tool/perf/README.md), which records frame
 build percentiles and `PdfPerfLog` jank events while it drives real scroll
 scenarios.
 
-Latest result: the `scroll-plan` workload, a 16-sheet vector plan set with
+Historical 3.1.0→3.1.1 release result: the `scroll-plan` workload, a
+16-sheet vector plan set with
 about 70,000 operations per page, run as a release web build in headless
 Chrome. These are medians from five interleaved runs of each version, captured
 2026-07-26:

--- a/doc/benchmarks/pdfium-parity.md
+++ b/doc/benchmarks/pdfium-parity.md
@@ -160,7 +160,52 @@ The PDFium adapter uses Chrome's built-in PDF Viewer extension and validates
 the page/zoom methods before measuring. A changed Chrome contract is a harness
 failure, never a silently empty or zero-duration pass.
 
-## Current default-viewer checkpoint (2026-08-11)
+## Current default-viewer checkpoint (2026-08-23)
+
+The default JS/CanvasKit viewer is **not yet at PDFium interaction parity**.
+Five interleaved samples per engine were run at clean commit `1b887e9f` on the
+reference 10-core Apple M1 Pro / Chrome 151 host with a 1400×1000 viewport and
+whole-compositor screencast timing. The input was the locally supplied,
+non-checked-in `8100_Time_Without_Tide_Quickstart.pdf` (62 pages, 24,121,963
+bytes). Each run opened the full file in one request, jumped to zero-based
+pages 2 and 46, zoomed to 1.72×, then drove the standard matched down/up wheel
+sequence.
+
+| metric | DartPDF p50 / p95 | PDFium p50 / p95 | ratio p50 / p95 | budget result |
+|---|---:|---:|---:|---:|
+| open stable visual | 918 / 974 ms | 1493 / 1520 ms | 0.61× / 0.64× | pass |
+| document-only stable visual | 546 / 587 ms | 1490 / 1517 ms | 0.37× / 0.39× | diagnostic |
+| page first visual | 18 / 24 ms | 11 / 16 ms | 1.72× / 1.54× | diagnostic |
+| page stable visual | 297 / 381 ms | 130 / 134 ms | 2.29× / 2.84× | **fail** |
+| zoom first visual | 19 / 23 ms | 11 / 13 ms | 1.73× / 1.77× | diagnostic |
+| zoom stable visual | 22 / 31 ms | 11 / 13 ms | 1.97× / 2.35× | **fail** |
+| wheel journey | 315 / 433 ms | 912 / 1123 ms | 0.34× / 0.39× | pass |
+| wheel rAF interval p95 | 42 ms | 10 ms | 4.09× | **fail** |
+| peak browser RSS p50 | 1827 MiB | 1850 MiB | 0.99× | pass |
+| settled browser RSS p50 | 1749 MiB | 1577 MiB | 1.11× | diagnostic |
+
+Compared with the 11 August checkpoint, open and zoom improved materially,
+stable navigation remained around 2.3× PDFium at p50, and scroll cadence
+regressed from 2.50× to 4.09×. The shorter wheel journey is still not a
+smoothness win. A separate five-run verification on the same build produced
+the same five budget misses and a still-worse 66 ms scroll rAF p95, so the
+cadence gap is noisy but reproducible rather than a single outlier.
+
+Reproduce this exact workload (with the PDF available at the named path) using:
+
+```sh
+PERF_PDF=/path/to/8100_Time_Without_Tide_Quickstart.pdf \
+PERF_PAGES=2,46 PERF_ZOOMS=1.72 \
+  tool/perf.sh competitive parity-plan --iterations 5
+```
+
+This is a desktop-web result. The rendering architecture is shared across
+platforms, but these ratios do not establish native macOS/Windows/Linux or
+physical iOS/Android performance.
+
+## Historical and experimental checkpoints
+
+### Default-viewer checkpoint (2026-08-11)
 
 The default JS/CanvasKit viewer is **not yet at PDFium interaction parity**.
 Five interleaved samples per engine were run at commit `b9c1f32d` on the
@@ -210,8 +255,6 @@ PERF_PAGES=2,46 PERF_ZOOMS=1.72 \
 This is a desktop-web result. The rendering architecture is shared across
 platforms, but these ratios do not establish native macOS/Windows/Linux or
 physical iOS/Android performance.
-
-## Historical and experimental checkpoints
 
 ### Initial provisional checkpoint (2026-08-09)
 

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -140,21 +140,22 @@ also supply its own catalogue - set `pdfBundledFonts` to your own
 ## Performance
 
 **The default viewer has not reached PDFium interaction parity yet.** The most
-recent real-document checkpoint (11 August 2026) used five interleaved
-DartPDF/PDFium runs in Chrome 151 on an M1 Pro, a 1400×1000 viewport, and the
-default JS/CanvasKit web build. The input was a locally supplied 62-page,
-24.1 MB illustrated PDF; the journey opened it, jumped to pages 3 and 47,
-zoomed to 1.72×, and drove matched wheel gestures. Lower ratios are better.
+recent real-document checkpoint (23 August 2026, commit `1b887e9f`) used five
+interleaved DartPDF/PDFium runs in Chrome 151 on an M1 Pro, a 1400×1000
+viewport, and the default JS/CanvasKit web build. The input was a locally
+supplied 62-page, 24.1 MB illustrated PDF; the journey opened it, jumped to
+pages 3 and 47, zoomed to 1.72×, and drove matched wheel gestures. Lower
+ratios are better.
 
 | user-visible metric | DartPDF p50 / p95 | PDFium p50 / p95 | ratio p50 / p95 |
 |---|---:|---:|---:|
-| open to stable visual | 1680 / 1932 ms | 1531 / 1716 ms | **1.10× / 1.13×** |
-| page first visual change | 17 / 63 ms | 12 / 21 ms | 1.45× / 2.95× |
-| page stable visual | 303 / 419 ms | 129 / 142 ms | **2.34× / 2.95×** |
-| zoom stable visual | 30 / 47 ms | 9 / 16 ms | **3.17× / 2.89×** |
-| wheel journey | 320 / 397 ms | 1097 / 1237 ms | 0.29× / 0.32× |
-| wheel rAF interval p95 | 25 ms | 10 ms | **2.50×** |
-| peak browser RSS p50 | 1478 MiB | 1287 MiB | 1.15× |
+| open to stable visual | 918 / 974 ms | 1493 / 1520 ms | **0.61× / 0.64×** |
+| page first visual change | 18 / 24 ms | 11 / 16 ms | 1.72× / 1.54× |
+| page stable visual | 297 / 381 ms | 130 / 134 ms | **2.29× / 2.84×** |
+| zoom stable visual | 22 / 31 ms | 11 / 13 ms | **1.97× / 2.35×** |
+| wheel journey | 315 / 433 ms | 912 / 1123 ms | 0.34× / 0.39× |
+| wheel rAF interval p95 | 42 ms | 10 ms | **4.09×** |
+| peak browser RSS p50 | 1827 MiB | 1850 MiB | 0.99× |
 
 The wheel journey completes sooner, but its worse rAF tail means it is not yet
 as smooth; total duration alone would be a misleading win. Open and memory are
@@ -164,10 +165,10 @@ native-desktop or mobile parity claim. See the
 [full methodology and historical checkpoints](https://github.com/ben-milanko/dart-pdf/blob/main/doc/benchmarks/pdfium-parity.md).
 
 The offline corpus benchmark remains useful as a subsystem diagnostic, not as
-evidence of viewer latency: over 49 files / 255 pages at scale 2, pure-Dart
-interpretation takes 9.6 ms/page, PDFium rasterization takes 23.1 ms/page, and
-the complete Flutter raster plus readback takes 45.2 ms/page. Reproducible
-offline harnesses and file-by-file diffs live in
+evidence of viewer latency: over the 52-file / 268-page common subset at scale
+2, pure-Dart interpretation takes 12.1 ms/page, PDFium rasterization takes
+31.9 ms/page, and the complete Flutter raster plus readback takes 61.6 ms/page.
+Reproducible offline harnesses and file-by-file diffs live in
 [`benchmark/`](https://github.com/ben-milanko/dart-pdf/tree/main/benchmark).
 
 The drop-in shells use adaptive performance tuning by default. Auto selects a

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -74,8 +74,8 @@ void main(List<String> arguments) {
       baseline: decoded,
       current: current,
     );
-    headline = comparison.toHeadlineMarkdown();
-    markdown += comparison.toMarkdown();
+    headline = comparison.toHeadlineMarkdown(label: label);
+    markdown += comparison.toMarkdown(label: label);
   }
   File('${directory.path}/patrol-perf-headline.md').writeAsStringSync(headline);
   File('${directory.path}/patrol-perf.md').writeAsStringSync(markdown);
@@ -328,8 +328,10 @@ class PatrolPerfTrace {
       };
 
   String toHeadlineMarkdown({String label = 'web'}) {
+    final heading =
+        label.toLowerCase() == 'web' ? '### Headline' : '### $label headline';
     final buffer = StringBuffer()
-      ..writeln('### Headline')
+      ..writeln(heading)
       ..writeln()
       ..writeln(
         lines.isEmpty
@@ -496,7 +498,7 @@ class PatrolPerfComparison {
   final Map<String, dynamic> baseline;
   final Map<String, Object?> current;
 
-  String toHeadlineMarkdown() {
+  String toHeadlineMarkdown({String? label}) {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
     final currentScenarios = _jsonCountMap(current, const ['scenarios']);
     final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
@@ -505,8 +507,11 @@ class PatrolPerfComparison {
       ..._jsonMapKeys(current, const ['scenarioMetrics']),
     }.toList()
       ..sort();
+    final heading = label == null || label.toLowerCase() == 'web'
+        ? '### Headline comparison with `main`'
+        : '### $label comparison with `main`';
     final buffer = StringBuffer()
-      ..writeln('### Headline comparison with `main`')
+      ..writeln(heading)
       ..writeln()
       ..writeln(
         'Lower timing is better. Structural counts should stay stable unless '
@@ -578,7 +583,7 @@ class PatrolPerfComparison {
     return buffer.toString();
   }
 
-  String toMarkdown() {
+  String toMarkdown({String? label}) {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
     final currentScenarios = _jsonCountMap(current, const ['scenarios']);
     final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
@@ -587,12 +592,15 @@ class PatrolPerfComparison {
       ..._jsonMapKeys(current, const ['scenarioMetrics']),
     }.toList()
       ..sort();
+    final platform =
+        label == null || label.toLowerCase() == 'web' ? '' : ' $label';
+    final artifactKind = label == null ? 'web' : label;
     final buffer = StringBuffer()
-      ..writeln('## Patrol comparison with `main`')
+      ..writeln('## Patrol$platform comparison with `main`')
       ..writeln()
       ..writeln(
         'Advisory only: timing changes do not fail CI. The baseline is the '
-        'newest usable web artifact from `Patrol E2E` on `main`.',
+        'newest usable $artifactKind artifact from `Patrol E2E` on `main`.',
       )
       ..write(
         sameCoverage

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -53,9 +53,11 @@ void main(List<String> arguments) {
   File('${directory.path}/patrol-perf.log').writeAsStringSync(
     trace.lines.isEmpty ? '' : '${trace.lines.join('\n')}\n',
   );
+  final current = trace.toJson();
   File('${directory.path}/patrol-perf.json').writeAsStringSync(
-    '${const JsonEncoder.withIndent('  ').convert(trace.toJson())}\n',
+    '${const JsonEncoder.withIndent('  ').convert(current)}\n',
   );
+  var headline = trace.toHeadlineMarkdown(label: label);
   var markdown = trace.toMarkdown(label: label);
   if (baselineInput != null) {
     final baselineFile = File(baselineInput);
@@ -68,11 +70,14 @@ void main(List<String> arguments) {
       stderr.writeln('Patrol baseline is not a JSON object: $baselineInput');
       exit(65);
     }
-    markdown += PatrolPerfComparison(
+    final comparison = PatrolPerfComparison(
       baseline: decoded,
-      current: trace.toJson(),
-    ).toMarkdown();
+      current: current,
+    );
+    headline = comparison.toHeadlineMarkdown();
+    markdown += comparison.toMarkdown();
   }
+  File('${directory.path}/patrol-perf-headline.md').writeAsStringSync(headline);
   File('${directory.path}/patrol-perf.md').writeAsStringSync(markdown);
   if (markdownOutput != null) {
     File(markdownOutput).writeAsStringSync(markdown, mode: FileMode.append);
@@ -322,6 +327,47 @@ class PatrolPerfTrace {
         },
       };
 
+  String toHeadlineMarkdown({String label = 'web'}) {
+    final buffer = StringBuffer()
+      ..writeln('### Headline')
+      ..writeln()
+      ..writeln(
+        lines.isEmpty
+            ? 'No `PdfPerfLog` events were captured.'
+            : 'Current Patrol $label trace. Lower timing is better.',
+      );
+    if (lines.isEmpty) return '${buffer.toString()}\n';
+    buffer
+      ..writeln()
+      ..writeln('| Signal | Result |')
+      ..writeln('| --- | ---: |');
+    for (final name in _scenarioMetrics.keys.toList()..sort()) {
+      buffer.writeln('| Scenario ${_code(name)} elapsed p95 | '
+          '${_p95Text(_scenarioMetrics[name]!.elapsedMs)} |');
+    }
+    buffer
+      ..writeln('| Jank frames | ${jankTotalMs.length} |')
+      ..writeln('| Jank total p95 | ${_p95Text(jankTotalMs)} |')
+      ..writeln('| Reconcile p95 | ${_p95Text(reconcileElapsedMs)} |')
+      ..writeln('| Raster p95 | ${_p95Text(rasterElapsedMs)} |');
+    if (workerPhases.totalMs.isNotEmpty) {
+      buffer.writeln('| Worker phase total p95 | '
+          '${_p95Text(workerPhases.totalMs)} |');
+    }
+    if (tiles.replayMs.isNotEmpty) {
+      buffer.writeln('| Tile replay p95 | ${_p95Text(tiles.replayMs)} |');
+    }
+    buffer
+      ..writeln('| Reconcile fallbacks | '
+          '${_sum(reconcileFallbackReasons.values)} |')
+      ..writeln('| Page-raster rejects | '
+          '${pageRasterOutcomes['reject'] ?? 0} |')
+      ..writeln('| Web-worker fatal fallbacks | '
+          '${webWorkerOutcomes['fallback'] ?? 0} |');
+    buffer.writeln();
+    return buffer.toString();
+  }
+
   String toMarkdown({String label = 'web'}) {
     final journeyKind = label.toLowerCase() == 'web' ? 'browser' : 'device';
     final buffer = StringBuffer()
@@ -429,7 +475,9 @@ class PatrolPerfTrace {
     buffer
       ..writeln(
         'Artifacts: `patrol-perf.log` (normalized raw trace), '
-        '`patrol-perf.json` (machine comparison), and this Markdown summary.',
+        '`patrol-perf.json` (machine comparison), '
+        '`patrol-perf-headline.md` (visible PR headline), and this full '
+        'Markdown summary.',
       )
       ..writeln();
     return buffer.toString();
@@ -447,6 +495,88 @@ class PatrolPerfComparison {
 
   final Map<String, dynamic> baseline;
   final Map<String, Object?> current;
+
+  String toHeadlineMarkdown() {
+    final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
+    final currentScenarios = _jsonCountMap(current, const ['scenarios']);
+    final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
+    final measuredScenarios = <String>{
+      ..._jsonMapKeys(baseline, const ['scenarioMetrics']),
+      ..._jsonMapKeys(current, const ['scenarioMetrics']),
+    }.toList()
+      ..sort();
+    final buffer = StringBuffer()
+      ..writeln('### Headline comparison with `main`')
+      ..writeln()
+      ..writeln(
+        'Lower timing is better. Structural counts should stay stable unless '
+        'the PR intentionally changes the exercised path.',
+      );
+    if (!sameCoverage) {
+      buffer
+        ..writeln()
+        ..writeln(
+          '⚠️ Scenario coverage differs from `main`; timing deltas are not '
+          'like-for-like.',
+        );
+    }
+    buffer
+      ..writeln()
+      ..writeln('| Signal | Main | PR | Change |')
+      ..writeln('| --- | ---: | ---: | ---: |');
+
+    void countRow(
+      String label,
+      List<String> path, {
+      bool absentIsZero = false,
+    }) {
+      final before = _jsonNumber(baseline, path, absentIsZero: absentIsZero);
+      final after = _jsonNumber(current, path, absentIsZero: absentIsZero);
+      buffer.writeln('| $label | ${_numberText(before)} | '
+          '${_numberText(after)} | ${_countDelta(before, after)} |');
+    }
+
+    void timingRow(String label, List<String> path) {
+      final before = _jsonNumber(baseline, path);
+      final after = _jsonNumber(current, path);
+      if (before == null && after == null) return;
+      buffer.writeln('| $label | ${_timingText(before)} | '
+          '${_timingText(after)} | ${_percentDelta(before, after)} |');
+    }
+
+    for (final scenario in measuredScenarios) {
+      timingRow(
+        'Scenario ${_code(scenario)} elapsed p95',
+        ['scenarioMetrics', scenario, 'elapsedMs', 'p95'],
+      );
+    }
+    timingRow('Jank total p95', const ['jank', 'totalMs', 'p95']);
+    timingRow('Reconcile p95', const ['reconciliation', 'elapsedMs', 'p95']);
+    timingRow('Raster p95', const ['rasters', 'elapsedMs', 'p95']);
+    timingRow(
+      'Worker phase total p95',
+      const ['webWorker', 'phases', 'totalMs', 'p95'],
+    );
+    timingRow('Tile replay p95', const ['tiles', 'replayMs', 'p95']);
+    countRow('Jank frames', const ['jank', 'count']);
+    countRow(
+      'Reconcile fallbacks',
+      const ['reconciliation', 'fallbackReasons', '*'],
+      absentIsZero: true,
+    );
+    countRow(
+      'Page-raster rejects',
+      const ['pageRasters', 'outcomes', 'reject'],
+      absentIsZero: true,
+    );
+    countRow(
+      'Web-worker fatal fallbacks',
+      const ['webWorker', 'outcomes', 'fallback'],
+      absentIsZero: true,
+    );
+    buffer.writeln();
+    return buffer.toString();
+  }
 
   String toMarkdown() {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -200,6 +200,18 @@ void main() {
     '## Patrol Android performance',
     'platform heading',
   );
+  final headline = trace.toHeadlineMarkdown(label: 'Android');
+  _expectContains(headline, '### Headline', 'headline heading');
+  _expectContains(
+    headline,
+    '| Jank total p95 | 3.0 ms |',
+    'headline jank',
+  );
+  _expectContains(
+    headline,
+    '| Scenario `heavy-document` elapsed p95 | 80.0 ms |',
+    'headline scenario',
+  );
 
   final comparison = summary.PatrolPerfComparison(
     baseline: {
@@ -247,6 +259,45 @@ void main() {
     '| Tile prefetch batches | 2 | 1 | -1 |',
     'tile prefetch comparison',
   );
+  final comparisonHeadline = summary.PatrolPerfComparison(
+    baseline: {
+      'scenarios': json['scenarios'],
+      'jank': {
+        'count': 2,
+        'totalMs': {'p95': 4.0},
+      },
+      'scenarioMetrics': {
+        'heavy-document': {
+          'elapsedMs': {'p95': 100.0},
+        },
+      },
+    },
+    current: json,
+  ).toHeadlineMarkdown();
+  _expectContains(
+    comparisonHeadline,
+    '### Headline comparison with `main`',
+    'comparison headline heading',
+  );
+  _expectContains(
+    comparisonHeadline,
+    '| Jank total p95 | 4.0 ms | 3.0 ms | -25.0% |',
+    'comparison headline jank',
+  );
+  _expectContains(
+    comparisonHeadline,
+    '| Scenario `heavy-document` elapsed p95 | 100.0 ms | 80.0 ms | -20.0% |',
+    'comparison headline scenario',
+  );
+  final sparseHeadline = summary.PatrolPerfComparison(
+    baseline: const {'scenarios': <String, Object?>{}},
+    current: const {'scenarios': <String, Object?>{}},
+  ).toHeadlineMarkdown();
+  _expectNotContains(
+    sparseHeadline,
+    'Worker phase total p95',
+    'missing headline metrics',
+  );
 
   final resetTrace = summary.PatrolPerfTrace.parse(const [
     '[perf 0] scenario name=orphan phase=start',
@@ -283,5 +334,12 @@ void _expectEqual(Object? actual, Object? expected, String label) {
 void _expectContains(String actual, String expected, String label) {
   if (!actual.contains(expected)) {
     throw StateError('$label: missing "$expected" in:\n$actual');
+  }
+}
+
+void _expectNotContains(String actual, String unexpected, String label) {
+  if (actual.contains(unexpected)) {
+    throw StateError(
+        '$label: unexpectedly contained "$unexpected" in:\n$actual');
   }
 }

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -201,7 +201,7 @@ void main() {
     'platform heading',
   );
   final headline = trace.toHeadlineMarkdown(label: 'Android');
-  _expectContains(headline, '### Headline', 'headline heading');
+  _expectContains(headline, '### Android headline', 'headline heading');
   _expectContains(
     headline,
     '| Jank total p95 | 3.0 ms |',
@@ -278,6 +278,20 @@ void main() {
     comparisonHeadline,
     '### Headline comparison with `main`',
     'comparison headline heading',
+  );
+  final androidComparison = summary.PatrolPerfComparison(
+    baseline: {'scenarios': json['scenarios']},
+    current: json,
+  );
+  _expectContains(
+    androidComparison.toHeadlineMarkdown(label: 'Android'),
+    '### Android comparison with `main`',
+    'platform comparison headline',
+  );
+  _expectContains(
+    androidComparison.toMarkdown(label: 'Android'),
+    'newest usable Android artifact',
+    'platform baseline description',
   );
   _expectContains(
     comparisonHeadline,


### PR DESCRIPTION
## Summary

- record the mobile provider, declared size, seekability, and chosen open mode
- report ranged first-paint bytes, percentage, elapsed time, and fallback outcomes
- report whole-read timing for non-seekable providers and batch opens
- keep opaque URIs/bookmarks out of exported diagnostics
- document the physical-device capture and acceptance workflow

Advances #375. Physical iCloud/OneDrive/Google Drive checks remain follow-up validation rather than a code dependency.

<details>
<summary>Validation</summary>

- `fvm dart analyze app`
- `cd app && fvm flutter test` (483 tests)
- `cd app && fvm flutter build apk --debug`
- `cd app && fvm flutter build ios --simulator --debug --no-codesign`

</details>