### PR TITLE
perf(web): bound dense foreground detail work

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -705,6 +705,14 @@ class PdfPageView extends StatefulWidget {
   /// the full requested density once the complete rung is resident.
   static int denseQuickDetailMaxPixels = 1 << 21;
 
+  /// Maximum exact-rung tiles a strip-routed scene admits in one paint.
+  ///
+  /// Eight center-out misses can sparsely span a 4x3 tile box; slab batching
+  /// then reads back all twelve cells before any tile becomes visible. Four
+  /// keeps the cold batch near a 2x2 box while preserving the fixed-overhead
+  /// win of batching adjacent tiles.
+  static const int stripTileMaxNewTilesPerPaint = 4;
+
   /// Settles that consumed a speculatively-binned worker strip plan (the
   /// [transformScale]-driven pre-request matched the settle's geometry
   /// exactly and resolved to a plan). Test telemetry, following the
@@ -5030,22 +5038,22 @@ class _PdfPageViewState extends State<PdfPageView>
     final scheduling = session is PdfTileRasterScheduling
         ? session as PdfTileRasterScheduling
         : null;
+    final tileDetailScene = _tileDetailScene;
     final sessionCap = scheduling?.maxNewTilesPerPaint;
     final sceneCap = scene.regionIndexBuildIsHeavy ? 1 : null;
-    final maxNewTiles = sessionCap == null
-        ? sceneCap
-        : sceneCap == null
-            ? sessionCap
-            : math.min(sessionCap, sceneCap);
+    final stripCap = _stripReplayScene(tileDetailScene ?? scene)
+        ? PdfPageView.stripTileMaxNewTilesPerPaint
+        : null;
+    final caps = [sessionCap, sceneCap, stripCap].whereType<int>();
+    final maxNewTiles = caps.isEmpty ? null : caps.reduce(math.min);
     // Per-paint admission alone is not a queue bound: any unrelated frame can
-    // paint the layer again before the first raster lands. Ordinary scenes get
-    // one eight-tile slab; dense/session-paced scenes keep two of their smaller
-    // admission windows live. Either way a subsequent pan is never trapped
-    // behind the 30-35 tile submissions seen in the field trace.
+    // paint the layer again before the first raster lands. Ordinary unpaced
+    // scenes get one eight-tile slab; strip/grid/session-paced scenes keep two
+    // of their smaller admission windows live. Either way a subsequent pan is
+    // never trapped behind the 30-35 tile submissions seen in the field trace.
     final maxInFlightTiles =
         maxNewTiles == null ? 8 : math.max(2, maxNewTiles * 2);
     final fallbackOcclusion = _fallbackOcclusionFraction(store, desired);
-    final tileDetailScene = _tileDetailScene;
     return Positioned.fill(
       key: foreground ? const ValueKey('pdf-page-sharp-tile-foreground') : null,
       child: PdfTileLayer(
@@ -5073,12 +5081,11 @@ class _PdfPageViewState extends State<PdfPageView>
         canRasterize: _tileRegionRasterizable,
         batchRasters: scheduling?.batchAdjacentTiles,
         // A grid-indexed CAD scene can select tens of thousands of commands
-        // across one viewport slab. replayRegion records those commands
-        // synchronously before toImage yields, so batching every missing tile
-        // made the whole slab one UI-frame stall (271ms in the field trace).
-        // Admit one tile per paint instead. A tile completion repaints the
-        // layer and advances the center-out fill; ordinary scenes retain the
-        // lower-overhead batched path.
+        // across one viewport slab, so it admits one tile per paint. A
+        // strip-routed scene keeps a four-tile batch: eight center-out misses
+        // formed a sparse 4x3 slab and made its oversized readback one UI-frame
+        // stall. Tile completion repaints advance both paths center-out;
+        // ordinary scenes retain the lower-overhead eight-tile batch.
         maxNewTilesPerPaint: maxNewTiles,
         maxInFlightTiles: maxInFlightTiles,
         // A scale-changing settle sharpens the exact visible patch first. Only

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -695,6 +695,16 @@ class PdfPageView extends StatefulWidget {
   /// Null (production) asks the engine.
   static bool? debugStripZoomReplayBackendOverride;
 
+  /// Test hook for the web-only quick-patch budget used while a dense tile
+  /// route prepares its exact rung. Null uses [kIsWeb].
+  static bool? debugQuickDetailBackendOverride;
+
+  /// A transient dense-page patch exists to replace a heavily magnified base
+  /// while exact tiles prepare. Bounding it to 2 MP keeps its uncancellable
+  /// `Picture.toImage` readback short; the tile foreground still promotes at
+  /// the full requested density once the complete rung is resident.
+  static int denseQuickDetailMaxPixels = 1 << 21;
+
   /// Settles that consumed a speculatively-binned worker strip plan (the
   /// [transformScale]-driven pre-request matched the settle's geometry
   /// exactly and resolved to a plan). Test telemetry, following the
@@ -4140,6 +4150,9 @@ class _PdfPageViewState extends State<PdfPageView>
       'pass=visible '
       'strip=$stripDetail vectorOnly=$_sceneIsVectorOnly '
       'retainedCovers=$retainedCoversRegion '
+      'ratio=${ratio.toStringAsFixed(2)} '
+      'img=${(region.width * ratio).ceil()}x'
+      '${(region.height * ratio).ceil()} '
       // scene/tiles: why this page does or does not get reusable tiles instead
       // of a fresh full-viewport raster on every pan step.
       'scene=${heldScene != null} tiles=$_tilePathStatus',
@@ -4485,6 +4498,20 @@ class _PdfPageViewState extends State<PdfPageView>
       ratio,
       _maxDimension / math.max(region.width, region.height),
     );
+    final quickDetailBackend =
+        PdfPageView.debugQuickDetailBackendOverride ?? kIsWeb;
+    final scene = _scene;
+    if (_awaitingExactDetailPaint &&
+        quickDetailBackend &&
+        _tilePathStatus == 'active' &&
+        scene != null &&
+        _stripReplayScene(scene)) {
+      ratio = math.min(
+        ratio,
+        math.sqrt(PdfPageView.denseQuickDetailMaxPixels /
+            (region.width * region.height)),
+      );
+    }
     return _DetailGeometry(fraction, visibleFraction, region, ratio);
   }
 
@@ -5653,22 +5680,38 @@ class _PdfPageViewState extends State<PdfPageView>
       return null;
     }
     _logImageStats(pageIndex, detail.commands);
+    final sceneClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     final scene = await PdfRetainedScene.fromCommands(
       widget.page,
       detail.commands,
       plan: _renderPlan,
       maxImagePixelRatio: ratio,
     );
+    final sceneMs = sceneClock?.elapsedMicroseconds.toDouble() ?? 0;
     if (_abandoned(pageIndex) || !_acceptsForegroundDetail(generation)) {
       scene.dispose();
       return null;
     }
     try {
-      return await scene.rasterizeRegionStrips(
+      final timing = PdfPerfLog.enabled ? PdfStripRasterTiming() : null;
+      final image = await scene.rasterizeRegionStrips(
         rasterRegion,
         pixelRatio: ratio,
         stripPlan: detail.plan,
+        timing: timing,
       );
+      if (timing != null) {
+        PdfPerfLog.log(
+          'detail strip phases page=$pageIndex '
+          'scene=${(sceneMs / 1000).toStringAsFixed(1)}ms '
+          'picture=${timing.pictureMs.toStringAsFixed(1)}ms '
+          'route=${timing.routeMs.toStringAsFixed(1)}ms '
+          'atlas=${timing.atlasDecodeMs.toStringAsFixed(1)}ms '
+          'tape=${timing.tapeReplayMs.toStringAsFixed(1)}ms '
+          'toImage=${timing.toImageMs.toStringAsFixed(1)}ms',
+        );
+      }
+      return image;
     } finally {
       scene.dispose();
     }

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1202,6 +1202,15 @@ class _PdfPageViewState extends State<PdfPageView>
     } else if (settleChanged) {
       _cancelTilePanAhead();
     }
+    if (settleChanged) {
+      // The transform has reached the page as a settled generation. A live
+      // transform's 50 ms speculation timer may still be waiting behind a
+      // busy browser frame; if it fires now it cancels the exact foreground
+      // detail request that this update is about to schedule, then computes
+      // the same geometry as unused speculation. Already-started speculation
+      // remains available through [_speculativeStripDetail].
+      _speculateTimer?.cancel();
+    }
     final transition = _renderSession.update(_renderIntent(widget));
     if (transition.scheduleRender ||
         oldWidget.previewIndex != widget.previewIndex ||

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2088,6 +2088,24 @@ class _PdfViewerState extends State<PdfViewer>
     _renderScheduler.parked = !widget.active;
   }
 
+  /// Releases settled render work only after this frame has rebuilt the page
+  /// widgets with the new settle generation.
+  ///
+  /// Releasing synchronously from a settle timer lets the scheduler grant a
+  /// queued page before [setState] has propagated its generation to that page.
+  /// The page then rebuilds a few milliseconds later, invalidates the job that
+  /// just started, and repeats the same visible-region render. A dense CAD
+  /// trace paid this race on every initial deep zoom: one ~8 MB worker detail
+  /// result was discarded before the identical request ran again.
+  void _releaseSettledRenderHoldAfterBuild() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _settleRenderHold();
+      _schedulePreviewPrerender();
+      _scheduleRasterWarm();
+    });
+  }
+
   void _beginMotionRenderHold() {
     _cancelPreviewPrerenderSchedule();
     _motionHoldReleaseTimer?.cancel();
@@ -2533,12 +2551,18 @@ class _PdfViewerState extends State<PdfViewer>
     // internal layout/transform machinery works in fit-width multiples
     final target = _fitScale <= 0 ? scale : scale / _fitScale;
     _zoomTo(target, Offset(_viewWidth / 2, _viewHeight / 2));
-    // A controller call is one complete, discrete zoom command, not a stream
-    // of gesture updates. `_zoomTo` synchronously notifies the transform
-    // listener and arms its 200 ms motion debounce; settle that work now so a
-    // toolbar/API zoom starts its sharp visible-region render immediately.
-    // Wheel, pinch, double-tap animation, and trackpad paths still use the
-    // debounce and continue to coalesce their many intermediate transforms.
+    _settleControllerViewportCommand();
+  }
+
+  /// Settles one complete controller-driven zoom/viewport command now.
+  ///
+  /// Controller calls are discrete, not a stream of gesture updates. Their
+  /// transform and scroll listeners still arm the 200/500 ms gesture
+  /// debounces, which would otherwise invalidate work already started for the
+  /// final controller geometry. Wheel, pinch, double-tap animation, and
+  /// trackpad paths do not call this and continue to coalesce intermediate
+  /// transforms through those quiet windows.
+  void _settleControllerViewportCommand() {
     if (_settleTimer != null) _settleTransformChange();
     // Zooming below fit changes the page layout and preserves the focal point
     // with a ScrollPosition jump. That jump arms the separate 500 ms
@@ -2628,8 +2652,6 @@ class _PdfViewerState extends State<PdfViewer>
     _settleTimer?.cancel();
     _settleTimer = null;
     if (!mounted) return;
-    // stay held while the viewer is paused (a view overlays it)
-    _settleRenderHold();
     final target = math.max(1.0, _transform.value.getMaxScaleOnAxis());
     // wheel zoom never fires onInteractionEnd, so the pan flag also settles
     // here
@@ -2646,9 +2668,7 @@ class _PdfViewerState extends State<PdfViewer>
       // any settled transform change moves the deep-zoom detail patch
       _settleGeneration++;
     });
