### PR TITLE
ci(perf): repeat Patrol performance scenarios

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -14,6 +14,7 @@ env:
   FLUTTER_VERSION: 3.47.0
   PATROL_CLI_VERSION: 4.7.0
   PATROL_ANALYTICS_ENABLED: "false"
+  PATROL_PERF_REPETITIONS: 3
   EXAMPLE_DIR: packages/dart_pdf_editor/example
   PDF_PATROL_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -64,20 +65,24 @@ jobs:
         working-directory: ${{ env.EXAMPLE_DIR }}
         shell: bash
         run: |
-          set -o pipefail
-          patrol test \
-            --device chrome \
-            --target patrol_test/perf_e2e_test.dart \
-            --dart-define PDF_PERF_LOG=true \
-            --dart-define PDF_BUILD_COMMIT=${{ github.sha }} \
-            --show-flutter-logs \
-            --web-headless \
-            --web-locale en-US \
-            --web-workers 1 \
-            --web-viewport '{"width":2600,"height":2600}' \
-            --web-video retain-on-failure \
-            --verbose \
-            2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
+          set -euo pipefail
+          for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
+            echo "::group::Patrol performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+            patrol test \
+              --device chrome \
+              --target patrol_test/perf_e2e_test.dart \
+              --dart-define PDF_PERF_LOG=true \
+              --dart-define PDF_BUILD_COMMIT=${{ github.sha }} \
+              --show-flutter-logs \
+              --web-headless \
+              --web-locale en-US \
+              --web-workers 1 \
+              --web-viewport '{"width":2600,"height":2600}' \
+              --web-video retain-on-failure \
+              --verbose \
+              2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
+            echo "::endgroup::"
+          done
       - name: Collect Patrol performance trace
         if: always()
         working-directory: ${{ env.EXAMPLE_DIR }}
@@ -226,7 +231,7 @@ jobs:
         working-directory: ${{ env.EXAMPLE_DIR }}
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           patrol test \
             --device "${{ steps.simulator.outputs.device_id }}" \
             --target patrol_test/demo_e2e_test.dart \
@@ -235,14 +240,18 @@ jobs:
             --show-flutter-logs \
             --verbose \
             2>&1 | tee "$RUNNER_TEMP/patrol-ios.log"
-          patrol test \
-            --device "${{ steps.simulator.outputs.device_id }}" \
-            --target patrol_test/native_perf_e2e_test.dart \
-            --dart-define PDF_PERF_LOG=true \
-            --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
-            --show-flutter-logs \
-            --verbose \
-            2>&1 | tee -a "$RUNNER_TEMP/patrol-ios.log"
+          for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
+            echo "::group::Patrol native performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+            patrol test \
+              --device "${{ steps.simulator.outputs.device_id }}" \
+              --target patrol_test/native_perf_e2e_test.dart \
+              --dart-define PDF_PERF_LOG=true \
+              --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
+              --show-flutter-logs \
+              --verbose \
+              2>&1 | tee -a "$RUNNER_TEMP/patrol-ios.log"
+            echo "::endgroup::"
+          done
       - name: Download latest main Patrol iOS baseline
         id: patrol-baseline
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -91,6 +91,11 @@ jobs:
           "$RUNNER_TEMP/patrol-web.log"
           --output test-results/perf
           --markdown "$GITHUB_STEP_SUMMARY"
+          --require-scenario-runs "cad-image-deep-zoom=$PATROL_PERF_REPETITIONS"
+          --require-scenario-runs "heavy-document=$PATROL_PERF_REPETITIONS"
+          --require-scenario-runs "jpeg-consumer-decode=$PATROL_PERF_REPETITIONS"
+          --require-scenario-runs "rounded-rung-pressure=$PATROL_PERF_REPETITIONS"
+          --require-scenario-runs "web-worker=$PATROL_PERF_REPETITIONS"
       - name: Upload Patrol web results
         if: always()
         uses: actions/upload-artifact@v7
@@ -183,6 +188,7 @@ jobs:
             --output test-results/perf/android
             --markdown "$GITHUB_STEP_SUMMARY"
             --label Android
