### PR TITLE
perf(web): avoid double-budgeting decoded images

### DIFF
--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -1503,8 +1503,12 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
             // pure-Dart colour conversion as every other decoder. Unsupported
             // image semantics fall through untouched to serializeCommands'
             // general path.
-            final target =
-                _browserFlateTarget(cos, request, maxImagePixelRatio);
+            final target = _browserFlateTarget(
+              cos,
+              request,
+              maxImagePixelRatio,
+              budgetScale: imageBudgetScale,
+            );
             if (target != null) {
               decoded = imageCache.get(
                 request.stream,
@@ -1624,8 +1628,9 @@ bool _axisAlignedImageOutsideRegion(
 (int, int)? _browserFlateTarget(
   CosDocument cos,
   PdfImageRequest request,
-  double ratio,
-) {
+  double ratio, {
+  double budgetScale = 1.0,
+}) {
   if (!globalContext.has('DecompressionStream')) return null;
   final dict = request.stream.dictionary;
   if (dict.containsKey('SMask')) return null;
@@ -1654,18 +1659,22 @@ bool _axisAlignedImageOutsideRegion(
           bits.value == 2 ||
           bits.value == 4 ||
           bits.value == 8)) {
-    return _browserImageTarget(cos, request, ratio);
+    return _browserImageTarget(cos, request, ratio, budgetScale);
   }
 
   // One-bit gray/stencil images use the same direct packed-sample path.
   if (bits.value == 1) {
-    if (isMask) return _browserImageTarget(cos, request, ratio);
+    if (isMask) {
+      return _browserImageTarget(cos, request, ratio, budgetScale);
+    }
     final colorSpace = cos.resolve(dict['ColorSpace']);
     final directGray = family == 'DeviceGray' &&
         colorSpace is CosName &&
         (colorSpace.value == 'DeviceGray' || colorSpace.value == 'G') &&
         supportedMask;
-    return directGray ? _browserImageTarget(cos, request, ratio) : null;
+    return directGray
+        ? _browserImageTarget(cos, request, ratio, budgetScale)
+        : null;
   }
   if (bits.value != 8 || dict.containsKey('Mask')) return null;
   final components = switch (family) {
@@ -1686,7 +1695,7 @@ bool _axisAlignedImageOutsideRegion(
           colorSpace.value != 'RGB')) {
     return null;
   }
-  return _browserImageTarget(cos, request, ratio);
+  return _browserImageTarget(cos, request, ratio, budgetScale);
 }
 
 (int, int)? _browserImageTarget(

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -839,10 +839,33 @@ _CommandImage? _decodeImageForCommand(
     }
   }
   if (predecoded != null) {
-    final decoded = maxImageRatio == null
-        ? predecoded
-        : _capImageResolution(
-            predecoded, request.transform, maxImageRatio, budgetScale);
+    // A producer may attach pixels that are already capped to this exact
+    // display/page budget (the web worker's browser-native Flate path does).
+    // Derive the final target from the source stream, not from the attached
+    // plane: treating that smaller plane as native applies [budgetScale] a
+    // second time, paying for another downsample and shipping blurry pixels.
+    final target = maxImageRatio == null
+        ? null
+        : _targetDecodedSize(
+            document,
+            request,
+            maxImageRatio,
+            budgetScale,
+          );
+    final targetWidth = target == null
+        ? predecoded.width
+        : math.min(predecoded.width, target.$1);
+    final targetHeight = target == null
+        ? predecoded.height
+        : math.min(predecoded.height, target.$2);
+    final decoded =
+        targetWidth == predecoded.width && targetHeight == predecoded.height
+            ? predecoded
+            : downsamplePdfDecodedPixels(
+                predecoded,
+                targetWidth,
+                targetHeight,
+              );
     return _CommandImage(_copyImageRequest(request, decoded: decoded), decoded);
   }
   if (maxImageRatio != null) {

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -1318,6 +1318,59 @@ void main() {
           greaterThanOrEqualTo(4 * (before - after) - 1024));
     });
 
+    test('does not apply the page budget twice to predecoded pixels', () {
+      // The web worker first decodes simple Flate images asynchronously with
+      // the browser inflater, then hands those already-budgeted pixels to the
+      // command serializer. Recomputing the cap from that smaller plane would
+      // multiply the page scale a second time and blur layered pages.
+      final doc = PdfDocument.open(_layeredImagePdf(draws: 4));
+      final page = doc.page(0);
+      final recorder = RecordingPdfDevice();
+      PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(
+          page, ContentStreamParser.parse(page.contentBytes()));
+      final ratio = 256 / page.cropBox.width;
+      final raster = pdfPageRasterPixels(page.cropBox, ratio)!;
+
+      final first = serializeCommands(
+        recorder.commands,
+        cos: doc.cos,
+        decodeImages: true,
+        maxImagePixelRatio: ratio,
+        pageRasterPixels: raster,
+      )!;
+      final firstImages = _imageCommands(deserializeCommands(first));
+      var imageIndex = 0;
+      final predecoded = <PdfRenderCommand>[];
+      for (final command in recorder.commands) {
+        if (command is! PdfDrawImageCommand) {
+          predecoded.add(command);
+          continue;
+        }
+        final request = command.request;
+        predecoded.add(PdfDrawImageCommand(PdfImageRequest(
+          stream: request.stream,
+          transform: request.transform,
+          alpha: request.alpha,
+          isStencil: request.isStencil,
+          stencilColor: request.stencilColor,
+          isInline: request.isInline,
+          decoded: firstImages[imageIndex++].request.decoded,
+          sourceReference: request.sourceReference,
+        )));
+      }
+
+      final second = serializeCommands(
+        predecoded,
+        cos: doc.cos,
+        decodeImages: true,
+        maxImagePixelRatio: ratio,
+        pageRasterPixels: raster,
+      )!;
+      expect(second, first,
+          reason: 'pixels already decoded to the final page budget must pass '
+              'through the command seam byte-for-byte');
+    });
+
     test('never scales a lone underlay a page render legitimately wants', () {
       final doc = PdfDocument.open(_layeredImagePdf(draws: 1));
       final page = doc.page(0);


### PR DESCRIPTION
## Headline versus `main`

- Page-jump stable p50: **317.5 ms → 296.0 ms (-6.8%)**
- Page-jump stable p95: **360.0 ms → 327.5 ms (-9.0%)**
- Representative worker serialization: page 2 **88 → 81 ms (-8.0%)**; page 46 **93 → 82 ms (-11.8%)**
- Five-run wheel rAF p95 remained within the PDFium budget: **10.3 ms vs 9.4 ms (1.10×)**

## What changed

The browser-native Flate path already knows the page-wide decoded-image budget, but it decoded at the per-image target and made `serializeCommands` apply the page scale afterwards. The serializer also treated attached, already-budgeted pixels as if they were native-size input, so applying the budget early would scale them twice.

This change passes the page budget into browser Flate decoding and makes command serialization derive the final target from the original source stream. Pixels already at or below that target now pass through unchanged. The regression test proves the first and repeated command buffers are byte-identical.

<details>
<summary>Validation and benchmark detail</summary>

Exact reference journey: five interleaved DartPDF/PDFium runs over `8100_Time_Without_Tide_Quickstart.pdf`, pages 2 and 46, zoom 1.72, 1400×1000 Chrome 151 JS/CanvasKit.

The ten-run repetition confirmed substantial compositor variance: navigation p50/p95 was 315.7/349.5 ms and wheel rAF p95 ranged between roughly 9 and 58 ms by run. This PR therefore claims the stable worker-phase reduction and the conservative five-run navigation improvement, not a new PDFium-parity result. Zoom remains a follow-up.

Validation:

- `fvm dart test` in `packages/pdf_graphics` — 1,042 passed
- `fvm flutter test test/render_worker_test.dart test/render_worker_host_test.dart` — 80 passed
- `fvm dart analyze` — clean
- Web render worker release compilation — clean

</details>