-    // the background prerender yields while the hold is up; pick it back up
-    _schedulePreviewPrerender();
-    _scheduleRasterWarm();
+    _releaseSettledRenderHoldAfterBuild();
   }
 
   /// Debounced scroll-settle: scrolling moves pages under a deep-zoom detail
@@ -2695,12 +2715,8 @@ class _PdfViewerState extends State<PdfViewer>
           'ready=${_rasteredPages.contains(jumpFocus)} '
           'retained=${_jumpFocusPage != null}');
     }
-    // stay held while the viewer is paused (a view overlays it)
-    _settleRenderHold();
     if (mounted) setState(() => _settleGeneration++);
-    // the prerender pauses while the user scrolls; pick it back up
-    _schedulePreviewPrerender();
-    _scheduleRasterWarm();
+    _releaseSettledRenderHoldAfterBuild();
   }
 
   /// Warms the next likely navigation targets without replaying or
@@ -5125,6 +5141,7 @@ class _PdfViewerState extends State<PdfViewer>
       setState(() => _zoomed = scale > 1.01);
     }
     _controller._bumpViewport();
+    _settleControllerViewportCommand();
   }
 
   /// Frames [rect] (page space on page [index]): centers it in the
@@ -9283,8 +9300,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                                 zoom: zoom,
                                 predictStrokes: widget.predictStrokes,
                                 contextMenuEnabled: widget.contextMenuEnabled,