+            --require-scenario-runs "native-mobile-tiles=$PATROL_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then
@@ -240,8 +246,13 @@ jobs:
             --show-flutter-logs \
             --verbose \
             2>&1 | tee "$RUNNER_TEMP/patrol-ios.log"
-          for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
-            echo "::group::Patrol native performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+          completed=0
+          attempt=0
+          max_attempts=$((PATROL_PERF_REPETITIONS + 2))
+          while ((completed < PATROL_PERF_REPETITIONS && attempt < max_attempts)); do
+            attempt=$((attempt + 1))
+            attempt_log="$RUNNER_TEMP/patrol-ios-perf-$attempt.log"
+            echo "::group::Patrol native performance attempt $attempt/$max_attempts"
             patrol test \
               --device "${{ steps.simulator.outputs.device_id }}" \
               --target patrol_test/native_perf_e2e_test.dart \
@@ -249,9 +260,23 @@ jobs:
               --dart-define PDF_BUILD_COMMIT=${{ env.PDF_PATROL_BUILD_COMMIT }} \
               --show-flutter-logs \
               --verbose \
-              2>&1 | tee -a "$RUNNER_TEMP/patrol-ios.log"
+              2>&1 | tee "$attempt_log"
             echo "::endgroup::"
+            if dart ../../../tool/patrol_perf_summary.dart \
+              "$attempt_log" \
+              --output "$RUNNER_TEMP/patrol-ios-perf-${attempt}-summary" \
+              --require-scenario-runs native-mobile-tiles=1 \
+              >/dev/null 2>&1; then
+              tee -a "$RUNNER_TEMP/patrol-ios.log" < "$attempt_log" >/dev/null
+              completed=$((completed + 1))
+            else
+              echo "::warning::iOS Patrol attempt $attempt returned without a complete performance marker; retrying"
+            fi
           done
+          if ((completed < PATROL_PERF_REPETITIONS)); then
+            echo "::error::iOS Patrol produced $completed/$PATROL_PERF_REPETITIONS complete performance repetitions"
+            exit 1
+          fi
       - name: Download latest main Patrol iOS baseline
         id: patrol-baseline
         if: always() && github.event_name == 'pull_request'
@@ -292,6 +317,7 @@ jobs:
             --output test-results/perf/ios
             --markdown "$GITHUB_STEP_SUMMARY"
             --label "iOS Simulator"
+            --require-scenario-runs "native-mobile-tiles=$PATROL_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -19,6 +19,7 @@ env:
   FIREBASE_TOOLS_VERSION: 15.22.4
   PATROL_CLI_VERSION: 4.7.0
   PATROL_ANALYTICS_ENABLED: "false"
+  PATROL_PERF_REPETITIONS: 3
 
 jobs:
   build:
@@ -95,20 +96,24 @@ jobs:
         working-directory: packages/dart_pdf_editor/example
         shell: bash
         run: |
-          set -o pipefail
-          patrol test \
-            --device chrome \
-            --target patrol_test/perf_e2e_test.dart \
-            --dart-define PDF_PERF_LOG=true \
-            --dart-define PDF_BUILD_COMMIT=${{ github.event.pull_request.head.sha }} \
-            --show-flutter-logs \
-            --web-headless \
-            --web-locale en-US \
-            --web-workers 1 \
-            --web-viewport '{"width":2600,"height":2600}' \
-            --web-video retain-on-failure \
-            --verbose \
-            2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
+          set -euo pipefail
+          for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
+            echo "::group::Patrol performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+            patrol test \
+              --device chrome \
+              --target patrol_test/perf_e2e_test.dart \
+              --dart-define PDF_PERF_LOG=true \
+              --dart-define PDF_BUILD_COMMIT=${{ github.event.pull_request.head.sha }} \
+              --show-flutter-logs \
+              --web-headless \
+              --web-locale en-US \
+              --web-workers 1 \
+              --web-viewport '{"width":2600,"height":2600}' \
+              --web-video retain-on-failure \
+              --verbose \
+              2>&1 | tee -a "$RUNNER_TEMP/patrol-web.log"
+            echo "::endgroup::"
+          done
 
       - name: Download latest main Patrol web baseline
         id: patrol-baseline

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -156,6 +156,11 @@ jobs:
             "$RUNNER_TEMP/patrol-web.log"
             --output test-results/perf
             --markdown "$GITHUB_STEP_SUMMARY"
