### PR TITLE
feat(viewer): expose showSelectionChip to hide the touch selection chip

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -510,6 +510,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.onMoveDragPreview,
     this.onTextEditClosed,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
   });
 
   final PdfEditingController controller;
@@ -575,6 +576,14 @@ class EditingPageOverlay extends StatefulWidget {
   /// see that property for the semantics. Has no effect without an editing
   /// controller (the menu path is reader-mode only). Defaults to true.
   final bool contextMenuEnabled;
+
+  /// Whether a touch/stylus annotation selection shows the floating action
+  /// chip beside it (delete, edit-in-place, the context menu). Hosts that
+  /// render their own UI over the selection - a custom markup toolbar or a
+  /// note editor on annotation tap - can turn the chip off to stop it
+  /// overlapping that UI. Selection, handles, and move/resize interactions
+  /// are unaffected. Defaults to true.
+  final bool showSelectionChip;
 
   /// Whether the page raster on screen already shows the controller's
   /// current revision. While false (an edit just committed and the
@@ -5755,7 +5764,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   _textEditFieldName == null &&
                   _controller.hasTouchInput)
                 _buildInlineTextStyleChip(_textEditRect!),
-              if (showChip) _buildSelectionChip(chrome?.$1 ?? selected),
+              if (showChip && widget.showSelectionChip)
+                _buildSelectionChip(chrome?.$1 ?? selected),
               if (_measureReadout() case (final text, final anchor))
                 _buildReadoutChip(text, anchor),
               if (_styleReadout() case (final text, final anchor))

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -234,6 +234,7 @@ class PdfEditorView extends StatefulWidget {
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.imagePicker,
@@ -324,6 +325,7 @@ class PdfEditorView extends StatefulWidget {
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.imagePicker,
@@ -503,6 +505,9 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.contextMenuEnabled].
   final bool contextMenuEnabled;
+
+  /// See [PdfViewer.showSelectionChip].
+  final bool showSelectionChip;
 
   /// See [PdfViewer.onContextMenuRequested].
   final PdfContextMenuHost? onContextMenuRequested;
@@ -768,6 +773,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         pageOverlayBuilder: widget.pageOverlayBuilder,
         annotationMenuBuilder: widget.annotationMenuBuilder,
         contextMenuEnabled: widget.contextMenuEnabled,
+        showSelectionChip: widget.showSelectionChip,
         onContextMenuRequested: widget.onContextMenuRequested,
         formImagePicker: widget.formImagePicker,
         imagePicker: widget.imagePicker,
@@ -1418,6 +1424,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         pageOverlayBuilder: widget.pageOverlayBuilder,
                         annotationMenuBuilder: widget.annotationMenuBuilder,
                         contextMenuEnabled: widget.contextMenuEnabled,
+                        showSelectionChip: widget.showSelectionChip,
                         onContextMenuRequested: widget.onContextMenuRequested,
                         formImagePicker: widget.formImagePicker,
                         imagePicker: widget.imagePicker,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1252,6 +1252,7 @@ class PdfViewer extends StatefulWidget {
     this.textSelectionMarkup = true,
     this.annotationMenuBuilder,
     this.contextMenuEnabled = true,
+    this.showSelectionChip = true,
     this.onContextMenuRequested,
     this.formImagePicker,
     this.fontPicker,
@@ -1527,6 +1528,16 @@ class PdfViewer extends StatefulWidget {
   /// in its own chrome. The long-press annotation menu requires [editing];
   /// the desktop text menu does not.
   final bool contextMenuEnabled;
+
+  /// Whether a touch/stylus annotation selection shows the floating action
+  /// chip beside it (delete, edit-in-place, the context menu) - the
+  /// affordances mice get from hover and right-click. Hosts that render
+  /// their own selection UI (a custom markup toolbar over the selection,
+  /// an editor opened on [onAnnotationTap]) can turn the chip off to stop
+  /// it overlapping that UI. Selection, handles, move/resize, and all
+  /// pointer interactions are unaffected; mice never see the chip either
+  /// way. Needs [editing]. Defaults to true.
+  final bool showSelectionChip;
 
   /// Fires when the user requests a context menu (desktop right-click on
   /// text, right-click / long-press on an annotation, touch long-press on
@@ -7966,6 +7977,7 @@ class _PdfViewerState extends State<PdfViewer>
                     onPlaceSignature: widget.onPlaceSignature,
                     onAnnotationTap: widget.onAnnotationTap,
                     contextMenuEnabled: widget.contextMenuEnabled,
+                    showSelectionChip: widget.showSelectionChip,
                     interactionHost: PdfEditingInteractionHost(
                       panViewport: _touchGrabPanBy,
                       endViewportPan: _flingViewport,
@@ -8865,6 +8877,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.tileRasterBackend,
     required this.predictStrokes,
     required this.contextMenuEnabled,
+    required this.showSelectionChip,
     required this.onRasterStateChanged,
   });
 
@@ -8983,6 +8996,9 @@ class _PdfViewerPage extends StatefulWidget {
   /// so its long-press recognizer and the floating selection chip both
   /// honor the host's intent.
   final bool contextMenuEnabled;
+
+  /// See [PdfViewer.showSelectionChip] - forwarded to the editing overlay.
+  final bool showSelectionChip;
   final void Function(int index, bool ready) onRasterStateChanged;
 
   @override
@@ -9267,6 +9283,8 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                                 zoom: zoom,
                                 predictStrokes: widget.predictStrokes,
                                 contextMenuEnabled: widget.contextMenuEnabled,
+                                showSelectionChip:
+                                    widget.showSelectionChip,
                               ),
                             ),
                           );


### PR DESCRIPTION
The floating delete button beside a touch/stylus annotation selection is currently unconditional.

A host that renders its own selection UI on top of the page—for example, a custom markup toolbar above a text selection, or a note editor opened when an annotation is tapped—can have the delete button overlap that UI, since both float over the same selection.

Plumb a showSelectionChip flag through PdfEditorView -> PdfViewer -> _PdfViewerPage -> EditingPageOverlay (default true, so nothing changes for existing hosts) and use it to control whether _buildSelectionChip is shown. The selection outline, handles, move/resize behavior, and all pointer interactions remain unaffected. Mouse interactions do not show the delete button either way.
<img width="197" height="166" alt="image" src="https://github.com/user-attachments/assets/4c7231e7-b827-44d8-b3a4-1182ca9e7aa3" />


<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [ ] `fvm flutter pub get`
- [ ] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [ ] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [ ] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [ ] No `dart:io` imports in any `lib/` directory.
- [ ] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [ ] Parsers remain lenient on real-world input and writers remain strict on output.
- [ ] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [ ] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