-                                showSelectionChip:
-                                    widget.showSelectionChip,
+                                showSelectionChip: widget.showSelectionChip,
                               ),
                             ),
                           );

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -41,6 +41,16 @@ class PdfSceneBuildTiming {
   double decodeMs = 0;
 }
 
+/// Phase attribution for one strip-region raster. Allocated only while the
+/// opt-in performance log is enabled, so ordinary rendering pays no cost.
+class PdfStripRasterTiming {
+  double pictureMs = 0;
+  double routeMs = 0;
+  double atlasDecodeMs = 0;
+  double tapeReplayMs = 0;
+  double toImageMs = 0;
+}
+
 /// A page retained as a replayable scene: the recorded interpreter command
 /// buffer plus its decoded images, both produced exactly once in [record].
 ///
@@ -803,16 +813,19 @@ class PdfRetainedScene {
       {required double pixelRatio,
       StripPlan? stripPlan,
       bool slugGlyphs = false,
+      PdfStripRasterTiming? timing,
       void Function(({int quads, int fallbackOutlineRuns}))?
           onSlugStats}) async {
     assert(!_disposed, 'replay after dispose');
     final geometry = stripRegionGeometry(region, pixelRatio: pixelRatio);
     try {
       return await _stripPicture(
-          geometry, region, pixelRatio, stripPlan, slugGlyphs, onSlugStats);
+          geometry, region, pixelRatio, stripPlan, slugGlyphs, onSlugStats,
+          timing: timing);
     } on StripPlanMismatchError {
       return _stripPicture(
-          geometry, region, pixelRatio, null, slugGlyphs, onSlugStats);
+          geometry, region, pixelRatio, null, slugGlyphs, onSlugStats,
+          timing: timing);
     }
   }
 