+            --require-scenario-runs "cad-image-deep-zoom=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "heavy-document=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "jpeg-consumer-decode=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "rounded-rung-pressure=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "web-worker=$PATROL_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then

--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -51,6 +51,9 @@ compare the JSON with a recent `main` run from the same hosted-runner lane. CI
 runs each dedicated performance target three times. Scenario headlines compare
 the median (`p50`) across those repetitions, while the detailed report retains
 `p95` tail timings and warns when either artifact has fewer than three samples.
+The collection step fails if the current run produces fewer than all three
+complete scenario samples; iOS retries a passed Patrol invocation when its
+Flutter performance markers are missing from the captured native log.
 The summary keeps global aggregates for continuity and a scenario breakdown for
 elapsed time, jank, reconciliation, raster work, worker phases, decoded-image
 cache pressure and per-request hit/miss deltas, and worker outcomes, so a slow

--- a/packages/dart_pdf_editor/example/README.md
+++ b/packages/dart_pdf_editor/example/README.md
@@ -47,8 +47,11 @@ The CI web journey enables `PdfPerfLog` and uploads `patrol-perf.log`,
 `patrol-perf.json`, and `patrol-perf.md` inside the `patrol-web-results`
 artifact. Pull requests also show the Markdown summary in the Actions run.
 These wall-clock measurements are review evidence rather than a pass/fail gate;
-compare the JSON with a recent `main` run from the same hosted-runner lane. The
-summary keeps global aggregates for continuity and a scenario breakdown for
+compare the JSON with a recent `main` run from the same hosted-runner lane. CI
+runs each dedicated performance target three times. Scenario headlines compare
+the median (`p50`) across those repetitions, while the detailed report retains
+`p95` tail timings and warns when either artifact has fewer than three samples.
+The summary keeps global aggregates for continuity and a scenario breakdown for
 elapsed time, jank, reconciliation, raster work, worker phases, decoded-image
 cache pressure and per-request hit/miss deltas, and worker outcomes, so a slow
 heavy-document journey is not hidden inside the other browser journeys. The

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -339,13 +339,23 @@ class PatrolPerfTrace {
             : 'Current Patrol $label trace. Lower timing is better.',
       );
     if (lines.isEmpty) return '${buffer.toString()}\n';
+    if (_scenarioMetrics.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln(
+          'Scenario elapsed uses p50 across repeated runs; phase and tail '
+          'signals remain p95.',
+        );
+    }
     buffer
       ..writeln()
       ..writeln('| Signal | Result |')
       ..writeln('| --- | ---: |');
     for (final name in _scenarioMetrics.keys.toList()..sort()) {
-      buffer.writeln('| Scenario ${_code(name)} elapsed p95 | '
-          '${_p95Text(_scenarioMetrics[name]!.elapsedMs)} |');
+      final elapsed = _scenarioMetrics[name]!.elapsedMs;
+      buffer.writeln('| Scenario ${_code(name)} elapsed p50 '
+          '(${elapsed.length} ${elapsed.length == 1 ? 'run' : 'runs'}) | '
+          '${_p50Text(elapsed)} |');
     }
     buffer
       ..writeln('| Jank frames | ${jankTotalMs.length} |')
@@ -517,6 +527,45 @@ class PatrolPerfComparison {
         'Lower timing is better. Structural counts should stay stable unless '
         'the PR intentionally changes the exercised path.',
       );