@@ -825,8 +838,9 @@ class PdfRetainedScene {
       double pixelRatio,
       StripPlan? stripPlan,
       bool slugGlyphs,
-      void Function(({int quads, int fallbackOutlineRuns}))?
-          onSlugStats) async {
+      void Function(({int quads, int fallbackOutlineRuns}))? onSlugStats,
+      {PdfStripRasterTiming? timing}) async {
+    final pictureClock = timing == null ? null : (Stopwatch()..start());
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder)..scale(pixelRatio);
     if (region != null) canvas.translate(-region.left, -region.top);
@@ -845,13 +859,22 @@ class PdfRetainedScene {
     try {
       final sw = Stopwatch()..start();
       replayCommands(commands, device);
-      StripPdfDevice.totalRouteMicros += sw.elapsedMicroseconds;
+      final routeMicros = sw.elapsedMicroseconds;
+      StripPdfDevice.totalRouteMicros += routeMicros;
       await device.finish(); // must precede endRecording
+      if (timing != null) {
+        timing.routeMs = routeMicros / 1000;
+        timing.atlasDecodeMs = device.atlasDecodeMicros / 1000;
+        timing.tapeReplayMs = device.tapeReplayMicros / 1000;
+      }
       onSlugStats?.call((
         quads: device.slugQuadCount,
         fallbackOutlineRuns: device.slugFallbackOutlineRuns,
       ));
       picture = recorder.endRecording();
+      if (pictureClock != null) {
+        timing!.pictureMs = pictureClock.elapsedMicroseconds / 1000;
+      }
     } catch (_) {
       recorder.endRecording().dispose();
       device.dispose();
@@ -881,14 +904,21 @@ class PdfRetainedScene {
   /// Convenience: [replayRegionStrips] + `toImage`, the strip-router
   /// counterpart of [rasterizeRegion].
   Future<ui.Image> rasterizeRegionStrips(Rect region,
-      {required double pixelRatio, StripPlan? stripPlan}) async {
+      {required double pixelRatio,
+      StripPlan? stripPlan,
+      PdfStripRasterTiming? timing}) async {
     final picture = await replayRegionStrips(region,
-        pixelRatio: pixelRatio, stripPlan: stripPlan);
+        pixelRatio: pixelRatio, stripPlan: stripPlan, timing: timing);
     try {
-      return await picture.toImage(
+      final rasterClock = timing == null ? null : (Stopwatch()..start());
+      final image = await picture.toImage(
         (region.width * pixelRatio).ceil().clamp(1, 1 << 14),
         (region.height * pixelRatio).ceil().clamp(1, 1 << 14),
       );
+      if (rasterClock != null) {
+        timing!.toImageMs = rasterClock.elapsedMicroseconds / 1000;
+      }
+      return image;
     } finally {
       picture.dispose();
     }

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -207,6 +207,11 @@ class StripPdfDevice extends StripBinningDevice {
   /// [totalReplayMicros] this is the UI-thread-blocking share of a settle.
   static int totalRouteMicros = 0;
 
+  /// Per-device phase timings used by a single render's perf attribution.
+  /// The static totals above remain the aggregate benchmark surface.
+  int atlasDecodeMicros = 0;
+  int tapeReplayMicros = 0;
+
   /// Precomputed plans rejected (stale geometry) or failing verification at
   /// [finish] - each one transparently fell back to local binning.
   static int totalPlanMismatches = 0;
@@ -541,7 +546,8 @@ class StripPdfDevice extends StripBinningDevice {
       for (final b in _batches) b.decodeAtlas(),
       for (final b in _slugBatches) b.decodeAtlas(),
     ]);
-    totalAtlasDecodeMicros += sw.elapsedMicroseconds;
+    atlasDecodeMicros = sw.elapsedMicroseconds;
+    totalAtlasDecodeMicros += atlasDecodeMicros;
 
     sw.reset();
     final fallback = CanvasPdfDevice(canvas, images: images);
@@ -554,7 +560,8 @@ class StripPdfDevice extends StripBinningDevice {
         (entry as void Function(CanvasPdfDevice))(fallback);
       }
     }
-    totalReplayMicros += sw.elapsedMicroseconds;
+    tapeReplayMicros = sw.elapsedMicroseconds;
+    totalReplayMicros += tapeReplayMicros;
   }
 
   /// Debug: slug shader diagnostic output mode (see pdf_slug.frag uDebug).

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1015,6 +1015,49 @@ void main() {
     );
   });
 
+  testWidgets('controller viewport commands coalesce before releasing renders',
+      (tester) async {
+    final controller = await pumpViewer(tester, pages: 1);
+    final before =
+        tester.widget<PdfPageView>(find.byType(PdfPageView)).settleGeneration;
+    controller.setZoom(4);
+    final viewport = controller.captureViewport()!;
+    controller.restoreViewport(PdfViewport(
+      page: 0,
+      left: 0.02,
+      zoom: viewport.zoom,
+    ));
+
+    expect(
+      controller.debugRenderHold,
+      isTrue,
+      reason: 'the page still has the old settle generation until the next '
+          'build, so granting work here would immediately make it stale',
+    );
+    expect(
+      tester.widget<PdfPageView>(find.byType(PdfPageView)).settleGeneration,
+      before,
+    );
+
+    await tester.pump();
+
+    final settled =
+        tester.widget<PdfPageView>(find.byType(PdfPageView)).settleGeneration;
+    expect(
+      settled,
+      greaterThan(before),
+    );
+    expect(controller.debugRenderHold, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(
+      tester.widget<PdfPageView>(find.byType(PdfPageView)).settleGeneration,
+      settled,
+      reason: 'restoring the final viewport is one discrete command, not a '
+          'second gesture settle after detail work has started',
+    );
+  });
+
   testWidgets('tapping a URI link surfaces the action', (tester) async {
     // The default launcher only opens well-known external schemes, so the
     // fixture's app:// link falls through to onAction unchanged.

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -320,7 +320,7 @@ void main() {
 
     await tester.pumpWidget(at(1, 0));
     await router.settleRaster(tester, 612);
-    await tester.pumpWidget(at(16, 1));
+    await tester.pumpWidget(at(4, 1));
     const detailKey = ValueKey('pdf-page-detail-image');
     for (var i = 0; i < 100 && find.byKey(detailKey).evaluate().isEmpty; i++) {
       await tester.runAsync(
@@ -338,6 +338,24 @@ void main() {
     );
     expect(detail.width * detail.height, greaterThan(1 << 20),
         reason: 'the quick patch should still materially sharpen the base');
+    final tileLayer = find.byKey(const ValueKey('pdf-page-tile-layer'));
+    for (var i = 0; i < 100 && tileLayer.evaluate().isEmpty; i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+      await tester.pump();
+    }
+    final tilePaint = tester.widget<CustomPaint>(
+      tileLayer,
+    );
+    expect(
+      (tilePaint.painter as dynamic).maxNewTilesPerPaint,
+      PdfPageView.stripTileMaxNewTilesPerPaint,
+      reason: 'strip-routed exact tiles must bound the first slab instead of '
+          'reading back a sparse viewport-sized box',
+    );
+    expect((tilePaint.painter as dynamic).maxInFlightTiles, 8,
+        reason: 'two bounded strip batches may overlap across repaints');
   });
 
   // Speculative binning: while the gesture quiesces (the live transformScale

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -273,6 +273,73 @@ void main() {
     expect(StripPdfDevice.totalPlanMismatches, 0);
   });
 
+  testWidgets('dense web tile pages bound the transient foreground patch',
+      (tester) async {
+    final oldFlatLimit = PdfPageView.retainedZoomReplayMaxCommands;
+    final oldTileDetail = PdfPageView.tileStoreDetail;
+    final oldQuickPixels = PdfPageView.denseQuickDetailMaxPixels;
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    PdfPageView.debugQuickDetailBackendOverride = true;
+    PdfPageView.denseQuickDetailMaxPixels = 1 << 21;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = oldFlatLimit;
+      PdfPageView.stripZoomReplay = true;
+      PdfPageView.tileStoreDetail = oldTileDetail;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+      PdfPageView.debugQuickDetailBackendOverride = null;
+      PdfPageView.denseQuickDetailMaxPixels = oldQuickPixels;
+    });
+    tester.view.physicalSize = const Size(800, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildVectorPdf();
+    final doc = PdfDocument.open(bytes);
+    late PdfRenderWorker worker;
+    await tester.runAsync(() async {
+      worker = PdfRenderWorker.start(bytes);
+    });
+    addTearDown(worker.dispose);
+
+    Widget at(double scale, int generation) => Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: doc.page(0),
+              scale: scale,
+              settleGeneration: generation,
+              renderWorker: worker,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(1, 0));
+    await router.settleRaster(tester, 612);
+    await tester.pumpWidget(at(16, 1));
+    const detailKey = ValueKey('pdf-page-detail-image');
+    for (var i = 0; i < 100 && find.byKey(detailKey).evaluate().isEmpty; i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+      await tester.pump();
+    }
+
+    final detail = tester.widget<RawImage>(find.byKey(detailKey)).image!;
+    expect(
+      detail.width * detail.height,
+      lessThanOrEqualTo((PdfPageView.denseQuickDetailMaxPixels * 1.01).ceil()),
+      reason: 'the first dense-page patch is transient; the exact tile rung '
+          'must own the larger readbacks',
+    );
+    expect(detail.width * detail.height, greaterThan(1 << 20),
+        reason: 'the quick patch should still materially sharpen the base');
+  });
+
   // Speculative binning: while the gesture quiesces (the live transformScale
   // stops moving for 50 ms), the page pre-requests the worker plan for the
   // geometry the settle will ask for; the settle then consumes it instead of


### PR DESCRIPTION
## Performance versus main

- Dense quick-detail readback is capped at 2.1 MP versus up to 16.8 MP on main for a square 4096px patch: up to 8x fewer transient pixels.
- Strip-routed cold batches admit 4 tiles versus 8 on main, keeping the usual slab near 2x2 instead of a sparse 4x3: up to 3x fewer readback pixels before the first exact tiles land.
- Settled viewport commands coalesce into one post-build render release instead of scheduling competing scroll/zoom work.

## What changed

- Coalesce page jumps, zooms, and match navigation through one settled viewport command path.
- Bound the temporary dense-page foreground patch while exact tiles are preparing.
- Add strip replay phase attribution to the perf log.
- Pace strip-routed tile slabs independently from ordinary Canvas scenes.

## Validation

- `fvm dart analyze`
- `fvm flutter test test/pdf_viewer_test.dart test/tile_backend_warm_up_test.dart`
- `fvm flutter test test/strip_plan_device_test.dart`

<details>
<summary>Implementation notes</summary>

The caps affect only temporary foreground work. Exact detail still promotes at the requested LoD once the complete rung is resident, and non-strip scenes keep the existing batching path.

</details>