+    if (measuredScenarios.isNotEmpty) {
+      final samples = measuredScenarios.map((scenario) {
+        final before = _jsonNumber(
+          baseline,
+          ['scenarioMetrics', scenario, 'runs'],
+        );
+        final after = _jsonNumber(
+          current,
+          ['scenarioMetrics', scenario, 'runs'],
+        );
+        return '${_code(scenario)} ${_numberText(before)} / '
+            '${_numberText(after)}';
+      }).join(', ');
+      final sparseSamples = measuredScenarios.any((scenario) {
+        final before = _jsonNumber(
+          baseline,
+          ['scenarioMetrics', scenario, 'runs'],
+        );
+        final after = _jsonNumber(
+          current,
+          ['scenarioMetrics', scenario, 'runs'],
+        );
+        return before == null || after == null || before < 3 || after < 3;
+      });
+      buffer
+        ..writeln()
+        ..writeln(
+          'Scenario elapsed uses p50 across repeated runs; phase and tail '
+          'signals remain p95. Samples (main / PR): $samples.',
+        );
+      if (sparseSamples) {
+        buffer
+          ..writeln()
+          ..writeln(
+            '⚠️ At least one scenario has fewer than three samples; treat '
+            'its timing delta as provisional.',
+          );
+      }
+    }
     if (!sameCoverage) {
       buffer
         ..writeln()
@@ -551,8 +600,8 @@ class PatrolPerfComparison {
 
     for (final scenario in measuredScenarios) {
       timingRow(
-        'Scenario ${_code(scenario)} elapsed p95',
-        ['scenarioMetrics', scenario, 'elapsedMs', 'p95'],
+        'Scenario ${_code(scenario)} elapsed p50',
+        ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
       );
     }
     timingRow('Jank total p95', const ['jank', 'totalMs', 'p95']);
@@ -687,6 +736,10 @@ class PatrolPerfComparison {
       countRow(
         'Scenario $scenario runs',
         ['scenarioMetrics', scenario, 'runs'],
+      );
+      timingRow(
+        'Scenario $scenario elapsed p50',
+        ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
       );
       timingRow(
         'Scenario $scenario elapsed p95',
@@ -1147,6 +1200,11 @@ String _distributionText(List<double> values) {
 String _p95Text(List<double> values) {
   final distribution = _distribution(values);
   return distribution == null ? 'n/a' : _formatMs(distribution['p95']!);
+}
+
+String _p50Text(List<double> values) {
+  final distribution = _distribution(values);
+  return distribution == null ? 'n/a' : _formatMs(distribution['p50']!);
 }
 
 String _mapText(Map<String, int> values) {

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -511,7 +511,7 @@ class PatrolPerfComparison {
   String toHeadlineMarkdown({String? label}) {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
     final currentScenarios = _jsonCountMap(current, const ['scenarios']);
-    final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
+    final sameCoverage = _sameMapKeys(baselineScenarios, currentScenarios);
     final measuredScenarios = <String>{
       ..._jsonMapKeys(baseline, const ['scenarioMetrics']),
       ..._jsonMapKeys(current, const ['scenarioMetrics']),
@@ -635,7 +635,7 @@ class PatrolPerfComparison {
   String toMarkdown({String? label}) {
     final baselineScenarios = _jsonCountMap(baseline, const ['scenarios']);
     final currentScenarios = _jsonCountMap(current, const ['scenarios']);
-    final sameCoverage = _sameCountMap(baselineScenarios, currentScenarios);
+    final sameCoverage = _sameMapKeys(baselineScenarios, currentScenarios);
     final measuredScenarios = <String>{
       ..._jsonMapKeys(baseline, const ['scenarioMetrics']),
       ..._jsonMapKeys(current, const ['scenarioMetrics']),
@@ -1267,9 +1267,8 @@ Set<String> _jsonMapKeys(Object? root, List<String> path) {
       : const {};
 }
 
-bool _sameCountMap(Map<String, int> a, Map<String, int> b) =>
-    a.length == b.length &&
-    a.entries.every((entry) => b[entry.key] == entry.value);
+bool _sameMapKeys(Map<String, int> a, Map<String, int> b) =>
+    a.length == b.length && a.keys.every(b.containsKey);
 
 String _mapComparisonRow(
   String label,

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -12,7 +12,7 @@ void main(List<String> arguments) {
     stdout.writeln(
       'Usage: dart tool/patrol_perf_summary.dart <patrol-log> '
       '--output <directory> [--markdown <file>] [--baseline <json>] '
-      '[--label <platform>]',
+      '[--label <platform>] [--require-scenario-runs <name>=<count>]',
     );
     exit(arguments.contains('--help') ? 0 : 64);
   }
@@ -22,6 +22,7 @@ void main(List<String> arguments) {
   String? markdownOutput;
   String? baselineInput;
   var label = 'web';
+  final requiredScenarioRuns = <String, int>{};
   for (var i = 1; i < arguments.length; i++) {
     switch (arguments[i]) {
       case '--output':
@@ -32,6 +33,19 @@ void main(List<String> arguments) {
         baselineInput = _nextArgument(arguments, ++i, '--baseline');
       case '--label':
         label = _nextArgument(arguments, ++i, '--label');
+      case '--require-scenario-runs':
+        final raw = _nextArgument(arguments, ++i, '--require-scenario-runs');
+        final separator = raw.lastIndexOf('=');
+        final name = separator < 0 ? '' : raw.substring(0, separator);
+        final count =
+            separator < 0 ? null : int.tryParse(raw.substring(separator + 1));
+        if (name.isEmpty || count == null || count < 1) {
+          stderr.writeln(
+            '--require-scenario-runs expects <name>=<positive-count>: $raw',
+          );
+          exit(64);
+        }
+        requiredScenarioRuns[name] = count;
       default:
         stderr.writeln('Unknown argument: ${arguments[i]}');
         exit(64);
@@ -83,9 +97,45 @@ void main(List<String> arguments) {
     File(markdownOutput).writeAsStringSync(markdown, mode: FileMode.append);
   }
 
+  final shortfalls = patrolPerfScenarioRunShortfalls(
+    current,
+    requiredScenarioRuns,
+  );
+  if (shortfalls.isNotEmpty) {
+    for (final entry in shortfalls.entries) {
+      stderr.writeln(
+        'Scenario ${entry.key} produced ${entry.value} complete run(s); '
+        'required ${requiredScenarioRuns[entry.key]}.',
+      );
+    }
+    exit(65);
+  }
+
   stdout.writeln(
     'Collected ${trace.lines.length} Patrol perf events in ${directory.path}',
   );
+}
+
+/// Returns the observed run count for every required scenario that did not
+/// produce enough complete start/end pairs.
+///
+/// CI uses this after writing the report artifacts: a flaky Patrol invocation
+/// remains diagnosable, but cannot silently turn a three-sample comparison
+/// into a one- or two-sample result.
+Map<String, int> patrolPerfScenarioRunShortfalls(
+  Map<String, Object?> trace,
+  Map<String, int> required,
+) {
+  final shortfalls = <String, int>{};
+  for (final entry in required.entries) {
+    final actual = _jsonNumber(
+          trace,
+          ['scenarioMetrics', entry.key, 'runs'],
+        )?.round() ??
+        0;
+    if (actual < entry.value) shortfalls[entry.key] = actual;
+  }
+  return shortfalls;
 }
 
 String _nextArgument(List<String> arguments, int index, String option) {

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -209,7 +209,7 @@ void main() {
   );
   _expectContains(
     headline,
-    '| Scenario `heavy-document` elapsed p95 | 80.0 ms |',
+    '| Scenario `heavy-document` elapsed p50 (1 run) | 80.0 ms |',
     'headline scenario',
   );
 
@@ -227,7 +227,7 @@ void main() {
       'scenarioMetrics': {
         'heavy-document': {
           'runs': 1,
-          'elapsedMs': {'p95': 100.0},
+          'elapsedMs': {'p50': 100.0, 'p95': 100.0},
           'jank': {
             'totalMs': {'p95': 4.0},
           },
@@ -241,8 +241,13 @@ void main() {
   ).toMarkdown();
   _expectContains(
     comparison,
+    '| Scenario heavy-document elapsed p50 | 100.0 ms | 80.0 ms | -20.0% |',
+    'scenario median comparison',
+  );
+  _expectContains(
+    comparison,
     '| Scenario heavy-document elapsed p95 | 100.0 ms | 80.0 ms | -20.0% |',
-    'scenario comparison',
+    'scenario tail comparison',
   );
   _expectContains(
     comparison,
@@ -268,7 +273,8 @@ void main() {
       },
       'scenarioMetrics': {
         'heavy-document': {
-          'elapsedMs': {'p95': 100.0},
+          'runs': 1,
+          'elapsedMs': {'p50': 100.0, 'p95': 100.0},
         },
       },
     },
@@ -300,8 +306,13 @@ void main() {
   );
   _expectContains(
     comparisonHeadline,
-    '| Scenario `heavy-document` elapsed p95 | 100.0 ms | 80.0 ms | -20.0% |',
+    '| Scenario `heavy-document` elapsed p50 | 100.0 ms | 80.0 ms | -20.0% |',
     'comparison headline scenario',
+  );
+  _expectContains(
+    comparisonHeadline,
+    'fewer than three samples',
+    'sparse comparison warning',
   );
   final sparseHeadline = summary.PatrolPerfComparison(
     baseline: const {'scenarios': <String, Object?>{}},
@@ -322,6 +333,46 @@ void main() {
   final orphan = _map(_map(resetTrace, 'scenarioMetrics'), 'orphan');
   _expectEqual(orphan['runs'], 0, 'cross-process scenario is incomplete');
   _expectEqual(orphan['elapsedMs'], null, 'cross-process elapsed is absent');
+
+  final repeatedTrace = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] build commit=repeated',
+    '[perf 10] scenario name=repeatable phase=start',
+    '[perf 110] scenario name=repeatable phase=validated',
+    '[perf 0] build commit=repeated',
+    '[perf 10] scenario name=repeatable phase=start',
+    '[perf 310] scenario name=repeatable phase=validated',
+    '[perf 0] build commit=repeated',
+    '[perf 10] scenario name=repeatable phase=start',
+    '[perf 210] scenario name=repeatable phase=validated',
+  ]);
+  final repeatedJson = repeatedTrace.toJson();
+  final repeatedScenario =
+      _map(_map(repeatedJson, 'scenarioMetrics'), 'repeatable');
+  _expectEqual(repeatedScenario['runs'], 3, 'repeated scenario runs');
+  _expectEqual(
+    _map(repeatedScenario, 'elapsedMs'),
+    const {'p50': 200.0, 'p95': 300.0, 'max': 300.0},
+    'repeated scenario distribution',
+  );
+  _expectContains(
+    repeatedTrace.toHeadlineMarkdown(),
+    '| Scenario `repeatable` elapsed p50 (3 runs) | 200.0 ms |',
+    'repeated headline median',
+  );
+  final repeatedComparison = summary.PatrolPerfComparison(
+    baseline: repeatedJson,
+    current: repeatedJson,
+  ).toHeadlineMarkdown();
+  _expectContains(
+    repeatedComparison,
+    'Samples (main / PR): `repeatable` 3 / 3.',
+    'repeated comparison sample counts',
+  );
+  _expectNotContains(
+    repeatedComparison,
+    'fewer than three samples',
+    'repeated comparison is not sparse',
+  );
 
   print('Patrol performance summarizer tests passed');
 }

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -403,6 +403,22 @@ void main() {
     'fewer than three samples',
     'repetition transition remains provisional',
   );
+  _expectEqual(
+    summary.patrolPerfScenarioRunShortfalls(
+      repeatedJson,
+      const {'repeatable': 3},
+    ),
+    const <String, int>{},
+    'complete repetitions satisfy the CI requirement',
+  );
+  _expectEqual(
+    summary.patrolPerfScenarioRunShortfalls(
+      repeatedJson,
+      const {'repeatable': 4, 'missing': 3},
+    ),
+    const {'repeatable': 3, 'missing': 0},
+    'incomplete repetitions fail the CI requirement',
+  );
 
   print('Patrol performance summarizer tests passed');
 }

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -373,6 +373,36 @@ void main() {
     'fewer than three samples',
     'repeated comparison is not sparse',
   );
+  final repetitionTransitionComparison = summary.PatrolPerfComparison(
+    baseline: const {
+      'scenarios': {
+        'repeatable:start': 1,
+        'repeatable:validated': 1,
+      },
+      'scenarioMetrics': {
+        'repeatable': {
+          'runs': 1,
+          'elapsedMs': {'p50': 200.0, 'p95': 200.0},
+        },
+      },
+    },
+    current: repeatedJson,
+  ).toHeadlineMarkdown();
+  _expectNotContains(
+    repetitionTransitionComparison,
+    'Scenario coverage differs',
+    'repetition count does not change scenario coverage',
+  );
+  _expectContains(
+    repetitionTransitionComparison,
+    'Samples (main / PR): `repeatable` 1 / 3.',
+    'repetition transition reports sample counts',
+  );
+  _expectContains(
+    repetitionTransitionComparison,
+    'fewer than three samples',
+    'repetition transition remains provisional',
+  );
 
   print('Patrol performance summarizer tests passed');
 }

--- a/tool/run_android_patrol_ci.sh
+++ b/tool/run_android_patrol_ci.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 
 : "${RUNNER_TEMP:?RUNNER_TEMP must be set by GitHub Actions}"
 : "${PDF_PATROL_BUILD_COMMIT:?PDF_PATROL_BUILD_COMMIT must be set}"
+: "${PATROL_PERF_REPETITIONS:=3}"
+
+if ! [[ "$PATROL_PERF_REPETITIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PATROL_PERF_REPETITIONS must be a positive integer" >&2
+  exit 64
+fi
 
 patrol test \
   --device emulator-5554 \
@@ -14,11 +20,15 @@ patrol test \
   --verbose \
   2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
 
-patrol test \
-  --device emulator-5554 \
-  --target patrol_test/native_perf_e2e_test.dart \
-  --dart-define PDF_PERF_LOG=true \
-  --dart-define "PDF_BUILD_COMMIT=$PDF_PATROL_BUILD_COMMIT" \
-  --show-flutter-logs \
-  --verbose \
-  2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
+for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
+  echo "::group::Patrol native performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+  patrol test \
+    --device emulator-5554 \
+    --target patrol_test/native_perf_e2e_test.dart \
+    --dart-define PDF_PERF_LOG=true \
+    --dart-define "PDF_BUILD_COMMIT=$PDF_PATROL_BUILD_COMMIT" \
+    --show-flutter-logs \
+    --verbose \
+    2>&1 | tee -a "$RUNNER_TEMP/patrol-android.log"
+  echo "::endgroup::"
+done


### PR DESCRIPTION
## Outcome

Patrol performance comments now headline the median of three dedicated scenario runs instead of presenting one noisy journey as p95. Web, Android, and iOS collect three complete samples; phase and tail diagnostics remain p95.

The report shows main / PR sample counts and marks any scenario with fewer than three samples provisional. Current CI also rejects an incomplete PR sample set, so a native logging race cannot silently weaken the comparison.

## Changes

- repeat the web performance target three times on main and preview workflows
- repeat the native performance target three times on Android and iOS
- use scenario elapsed p50 in visible headlines while retaining p95 detail
- distinguish repetition counts from scenario coverage
- require every current scenario to produce all three complete start/end pairs
- retry iOS attempts whose passed XCTest run omits the Flutter completion marker
- document the sampling and baseline-transition contract

## Validation

- full repository analysis: clean
- Patrol summarizer tests: pass, including aggregation, sparse warnings, coverage, and completeness checks
- web PR run: all five scenarios produced 3 samples; medians stayed close to main
- Android PR run: 3 stable native tile samples
- iOS first PR run: 3 stable native tile samples
- observed iOS race: the new guard rejects the real 2-sample artifact; the retry path is exercised by CI
- workflow YAML parses and the Android runner passes bash syntax plus a mocked 1+3 invocation check

<details>
<summary>Baseline transition</summary>

This PR initially compares three PR samples against the latest one-sample main artifact and therefore labels timing deltas provisional. Once merged, the next main Patrol run publishes the first three-sample baseline; subsequent PR reports become like-for-like automatically.

</details>
