### PR TITLE
perf(gpu): expand exact rendering and remove cold tile stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
         working-directory: packages/dart_pdf_editor_flutter_gpu
         run: >-
           flutter test --enable-impeller --enable-flutter-gpu
+          --dart-define PDF_GPU_CI_SMOKE=true
           test/gpu_ci_smoke_test.dart --reporter expanded
 
   # The real bundled web render worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,26 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  # The broad GPU suite above deliberately self-skips on Linux runners without
+  # an Impeller context. This designated Metal lane is the non-optional proof:
+  # the checked-in Flutter-3.47 shader bundle must load, an accepted scene must
+  # create a session and render a tile, and the pixels must agree with Canvas.
+  flutter-gpu-smoke:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.47.0
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - name: Require a real flutter_gpu tile
+        working-directory: packages/dart_pdf_editor_flutter_gpu
+        run: >-
+          flutter test --enable-impeller --enable-flutter-gpu
+          test/gpu_ci_smoke_test.dart --reporter expanded
+
   # The real bundled web render worker
   # (`packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js`) is a
   # ~1 MB `dart compile js` artifact that is NO LONGER committed (issue #582):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
   # create a session and render a tile, and the pixels must agree with Canvas.
   flutter-gpu-smoke:
     runs-on: macos-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: subosito/flutter-action@v2
@@ -183,6 +186,204 @@ jobs:
           flutter test --enable-impeller --enable-flutter-gpu
           --dart-define PDF_GPU_CI_SMOKE=true
           test/gpu_ci_smoke_test.dart --reporter expanded
+
+      - name: Download latest main Flutter GPU performance baseline
+        id: gpu-baseline
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          for baseline_run in $(gh run list \
+            --workflow ci.yml \
+            --branch main \
+            --event push \
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId'); do
+            destination="$RUNNER_TEMP/flutter-gpu-baseline/$baseline_run"
+            if gh run download "$baseline_run" \
+              --name flutter-gpu-performance \
+              --dir "$destination"; then
+              json="$(find "$destination" -name patrol-perf.json -print -quit)"
+              if [[ -n "$json" && -f "$json" ]]; then
+                echo "json=$json" >> "$GITHUB_OUTPUT"
+                echo "Using Flutter GPU baseline from run $baseline_run"
+                exit 0
+              fi
+            fi
+          done
+          echo "::notice::No usable main Flutter GPU artifact is available yet"
+
+      - name: Measure Flutter GPU warm-up and first-tile performance
+        id: gpu-performance
+        working-directory: packages/dart_pdf_editor_flutter_gpu
+        shell: bash
+        env:
+          PERF_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/flutter-gpu-performance.log"
+          : > "$log"
+          for iteration in 1 2 3; do
+            while read -r label pdf; do
+              echo "::group::Flutter GPU $label repetition $iteration/3"
+              env \
+                PDF_GPU_BENCHMARK_PDF="$pdf" \
+                PDF_GPU_BENCHMARK_PAGES=0 \
+                PDF_GPU_BENCHMARK_WARMUP=1 \
+                PDF_GPU_BENCHMARK_SCENE_WARMUP=1 \
+                PDF_GPU_BENCHMARK_OVERPRINT=0 \
+                PDF_GPU_BENCHMARK_SCENARIO="$label" \
+                flutter test \
+                  --enable-impeller \
+                  --enable-flutter-gpu \
+                  --dart-define PDF_PERF_LOG=true \
+                  --dart-define "PDF_BUILD_COMMIT=$PERF_COMMIT" \
+                  test/real_document_benchmark_test.dart \
+                  --reporter expanded \
+                  2>&1 | tee -a "$log"
+              echo "::endgroup::"
+            done <<'SCENARIOS'
+          tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          radial ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          SCENARIOS
+          done
+          echo "log=$log" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize Flutter GPU performance
+        if: always()
+        working-directory: packages/dart_pdf_editor_flutter_gpu
+        shell: bash
+        run: |
+          set -euo pipefail
+          log="${{ steps.gpu-performance.outputs.log }}"
+          if [[ -z "$log" || ! -f "$log" ]]; then
+            log="$RUNNER_TEMP/flutter-gpu-performance.log"
+            touch "$log"
+          fi
+          arguments=(
+            "$log"
+            --output test-results/gpu
+            --markdown "$GITHUB_STEP_SUMMARY"
+            --label "macOS Metal GPU"
+            --require-scenario-runs gpu-tiling-pipeline-warm=3
+            --require-scenario-runs gpu-tiling-page-0-scene-warm=3
+            --require-scenario-runs gpu-tiling-page-0-first-tile=3
+            --require-scenario-runs gpu-tiling-page-0-canvas-tile=3
+            --require-scenario-runs gpu-radial-pipeline-warm=3
+            --require-scenario-runs gpu-radial-page-0-scene-warm=3
+            --require-scenario-runs gpu-radial-page-0-first-tile=3
+            --require-scenario-runs gpu-radial-page-0-canvas-tile=3
+          )
+          baseline="${{ steps.gpu-baseline.outputs.json }}"
+          if [[ -n "$baseline" && -f "$baseline" ]]; then
+            arguments+=(--baseline "$baseline")
+          fi
+          dart ../../../tool/patrol_perf_summary.dart "${arguments[@]}"
+
+      - name: Upload Flutter GPU performance report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flutter-gpu-performance
+          path: packages/dart_pdf_editor_flutter_gpu/test-results/gpu
+          if-no-files-found: error
+
+  flutter-gpu-performance-report:
+    name: Flutter GPU performance report
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: [flutter-gpu-smoke]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download Flutter GPU performance report
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: flutter-gpu-performance
+          path: flutter-gpu-performance
+
+      - name: Comment Flutter GPU performance report
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        env:
+          GPU_PERF_MARKER: dart-pdf-flutter-gpu-performance
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const marker = `<!-- ${process.env.GPU_PERF_MARKER} -->`;
+            const find = (root, name) => {
+              if (!fs.existsSync(root)) return null;
+              for (const entry of fs.readdirSync(root, {withFileTypes: true})) {
+                const candidate = path.join(root, entry.name);
+                if (entry.isDirectory()) {
+                  const nested = find(candidate, name);
+                  if (nested) return nested;
+                } else if (entry.name === name) {
+                  return candidate;
+                }
+              }
+              return null;
+            };
+            const headlinePath = find('flutter-gpu-performance', 'patrol-perf-headline.md');
+            const reportPath = find('flutter-gpu-performance', 'patrol-perf.md');
+            const headline = headlinePath
+              ? fs.readFileSync(headlinePath, 'utf8').trim()
+              : 'No headline Flutter GPU performance summary was produced.';
+            const report = reportPath
+              ? fs.readFileSync(reportPath, 'utf8').trim()
+              : 'No Flutter GPU performance artifact was produced. Open the workflow run for the failing step and raw logs.';
+            const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              '## Flutter GPU performance',
+              '',
+              `Automated on macOS Metal for commit \`${sha}\` · [workflow run and downloadable traces](${runUrl})`,
+              '',
+              headline,
+              '',
+              '<details>',
+              '<summary>View Flutter GPU performance details</summary>',
+              '',
+              report,
+              '',
+              '</details>',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   # The real bundled web render worker
   # (`packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js`) is a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
           if [[ -n "$baseline" && -f "$baseline" ]]; then
             arguments+=(--baseline "$baseline")
           fi
-          dart ../../../tool/patrol_perf_summary.dart "${arguments[@]}"
+          dart ../../tool/patrol_perf_summary.dart "${arguments[@]}"
 
       - name: Upload Flutter GPU performance report
         if: always()

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+- Let optional tile backends prepare view-scoped resources after the viewer's
+  first frame, keeping first paint unchanged while avoiding cold setup during
+  the first deep-zoom interaction.
+
 ## 3.8.0
 
 - Let annotations extend beyond the page edge while remaining selectable,

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Next
 
-- Let optional tile backends prepare view-scoped resources after the viewer's
-  first frame, keeping first paint unchanged while avoiding cold setup during
-  the first deep-zoom interaction.
+- Let optional tile backends prepare view-scoped resources and live-page scene
+  sessions after first useful pixels and a 750 ms quiet window. Foreground
+  rendering cancels and restarts the delay, keeping first paint and immediate
+  navigation uncontended while avoiding cold setup during deep zoom.
 
 ## 3.8.0
 

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -713,6 +713,12 @@ class PdfPageView extends StatefulWidget {
   /// win of batching adjacent tiles.
   static const int stripTileMaxNewTilesPerPaint = 4;
 
+  /// Quiet time after useful page pixels land before an optional tile session
+  /// prepares scene geometry and uploads. A real idle window prevents a large
+  /// accepted page's one-pixel preparation pass from entering the GPU queue as
+  /// the reader immediately starts scrolling again.
+  static const Duration tileSessionWarmIdleDelay = Duration(milliseconds: 750);
+
   /// Settles that consumed a speculatively-binned worker strip plan (the
   /// [transformScale]-driven pre-request matched the settle's geometry
   /// exactly and resolved to a plan). Test telemetry, following the
@@ -796,6 +802,9 @@ class _PdfPageViewState extends State<PdfPageView>
   /// while the store remains backend-agnostic and document-revision safe.
   final Map<PdfRetainedScene, PdfTileRasterSession> _tileRasterSessions =
       Map.identity();
+  final Set<PdfRetainedScene> _tileWarmAttempts = Set.identity();
+  Timer? _tileWarmTimer;
+  PdfRetainedScene? _tileWarmPendingScene;
 
   PdfRetainedSceneHandle? _sceneHandle;
   ui.Image? _image;
@@ -1006,6 +1015,7 @@ class _PdfPageViewState extends State<PdfPageView>
     PdfLiveRasterBudget.instance.register(this);
     _renderSession = PdfPageRenderSession(_renderIntent(widget));
     widget.renderHold?.addListener(_onRenderHoldChanged);
+    widget.renderScheduler?.activity.addListener(_onRenderSchedulerActivity);
     widget.previewCache?.addListener(_onPreviewCacheChanged);
     _liveTransformFor(widget)?.addListener(_onLiveTransformChanged);
     _refreshPreview();
@@ -1041,13 +1051,32 @@ class _PdfPageViewState extends State<PdfPageView>
     // hide the transform-sharp glyphs during pinch/pan. The next settle
     // rebuilds the complete detail composite for image resolution.
     if (_slugPicture != null && _detailImage != null) _dropDetail();
+    _cancelTileSessionWarmUp();
     _speculateTimer?.cancel();
-    _speculateTimer = Timer(_speculateDebounce, _speculateStripPlan);
+    _speculateTimer = Timer(_speculateDebounce, () {
+      _speculateStripPlan();
+      _scheduleTileSessionWarmUp();
+    });
   }
 
   void _onRenderHoldChanged() {
+    if (widget.renderHold?.value ?? false) {
+      _cancelTileSessionWarmUp();
+    } else {
+      _scheduleTileSessionWarmUp();
+    }
     if (widget.renderHold?.value == false && _renderSession.releaseHold()) {
       if (mounted) _render();
+    }
+  }
+
+  void _onRenderSchedulerActivity() {
+    final scheduler = widget.renderScheduler;
+    if (scheduler == null) return;
+    if (scheduler.parked || scheduler.busy) {
+      _cancelTileSessionWarmUp();
+    } else {
+      _scheduleTileSessionWarmUp();
     }
   }
 
@@ -1199,6 +1228,7 @@ class _PdfPageViewState extends State<PdfPageView>
       _deferredOffscreenRasterRefresh = true;
       _awaitingExactDetailPaint = false;
       _cancelTilePanAhead();
+      _cancelTileSessionWarmUp();
       widget.renderScheduler?.cancel(this);
     }
     final enteredDeepForeground = widget.onScreen &&
@@ -1254,13 +1284,20 @@ class _PdfPageViewState extends State<PdfPageView>
       _onRenderHoldChanged();
     }
     if (!identical(oldWidget.renderScheduler, widget.renderScheduler)) {
+      oldWidget.renderScheduler?.activity
+          .removeListener(_onRenderSchedulerActivity);
       oldWidget.renderScheduler?.cancel(this);
+      widget.renderScheduler?.activity.addListener(_onRenderSchedulerActivity);
+      _onRenderSchedulerActivity();
       // the new scheduler picks this page up on its next _render
     }
     if (!identical(oldWidget.tileRasterBackend, widget.tileRasterBackend)) {
       // Cached tiles remain valid because every backend promises the same
       // pixels. Only scene-level resources and future misses change owner.
+      _cancelTileSessionWarmUp();
       _disposeTileRasterSessions();
+      _tileWarmAttempts.clear();
+      _scheduleTileSessionWarmUp();
     }
     final oldLiveTransform = _liveTransformFor(oldWidget);
     final liveTransform = _liveTransformFor(widget);
@@ -1362,6 +1399,7 @@ class _PdfPageViewState extends State<PdfPageView>
     final becameQualityVisible = widget.onScreen &&
         widget.qualityVisible &&
         (!oldWidget.onScreen || !oldWidget.qualityVisible);
+    if (becameQualityVisible) _scheduleTileSessionWarmUp();
     if ((widget.focusDistance < oldWidget.focusDistance &&
             widget.qualityVisible) ||
         becameQualityVisible) {
@@ -1497,8 +1535,10 @@ class _PdfPageViewState extends State<PdfPageView>
     PdfLiveRasterBudget.instance.unregister(this);
     PdfDebugDetailRegions.instance.report(widget.previewIndex, null);
     widget.renderHold?.removeListener(_onRenderHoldChanged);
+    widget.renderScheduler?.activity.removeListener(_onRenderSchedulerActivity);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
     _speculateTimer?.cancel();
+    _tileWarmTimer?.cancel();
     _cancelTilePanAhead();
     // any pending speculative bin is reaped by the cancelBinStrips below;
     // its null result resolves into a future nobody awaits any more
@@ -1645,7 +1685,11 @@ class _PdfPageViewState extends State<PdfPageView>
   void _releaseScene() {
     final previous = _scene;
     if (previous != null) {
+      if (identical(_tileWarmPendingScene, previous)) {
+        _cancelTileSessionWarmUp();
+      }
       _disposeTileRasterSession(previous);
+      _tileWarmAttempts.remove(previous);
     }
     final handle = _sceneHandle;
     _sceneHandle = null;
@@ -1685,6 +1729,64 @@ class _PdfPageViewState extends State<PdfPageView>
     // next _workerStripPlan's cancelBinStrips reaps the worker-side job)
     _speculativeStripPlan = null;
     _speculativeStripDetail = null;
+  }
+
+  void _notifyRasterReady() {
+    widget.onRasterReady?.call();
+    _scheduleTileSessionWarmUp();
+  }
+
+  void _scheduleTileSessionWarmUp() {
+    final scene = _scene;
+    final backend = widget.tileRasterBackend;
+    final scheduler = widget.renderScheduler;
+    if (scene == null ||
+        _sceneIsVectorOnly ||
+        !backend.supportsSessionWarmUp ||
+        !widget.onScreen ||
+        !widget.qualityVisible ||
+        (scheduler?.parked ?? false) ||
+        (scheduler?.busy ?? false) ||
+        (widget.renderHold?.value ?? false) ||
+        !_tileWarmAttempts.add(scene)) {
+      return;
+    }
+    _tileWarmTimer?.cancel();
+    _tileWarmPendingScene = scene;
+    _tileWarmTimer = Timer(PdfPageView.tileSessionWarmIdleDelay, () {
+      _tileWarmTimer = null;
+      _tileWarmPendingScene = null;
+      if (!mounted ||
+          !identical(_scene, scene) ||
+          !identical(widget.tileRasterBackend, backend) ||
+          !widget.onScreen ||
+          !widget.qualityVisible ||
+          (widget.renderScheduler?.parked ?? false) ||
+          (widget.renderScheduler?.busy ?? false) ||
+          (widget.renderHold?.value ?? false)) {
+        _tileWarmAttempts.remove(scene);
+        return;
+      }
+      final session = _tileRasterSessionFor(scene);
+      if (session is! PdfTileRasterWarmUp) return;
+      unawaited(
+          (session as PdfTileRasterWarmUp).warmUp().catchError((Object error) {
+        // The fallback adapter retires a failed optional backend itself. This
+        // log preserves the idle failure reason without affecting page pixels.
+        PdfPerfLog.log(
+          'tile session warm-up failed page=${widget.previewIndex} '
+          'backend=${backend.debugLabel} error=$error',
+        );
+      }));
+    });
+  }
+
+  void _cancelTileSessionWarmUp() {
+    _tileWarmTimer?.cancel();
+    _tileWarmTimer = null;
+    final scene = _tileWarmPendingScene;
+    _tileWarmPendingScene = null;
+    if (scene != null) _tileWarmAttempts.remove(scene);
   }
 
   /// Whether [_scene] came from the render worker (see [_setScene]).
@@ -2297,10 +2399,10 @@ class _PdfPageViewState extends State<PdfPageView>
       // _PdfViewerPage records readiness with setState. Calling it from this
       // child's LayoutBuilder would mark the parent dirty during build.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) widget.onRasterReady?.call();
+        if (mounted) _notifyRasterReady();
       });
     } else {
-      widget.onRasterReady?.call();
+      _notifyRasterReady();
     }
     return true;
   }
@@ -2355,7 +2457,7 @@ class _PdfPageViewState extends State<PdfPageView>
       'preview-promote page=${widget.previewIndex} '
       '${image.width}x${image.height} target=${dimensions.$1}x${dimensions.$2}',
     );
-    widget.onRasterReady?.call();
+    _notifyRasterReady();
     return true;
   }
 
@@ -2431,7 +2533,7 @@ class _PdfPageViewState extends State<PdfPageView>
     PdfPerfLog.log(
       'full-raster disk hit page=$pageIndex ${image.width}x${image.height}',
     );
-    widget.onRasterReady?.call();
+    _notifyRasterReady();
     return true;
   }
 
@@ -2639,7 +2741,7 @@ class _PdfPageViewState extends State<PdfPageView>
     PdfPerfLog.log(
       'web-worker-surface presented page=${widget.previewIndex}',
     );
-    widget.onRasterReady?.call();
+    _notifyRasterReady();
   }
 
   void _webSurfaceRejected() {
@@ -3801,7 +3903,7 @@ class _PdfPageViewState extends State<PdfPageView>
             if (_abandoned(pageIndex) || !identical(_scene, retainedScene)) {
               return;
             }
-            widget.onRasterReady?.call();
+            _notifyRasterReady();
             if (cache != null && _renderedAtFullImageRatio()) {
               _schedulePreviewFeed(cache, picture, generation, pageIndex);
             }
@@ -3855,7 +3957,7 @@ class _PdfPageViewState extends State<PdfPageView>
       await SchedulerBinding.instance.endOfFrame;
       if (!_superseded(generation, pageIndex) &&
           identical(_directPicture, picture)) {
-        widget.onRasterReady?.call();
+        _notifyRasterReady();
       }
       return;
     }
@@ -3961,7 +4063,7 @@ class _PdfPageViewState extends State<PdfPageView>
       }
     }
     final detailReady = await _updateDetail();
-    if (stale && detailReady) widget.onRasterReady?.call();
+    if (stale && detailReady) _notifyRasterReady();
     if (stale && detailReady) _scheduleFocusedImageRefinement();
     if (stale && detailReady && _renderedAtFullImageRatio()) {
       final cache = widget.previewCache;
@@ -5983,7 +6085,10 @@ class _PdfPageViewState extends State<PdfPageView>
 /// session stays owned until dispose: another slab may already be in flight,
 /// and the backend contract allows it to finish before resources are freed.
 class _FallbackTileRasterSession
-    implements PdfTileRasterSession, PdfTileRasterScheduling {
+    implements
+        PdfTileRasterSession,
+        PdfTileRasterScheduling,
+        PdfTileRasterWarmUp {
   _FallbackTileRasterSession({
     required PdfTileRasterSession primary,
     required this.fallback,
@@ -6014,6 +6119,21 @@ class _FallbackTileRasterSession
     return active is PdfTileRasterScheduling
         ? (active as PdfTileRasterScheduling).maxNewTilesPerPaint
         : null;
+  }
+
+  @override
+  Future<void> warmUp() async {
+    if (!_primaryEnabled || _primary is! PdfTileRasterWarmUp) return;
+    try {
+      await (_primary as PdfTileRasterWarmUp).warmUp();
+    } catch (error) {
+      if (_primaryEnabled) {
+        _primaryEnabled = false;
+        _disposePrimary();
+        onFallback(error);
+      }
+      rethrow;
+    }
   }
 
   @override

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1144,6 +1144,13 @@ typedef PdfScrollIndicatorBuilder = Widget Function(BuildContext context,
 /// search with highlights. Pages re-rasterize at the settled zoom; past the
 /// full-page raster caps a detail patch keeps the visible region sharp.
 class PdfViewer extends StatefulWidget {
+  /// Quiet time after foreground page rendering settles before an optional
+  /// tile backend compiles reusable process- or view-scoped GPU resources.
+  ///
+  /// A delayed idle pass avoids putting shader compilation into the GPU queue
+  /// while the reader is already starting their next scroll or zoom gesture.
+  static const Duration tileBackendWarmIdleDelay = Duration(milliseconds: 750);
+
   /// Test hook for delaying annotation appearance rendering across lifecycle
   /// transitions. Null uses [PdfPageRenderer.renderAnnotationPicture].
   @visibleForTesting
@@ -2344,13 +2351,21 @@ class _PdfViewerState extends State<PdfViewer>
 
   PdfTileRasterBackend? _pendingTileBackendWarmUp;
   bool _tileBackendWarmUpFramePending = false;
+  Timer? _tileBackendWarmUpTimer;
 
   void _scheduleTileBackendWarmUp() {
-    if (!widget.active) {
+    final backend = widget.tileRasterBackend;
+    if (!widget.active || !backend.supportsWarmUp) {
       _pendingTileBackendWarmUp = null;
+      _tileBackendWarmUpTimer?.cancel();
+      _tileBackendWarmUpTimer = null;
       return;
     }
-    _pendingTileBackendWarmUp = widget.tileRasterBackend;
+    if (!identical(_pendingTileBackendWarmUp, backend)) {
+      _tileBackendWarmUpTimer?.cancel();
+      _tileBackendWarmUpTimer = null;
+    }
+    _pendingTileBackendWarmUp = backend;
     _armTileBackendWarmUp();
   }
 
@@ -2369,15 +2384,25 @@ class _PdfViewerState extends State<PdfViewer>
       // page finish its initial record/replay before a driver-compilation pass
       // enters the GPU queue; the scheduler's idle edge re-arms this callback.
       if (_renderScheduler.busy) return;
-      _pendingTileBackendWarmUp = null;
-      unawaited(backend.warmUp().catchError((Object error) {
-        // Acceleration is optional. A failed warm-up leaves createSession's
-        // normal conservative Canvas fallback in charge of the first tile.
-        PdfPerfLog.log(
-          'tile backend warm-up failed backend=${backend.debugLabel} '
-          'error=$error',
-        );
-      }));
+      _tileBackendWarmUpTimer ??= Timer(PdfViewer.tileBackendWarmIdleDelay, () {
+        _tileBackendWarmUpTimer = null;
+        if (!mounted ||
+            !widget.active ||
+            !identical(widget.tileRasterBackend, backend) ||
+            !identical(_pendingTileBackendWarmUp, backend)) {
+          return;
+        }
+        if (_renderScheduler.busy) return;
+        _pendingTileBackendWarmUp = null;
+        unawaited(backend.warmUp().catchError((Object error) {
+          // Acceleration is optional. A failed warm-up leaves createSession's
+          // normal conservative Canvas fallback in charge of the first tile.
+          PdfPerfLog.log(
+            'tile backend warm-up failed backend=${backend.debugLabel} '
+            'error=$error',
+          );
+        }));
+      });
     });
   }
 
@@ -2438,7 +2463,10 @@ class _PdfViewerState extends State<PdfViewer>
   /// that notification as the wake-up edge instead.
   void _onRenderSchedulerActivity() {
     _scheduleRasterWarm();
-    if (!_renderScheduler.busy) {
+    if (_renderScheduler.busy) {
+      _tileBackendWarmUpTimer?.cancel();
+      _tileBackendWarmUpTimer = null;
+    } else {
       _schedulePreviewPrerender();
       if (_pendingTileBackendWarmUp != null) _armTileBackendWarmUp();
     }
@@ -3740,6 +3768,8 @@ class _PdfViewerState extends State<PdfViewer>
       _renderScheduler.parked = !widget.active;
       if (!widget.active) {
         _pendingTileBackendWarmUp = null;
+        _tileBackendWarmUpTimer?.cancel();
+        _tileBackendWarmUpTimer = null;
         _commandWarmAnchor = null;
         _commandWarmGeneration++;
         _cancelPreviewPrerenderSchedule();
@@ -4600,6 +4630,7 @@ class _PdfViewerState extends State<PdfViewer>
     _gestureQuietTimer?.cancel();
     _previewIdleTimer?.cancel();
     _rasterWarmTimer?.cancel();
+    _tileBackendWarmUpTimer?.cancel();
     // when the host recreates the viewer element (e.g. a panel appearing
     // shifts it to a new slot in a Row), the replacement state attaches in
     // initState BEFORE this deferred dispose runs - only detach if the

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2339,6 +2339,46 @@ class _PdfViewerState extends State<PdfViewer>
     // preview reach the worker queue first during cold open.
     _schedulePreviewPrerender();
     _scheduleRasterWarm();
+    _scheduleTileBackendWarmUp();
+  }
+
+  PdfTileRasterBackend? _pendingTileBackendWarmUp;
+  bool _tileBackendWarmUpFramePending = false;
+
+  void _scheduleTileBackendWarmUp() {
+    if (!widget.active) {
+      _pendingTileBackendWarmUp = null;
+      return;
+    }
+    _pendingTileBackendWarmUp = widget.tileRasterBackend;
+    _armTileBackendWarmUp();
+  }
+
+  void _armTileBackendWarmUp() {
+    if (_tileBackendWarmUpFramePending) return;
+    _tileBackendWarmUpFramePending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _tileBackendWarmUpFramePending = false;
+      final backend = _pendingTileBackendWarmUp;
+      if (!mounted || backend == null || !widget.active) return;
+      if (!identical(widget.tileRasterBackend, backend)) {
+        _scheduleTileBackendWarmUp();
+        return;
+      }
+      // First frame is not the same as first useful pixels. Let the focused
+      // page finish its initial record/replay before a driver-compilation pass
+      // enters the GPU queue; the scheduler's idle edge re-arms this callback.
+      if (_renderScheduler.busy) return;
+      _pendingTileBackendWarmUp = null;
+      unawaited(backend.warmUp().catchError((Object error) {
+        // Acceleration is optional. A failed warm-up leaves createSession's
+        // normal conservative Canvas fallback in charge of the first tile.
+        PdfPerfLog.log(
+          'tile backend warm-up failed backend=${backend.debugLabel} '
+          'error=$error',
+        );
+      }));
+    });
   }
 
   /// The platform is short of memory (iOS/Android send this; the web never
@@ -2398,7 +2438,10 @@ class _PdfViewerState extends State<PdfViewer>
   /// that notification as the wake-up edge instead.
   void _onRenderSchedulerActivity() {
     _scheduleRasterWarm();
-    if (!_renderScheduler.busy) _schedulePreviewPrerender();
+    if (!_renderScheduler.busy) {
+      _schedulePreviewPrerender();
+      if (_pendingTileBackendWarmUp != null) _armTileBackendWarmUp();
+    }
   }
 
   void _onPerformanceTimings(List<FrameTiming> timings) {
@@ -3696,6 +3739,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (oldWidget.active != widget.active) {
       _renderScheduler.parked = !widget.active;
       if (!widget.active) {
+        _pendingTileBackendWarmUp = null;
         _commandWarmAnchor = null;
         _commandWarmGeneration++;
         _cancelPreviewPrerenderSchedule();
@@ -3703,10 +3747,15 @@ class _PdfViewerState extends State<PdfViewer>
       } else {
         _renderScheduler.holding = false;
         _schedulePreviewPrerender();
+        _scheduleTileBackendWarmUp();
       }
       // a parked viewer does no background full-raster work; a foregrounded
       // one restarts its idle countdown
       _scheduleRasterWarm();
+    }
+    if (!identical(oldWidget.tileRasterBackend, widget.tileRasterBackend) &&
+        oldWidget.active == widget.active) {
+      _scheduleTileBackendWarmUp();
     }
   }
 

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -43,22 +43,34 @@ abstract class PdfTileRasterBackend {
   /// [PdfRetainedScene.releaseDecodedImagePixels].
   bool get prefersDirectDecodedImageUploads => false;
 
+  /// Whether [warmUp] performs useful process- or view-scoped preparation.
+  ///
+  /// False lets the viewer skip its idle timer entirely for Canvas and other
+  /// no-op backends. Implementations that opt in must coalesce repeated calls.
+  bool get supportsWarmUp => false;
+
+  /// Whether sessions returned by [createSession] implement
+  /// [PdfTileRasterWarmUp]. False avoids creating an otherwise-unused session
+  /// for backends that have no scene-specific preparation.
+  bool get supportsSessionWarmUp => false;
+
   /// Prepares process- or view-scoped resources before the first tile.
   ///
-  /// [PdfViewer] calls this after its first frame, never while constructing
-  /// the initial page. Backends can use the idle lead time to load shaders or
-  /// issue a bounded compilation pass. Calls may repeat after a backend or
-  /// native view changes, so implementations must coalesce their own work.
-  /// The default Canvas implementation has nothing to prepare.
+  /// [PdfViewer] calls this after useful pixels and a quiet window, never while
+  /// constructing the initial page. Backends can use the idle lead time to
+  /// load shaders or issue a bounded compilation pass. Calls may repeat after
+  /// a backend or native view changes, so implementations must coalesce their
+  /// own work. The default Canvas implementation has nothing to prepare.
   Future<void> warmUp() => Future<void>.value();
 
   /// Creates a lightweight owner for resources retained across tile renders.
   ///
-  /// This is called lazily, when the tile path first needs pixels—not while
-  /// the page's initial raster is being prepared. Scene-specific work should
-  /// itself be deferred by the returned session until
+  /// This is called lazily when the tile path first needs pixels, or by an
+  /// opted-in [PdfTileRasterWarmUp] pass after useful page pixels and a quiet
+  /// window—not while the page's initial raster is being prepared.
+  /// Scene-specific work otherwise stays deferred until
   /// [PdfTileRasterSession.rasterizeRegion]; only view-scoped work belongs in
-  /// [warmUp], after first paint.
+  /// [warmUp].
   PdfTileRasterSession? createSession(PdfRetainedScene scene);
 }
 
@@ -113,6 +125,16 @@ abstract interface class PdfTileRasterScheduling {
   /// to keep command submission and texture allocation within a frame budget
   /// while the base/coarser image remains visible underneath.
   int? get maxNewTilesPerPaint;
+}
+
+/// Optional idle preparation for a scene-scoped tile session.
+///
+/// A page invokes this only after its first useful pixels have landed. The
+/// session stays owned by that page and is disposed through the ordinary
+/// scene lifecycle, so a backend can prepare geometry and uploads without
+/// creating a separate document-wide cache or extending resource lifetimes.
+abstract interface class PdfTileRasterWarmUp {
+  Future<void> warmUp();
 }
 
 /// Bounded, always-on page/tile routing diagnostics for support exports.

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -43,13 +43,22 @@ abstract class PdfTileRasterBackend {
   /// [PdfRetainedScene.releaseDecodedImagePixels].
   bool get prefersDirectDecodedImageUploads => false;
 
+  /// Prepares process- or view-scoped resources before the first tile.
+  ///
+  /// [PdfViewer] calls this after its first frame, never while constructing
+  /// the initial page. Backends can use the idle lead time to load shaders or
+  /// issue a bounded compilation pass. Calls may repeat after a backend or
+  /// native view changes, so implementations must coalesce their own work.
+  /// The default Canvas implementation has nothing to prepare.
+  Future<void> warmUp() => Future<void>.value();
+
   /// Creates a lightweight owner for resources retained across tile renders.
   ///
   /// This is called lazily, when the tile path first needs pixels—not while
-  /// the page's initial raster is being prepared. Expensive initialization
-  /// should itself be deferred by the returned session until
-  /// [PdfTileRasterSession.rasterizeRegion], so enabling an experimental
-  /// backend cannot delay first paint.
+  /// the page's initial raster is being prepared. Scene-specific work should
+  /// itself be deferred by the returned session until
+  /// [PdfTileRasterSession.rasterizeRegion]; only view-scoped work belongs in
+  /// [warmUp], after first paint.
   PdfTileRasterSession? createSession(PdfRetainedScene scene);
 }
 

--- a/packages/dart_pdf_editor/test/tile_backend_warm_up_test.dart
+++ b/packages/dart_pdf_editor/test/tile_backend_warm_up_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,11 +7,52 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 class _WarmUpBackend extends PdfCanvasTileRasterBackend {
   int warmUps = 0;
+  int sceneWarmUps = 0;
+
+  @override
+  bool get supportsWarmUp => true;
+
+  @override
+  bool get supportsSessionWarmUp => true;
 
   @override
   Future<void> warmUp() async {
     warmUps++;
   }
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) =>
+      _WarmUpSession(this, super.createSession(scene));
+}
+
+class _WarmUpSession implements PdfTileRasterSession, PdfTileRasterWarmUp {
+  _WarmUpSession(this.backend, this.delegate);
+
+  final _WarmUpBackend backend;
+  final PdfTileRasterSession delegate;
+
+  @override
+  PdfRetainedScene get scene => delegate.scene;
+
+  @override
+  Future<void> warmUp() async {
+    backend.sceneWarmUps++;
+  }
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    ui.Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) =>
+      delegate.rasterizeRegion(
+        region,
+        pixelRatio: pixelRatio,
+        tracePage: tracePage,
+      );
+
+  @override
+  void dispose() => delegate.dispose();
 }
 
 void main() {
@@ -19,7 +62,11 @@ void main() {
     final first = _WarmUpBackend();
     final second = _WarmUpBackend();
 
-    Future<void> pump(_WarmUpBackend backend, {required bool active}) async {
+    Future<void> pump(
+      _WarmUpBackend backend, {
+      required bool active,
+      bool waitForWarmUp = true,
+    }) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: PdfViewer(
@@ -32,19 +79,36 @@ void main() {
         ),
       ));
       await tester.pump();
+      if (!waitForWarmUp) return;
+      await tester.pump(PdfViewer.tileBackendWarmIdleDelay);
+      await tester.pump(PdfPageView.tileSessionWarmIdleDelay);
     }
 
     await pump(first, active: false);
     expect(first.warmUps, 0, reason: 'a parked viewer must do no GPU work');
 
+    await pump(first, active: true, waitForWarmUp: false);
+    expect(first.warmUps, 0,
+        reason: 'useful pixels alone are not an idle edge');
+    expect(first.sceneWarmUps, 0);
+
+    await pump(first, active: false);
+    expect(first.warmUps, 0,
+        reason: 'parking during the quiet window cancels preparation');
+    expect(first.sceneWarmUps, 0);
+
     await pump(first, active: true);
     expect(first.warmUps, 1);
+    expect(first.sceneWarmUps, 1,
+        reason: 'the useful page raster lands before its session is prepared');
 
     await pump(first, active: true);
     expect(first.warmUps, 1, reason: 'ordinary rebuilds keep the same warm-up');
+    expect(first.sceneWarmUps, 1);
 
     await pump(second, active: true);
     expect(first.warmUps, 1);
     expect(second.warmUps, 1, reason: 'a replacement backend gets prepared');
+    expect(second.sceneWarmUps, 1);
   });
 }

--- a/packages/dart_pdf_editor/test/tile_backend_warm_up_test.dart
+++ b/packages/dart_pdf_editor/test/tile_backend_warm_up_test.dart
@@ -1,0 +1,50 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+class _WarmUpBackend extends PdfCanvasTileRasterBackend {
+  int warmUps = 0;
+
+  @override
+  Future<void> warmUp() async {
+    warmUps++;
+  }
+}
+
+void main() {
+  testWidgets('viewer warms a new tile backend only after it is active',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final first = _WarmUpBackend();
+    final second = _WarmUpBackend();
+
+    Future<void> pump(_WarmUpBackend backend, {required bool active}) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            document: document,
+            active: active,
+            pagePreviews: false,
+            autoRenderWorker: false,
+            tileRasterBackend: backend,
+          ),
+        ),
+      ));
+      await tester.pump();
+    }
+
+    await pump(first, active: false);
+    expect(first.warmUps, 0, reason: 'a parked viewer must do no GPU work');
+
+    await pump(first, active: true);
+    expect(first.warmUps, 1);
+
+    await pump(first, active: true);
+    expect(first.warmUps, 1, reason: 'ordinary rebuilds keep the same warm-up');
+
+    await pump(second, active: true);
+    expect(first.warmUps, 1);
+    expect(second.warmUps, 1, reason: 'a replacement backend gets prepared');
+  });
+}

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Next
+
+- Warm every tile shader with a one-pixel post-first-frame submission, shared
+  per Impeller context and MSAA mode, so first-use driver compilation does not
+  land on the first deep-zoom tile.
+- Accelerate exact vector tiling cells, axial gradients (including embedded
+  outline text), and nested-circle radial gradients while retaining explicit
+  Canvas fallback for unsafe variants.
+
 ## 0.1.6
 
 - Align the experimental Flutter GPU backend with the 3.8.0 package suite. No

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Next
 
-- Warm every tile shader with a one-pixel post-first-frame submission, shared
-  per Impeller context and MSAA mode, so first-use driver compilation does not
-  land on the first deep-zoom tile.
+- Warm every tile shader with a one-pixel idle submission, shared per Impeller
+  context and MSAA mode, then compile and submit each live page's retained
+  scene at one-pixel scale. Both passes wait for useful pixels plus a 750 ms
+  quiet window, so first-use driver, geometry, and upload work does not land on
+  the first deep-zoom tile or contend with immediate navigation.
 - Accelerate exact vector tiling cells, axial gradients (including embedded
   outline text), and nested-circle radial gradients while retaining explicit
   Canvas fallback for unsafe variants.

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -6,7 +6,9 @@
   context and MSAA mode, then compile and submit each live page's retained
   scene at one-pixel scale. Both passes wait for useful pixels plus a 750 ms
   quiet window, so first-use driver, geometry, and upload work does not land on
-  the first deep-zoom tile or contend with immediate navigation.
+  the first deep-zoom tile or contend with immediate navigation. Proactive
+  warm-up defaults to desktop; mobile stays on-demand unless the host opts in,
+  avoiding a large idle context allocation on memory-constrained devices.
 - Benchmark tiling-pattern and radial-shading pipeline warm-up, scene warm-up,
   first GPU tiles, and Canvas parity three times on the designated macOS
   Metal CI lane. PRs receive a main comparison with details collapsed beneath

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -7,6 +7,10 @@
   scene at one-pixel scale. Both passes wait for useful pixels plus a 750 ms
   quiet window, so first-use driver, geometry, and upload work does not land on
   the first deep-zoom tile or contend with immediate navigation.
+- Benchmark tiling-pattern and radial-shading pipeline warm-up, scene warm-up,
+  first GPU tiles, and Canvas parity three times on the designated macOS
+  Metal CI lane. PRs receive a main comparison with details collapsed beneath
+  the headline, and retain the normalized trace as a downloadable artifact.
 - Accelerate exact vector tiling cells, axial gradients (including embedded
   outline text), and nested-circle radial gradients while retaining explicit
   Canvas fallback for unsafe variants.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -159,6 +159,11 @@ Set `PDF_GPU_BENCHMARK_WARMUP=1` to measure the viewer's pipeline warm-up before
 the first real tile.
 Set `PDF_GPU_BENCHMARK_SCENE_WARMUP=1` to additionally compile and submit the
 retained scene before measuring that tile.
+Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
+markers for each pipeline/scene/tile phase. CI uses those markers to run the
+checked-in tiling-pattern and radial-shading pages three times on macOS Metal,
+compare PR medians with the latest `main` artifact, and publish both a concise
+PR headline and a collapsed detailed trace.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -84,6 +84,13 @@ first deep-zoom interaction without delaying initial document paint or
 competing with an immediate scroll. This work is coalesced per native view and
 MSAA mode, even when several readers share the same process.
 
+Proactive warm-up defaults on for macOS, Windows, and Linux. Android and iOS
+stay on-demand by default because merely creating an Impeller GPU context can
+reserve significant memory before a page is known to be GPU-compatible. A host
+that has validated its mobile device range can opt in with
+`enableProactiveWarmUp: true`; normal on-demand GPU tiles remain available when
+the option is false.
+
 The same idle gate then prepares the live page's retained tile session: scene
 geometry and decoded-image uploads are compiled once and every scene pipeline
 is submitted at one-pixel page scale. The real first tile reuses those retained

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -57,7 +57,8 @@ PDF features return to the Canvas tile backend automatically. Web gets a
 compile-time stub and therefore preserves the all-platform host surface.
 
 The current exact subset is solid paths and strokes, embedded-outline text,
-decoded images/image masks, Gouraud meshes, normal blending, rectangular and
+decoded images/image masks, Gouraud meshes, axial gradients, nested-circle
+radial gradients, vector tiling cells, normal blending, rectangular and
 arbitrary path clips, and the common isolated single-image soft-mask group.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
@@ -76,6 +77,12 @@ after their scene is disposed and every submitted command buffer completes.
 This keeps command-heavy CAD navigation bounded without relying on delayed
 native finalizers; a scene that cannot lease enough geometry also falls back.
 
+The viewer asks the backend to warm its context after the first page frame.
+The backend submits one transparent pixel through each tile pipeline, moving
+Impeller/driver compilation out of the first deep-zoom interaction without
+delaying initial document paint. This work is coalesced per native view and
+MSAA mode, even when several readers share the same process.
+
 `backend.stats` reports accepted/rejected/active sessions, the latest actual
 tile route, runtime fallback reasons, scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
@@ -86,9 +93,10 @@ instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
 Pages with other transparency groups or soft masks, non-normal blends,
-gradients, tiling cells, unsafe overprint, complex clips nested inside the
-single-image soft-mask shortcut, substituted/stroked text, hairlines, or
-missing image pixels are rejected as a whole rather than approximated.
+non-nested radial gradients, gradient overprint, stencil-image tiling cells,
+unsafe overprint, complex clips nested inside the single-image soft-mask
+shortcut, substituted/stroked text, hairlines, or missing image pixels are
+rejected as a whole rather than approximated.
 `allowOverprintApproximation` exists only for controlled experiments and
 defaults to false.
 
@@ -139,6 +147,8 @@ settle, Canvas parity, upload/cache counters, and RSS. It is opt-in via
 `PDF_GPU_BENCHMARK_PAGES`. Set `PDF_GPU_BENCHMARK_OUT` to a directory to save
 the center 512 px GPU and Canvas tiles for visual comparison, or
 `PDF_GPU_BENCHMARK_MSAA=0` to isolate multisample antialiasing differences.
+Set `PDF_GPU_BENCHMARK_WARMUP=1` to measure the viewer's pipeline warm-up before
+the first real tile.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -77,14 +77,22 @@ after their scene is disposed and every submitted command buffer completes.
 This keeps command-heavy CAD navigation bounded without relying on delayed
 native finalizers; a scene that cannot lease enough geometry also falls back.
 
-The viewer asks the backend to warm its context after the first page frame.
-The backend submits one transparent pixel through each tile pipeline, moving
-Impeller/driver compilation out of the first deep-zoom interaction without
-delaying initial document paint. This work is coalesced per native view and
+After useful page pixels land and foreground work stays quiet for 750 ms, the
+viewer asks the backend to warm its context. The backend submits one transparent
+pixel through each tile pipeline, moving Impeller/driver compilation out of the
+first deep-zoom interaction without delaying initial document paint or
+competing with an immediate scroll. This work is coalesced per native view and
 MSAA mode, even when several readers share the same process.
 
+The same idle gate then prepares the live page's retained tile session: scene
+geometry and decoded-image uploads are compiled once and every scene pipeline
+is submitted at one-pixel page scale. The real first tile reuses those retained
+resources. Starting new foreground work cancels and restarts both delays; page
+disposal releases the prepared resources through the ordinary scene lifecycle.
+
 `backend.stats` reports accepted/rejected/active sessions, the latest actual
-tile route, runtime fallback reasons, scene compile and tile-submit time,
+tile route, runtime fallback reasons, context and scene warm-up outcomes,
+scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
@@ -149,6 +157,8 @@ the center 512 px GPU and Canvas tiles for visual comparison, or
 `PDF_GPU_BENCHMARK_MSAA=0` to isolate multisample antialiasing differences.
 Set `PDF_GPU_BENCHMARK_WARMUP=1` to measure the viewer's pipeline warm-up before
 the first real tile.
+Set `PDF_GPU_BENCHMARK_SCENE_WARMUP=1` to additionally compile and submit the
+retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -115,7 +115,16 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       }
       _lastContext = context;
       stats.lastContextIdentity = identityHashCode(context);
-      final unitBuild = _buildGpuUnits(scene.commands);
+      final commandBuild = _buildGpuCommands(scene.commands);
+      final commands = commandBuild.commands;
+      if (commands == null) {
+        _lastSessionRejection = commandBuild.rejection;
+        stats.lastRejection = commandBuild.rejection;
+        stats.lastTileRoute = 'canvas-fallback';
+        stats.sessionsRejected++;
+        return null;
+      }
+      final unitBuild = _buildGpuUnits(commands);
       final units = unitBuild.units;
       if (units == null) {
         _lastSessionRejection = unitBuild.rejection;
@@ -124,8 +133,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         stats.sessionsRejected++;
         return null;
       }
-      final rejection =
-          _unsupportedReason(scene, units, allowOverprintApproximation);
+      final rejection = _unsupportedReason(
+          scene, commands, units, allowOverprintApproximation);
       if (rejection != null) {
         _lastSessionRejection = rejection;
         stats.lastRejection = rejection;
@@ -143,6 +152,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           math.max(stats.peakActiveSessions, stats.activeSessions);
       return _FlutterGpuTileSession(
         scene: scene,
+        commands: commands,
         context: context,
         pipelines: _GpuPipelines.instance(context),
         units: units,
@@ -160,8 +170,11 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     }
   }
 
-  static String? _unsupportedReason(PdfRetainedScene scene,
-      List<_GpuUnit> units, bool allowOverprintApproximation) {
+  static String? _unsupportedReason(
+      PdfRetainedScene scene,
+      List<PdfRenderCommand> commands,
+      List<_GpuUnit> units,
+      bool allowOverprintApproximation) {
     for (final unit in units) {
       if (unit.blendMode != PdfBlendMode.normal) {
         return 'blend mode ${unit.blendMode.name}';
@@ -174,7 +187,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         }
         continue;
       }
-      final command = scene.commands[unit.commandIndex];
+      final command = commands[unit.commandIndex];
       final overprint = _unsafeOverprint(unit, command);
       if (overprint != null) return overprint;
       if (unit.darken && !allowOverprintApproximation) {
@@ -213,7 +226,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           if (textReasons.isNotEmpty) {
             return 'unsupported text: ${textReasons.join(', ')}';
           }
-        case PdfFillPathGradientCommand() || PdfDrawTiledCellCommand():
+        case PdfFillPathGradientCommand():
           return 'unsupported ${command.runtimeType}';
         default:
           return 'unsupported ${command.runtimeType}';
@@ -224,15 +237,14 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         if (unit.endCommandIndex > unit.commandIndex)
           for (var i = unit.commandIndex; i <= unit.endCommandIndex; i++) i,
     };
-    for (var i = 0; i < scene.commands.length; i++) {
-      final command = scene.commands[i];
+    for (var i = 0; i < commands.length; i++) {
+      final command = commands[i];
       switch (command) {
         case PdfBeginGroupCommand() ||
               PdfEndGroupCommand() ||
               PdfBeginSoftMaskedCommand() ||
               PdfEndSoftMaskedCommand() ||
-              PdfFillPathGradientCommand() ||
-              PdfDrawTiledCellCommand():
+              PdfFillPathGradientCommand():
           if (covered.contains(i)) break;
           return 'unsafe ${command.runtimeType}';
         case PdfSetBlendModeCommand(:final mode):
@@ -351,6 +363,112 @@ class _SoftMaskImageSpec {
   final double backdropLuminance;
   final double transferScale;
   final double transferOffset;
+}
+
+class _GpuCommandBuild {
+  const _GpuCommandBuild(this.commands, this.rejection);
+
+  final List<PdfRenderCommand>? commands;
+  final String? rejection;
+}
+
+/// Expands retained tiling cells once for the GPU scene.
+///
+/// Canvas can stamp a vector sub-picture for every repeat. flutter_gpu does
+/// not expose a retained sub-pass transform, so keeping the nested command
+/// would otherwise require rebuilding the cell for every tile. Flattening it
+/// here preserves exact tile-major painter order while still compiling the
+/// resulting page-space geometry only once. The hard cap keeps pathological
+/// hatch grids on the existing Canvas sub-picture path instead of trading a
+/// compact transcript for unbounded GPU geometry.
+_GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
+  const maxExpandedCommands = 1000000;
+  var hasTiledCell = false;
+  String? tiledRejection;
+
+  int count(List<PdfRenderCommand> commands, Set<Object> active,
+      {bool inTiledCell = false}) {
+    if (!active.add(commands)) return maxExpandedCommands + 1;
+    var total = 0;
+    for (final command in commands) {
+      if (command
+          case PdfDrawTiledCellCommand(
+            :final cellCommands,
+            :final originsX,
+          )) {
+        hasTiledCell = true;
+        final cellCount = count(cellCommands, active, inTiledCell: true);
+        if (cellCount > maxExpandedCommands ||
+            originsX.length > maxExpandedCommands ||
+            (cellCount != 0 &&
+                originsX.length > maxExpandedCommands ~/ cellCount)) {
+          active.remove(commands);
+          return maxExpandedCommands + 1;
+        }
+        total += cellCount * originsX.length;
+      } else {
+        if (inTiledCell &&
+            command is PdfDrawImageCommand &&
+            command.request.isStencil) {
+          // Type 3 bitmap glyphs are retained as one-repeat tiling cells.
+          // Linear texture sampling does not yet match Canvas closely enough
+          // on the Ghent font grid, so do not let flattening accidentally
+          // promote those pages into the exact GPU subset.
+          tiledRejection ??= 'unsupported tiled stencil image';
+        }
+        total++;
+      }
+      if (total > maxExpandedCommands) {
+        active.remove(commands);
+        return total;
+      }
+    }
+    active.remove(commands);
+    return total;
+  }
+
+  final expandedCount = count(source, Set<Object>.identity());
+  if (!hasTiledCell) return _GpuCommandBuild(source, null);
+  if (tiledRejection != null) {
+    return _GpuCommandBuild(null, tiledRejection);
+  }
+  if (expandedCount > maxExpandedCommands) {
+    return const _GpuCommandBuild(
+      null,
+      'expanded tiling cells exceed GPU command cap',
+    );
+  }
+
+  final expanded = <PdfRenderCommand>[];
+  for (final command in source) {
+    if (command
+        case PdfDrawTiledCellCommand(
+          :final cellCommands,
+          :final originsX,
+          :final originsY,
+        )) {
+      final recorder = RecordingPdfDevice();
+      for (var i = 0; i < originsX.length; i++) {
+        // TranslatingPdfDevice intentionally does not implement the native
+        // tiled-cell capability. The generic replay path therefore expands
+        // nested cells too and composes their origins into page-space.
+        replayCommands(
+          cellCommands,
+          TranslatingPdfDevice(recorder, originsX[i], originsY[i]),
+        );
+      }
+      expanded.addAll(recorder.commands);
+    } else {
+      expanded.add(command);
+    }
+  }
+  if (expanded.length > maxExpandedCommands) {
+    return const _GpuCommandBuild(
+      null,
+      'expanded tiling cells exceed GPU command cap',
+    );
+  }
+  return _GpuCommandBuild(List.unmodifiable(expanded), null);
 }
 
 _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
@@ -704,6 +822,7 @@ class _FlutterGpuTileSession
     implements PdfTileRasterSession, PdfTileRasterScheduling {
   _FlutterGpuTileSession({
     required this.scene,
+    required this.commands,
     required this.context,
     required this.pipelines,
     required this.units,
@@ -715,6 +834,7 @@ class _FlutterGpuTileSession
 
   @override
   final PdfRetainedScene scene;
+  final List<PdfRenderCommand> commands;
 
   // This backend already returns a final GPU texture for every raster call.
   // Slab splitting would queue another texture-to-texture copy per tile; those
@@ -742,6 +862,7 @@ class _FlutterGpuTileSession
 
   Future<_CompiledScene> _compile() => _compiled ??= _CompiledScene.build(
         scene,
+        commands,
         context,
         units,
         stats,
@@ -830,6 +951,7 @@ class _CompiledScene {
 
   static Future<_CompiledScene> build(
     PdfRetainedScene scene,
+    List<PdfRenderCommand> commands,
     gpu.GpuContext context,
     List<_GpuUnit> units,
     FlutterGpuTileBackendStats stats,
@@ -856,7 +978,7 @@ class _CompiledScene {
             context,
             geometry,
             scene,
-            scene.commands[unit.commandIndex],
+            commands[unit.commandIndex],
             stats,
             imageCache,
             textureLeases,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -90,6 +90,12 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   /// reports that runtime reason through [stats].
   bool get isPlatformSupported => true;
 
+  @override
+  bool get supportsWarmUp => true;
+
+  @override
+  bool get supportsSessionWarmUp => true;
+
   /// Drops reusable texture ownership. Active compiled scenes retain the
   /// resources they are currently drawing.
   void clearImageCache() => _imageCache.clear(stats);
@@ -905,7 +911,10 @@ bool _commandNeedsDarken(
 }
 
 class _FlutterGpuTileSession
-    implements PdfTileRasterSession, PdfTileRasterScheduling {
+    implements
+        PdfTileRasterSession,
+        PdfTileRasterScheduling,
+        PdfTileRasterWarmUp {
   _FlutterGpuTileSession({
     required this.scene,
     required this.commands,
@@ -943,6 +952,7 @@ class _FlutterGpuTileSession
 
   Future<_CompiledScene>? _compiled;
   _CompiledScene? _ready;
+  Future<void>? _prewarm;
   bool _disposed = false;
   bool _failureReported = false;
 
@@ -963,6 +973,56 @@ class _FlutterGpuTileSession
       }).whenComplete(scene.releaseDecodedImagePixels);
 
   @override
+  Future<void> warmUp() => _prewarm ??= _warmUpScene();
+
+  Future<void> _warmUpScene() async {
+    if (_disposed) return;
+    final clock = Stopwatch()..start();
+    stats.sceneWarmUpRequests++;
+    ui.Image? image;
+    try {
+      final compiled = await _compile();
+      final gpuPipelines = await pipelines;
+      await gpuPipelines.warmUp(
+        context,
+        useMsaa: msaa && context.doesSupportOffscreenMSAA,
+      );
+      if (_disposed) throw StateError('flutter_gpu tile session disposed');
+      final size = scene.pageSize;
+      final ratio = 1 / math.max(1.0, math.max(size.width, size.height));
+      image = compiled.render(
+        units,
+        region: Offset.zero & size,
+        pixelRatio: ratio,
+        pipelines: gpuPipelines,
+        useMsaa: msaa,
+      );
+      final bytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      if (bytes == null) throw StateError('GPU scene warm-up readback failed');
+      stats.sceneWarmUpCompletions++;
+      PdfPerfLog.log(
+        'tile gpu scene warm commands=${units.length} '
+        'elapsed=${clock.elapsedMilliseconds}ms',
+      );
+    } catch (error) {
+      // A page leaving the cache while this optional idle pass is in flight is
+      // ordinary cancellation, not a backend failure or a reason to report a
+      // Canvas fallback for a scene that no longer has an owner.
+      if (_disposed) {
+        stats.sceneWarmUpCancellations++;
+        return;
+      }
+      stats
+        ..sceneWarmUpFailures += 1
+        ..lastSceneWarmUpError = error.toString();
+      rethrow;
+    } finally {
+      image?.dispose();
+      stats.sceneWarmUpMicros += clock.elapsedMicroseconds;
+    }
+  }
+
+  @override
   Future<ui.Image> rasterizeRegion(
     Rect region, {
     required double pixelRatio,
@@ -970,6 +1030,8 @@ class _FlutterGpuTileSession
   }) async {
     if (_disposed) throw StateError('flutter_gpu tile session disposed');
     try {
+      final prewarm = _prewarm;
+      if (prewarm != null) await prewarm;
       final compiled = await _compile();
       final gpuPipelines = await pipelines;
       if (_disposed) throw StateError('flutter_gpu tile session disposed');

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -27,9 +27,9 @@ import 'backend_stats.dart';
 /// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
 /// masks (with rectangular clips additionally using the hardware scissor).
 /// Other isolated groups, non-normal blend modes, complex clips *inside* the
-/// special soft-mask-image shortcut, radial gradients, substituted/stroked
-/// text, stencil-image tiling cells, unsafe overprint, or missing image pixels
-/// reject the whole scene.
+/// special soft-mask-image shortcut, non-nested radial gradients,
+/// substituted/stroked text, stencil-image tiling cells, unsafe overprint, or
+/// missing image pixels reject the whole scene.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -811,9 +811,7 @@ String? _unsafeOverprint(_GpuUnit unit, PdfRenderCommand command) {
 }
 
 String? _gradientUnsupportedReason(PdfGradient gradient, double alpha) {
-  if (gradient.isRadial) return 'unsupported radial gradient';
-  if (gradient.coords.length < 4 ||
-      gradient.colors.length < 2 ||
+  if (gradient.colors.length < 2 ||
       gradient.colors.length != gradient.stops.length ||
       gradient.transform.inverted() == null ||
       !alpha.isFinite ||
@@ -827,6 +825,25 @@ String? _gradientUnsupportedReason(PdfGradient gradient, double alpha) {
       ].every((value) => value.isFinite)) {
     return 'invalid axial gradient';
   }
+  if (gradient.isRadial) {
+    if (gradient.coords.length < 6) return 'invalid radial gradient';
+    final x0 = gradient.coords[0], y0 = gradient.coords[1];
+    final r0 = gradient.coords[2];
+    final x1 = gradient.coords[3], y1 = gradient.coords[4];
+    final r1 = gradient.coords[5];
+    final dx = x1 - x0, dy = y1 - y0, dr = r1 - r0;
+    final centerDistance = math.sqrt(dx * dx + dy * dy);
+    if (![x0, y0, r0, x1, y1, r1].every((value) => value.isFinite) ||
+        r0 < 0 ||
+        r1 < 0 ||
+        dr.abs() <= 1e-9 ||
+        centerDistance > dr.abs() + 1e-6) {
+      return 'unsupported non-nested radial gradient';
+    }
+  } else if (gradient.coords.length < 4) {
+    return 'invalid axial gradient';
+  }
+  if (gradient.isRadial) return null;
   final dx = gradient.coords[2] - gradient.coords[0];
   final dy = gradient.coords[3] - gradient.coords[1];
   if (!dx.isFinite || !dy.isFinite || dx * dx + dy * dy <= 1e-12) {
@@ -1627,7 +1644,7 @@ FutureOr<_GpuDraw?> _compileCommand(
         :final gradient,
         :final alpha,
       ):
-      return _compileAxialGradient(
+      return _compileGradient(
         geometry,
         path,
         rule,
@@ -1683,7 +1700,7 @@ FutureOr<_GpuDraw?> _compileCommand(
       }
       final gradient = run.gradient;
       if (gradient != null) {
-        return _compileAxialGradientSubpaths(
+        return _compileGradientSubpaths(
           geometry,
           subs,
           PdfFillRule.nonzero,
@@ -1753,7 +1770,7 @@ Future<_GpuDraw> _compileImageCommand(
   );
 }
 
-_GradientDraw? _compileAxialGradient(
+_GradientDraw? _compileGradient(
   _GpuGeometryArena geometry,
   PdfPath path,
   PdfFillRule rule,
@@ -1764,7 +1781,7 @@ _GradientDraw? _compileAxialGradient(
     return null;
   }
   final subpaths = flattenPath(path, PdfMatrix.identity, tolerance: 0.01);
-  return _compileAxialGradientSubpaths(
+  return _compileGradientSubpaths(
     geometry,
     subpaths,
     rule,
@@ -1773,7 +1790,7 @@ _GradientDraw? _compileAxialGradient(
   );
 }
 
-_GradientDraw? _compileAxialGradientSubpaths(
+_GradientDraw? _compileGradientSubpaths(
   _GpuGeometryArena geometry,
   List<FlatSubpath> subpaths,
   PdfFillRule rule,
@@ -1781,6 +1798,15 @@ _GradientDraw? _compileAxialGradientSubpaths(
   double alpha,
 ) {
   if (alpha <= 0) return null;
+  if (gradient.isRadial) {
+    return _compileRadialGradientSubpaths(
+      geometry,
+      subpaths,
+      rule,
+      gradient,
+      alpha,
+    );
+  }
   final stencil = _stencilGeometry(geometry, subpaths);
   if (stencil == null) return null;
   final bounds = stencil.$2;
@@ -1883,6 +1909,130 @@ _GradientDraw? _compileAxialGradientSubpaths(
         color[2],
         color[3],
       );
+    }
+  }
+  if (vertices.isEmpty) return null;
+  return _GradientDraw(
+    stencil.$1,
+    geometry.add(vertices.bytes, vertices.length ~/ 6),
+    rule,
+  );
+}
+
+_GradientDraw? _compileRadialGradientSubpaths(
+  _GpuGeometryArena geometry,
+  List<FlatSubpath> subpaths,
+  PdfFillRule rule,
+  PdfGradient gradient,
+  double alpha,
+) {
+  final stencil = _stencilGeometry(geometry, subpaths);
+  if (stencil == null) return null;
+  final bounds = stencil.$2;
+  final inverse = gradient.transform.inverted()!;
+  final x0 = gradient.coords[0], y0 = gradient.coords[1];
+  final r0 = gradient.coords[2];
+  final x1 = gradient.coords[3], y1 = gradient.coords[4];
+  final r1 = gradient.coords[5];
+  final dx = x1 - x0, dy = y1 - y0, dr = r1 - r0;
+
+  // Bound the extended, growing side by the fill path. The extra radii and
+  // centre travel are deliberately conservative; the path stencil discards
+  // the excess, while a too-small outer ring would leave a clipped corner
+  // transparent when /Extend asks for the terminal colour.
+  var reach = (math.sqrt(dx * dx + dy * dy) + r0 + r1) * 4 + 1;
+  for (final (px, py) in <(double, double)>[
+    (bounds.left, bounds.bottom),
+    (bounds.right, bounds.bottom),
+    (bounds.right, bounds.top),
+    (bounds.left, bounds.top),
+  ]) {
+    final x = inverse.transformX(px, py), y = inverse.transformY(px, py);
+    final d0 = math.sqrt((x - x0) * (x - x0) + (y - y0) * (y - y0));
+    final d1 = math.sqrt((x - x1) * (x - x1) + (y - y1) * (y - y1));
+    reach = math.max(reach, math.max(d0, d1) + r0 + r1);
+  }
+  if (!reach.isFinite) return null;
+
+  final double tLo;
+  final double tHi;
+  if (dr > 0) {
+    tLo = gradient.extendStart ? -r0 / dr : 0;
+    tHi = gradient.extendEnd ? (reach - r0) / dr : 1;
+  } else {
+    tLo = gradient.extendStart ? (reach - r0) / dr : 0;
+    tHi = gradient.extendEnd ? -r0 / dr : 1;
+  }
+  if (!tLo.isFinite || !tHi.isFinite || tLo >= tHi) return null;
+
+  final cuts = <double>{tLo, tHi};
+  for (final stop in <double>[0, ...gradient.stops, 1]) {
+    if (stop > tLo && stop < tHi) cuts.add(stop);
+  }
+  final ordered = cuts.toList()..sort();
+  const angular = 96;
+  final vertices =
+      FloatBuilder(math.max(angular * 36, (ordered.length - 1) * angular * 36));
+  final commandAlpha = alpha.clamp(0.0, 1.0);
+
+  List<double> colorAt(double t) {
+    final sample = t.clamp(0.0, 1.0);
+    var upper = 1;
+    while (upper < gradient.stops.length && gradient.stops[upper] < sample) {
+      upper++;
+    }
+    if (upper >= gradient.stops.length) {
+      return _premul(gradient.colors.last, commandAlpha);
+    }
+    final lower = upper - 1;
+    final lo = gradient.stops[lower], hi = gradient.stops[upper];
+    final mix = ((sample - lo) / (hi - lo)).clamp(0.0, 1.0);
+    final a = gradient.colors[lower], b = gradient.colors[upper];
+    return _premul(
+      PdfColor(
+        a.red + (b.red - a.red) * mix,
+        a.green + (b.green - a.green) * mix,
+        a.blue + (b.blue - a.blue) * mix,
+      ),
+      commandAlpha,
+    );
+  }
+
+  (double, double) point(double t, int step) {
+    final angle = 2 * math.pi * step / angular;
+    final radius = math.max(0.0, r0 + dr * t);
+    final x = x0 + dx * t + radius * math.cos(angle);
+    final y = y0 + dy * t + radius * math.sin(angle);
+    return (
+      gradient.transform.transformX(x, y),
+      gradient.transform.transformY(x, y),
+    );
+  }
+
+  for (var i = 0; i + 1 < ordered.length; i++) {
+    final a = ordered[i], b = ordered[i + 1];
+    if (b - a <= 1e-12) continue;
+    final ca = colorAt(a), cb = colorAt(b);
+    for (var j = 0; j < angular; j++) {
+      final p00 = point(a, j), p01 = point(a, j + 1);
+      final p10 = point(b, j), p11 = point(b, j + 1);
+      for (final (point, color) in <((double, double), List<double>)>[
+        (p00, ca),
+        (p10, cb),
+        (p11, cb),
+        (p00, ca),
+        (p11, cb),
+        (p01, ca),
+      ]) {
+        vertices.add6(
+          point.$1,
+          point.$2,
+          color[0],
+          color[1],
+          color[2],
+          color[3],
+        );
+      }
     }
   }
   if (vertices.isEmpty) return null;

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -204,11 +204,14 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           }
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
-          if (run.glyphs == null ||
-              !run.fill ||
-              run.gradient != null ||
-              run.strokeColor != null) {
-            return 'unsupported text rendering mode';
+          final textReasons = <String>[
+            if (run.glyphs == null) 'missing glyph outlines',
+            if (!run.fill) 'fill disabled',
+            if (run.gradient != null) 'gradient fill',
+            if (run.strokeColor != null) 'stroke',
+          ];
+          if (textReasons.isNotEmpty) {
+            return 'unsupported text: ${textReasons.join(', ')}';
           }
         case PdfFillPathGradientCommand() || PdfDrawTiledCellCommand():
           return 'unsupported ${command.runtimeType}';

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -27,9 +27,9 @@ import 'backend_stats.dart';
 /// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
 /// masks (with rectangular clips additionally using the hardware scissor).
 /// Other isolated groups, non-normal blend modes, complex clips *inside* the
-/// special soft-mask-image shortcut, gradients, substituted/stroked text,
-/// tiling cells, unsafe overprint, or missing image pixels reject the whole
-/// scene.
+/// special soft-mask-image shortcut, radial gradients, substituted/stroked
+/// text, stencil-image tiling cells, unsafe overprint, or missing image pixels
+/// reject the whole scene.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -227,7 +227,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             return 'unsupported text: ${textReasons.join(', ')}';
           }
         case PdfFillPathGradientCommand():
-          return 'unsupported ${command.runtimeType}';
+          final reason = _gradientUnsupportedReason(command);
+          if (reason != null) return reason;
         default:
           return 'unsupported ${command.runtimeType}';
       }
@@ -243,8 +244,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         case PdfBeginGroupCommand() ||
               PdfEndGroupCommand() ||
               PdfBeginSoftMaskedCommand() ||
-              PdfEndSoftMaskedCommand() ||
-              PdfFillPathGradientCommand():
+              PdfEndSoftMaskedCommand():
           if (covered.contains(i)) break;
           return 'unsafe ${command.runtimeType}';
         case PdfSetBlendModeCommand(:final mode):
@@ -792,10 +792,43 @@ String? _unsafeOverprint(_GpuUnit unit, PdfRenderCommand command) {
   switch (command) {
     case PdfFillMeshCommand():
       if (unit.fillOverprint) return 'mesh overprint';
+    case PdfFillPathGradientCommand():
+      if (unit.fillOverprint) return 'gradient overprint';
     default:
       // Images do not use CanvasPdfDevice's overprint approximation; the
       // interpreter has already resolved any image-adjacent colorant work.
       break;
+  }
+  return null;
+}
+
+String? _gradientUnsupportedReason(PdfFillPathGradientCommand command) {
+  final gradient = command.gradient;
+  if (gradient.isRadial) return 'unsupported radial gradient';
+  if (gradient.coords.length < 4 ||
+      gradient.colors.length < 2 ||
+      gradient.colors.length != gradient.stops.length ||
+      gradient.transform.inverted() == null ||
+      !command.alpha.isFinite ||
+      ![
+        gradient.transform.a,
+        gradient.transform.b,
+        gradient.transform.c,
+        gradient.transform.d,
+        gradient.transform.e,
+        gradient.transform.f,
+      ].every((value) => value.isFinite)) {
+    return 'invalid axial gradient';
+  }
+  final dx = gradient.coords[2] - gradient.coords[0];
+  final dy = gradient.coords[3] - gradient.coords[1];
+  if (!dx.isFinite || !dy.isFinite || dx * dx + dy * dy <= 1e-12) {
+    return 'invalid axial gradient';
+  }
+  var previous = double.negativeInfinity;
+  for (final stop in gradient.stops) {
+    if (!stop.isFinite || stop <= previous) return 'invalid axial gradient';
+    previous = stop;
   }
   return null;
 }
@@ -1581,6 +1614,19 @@ FutureOr<_GpuDraw?> _compileCommand(
       ):
       final subs = flattenPath(path, PdfMatrix.identity, tolerance: 0.01);
       return _stencilDraw(geometry, subs, color, alpha, rule, false);
+    case PdfFillPathGradientCommand(
+        :final path,
+        :final rule,
+        :final gradient,
+        :final alpha,
+      ):
+      return _compileAxialGradient(
+        geometry,
+        path,
+        rule,
+        gradient,
+        alpha,
+      );
     case PdfStrokePathCommand(
         :final path,
         :final color,
@@ -1687,6 +1733,132 @@ Future<_GpuDraw> _compileImageCommand(
       offsetInBytes: 0,
       lengthInBytes: info.lengthInBytes,
     ),
+  );
+}
+
+_GradientDraw? _compileAxialGradient(
+  _GpuGeometryArena geometry,
+  PdfPath path,
+  PdfFillRule rule,
+  PdfGradient gradient,
+  double alpha,
+) {
+  if (alpha <= 0 ||
+      _gradientUnsupportedReason(
+              PdfFillPathGradientCommand(path, rule, gradient, alpha)) !=
+          null) {
+    return null;
+  }
+  final subpaths = flattenPath(path, PdfMatrix.identity, tolerance: 0.01);
+  final stencil = _stencilGeometry(geometry, subpaths);
+  if (stencil == null) return null;
+  final bounds = stencil.$2;
+  final inverse = gradient.transform.inverted()!;
+  final x0 = gradient.coords[0], y0 = gradient.coords[1];
+  final dx = gradient.coords[2] - x0, dy = gradient.coords[3] - y0;
+  final length2 = dx * dx + dy * dy;
+  final nx = -dy, ny = dx;
+  var minT = double.infinity, maxT = double.negativeInfinity;
+  var minU = double.infinity, maxU = double.negativeInfinity;
+  for (final (px, py) in <(double, double)>[
+    (bounds.left, bounds.bottom),
+    (bounds.right, bounds.bottom),
+    (bounds.right, bounds.top),
+    (bounds.left, bounds.top),
+  ]) {
+    final x = inverse.transformX(px, py), y = inverse.transformY(px, py);
+    final gx = x - x0, gy = y - y0;
+    final t = (gx * dx + gy * dy) / length2;
+    final u = (gx * nx + gy * ny) / length2;
+    minT = math.min(minT, t);
+    maxT = math.max(maxT, t);
+    minU = math.min(minU, u);
+    maxU = math.max(maxU, u);
+  }
+  if (![minT, maxT, minU, maxU].every((value) => value.isFinite) ||
+      minT >= maxT ||
+      minU >= maxU) {
+    return null;
+  }
+
+  final cuts = <double>{minT, maxT};
+  for (final stop in <double>[0, ...gradient.stops, 1]) {
+    if (stop > minT && stop < maxT) cuts.add(stop);
+  }
+  final ordered = cuts.toList()..sort();
+  final vertices = FloatBuilder(math.max(36, (ordered.length - 1) * 36));
+  final commandAlpha = alpha.clamp(0.0, 1.0);
+
+  List<double> colorAt(double t) {
+    final sample = t.clamp(0.0, 1.0);
+    var upper = 1;
+    while (upper < gradient.stops.length && gradient.stops[upper] < sample) {
+      upper++;
+    }
+    if (upper >= gradient.stops.length) {
+      return _premul(gradient.colors.last, commandAlpha);
+    }
+    final lower = upper - 1;
+    final lo = gradient.stops[lower], hi = gradient.stops[upper];
+    final mix = hi <= lo ? 1.0 : ((sample - lo) / (hi - lo)).clamp(0.0, 1.0);
+    final a = gradient.colors[lower], b = gradient.colors[upper];
+    return _premul(
+      PdfColor(
+        a.red + (b.red - a.red) * mix,
+        a.green + (b.green - a.green) * mix,
+        a.blue + (b.blue - a.blue) * mix,
+      ),
+      commandAlpha,
+    );
+  }
+
+  (double, double) point(double t, double u) {
+    final x = x0 + dx * t + nx * u;
+    final y = y0 + dy * t + ny * u;
+    return (
+      gradient.transform.transformX(x, y),
+      gradient.transform.transformY(x, y),
+    );
+  }
+
+  for (var i = 0; i + 1 < ordered.length; i++) {
+    final a = ordered[i], b = ordered[i + 1];
+    if (b - a <= 1e-12) continue;
+    final outsideStart = b <= 0;
+    final outsideEnd = a >= 1;
+    final ca = outsideStart && !gradient.extendStart ||
+            outsideEnd && !gradient.extendEnd
+        ? const <double>[0, 0, 0, 0]
+        : colorAt(a);
+    final cb = outsideStart && !gradient.extendStart ||
+            outsideEnd && !gradient.extendEnd
+        ? const <double>[0, 0, 0, 0]
+        : colorAt(b);
+    final p00 = point(a, minU), p01 = point(a, maxU);
+    final p10 = point(b, minU), p11 = point(b, maxU);
+    for (final (point, color) in <((double, double), List<double>)>[
+      (p00, ca),
+      (p10, cb),
+      (p11, cb),
+      (p00, ca),
+      (p11, cb),
+      (p01, ca),
+    ]) {
+      vertices.add6(
+        point.$1,
+        point.$2,
+        color[0],
+        color[1],
+        color[2],
+        color[3],
+      );
+    }
+  }
+  if (vertices.isEmpty) return null;
+  return _GradientDraw(
+    stencil.$1,
+    geometry.add(vertices.bytes, vertices.length ~/ 6),
+    rule,
   );
 }
 
@@ -1939,6 +2111,17 @@ class _StencilDraw implements _GpuDraw {
       encoder.stencil(fan, cover, rule: rule, union: union);
 }
 
+class _GradientDraw implements _GpuDraw {
+  const _GradientDraw(this.fan, this.mesh, this.rule);
+
+  final _GpuBuffer fan;
+  final _GpuBuffer mesh;
+  final PdfFillRule rule;
+
+  @override
+  void encode(_GpuEncoder encoder) => encoder.gradient(fan, mesh, rule);
+}
+
 class _GpuClipDraw {
   const _GpuClipDraw(this.fan, this.cover, this.rule);
 
@@ -2129,6 +2312,32 @@ class _GpuEncoder {
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
     _drawBuffer(cover);
+  }
+
+  void gradient(_GpuBuffer fan, _GpuBuffer mesh, PdfFillRule rule) {
+    _accumulateStencil(
+      fan,
+      rule: rule,
+      union: false,
+      requiredClipBit: _activeClipBit,
+    );
+    pass
+      ..setStencilReference(0)
+      ..setColorBlendEquation(_srcOver)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.notEqual,
+        depthStencilPassOperation: gpu.StencilOperation.zero,
+        stencilFailureOperation: gpu.StencilOperation.keep,
+        readMask: _pathMask,
+        writeMask: _pathMask,
+      ))
+      ..bindPipeline(pipelines.solid)
+      ..bindUniform(pipelines.solidTransform, transform);
+    _drawBuffer(mesh);
+    // The gradient mesh conservatively covers the path bounds, but clearing
+    // the scratch bits explicitly keeps a malformed transform or degenerate
+    // interval from leaking winding state into the next draw.
+    _clearStencil(_pathMask);
   }
 
   void _accumulateStencil(

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -2191,6 +2191,7 @@ class _GpuPipelines {
   }
 
   static Future<gpu.ShaderLibrary> _loadLibrary() async {
+    final failures = <String, Object>{};
     for (final asset in const [
       'packages/dart_pdf_editor_flutter_gpu/assets/shaders/pdf_tile_gpu.shaderbundle',
       'assets/shaders/pdf_tile_gpu.shaderbundle',
@@ -2202,11 +2203,18 @@ class _GpuPipelines {
           gpu.ShaderLibrary.fromAsset(asset),
         );
         if (library != null) return library;
-      } catch (_) {
+      } catch (error) {
         // Package-prefixed in an app, bare while this package is the test root.
+        // Keep the actual loader error: an incompatible shader bundle must not
+        // be collapsed into the same terminal message as a missing asset.
+        failures[asset] = error;
       }
     }
-    throw StateError('pdf_tile_gpu.shaderbundle asset not found');
+    final detail = failures.entries
+        .map((entry) => '${entry.key}: ${entry.value}')
+        .join('; ');
+    throw StateError('pdf_tile_gpu.shaderbundle failed to load'
+        '${detail.isEmpty ? '' : ': $detail'}');
   }
 
   final gpu.RenderPipeline stencil;

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/painting.dart' show Offset, Rect;
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:pdf_document/pdf_document.dart';
@@ -37,6 +39,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     this.allowOverprintApproximation = false,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
+    this.enableProactiveWarmUp,
     FlutterGpuTileBackendStats? stats,
   })  : stats = stats ?? FlutterGpuTileBackendStats(),
         _imageCache = _GpuImageCache(maxTextureBytes),
@@ -69,6 +72,14 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   /// buffer has completed. A scene that cannot fit falls back to Canvas.
   final int maxGeometryBytes;
 
+  /// Whether the viewer should prepare GPU pipelines and live scenes at idle.
+  ///
+  /// Null (the default) enables proactive work on desktop and leaves mobile
+  /// on-demand. Mobile Impeller contexts can reserve substantial additional
+  /// memory even for a page that later falls back to Canvas; validated hosts
+  /// can opt in explicitly.
+  final bool? enableProactiveWarmUp;
+
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache _imageCache;
   final _GpuGeometryPool _geometryPool;
@@ -90,11 +101,21 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   /// reports that runtime reason through [stats].
   bool get isPlatformSupported => true;
 
-  @override
-  bool get supportsWarmUp => true;
+  bool get _proactiveWarmUpEnabled =>
+      enableProactiveWarmUp ??
+      switch (defaultTargetPlatform) {
+        TargetPlatform.macOS ||
+        TargetPlatform.windows ||
+        TargetPlatform.linux =>
+          true,
+        _ => false,
+      };
 
   @override
-  bool get supportsSessionWarmUp => true;
+  bool get supportsWarmUp => _proactiveWarmUpEnabled;
+
+  @override
+  bool get supportsSessionWarmUp => _proactiveWarmUpEnabled;
 
   /// Drops reusable texture ownership. Active compiled scenes retain the
   /// resources they are currently drawing.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -217,17 +217,21 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           }
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
+          final gradientReason = run.gradient == null
+              ? null
+              : _gradientUnsupportedReason(run.gradient!, run.fillAlpha);
           final textReasons = <String>[
             if (run.glyphs == null) 'missing glyph outlines',
             if (!run.fill) 'fill disabled',
-            if (run.gradient != null) 'gradient fill',
+            if (gradientReason != null) gradientReason,
             if (run.strokeColor != null) 'stroke',
           ];
           if (textReasons.isNotEmpty) {
             return 'unsupported text: ${textReasons.join(', ')}';
           }
         case PdfFillPathGradientCommand():
-          final reason = _gradientUnsupportedReason(command);
+          final reason =
+              _gradientUnsupportedReason(command.gradient, command.alpha);
           if (reason != null) return reason;
         default:
           return 'unsupported ${command.runtimeType}';
@@ -794,6 +798,10 @@ String? _unsafeOverprint(_GpuUnit unit, PdfRenderCommand command) {
       if (unit.fillOverprint) return 'mesh overprint';
     case PdfFillPathGradientCommand():
       if (unit.fillOverprint) return 'gradient overprint';
+    case PdfDrawTextCommand(:final run):
+      if (unit.fillOverprint && run.gradient != null) {
+        return 'gradient text overprint';
+      }
     default:
       // Images do not use CanvasPdfDevice's overprint approximation; the
       // interpreter has already resolved any image-adjacent colorant work.
@@ -802,14 +810,13 @@ String? _unsafeOverprint(_GpuUnit unit, PdfRenderCommand command) {
   return null;
 }
 
-String? _gradientUnsupportedReason(PdfFillPathGradientCommand command) {
-  final gradient = command.gradient;
+String? _gradientUnsupportedReason(PdfGradient gradient, double alpha) {
   if (gradient.isRadial) return 'unsupported radial gradient';
   if (gradient.coords.length < 4 ||
       gradient.colors.length < 2 ||
       gradient.colors.length != gradient.stops.length ||
       gradient.transform.inverted() == null ||
-      !command.alpha.isFinite ||
+      !alpha.isFinite ||
       ![
         gradient.transform.a,
         gradient.transform.b,
@@ -1674,8 +1681,18 @@ FutureOr<_GpuDraw?> _compileCommand(
           subs.add(FlatSubpath(mapped, closed: sub.closed));
         }
       }
+      final gradient = run.gradient;
+      if (gradient != null) {
+        return _compileAxialGradientSubpaths(
+          geometry,
+          subs,
+          PdfFillRule.nonzero,
+          gradient,
+          run.fillAlpha,
+        );
+      }
       return _stencilDraw(
-          geometry, subs, run.color, 1, PdfFillRule.nonzero, false);
+          geometry, subs, run.color, run.fillAlpha, PdfFillRule.nonzero, false);
     case PdfFillMeshCommand(:final mesh, :final alpha):
       if (mesh.triangles.isEmpty) return null;
       final vertices = FloatBuilder(mesh.triangles.length * 6);
@@ -1743,13 +1760,27 @@ _GradientDraw? _compileAxialGradient(
   PdfGradient gradient,
   double alpha,
 ) {
-  if (alpha <= 0 ||
-      _gradientUnsupportedReason(
-              PdfFillPathGradientCommand(path, rule, gradient, alpha)) !=
-          null) {
+  if (alpha <= 0 || _gradientUnsupportedReason(gradient, alpha) != null) {
     return null;
   }
   final subpaths = flattenPath(path, PdfMatrix.identity, tolerance: 0.01);
+  return _compileAxialGradientSubpaths(
+    geometry,
+    subpaths,
+    rule,
+    gradient,
+    alpha,
+  );
+}
+
+_GradientDraw? _compileAxialGradientSubpaths(
+  _GpuGeometryArena geometry,
+  List<FlatSubpath> subpaths,
+  PdfFillRule rule,
+  PdfGradient gradient,
+  double alpha,
+) {
+  if (alpha <= 0) return null;
   final stencil = _stencilGeometry(geometry, subpaths);
   if (stencil == null) return null;
   final bounds = stencil.$2;

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show FutureOr;
+import 'dart:async' show Completer, FutureOr;
 import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:typed_data';
@@ -93,6 +93,35 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   /// Drops reusable texture ownership. Active compiled scenes retain the
   /// resources they are currently drawing.
   void clearImageCache() => _imageCache.clear(stats);
+
+  /// Compiles this view's tile pipelines with a one-pixel GPU submission.
+  ///
+  /// The driver otherwise compiles the pipelines on the first deep-zoom tile,
+  /// which can leave the coarse page visible for hundreds of milliseconds.
+  /// This is safe to call repeatedly: work is shared per Impeller context and
+  /// MSAA mode, including between backend instances.
+  @override
+  Future<void> warmUp() async {
+    final clock = Stopwatch()..start();
+    stats.warmUpRequests++;
+    try {
+      final context = gpu.gpuContext;
+      final pipelines = await _GpuPipelines.instance(context);
+      final submitted = await pipelines.warmUp(
+        context,
+        useMsaa: msaa && context.doesSupportOffscreenMSAA,
+      );
+      if (submitted) stats.warmUpSubmissions++;
+      stats.warmUpCompletions++;
+    } catch (error) {
+      stats
+        ..warmUpFailures += 1
+        ..lastWarmUpError = error.toString();
+      rethrow;
+    } finally {
+      stats.warmUpMicros += clock.elapsedMicroseconds;
+    }
+  }
 
   @override
   String get debugLabel => 'flutter_gpu';
@@ -2703,6 +2732,256 @@ class _GpuPipelines {
     return _instances[context] = _loadLibrary().then(
       (library) => _GpuPipelines._(context, library),
     );
+  }
+
+  final Map<bool, Future<void>> _warmUps = {};
+
+  Future<bool> warmUp(gpu.GpuContext context, {required bool useMsaa}) async {
+    final existing = _warmUps[useMsaa];
+    if (existing != null) {
+      await existing;
+      return false;
+    }
+    final future = _submitWarmUp(context, useMsaa: useMsaa);
+    _warmUps[useMsaa] = future;
+    try {
+      await future;
+      return true;
+    } catch (_) {
+      if (identical(_warmUps[useMsaa], future)) _warmUps.remove(useMsaa);
+      rethrow;
+    }
+  }
+
+  Future<void> _submitWarmUp(
+    gpu.GpuContext context, {
+    required bool useMsaa,
+  }) {
+    final resolve = context.createTexture(
+      gpu.StorageMode.devicePrivate,
+      1,
+      1,
+      format: context.defaultColorFormat,
+    );
+    final color = useMsaa
+        ? context.createTexture(
+            gpu.StorageMode.deviceTransient,
+            1,
+            1,
+            format: context.defaultColorFormat,
+            sampleCount: 4,
+          )
+        : resolve;
+    final stencilTexture = context.createTexture(
+      gpu.StorageMode.deviceTransient,
+      1,
+      1,
+      format: context.defaultStencilFormat,
+      sampleCount: useMsaa ? 4 : 1,
+    );
+    final sample = context.createTexture(
+      gpu.StorageMode.hostVisible,
+      1,
+      1,
+      format: gpu.PixelFormat.r8g8b8a8UNormInt,
+    );
+    sample.overwrite(ByteData.sublistView(Uint8List.fromList(
+      const [255, 255, 255, 255],
+    )));
+
+    final transient = context.createHostBuffer();
+    final transform =
+        transient.emplace(ByteData.sublistView(Float32List.fromList(
+      const [
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ],
+    )));
+    final stencilVertices = transient.emplace(ByteData.sublistView(
+      Float32List.fromList(const [-1, -1, 3, -1, -1, 3]),
+    ));
+    final solidVertices = transient.emplace(ByteData.sublistView(
+      Float32List.fromList(const [
+        -1,
+        -1,
+        1,
+        1,
+        1,
+        1,
+        3,
+        -1,
+        1,
+        1,
+        1,
+        1,
+        -1,
+        3,
+        1,
+        1,
+        1,
+        1,
+      ]),
+    ));
+    final textureVertices = transient.emplace(ByteData.sublistView(
+      Float32List.fromList(const [
+        -1,
+        -1,
+        0,
+        0,
+        3,
+        -1,
+        1,
+        0,
+        -1,
+        3,
+        0,
+        1,
+      ]),
+    ));
+    final textureInfo = transient.emplace(ByteData.sublistView(
+      Float32List.fromList(const [1, 1, 1, 1, 0, 0, 0, 0]),
+    ));
+    final softMaskInfo = Float32List(36)
+      ..setRange(0, 16, const [
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ])
+      ..setRange(16, 20, const [1, 1, 1, 1])
+      ..setRange(20, 24, const [1, 1, 1, 1])
+      ..setRange(24, 28, const [0, 0, 0, 1])
+      ..setRange(28, 32, const [1, 0, 0, 0])
+      ..setRange(32, 36, const [-1, -1, 1, 1]);
+    final softMaskUniform =
+        transient.emplace(ByteData.sublistView(softMaskInfo));
+
+    final commandBuffer = context.createCommandBuffer();
+    final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
+      colorAttachments: [
+        gpu.ColorAttachment(
+          texture: color,
+          resolveTexture: useMsaa ? resolve : null,
+          clearValue: vm.Vector4.zero(),
+          storeAction: useMsaa
+              ? gpu.StoreAction.multisampleResolve
+              : gpu.StoreAction.store,
+        ),
+      ],
+      depthStencilAttachment: gpu.DepthStencilAttachment(
+        texture: stencilTexture,
+        stencilClearValue: 0,
+      ),
+    ));
+    pass
+      ..setCullMode(gpu.CullMode.none)
+      ..setWindingOrder(gpu.WindingOrder.counterClockwise)
+      ..setPrimitiveType(gpu.PrimitiveType.triangle)
+      ..setColorBlendEnable(true)
+      ..setStencilReference(0)
+      ..setColorBlendEquation(_GpuEncoder._noWrite)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.always,
+        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
+        readMask: 0,
+        writeMask: _GpuEncoder._pathMask,
+      ))
+      ..bindPipeline(stencil)
+      ..bindUniform(stencilTransform, transform);
+    _warmUpDraw(pass, stencilVertices, 3);
+    pass
+      ..setColorBlendEquation(_GpuEncoder._srcOver)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.always,
+        depthStencilPassOperation: gpu.StencilOperation.keep,
+        readMask: 0,
+        writeMask: 0,
+      ))
+      ..bindPipeline(solid)
+      ..bindUniform(solidTransform, transform);
+    _warmUpDraw(pass, solidVertices, 3);
+    pass
+      ..bindPipeline(texture)
+      ..bindUniform(textureTransform, transform)
+      ..bindUniform(this.textureInfo, textureInfo)
+      ..bindTexture(textureSampler, sample);
+    _warmUpDraw(pass, textureVertices, 3);
+    pass
+      ..clearBindings()
+      ..bindPipeline(softMask)
+      ..bindUniform(softMaskTransform, transform)
+      ..bindUniform(this.softMaskInfo, softMaskUniform)
+      ..bindTexture(softMaskContentSampler, sample)
+      ..bindTexture(softMaskMaskSampler, sample);
+    _warmUpDraw(pass, textureVertices, 3);
+    pass.clearBindings();
+
+    final completer = Completer<void>();
+    // Keep every command-buffer resource strongly reachable until Impeller's
+    // completion fence fires. The callback itself is the lifetime owner.
+    final resources = <Object>[
+      resolve,
+      color,
+      stencilTexture,
+      sample,
+      transient,
+      commandBuffer,
+      pass,
+    ];
+    try {
+      commandBuffer.submit(completionCallback: (success) {
+        if (resources.isEmpty) return;
+        if (success) {
+          completer.complete();
+        } else {
+          completer.completeError(StateError('GPU pipeline warm-up failed'));
+        }
+      });
+    } catch (error, stack) {
+      completer.completeError(error, stack);
+    }
+    return completer.future;
+  }
+
+  static void _warmUpDraw(
+    gpu.RenderPass pass,
+    gpu.BufferView vertices,
+    int count,
+  ) {
+    final dynamic dynamicPass = pass;
+    try {
+      dynamicPass.bindVertexBuffer(vertices);
+      dynamicPass.draw(count);
+    } on NoSuchMethodError {
+      dynamicPass.bindVertexBuffer(vertices, count);
+      dynamicPass.draw();
+    }
   }
 
   static Future<gpu.ShaderLibrary> _loadLibrary() async {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -11,6 +11,12 @@ class FlutterGpuTileBackendStats {
   int warmUpFailures = 0;
   int warmUpMicros = 0;
   String? lastWarmUpError;
+  int sceneWarmUpRequests = 0;
+  int sceneWarmUpCompletions = 0;
+  int sceneWarmUpFailures = 0;
+  int sceneWarmUpCancellations = 0;
+  int sceneWarmUpMicros = 0;
+  String? lastSceneWarmUpError;
   int sessionsCreated = 0;
   int sessionsRejected = 0;
   int sessionsDisposed = 0;
@@ -62,6 +68,12 @@ class FlutterGpuTileBackendStats {
         'warmUpFailures': warmUpFailures,
         'warmUpMicros': warmUpMicros,
         'lastWarmUpError': lastWarmUpError,
+        'sceneWarmUpRequests': sceneWarmUpRequests,
+        'sceneWarmUpCompletions': sceneWarmUpCompletions,
+        'sceneWarmUpFailures': sceneWarmUpFailures,
+        'sceneWarmUpCancellations': sceneWarmUpCancellations,
+        'sceneWarmUpMicros': sceneWarmUpMicros,
+        'lastSceneWarmUpError': lastSceneWarmUpError,
         'sessionsCreated': sessionsCreated,
         'sessionsRejected': sessionsRejected,
         'sessionsDisposed': sessionsDisposed,
@@ -118,6 +130,12 @@ class FlutterGpuTileBackendStats {
     warmUpFailures = 0;
     warmUpMicros = 0;
     lastWarmUpError = null;
+    sceneWarmUpRequests = 0;
+    sceneWarmUpCompletions = 0;
+    sceneWarmUpFailures = 0;
+    sceneWarmUpCancellations = 0;
+    sceneWarmUpMicros = 0;
+    lastSceneWarmUpError = null;
     peakActiveSessions = activeSessions;
     overprintApproximationSessions = 0;
     scenesCompiled = 0;
@@ -155,6 +173,11 @@ class FlutterGpuTileBackendStats {
       'warmUpRequests=$warmUpRequests warmUpSubmissions=$warmUpSubmissions '
       'warmUpCompletions=$warmUpCompletions warmUpFailures=$warmUpFailures '
       'warmUpUs=$warmUpMicros '
+      'sceneWarmUpRequests=$sceneWarmUpRequests '
+      'sceneWarmUpCompletions=$sceneWarmUpCompletions '
+      'sceneWarmUpFailures=$sceneWarmUpFailures '
+      'sceneWarmUpCancellations=$sceneWarmUpCancellations '
+      'sceneWarmUpUs=$sceneWarmUpMicros '
       'lastContext=$lastContextIdentity '
       'activeSessions=$activeSessions peakActiveSessions=$peakActiveSessions '
       'overprintApprox=$overprintApproximationSessions '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -5,6 +5,12 @@ class FlutterGpuTileBackendStats {
   int? lastContextIdentity;
   int contextsSeen = 0;
   int contextSwitches = 0;
+  int warmUpRequests = 0;
+  int warmUpSubmissions = 0;
+  int warmUpCompletions = 0;
+  int warmUpFailures = 0;
+  int warmUpMicros = 0;
+  String? lastWarmUpError;
   int sessionsCreated = 0;
   int sessionsRejected = 0;
   int sessionsDisposed = 0;
@@ -50,6 +56,12 @@ class FlutterGpuTileBackendStats {
         'lastContextIdentity': lastContextIdentity,
         'contextsSeen': contextsSeen,
         'contextSwitches': contextSwitches,
+        'warmUpRequests': warmUpRequests,
+        'warmUpSubmissions': warmUpSubmissions,
+        'warmUpCompletions': warmUpCompletions,
+        'warmUpFailures': warmUpFailures,
+        'warmUpMicros': warmUpMicros,
+        'lastWarmUpError': lastWarmUpError,
         'sessionsCreated': sessionsCreated,
         'sessionsRejected': sessionsRejected,
         'sessionsDisposed': sessionsDisposed,
@@ -100,6 +112,12 @@ class FlutterGpuTileBackendStats {
     sessionsDisposed = 0;
     rasterFallbacks = 0;
     contextSwitches = 0;
+    warmUpRequests = 0;
+    warmUpSubmissions = 0;
+    warmUpCompletions = 0;
+    warmUpFailures = 0;
+    warmUpMicros = 0;
+    lastWarmUpError = null;
     peakActiveSessions = activeSessions;
     overprintApproximationSessions = 0;
     scenesCompiled = 0;
@@ -134,6 +152,9 @@ class FlutterGpuTileBackendStats {
   String toString() => 'sessions=$sessionsCreated rejected=$sessionsRejected '
       'disposed=$sessionsDisposed rasterFallbacks=$rasterFallbacks '
       'contexts=$contextsSeen contextSwitches=$contextSwitches '
+      'warmUpRequests=$warmUpRequests warmUpSubmissions=$warmUpSubmissions '
+      'warmUpCompletions=$warmUpCompletions warmUpFailures=$warmUpFailures '
+      'warmUpUs=$warmUpMicros '
       'lastContext=$lastContextIdentity '
       'activeSessions=$activeSessions peakActiveSessions=$peakActiveSessions '
       'overprintApprox=$overprintApproximationSessions '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -9,6 +9,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     this.allowOverprintApproximation = false,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
+    this.enableProactiveWarmUp,
     FlutterGpuTileBackendStats? stats,
   }) : stats = stats ?? FlutterGpuTileBackendStats();
 
@@ -16,6 +17,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   final bool allowOverprintApproximation;
   final int maxTextureBytes;
   final int maxGeometryBytes;
+  final bool? enableProactiveWarmUp;
   final FlutterGpuTileBackendStats stats;
   String? _lastSessionRejection;
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -28,6 +28,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   void clearImageCache() {}
 
   @override
+  Future<void> warmUp() async {}
+
+  @override
   String get debugLabel => 'flutter_gpu-unavailable';
 
   @override

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -15,6 +15,12 @@ void main() {
       ..warmUpSubmissions = 1
       ..warmUpCompletions = 2
       ..warmUpMicros = 12000
+      ..sceneWarmUpRequests = 3
+      ..sceneWarmUpCompletions = 2
+      ..sceneWarmUpFailures = 1
+      ..sceneWarmUpCancellations = 1
+      ..sceneWarmUpMicros = 18000
+      ..lastSceneWarmUpError = 'test scene warm-up failure'
       ..activeSessions = 3
       ..peakActiveSessions = 4
       ..activeTextureLeases = 5
@@ -43,6 +49,11 @@ void main() {
     expect(stats.toJson(), containsPair('contextSwitches', 3));
     expect(stats.toJson(), containsPair('warmUpSubmissions', 1));
     expect(stats.toJson(), containsPair('warmUpMicros', 12000));
+    expect(stats.toJson(), containsPair('sceneWarmUpRequests', 3));
+    expect(stats.toJson(), containsPair('sceneWarmUpCompletions', 2));
+    expect(stats.toJson(), containsPair('sceneWarmUpFailures', 1));
+    expect(stats.toJson(), containsPair('sceneWarmUpCancellations', 1));
+    expect(stats.toJson(), containsPair('sceneWarmUpMicros', 18000));
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
@@ -54,6 +65,12 @@ void main() {
     expect(stats.warmUpSubmissions, 0);
     expect(stats.warmUpCompletions, 0);
     expect(stats.warmUpMicros, 0);
+    expect(stats.sceneWarmUpRequests, 0);
+    expect(stats.sceneWarmUpCompletions, 0);
+    expect(stats.sceneWarmUpFailures, 0);
+    expect(stats.sceneWarmUpCancellations, 0);
+    expect(stats.sceneWarmUpMicros, 0);
+    expect(stats.lastSceneWarmUpError, isNull);
     expect(stats.lastRejection, isNull);
     expect(stats.lastTileRoute, isNull);
     expect(stats.activeSessions, 3);

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -1,7 +1,34 @@
 import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('proactive warm-up defaults to desktop and remains opt-in on mobile',
+      () {
+    final previous = debugDefaultTargetPlatformOverride;
+    try {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final mobile = FlutterGpuTileRasterBackend();
+      expect(mobile.supportsWarmUp, isFalse);
+      expect(mobile.supportsSessionWarmUp, isFalse);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final desktop = FlutterGpuTileRasterBackend();
+      expect(desktop.supportsWarmUp, isTrue);
+      expect(desktop.supportsSessionWarmUp, isTrue);
+
+      final optedIn = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
+      expect(optedIn.supportsWarmUp, isTrue);
+      expect(optedIn.supportsSessionWarmUp, isTrue);
+      final optedOut =
+          FlutterGpuTileRasterBackend(enableProactiveWarmUp: false);
+      expect(optedOut.supportsWarmUp, isFalse);
+      expect(optedOut.supportsSessionWarmUp, isFalse);
+    } finally {
+      debugDefaultTargetPlatformOverride = previous;
+    }
+  });
+
   test('JSON snapshot includes outcomes and reset preserves live gauges', () {
     final stats = FlutterGpuTileBackendStats()
       ..sessionsCreated = 4

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -11,6 +11,10 @@ void main() {
       ..lastContextIdentity = 1234
       ..contextsSeen = 2
       ..contextSwitches = 3
+      ..warmUpRequests = 2
+      ..warmUpSubmissions = 1
+      ..warmUpCompletions = 2
+      ..warmUpMicros = 12000
       ..activeSessions = 3
       ..peakActiveSessions = 4
       ..activeTextureLeases = 5
@@ -37,6 +41,8 @@ void main() {
     expect(stats.toJson(), containsPair('lastContextIdentity', 1234));
     expect(stats.toJson(), containsPair('contextsSeen', 2));
     expect(stats.toJson(), containsPair('contextSwitches', 3));
+    expect(stats.toJson(), containsPair('warmUpSubmissions', 1));
+    expect(stats.toJson(), containsPair('warmUpMicros', 12000));
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
@@ -44,6 +50,10 @@ void main() {
     expect(stats.lastContextIdentity, 1234);
     expect(stats.contextsSeen, 2);
     expect(stats.contextSwitches, 0);
+    expect(stats.warmUpRequests, 0);
+    expect(stats.warmUpSubmissions, 0);
+    expect(stats.warmUpCompletions, 0);
+    expect(stats.warmUpMicros, 0);
     expect(stats.lastRejection, isNull);
     expect(stats.lastTileRoute, isNull);
     expect(stats.activeSessions, 3);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -178,6 +178,69 @@ void main() {
     });
   });
 
+  testWidgets('tiling cells expand once and preserve painter order',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfDrawTiledCellCommand(
+          [
+            PdfFillPathCommand(
+              _rect(80, 180, 170, 300),
+              const PdfColor(0.9, 0.1, 0.15),
+              PdfFillRule.nonzero,
+              0.55,
+            ),
+            PdfFillPathCommand(
+              _rect(135, 225, 225, 345),
+              const PdfColor(0.05, 0.25, 0.9),
+              PdfFillRule.nonzero,
+              0.55,
+            ),
+            PdfDrawTiledCellCommand(
+              [
+                PdfFillPathCommand(
+                  _rect(112, 205, 128, 221),
+                  const PdfColor(0.1, 0.75, 0.25),
+                  PdfFillRule.nonzero,
+                  0.8,
+                ),
+              ],
+              Float64List.fromList([0, 24]),
+              Float64List.fromList([0, 18]),
+            ),
+          ],
+          Float64List.fromList([0, 55, 110, 165]),
+          Float64List.fromList([0, 35, 70, 105]),
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(50, 120, 430, 420);
+      final canvas = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final accelerated =
+          await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(canvas.dispose);
+      addTearDown(accelerated.dispose);
+      final expected = await _pixels(canvas);
+      final actual = await _pixels(accelerated);
+      var difference = 0;
+      for (var i = 0; i < expected.length; i++) {
+        difference += (expected[i] - actual[i]).abs();
+      }
+      expect(difference / expected.length, lessThan(4),
+          reason: 'overlapping cell repeats must retain tile-major order');
+    });
+  });
+
   testWidgets('nested arbitrary clips and restored ancestors match Canvas',
       (tester) async {
     await tester.runAsync(() async {
@@ -618,6 +681,47 @@ void main() {
       expect(backend.createSession(substituted), isNull);
       expect(backend.stats.lastRejection,
           'unsupported text: missing glyph outlines');
+
+      final stencilSource = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          255,
+        ]),
+        const PdfMatrix(40, 0, 0, 40, 100, 100),
+        'tiled-stencil',
+      ).request;
+      final tiledStencil = await PdfRetainedScene.fromCommands(page, [
+        PdfDrawTiledCellCommand(
+          [
+            PdfDrawImageCommand(PdfImageRequest(
+              stream: stencilSource.stream,
+              transform: stencilSource.transform,
+              isStencil: true,
+              stencilColor: const PdfColor(0.1, 0.2, 0.8),
+              decoded: stencilSource.decoded,
+            )),
+          ],
+          Float64List.fromList([0]),
+          Float64List.fromList([0]),
+        ),
+      ]);
+      addTearDown(tiledStencil.dispose);
+      expect(backend.createSession(tiledStencil), isNull);
+      expect(backend.stats.lastRejection, 'unsupported tiled stencil image');
 
       final nonRectClip = await PdfRetainedScene.fromCommands(page, [
         const PdfSaveCommand(),

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -616,7 +616,8 @@ void main() {
       addTearDown(substituted.dispose);
       final backend = FlutterGpuTileRasterBackend();
       expect(backend.createSession(substituted), isNull);
-      expect(backend.stats.lastRejection, contains('text'));
+      expect(backend.stats.lastRejection,
+          'unsupported text: missing glyph outlines');
 
       final nonRectClip = await PdfRetainedScene.fromCommands(page, [
         const PdfSaveCommand(),

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -241,6 +241,70 @@ void main() {
     });
   });
 
+  testWidgets('axial gradients use exact path stencil and stop geometry',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const path = PdfPath([
+        PdfMoveTo(45, 120),
+        PdfLineTo(520, 120),
+        PdfLineTo(520, 510),
+        PdfLineTo(45, 510),
+        PdfClosePath(),
+        PdfMoveTo(210, 245),
+        PdfLineTo(355, 245),
+        PdfLineTo(355, 390),
+        PdfLineTo(210, 390),
+        PdfClosePath(),
+      ]);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfFillPathGradientCommand(
+          path,
+          PdfFillRule.evenOdd,
+          PdfGradient(
+            isRadial: false,
+            coords: [0, 0, 180, 0],
+            colors: [
+              PdfColor(0.9, 0.05, 0.1),
+              PdfColor(0.1, 0.75, 0.2),
+              PdfColor(0.05, 0.2, 0.95),
+            ],
+            stops: [0, 0.38, 1],
+            transform: PdfMatrix(2.1, 0.35, -0.2, 1.6, 90, 170),
+            extendStart: false,
+            extendEnd: false,
+          ),
+          0.72,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 90, 540, 450);
+      final canvas = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final accelerated =
+          await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(canvas.dispose);
+      addTearDown(accelerated.dispose);
+      final expected = await _pixels(canvas);
+      final actual = await _pixels(accelerated);
+      var difference = 0;
+      for (var i = 0; i < expected.length; i++) {
+        difference += (expected[i] - actual[i]).abs();
+      }
+      expect(difference / expected.length, lessThan(8),
+          reason: 'translucent gradient and stencil AA must stay within the '
+              'GPU corpus parity budget');
+    });
+  });
+
   testWidgets('nested arbitrary clips and restored ancestors match Canvas',
       (tester) async {
     await tester.runAsync(() async {
@@ -681,6 +745,24 @@ void main() {
       expect(backend.createSession(substituted), isNull);
       expect(backend.stats.lastRejection,
           'unsupported text: missing glyph outlines');
+
+      final radial = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathGradientCommand(
+          _rect(40, 40, 300, 300),
+          PdfFillRule.nonzero,
+          const PdfGradient(
+            isRadial: true,
+            coords: [100, 100, 0, 100, 100, 120],
+            colors: [PdfColor(1, 0, 0), PdfColor(0, 0, 1)],
+            stops: [0, 1],
+            transform: PdfMatrix.identity,
+          ),
+          1,
+        ),
+      ]);
+      addTearDown(radial.dispose);
+      expect(backend.createSession(radial), isNull);
+      expect(backend.stats.lastRejection, 'unsupported radial gradient');
 
       final stencilSource = _decodedImage(
         Uint8List.fromList([

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -341,6 +341,55 @@ void main() {
     });
   });
 
+  testWidgets('nested radial gradients use bounded ring geometry',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathGradientCommand(
+          _rect(35, 90, 560, 610),
+          PdfFillRule.nonzero,
+          const PdfGradient(
+            isRadial: true,
+            coords: [150, 220, 18, 205, 250, 190],
+            colors: [
+              PdfColor(1, 0.9, 0.1),
+              PdfColor(0.9, 0.1, 0.2),
+              PdfColor(0.05, 0.15, 0.8),
+            ],
+            stops: [0, 0.45, 1],
+            transform: PdfMatrix(1.15, 0.12, -0.08, 1.05, 35, 20),
+            extendStart: true,
+            extendEnd: true,
+          ),
+          0.8,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(10, 70, 580, 570);
+      final canvas = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final accelerated = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(canvas.dispose);
+      addTearDown(accelerated.dispose);
+      final expected = await _pixels(canvas);
+      final actual = await _pixels(accelerated);
+      var difference = 0;
+      for (var i = 0; i < expected.length; i++) {
+        difference += (expected[i] - actual[i]).abs();
+      }
+      expect(difference / expected.length, lessThan(12));
+    });
+  });
+
   testWidgets('nested arbitrary clips and restored ancestors match Canvas',
       (tester) async {
     await tester.runAsync(() async {
@@ -788,7 +837,7 @@ void main() {
           PdfFillRule.nonzero,
           const PdfGradient(
             isRadial: true,
-            coords: [100, 100, 0, 100, 100, 120],
+            coords: [80, 100, 50, 260, 100, 60],
             colors: [PdfColor(1, 0, 0), PdfColor(0, 0, 1)],
             stops: [0, 1],
             transform: PdfMatrix.identity,
@@ -798,7 +847,8 @@ void main() {
       ]);
       addTearDown(radial.dispose);
       expect(backend.createSession(radial), isNull);
-      expect(backend.stats.lastRejection, 'unsupported radial gradient');
+      expect(backend.stats.lastRejection,
+          'unsupported non-nested radial gradient');
 
       final stencilSource = _decodedImage(
         Uint8List.fromList([

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -280,6 +280,42 @@ void main() {
           ),
           0.72,
         ),
+        const PdfDrawTextCommand(PdfTextRun(
+          text: 'H',
+          transform: PdfMatrix(150, 12, 8, 165, 185, 185),
+          color: PdfColor.black,
+          width: 1,
+          fontName: 'EmbeddedGradient',
+          fontSize: 1,
+          fillAlpha: 0.68,
+          glyphs: [
+            PdfGlyphPlacement(
+              offset: 0,
+              outline: PdfPath([
+                PdfMoveTo(0, 0),
+                PdfLineTo(0.18, 0),
+                PdfLineTo(0.18, 0.42),
+                PdfLineTo(0.62, 0.42),
+                PdfLineTo(0.62, 0),
+                PdfLineTo(0.8, 0),
+                PdfLineTo(0.8, 1),
+                PdfLineTo(0.62, 1),
+                PdfLineTo(0.62, 0.6),
+                PdfLineTo(0.18, 0.6),
+                PdfLineTo(0.18, 1),
+                PdfLineTo(0, 1),
+                PdfClosePath(),
+              ]),
+            ),
+          ],
+          gradient: PdfGradient(
+            isRadial: false,
+            coords: [170, 180, 330, 360],
+            colors: [PdfColor(1, 0.5, 0), PdfColor(0.4, 0, 0.9)],
+            stops: [0, 1],
+            transform: PdfMatrix.identity,
+          ),
+        )),
       ]);
       addTearDown(scene.dispose);
       final backend = FlutterGpuTileRasterBackend();

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -70,6 +70,35 @@ void main() {
     });
   });
 
+  testWidgets('pipeline warm-up is shared by the Impeller context',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final first = FlutterGpuTileRasterBackend();
+      await first.warmUp();
+      expect(first.stats.warmUpRequests, 1);
+      expect(first.stats.warmUpSubmissions, 1);
+      expect(first.stats.warmUpCompletions, 1);
+      expect(first.stats.warmUpFailures, 0);
+      expect(first.stats.warmUpMicros, greaterThan(0));
+
+      await first.warmUp();
+      expect(first.stats.warmUpRequests, 2);
+      expect(first.stats.warmUpSubmissions, 1,
+          reason: 'the same backend reuses the completed context warm-up');
+
+      final second = FlutterGpuTileRasterBackend();
+      await second.warmUp();
+      expect(second.stats.warmUpRequests, 1);
+      expect(second.stats.warmUpSubmissions, 0,
+          reason: 'backend instances share context-owned pipeline work');
+      expect(second.stats.warmUpCompletions, 1);
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
   testWidgets('compiles once and replays retained buffers across tiles',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -99,6 +99,40 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('scene warm-up prepares retained resources before the first tile',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final scene = await PdfRetainedScene.record(
+          PdfDocument.open(buildEmbeddedFontImagePdf()).page(0));
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isA<PdfTileRasterWarmUp>(),
+          reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      await (session as PdfTileRasterWarmUp).warmUp();
+      expect(backend.stats.sceneWarmUpRequests, 1);
+      expect(backend.stats.sceneWarmUpCompletions, 1);
+      expect(backend.stats.sceneWarmUpFailures, 0);
+      expect(backend.stats.scenesCompiled, 1);
+      expect(backend.stats.tilesRendered, 0);
+
+      final image = await session.rasterizeRegion(
+        const Rect.fromLTWH(40, 50, 330, 190),
+        pixelRatio: 2,
+      );
+      addTearDown(image.dispose);
+      expect(backend.stats.scenesCompiled, 1,
+          reason: 'the first real tile reuses the prepared scene');
+      expect(backend.stats.tilesRendered, 1);
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
   testWidgets('compiles once and replays retained buffers across tiles',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
@@ -16,6 +16,10 @@ Future<Uint8List> _pixels(ui.Image image) async {
 void main() {
   testWidgets('CI renders an accepted tile through flutter_gpu',
       (tester) async {
+    if (!const bool.fromEnvironment('PDF_GPU_CI_SMOKE')) {
+      markTestSkipped('set PDF_GPU_CI_SMOKE=true in the designated GPU lane');
+      return;
+    }
     await tester.runAsync(() async {
       try {
         gpu.gpuContext.defaultColorFormat;

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+Future<Uint8List> _pixels(ui.Image image) async {
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  return data!.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+}
+
+void main() {
+  testWidgets('CI renders an accepted tile through flutter_gpu',
+      (tester) async {
+    await tester.runAsync(() async {
+      try {
+        gpu.gpuContext.defaultColorFormat;
+      } catch (error) {
+        fail('This smoke job requires a real flutter_gpu context: $error');
+      }
+
+      final scene = await PdfRetainedScene.record(
+        PdfDocument.open(buildEmbeddedFontImagePdf()).page(0),
+      );
+      try {
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        try {
+          const region = Rect.fromLTWH(40, 50, 330, 190);
+          final canvas = await scene.rasterizeRegion(region, pixelRatio: 2);
+          final accelerated =
+              await session!.rasterizeRegion(region, pixelRatio: 2);
+          try {
+            expect(accelerated.width, canvas.width);
+            expect(accelerated.height, canvas.height);
+            final expected = await _pixels(canvas);
+            final actual = await _pixels(accelerated);
+            var difference = 0;
+            for (var i = 0; i < expected.length; i++) {
+              difference += (expected[i] - actual[i]).abs();
+            }
+            expect(difference / expected.length, lessThan(12),
+                reason: 'the designated GPU fixture must agree with Canvas');
+          } finally {
+            canvas.dispose();
+            accelerated.dispose();
+          }
+
+          expect(backend.stats.contextsSeen, greaterThan(0));
+          expect(backend.stats.sessionsCreated, 1);
+          expect(backend.stats.tilesRendered, 1);
+          expect(backend.stats.rasterFallbacks, 0);
+          expect(backend.stats.completedSubmissions, 1);
+          expect(backend.stats.lastTileRoute, 'flutter_gpu');
+        } finally {
+          session?.dispose();
+        }
+      } finally {
+        scene.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+}

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -7,6 +7,7 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 
 const _passwords = {
   'issue6010_1.pdf': 'abc',
@@ -106,6 +107,8 @@ void _corpus(
 
   var accepted = 0;
   var rejected = 0;
+  final rejectionReasons = <String, int>{};
+  final missingOutlineFonts = <String, int>{};
   for (final file in files) {
     final name = file.uri.pathSegments.last;
     testWidgets('$suite/$name', (tester) async {
@@ -122,6 +125,19 @@ void _corpus(
             final session = backend.createSession(scene);
             if (session == null) {
               rejected++;
+              final reason = backend.lastSessionRejection ?? 'unspecified';
+              rejectionReasons.update(reason, (count) => count + 1,
+                  ifAbsent: () => 1);
+              final fonts = <String>{
+                for (final command in scene.commands)
+                  if (command case PdfDrawTextCommand(:final run))
+                    if (!run.invisible && run.glyphs == null)
+                      run.fontName ?? '<unnamed>',
+              };
+              for (final font in fonts) {
+                missingOutlineFonts.update(font, (count) => count + 1,
+                    ifAbsent: () => 1);
+              }
               continue;
             }
             accepted++;
@@ -166,6 +182,28 @@ void _corpus(
   tearDownAll(() {
     // ignore: avoid_print
     print('$suite flutter_gpu corpus: accepted=$accepted rejected=$rejected');
+    final grouped = rejectionReasons.entries.toList()
+      ..sort((a, b) {
+        final count = b.value.compareTo(a.value);
+        return count != 0 ? count : a.key.compareTo(b.key);
+      });
+    // Keep the grouped surface machine-readable in CI logs without requiring
+    // a separate artifact parser. This is the prioritization input for adding
+    // exact GPU coverage: frequent conservative fallbacks come first.
+    // ignore: avoid_print
+    print('$suite flutter_gpu rejection reasons: '
+        '${{for (final entry in grouped) entry.key: entry.value}}');
+    final fonts = missingOutlineFonts.entries.toList()
+      ..sort((a, b) {
+        final count = b.value.compareTo(a.value);
+        return count != 0 ? count : a.key.compareTo(b.key);
+      });
+    // One count per rejected page containing that substituted font, rather
+    // than per text run, so a dense drawing title block cannot swamp the
+    // prioritization signal.
+    // ignore: avoid_print
+    print('$suite flutter_gpu missing-outline fonts: '
+        '${{for (final entry in fonts) entry.key: entry.value}}');
     expect(accepted + rejected, greaterThan(0));
     // A zero acceptance rate would make the optional backend inert even if
     // all conservative-fallback tests passed.

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -84,6 +84,12 @@ void main() {
         msaa: msaa,
         allowOverprintApproximation: approximateOverprint,
       );
+      if (Platform.environment['PDF_GPU_BENCHMARK_WARMUP'] == '1') {
+        final warmUp = Stopwatch()..start();
+        await backend.warmUp();
+        // ignore: avoid_print
+        print('REAL_GPU_BENCHMARK warmUpUs=${warmUp.elapsedMicroseconds}');
+      }
       final output = Platform.environment['PDF_GPU_BENCHMARK_OUT'];
       if (output != null) Directory(output).createSync(recursive: true);
       final rssStart = ProcessInfo.currentRss;

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -77,6 +77,18 @@ void main() {
         return;
       }
       final document = PdfDocument.open(File(path).readAsBytesSync());
+      final configuredPages =
+          Platform.environment['PDF_GPU_BENCHMARK_PAGES']?.trim();
+      final requestedPages = _pages();
+      final pages = [
+        for (final page in requestedPages)
+          if (page >= 0 && page < document.pageCount) page,
+      ];
+      if (pages.isEmpty &&
+          (configuredPages == null || configuredPages.isEmpty) &&
+          document.pageCount > 0) {
+        pages.add(0);
+      }
       final msaa = Platform.environment['PDF_GPU_BENCHMARK_MSAA'] != '0';
       final approximateOverprint =
           Platform.environment['PDF_GPU_BENCHMARK_OVERPRINT'] != '0';
@@ -96,8 +108,7 @@ void main() {
       var peakRss = rssStart;
       final rows = <String>[];
 
-      for (final pageIndex in _pages()) {
-        if (pageIndex < 0 || pageIndex >= document.pageCount) continue;
+      for (final pageIndex in pages) {
         PdfImageCache.instance.clear();
         final timing = PdfSceneBuildTiming();
         final record = Stopwatch()..start();
@@ -116,6 +127,14 @@ void main() {
             continue;
           }
           try {
+            if (Platform.environment['PDF_GPU_BENCHMARK_SCENE_WARMUP'] == '1' &&
+                session is PdfTileRasterWarmUp) {
+              final warmUp = Stopwatch()..start();
+              await (session as PdfTileRasterWarmUp).warmUp();
+              // ignore: avoid_print
+              print('REAL_GPU_BENCHMARK sceneWarmUpUs='
+                  '${warmUp.elapsedMicroseconds}');
+            }
             final size = scene.pageSize;
             final center = Offset(size.width / 2, size.height / 2);
             final lod1 = 1.0;
@@ -169,7 +188,7 @@ void main() {
       }
 
       // ignore: avoid_print
-      print('REAL_GPU_BENCHMARK pages=${_pages()} msaa=$msaa '
+      print('REAL_GPU_BENCHMARK pages=$pages msaa=$msaa '
           'approximateOverprint=$approximateOverprint');
       for (final row in rows) {
         // ignore: avoid_print

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
 
 const _defaultPages = [27, 30, 29, 32, 31, 34, 37, 39, 28];
+const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
 
 bool _gpuAvailable() {
   try {
@@ -28,6 +29,24 @@ List<int> _pages() {
       .map((part) => int.tryParse(part.trim()))
       .whereType<int>()
       .toList();
+}
+
+String? _scenarioName(String? label, String stage, {int? page}) {
+  if (label == null || label.isEmpty) return null;
+  return 'gpu-$label${page == null ? '' : '-page-$page'}-$stage';
+}
+
+void _startScenario(String? name) {
+  if (name != null) PdfPerfLog.log('scenario name=$name phase=start');
+}
+
+void _finishScenario(String? name, int elapsedUs, {int? page}) {
+  if (name == null) return;
+  PdfPerfLog.log(
+    'raster page=${page ?? '-'} kind=$name '
+    'ms=${(elapsedUs / 1000).toStringAsFixed(3)}',
+  );
+  PdfPerfLog.log('scenario name=$name phase=validated');
 }
 
 Future<(int, ByteData, int, int)> _render(
@@ -65,6 +84,8 @@ double _meanDiff(ByteData a, ByteData b) {
 }
 
 void main() {
+  if (_buildCommit.isNotEmpty) PdfPerfLog.buildTag = 'commit=$_buildCommit';
+
   testWidgets('real document: cold scene plus two 512px LoDs', (tester) async {
     final path = Platform.environment['PDF_GPU_BENCHMARK_PDF'];
     if (path == null) {
@@ -79,6 +100,8 @@ void main() {
       final document = PdfDocument.open(File(path).readAsBytesSync());
       final configuredPages =
           Platform.environment['PDF_GPU_BENCHMARK_PAGES']?.trim();
+      final scenarioLabel =
+          Platform.environment['PDF_GPU_BENCHMARK_SCENARIO']?.trim();
       final requestedPages = _pages();
       final pages = [
         for (final page in requestedPages)
@@ -97,10 +120,14 @@ void main() {
         allowOverprintApproximation: approximateOverprint,
       );
       if (Platform.environment['PDF_GPU_BENCHMARK_WARMUP'] == '1') {
+        final scenario = _scenarioName(scenarioLabel, 'pipeline-warm');
+        _startScenario(scenario);
         final warmUp = Stopwatch()..start();
         await backend.warmUp();
+        final elapsedUs = warmUp.elapsedMicroseconds;
         // ignore: avoid_print
-        print('REAL_GPU_BENCHMARK warmUpUs=${warmUp.elapsedMicroseconds}');
+        print('REAL_GPU_BENCHMARK warmUpUs=$elapsedUs');
+        _finishScenario(scenario, elapsedUs);
       }
       final output = Platform.environment['PDF_GPU_BENCHMARK_OUT'];
       if (output != null) Directory(output).createSync(recursive: true);
@@ -129,11 +156,18 @@ void main() {
           try {
             if (Platform.environment['PDF_GPU_BENCHMARK_SCENE_WARMUP'] == '1' &&
                 session is PdfTileRasterWarmUp) {
+              final scenario = _scenarioName(
+                scenarioLabel,
+                'scene-warm',
+                page: pageIndex,
+              );
+              _startScenario(scenario);
               final warmUp = Stopwatch()..start();
               await (session as PdfTileRasterWarmUp).warmUp();
+              final elapsedUs = warmUp.elapsedMicroseconds;
               // ignore: avoid_print
-              print('REAL_GPU_BENCHMARK sceneWarmUpUs='
-                  '${warmUp.elapsedMicroseconds}');
+              print('REAL_GPU_BENCHMARK sceneWarmUpUs=$elapsedUs');
+              _finishScenario(scenario, elapsedUs, page: pageIndex);
             }
             final size = scene.pageSize;
             final center = Offset(size.width / 2, size.height / 2);
@@ -144,16 +178,34 @@ void main() {
               height: math.min(size.height, 512 / lod1),
             );
             try {
+              final coldScenario = _scenarioName(
+                scenarioLabel,
+                'first-tile',
+                page: pageIndex,
+              );
+              _startScenario(coldScenario);
               final coldGpu = await _render(
                 () => session.rasterizeRegion(region1, pixelRatio: lod1),
                 pngPath:
                     output == null ? null : '$output/page-$pageIndex-gpu.png',
               );
+              _finishScenario(coldScenario, coldGpu.$1, page: pageIndex);
+              final canvasScenario = _scenarioName(
+                scenarioLabel,
+                'canvas-tile',
+                page: pageIndex,
+              );
+              _startScenario(canvasScenario);
               final warmCanvas = await _render(
                 () => scene.rasterizeRegion(region1, pixelRatio: lod1),
                 pngPath: output == null
                     ? null
                     : '$output/page-$pageIndex-canvas.png',
+              );
+              _finishScenario(
+                canvasScenario,
+                warmCanvas.$1,
+                page: pageIndex,
               );
 
               final lod2 = 2.0;

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -380,8 +380,14 @@ class PatrolPerfTrace {
   String toHeadlineMarkdown({String label = 'web'}) {
     final heading =
         label.toLowerCase() == 'web' ? '### Headline' : '### $label headline';
-    final buffer = StringBuffer()
-      ..writeln(heading)
+    final speedup = _gpuTileSpeedupHeadline(toJson());
+    final buffer = StringBuffer()..writeln(heading);
+    if (speedup != null) {
+      buffer
+        ..writeln()
+        ..writeln(speedup);
+    }
+    buffer
       ..writeln()
       ..writeln(
         lines.isEmpty
@@ -570,8 +576,14 @@ class PatrolPerfComparison {
     final heading = label == null || label.toLowerCase() == 'web'
         ? '### Headline comparison with `main`'
         : '### $label comparison with `main`';
-    final buffer = StringBuffer()
-      ..writeln(heading)
+    final speedup = _gpuTileSpeedupHeadline(current, baseline: baseline);
+    final buffer = StringBuffer()..writeln(heading);
+    if (speedup != null) {
+      buffer
+        ..writeln()
+        ..writeln(speedup);
+    }
+    buffer
       ..writeln()
       ..writeln(
         'Lower timing is better. Structural counts should stay stable unless '
@@ -1315,6 +1327,65 @@ Set<String> _jsonMapKeys(Object? root, List<String> path) {
   return value is Map
       ? value.keys.map((key) => key.toString()).toSet()
       : const {};
+}
+
+typedef _GpuTileSpeedup = ({double firstTileMs, double canvasTileMs});
+
+Map<String, _GpuTileSpeedup> _gpuTileSpeedups(Object? trace) {
+  const suffix = '-first-tile';
+  final result = <String, _GpuTileSpeedup>{};
+  final scenarios = _jsonMapKeys(trace, const ['scenarioMetrics']).toList()
+    ..sort();
+  for (final scenario in scenarios) {
+    if (!scenario.startsWith('gpu-') || !scenario.endsWith(suffix)) continue;
+    final prefix = scenario.substring(0, scenario.length - suffix.length);
+    final firstTile = _jsonNumber(
+      trace,
+      ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
+    );
+    final canvasTile = _jsonNumber(
+      trace,
+      ['scenarioMetrics', '$prefix-canvas-tile', 'elapsedMs', 'p50'],
+    );
+    if (firstTile == null || canvasTile == null || firstTile <= 0) continue;
+    result[prefix.substring('gpu-'.length).replaceAll('-', ' ')] = (
+      firstTileMs: firstTile.toDouble(),
+      canvasTileMs: canvasTile.toDouble(),
+    );
+  }
+  return result;
+}
+
+String? _gpuTileSpeedupHeadline(
+  Object? current, {
+  Object? baseline,
+}) {
+  final before = baseline == null
+      ? const <String, _GpuTileSpeedup>{}
+      : _gpuTileSpeedups(baseline);
+  final after = _gpuTileSpeedups(current);
+  final workloads = <String>{...before.keys, ...after.keys}.toList()..sort();
+  if (workloads.isEmpty) return null;
+
+  String speedup(_GpuTileSpeedup? value) => value == null
+      ? 'n/a'
+      : '${(value.canvasTileMs / value.firstTileMs).toStringAsFixed(1)}×';
+
+  if (baseline != null) {
+    final values = workloads.map(
+        (workload) => '${_code(workload)} **${speedup(before[workload])} → '
+            '${speedup(after[workload])}**');
+    return '**GPU first tile vs Canvas (p50, main → PR):** '
+        '${values.join('; ')}.';
+  }
+
+  final values = workloads.map((workload) {
+    final value = after[workload]!;
+    return '${_code(workload)} **${speedup(value)}** '
+        '(${_formatMs(value.firstTileMs)} vs '
+        '${_formatMs(value.canvasTileMs)})';
+  });
+  return '**GPU first tile vs Canvas (p50):** ${values.join('; ')}.';
 }
 
 bool _sameMapKeys(Map<String, int> a, Map<String, int> b) =>

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -428,6 +428,9 @@ void main() {
     '[perf 206] scenario name=gpu-tiling-page-0-first-tile phase=start',
     '[perf 211] raster page=0 kind=gpu-tiling-page-0-first-tile ms=5.0',
     '[perf 212] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+    '[perf 213] scenario name=gpu-tiling-page-0-canvas-tile phase=start',
+    '[perf 562] raster page=0 kind=gpu-tiling-page-0-canvas-tile ms=349.0',
+    '[perf 563] scenario name=gpu-tiling-page-0-canvas-tile phase=validated',
     '[perf 0] build commit=gpu-test-2',
     '[perf 1] scenario name=gpu-tiling-pipeline-warm phase=start',
     '[perf 209] raster page=- kind=gpu-tiling-pipeline-warm ms=208.0',
@@ -435,6 +438,9 @@ void main() {
     '[perf 212] scenario name=gpu-tiling-page-0-first-tile phase=start',
     '[perf 218] raster page=0 kind=gpu-tiling-page-0-first-tile ms=6.0',
     '[perf 219] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+    '[perf 220] scenario name=gpu-tiling-page-0-canvas-tile phase=start',
+    '[perf 579] raster page=0 kind=gpu-tiling-page-0-canvas-tile ms=359.0',
+    '[perf 580] scenario name=gpu-tiling-page-0-canvas-tile phase=validated',
     '[perf 0] build commit=gpu-test-3',
     '[perf 1] scenario name=gpu-tiling-pipeline-warm phase=start',
     '[perf 199] raster page=- kind=gpu-tiling-pipeline-warm ms=198.0',
@@ -442,6 +448,9 @@ void main() {
     '[perf 202] scenario name=gpu-tiling-page-0-first-tile phase=start',
     '[perf 207] raster page=0 kind=gpu-tiling-page-0-first-tile ms=5.0',
     '[perf 208] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+    '[perf 209] scenario name=gpu-tiling-page-0-canvas-tile phase=start',
+    '[perf 548] raster page=0 kind=gpu-tiling-page-0-canvas-tile ms=339.0',
+    '[perf 549] scenario name=gpu-tiling-page-0-canvas-tile phase=validated',
   ]);
   final gpuJson = gpuTrace.toJson();
   final gpuScenarios = _map(gpuJson, 'scenarioMetrics');
@@ -467,6 +476,21 @@ void main() {
     gpuTrace.toHeadlineMarkdown(label: 'macOS Metal GPU'),
     'Scenario `gpu-tiling-page-0-first-tile` elapsed p50 (3 runs)',
     'GPU first-tile result reaches the PR headline',
+  );
+  _expectContains(
+    gpuTrace.toHeadlineMarkdown(label: 'macOS Metal GPU'),
+    '**GPU first tile vs Canvas (p50):** `tiling page 0` **58.3×** '
+        '(6.0 ms vs 350.0 ms).',
+    'GPU speedup leads the PR headline',
+  );
+  _expectContains(
+    summary.PatrolPerfComparison(
+      baseline: gpuJson,
+      current: gpuJson,
+    ).toHeadlineMarkdown(label: 'macOS Metal GPU'),
+    '**GPU first tile vs Canvas (p50, main → PR):** '
+        '`tiling page 0` **58.3× → 58.3×**.',
+    'GPU main comparison leads the PR headline',
   );
 
   print('Patrol performance summarizer tests passed');

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -420,6 +420,55 @@ void main() {
     'incomplete repetitions fail the CI requirement',
   );
 
+  final gpuTrace = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] build commit=gpu-test-1',
+    '[perf 1] scenario name=gpu-tiling-pipeline-warm phase=start',
+    '[perf 203] raster page=- kind=gpu-tiling-pipeline-warm ms=202.0',
+    '[perf 205] scenario name=gpu-tiling-pipeline-warm phase=validated',
+    '[perf 206] scenario name=gpu-tiling-page-0-first-tile phase=start',
+    '[perf 211] raster page=0 kind=gpu-tiling-page-0-first-tile ms=5.0',
+    '[perf 212] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+    '[perf 0] build commit=gpu-test-2',
+    '[perf 1] scenario name=gpu-tiling-pipeline-warm phase=start',
+    '[perf 209] raster page=- kind=gpu-tiling-pipeline-warm ms=208.0',
+    '[perf 211] scenario name=gpu-tiling-pipeline-warm phase=validated',
+    '[perf 212] scenario name=gpu-tiling-page-0-first-tile phase=start',
+    '[perf 218] raster page=0 kind=gpu-tiling-page-0-first-tile ms=6.0',
+    '[perf 219] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+    '[perf 0] build commit=gpu-test-3',
+    '[perf 1] scenario name=gpu-tiling-pipeline-warm phase=start',
+    '[perf 199] raster page=- kind=gpu-tiling-pipeline-warm ms=198.0',
+    '[perf 201] scenario name=gpu-tiling-pipeline-warm phase=validated',
+    '[perf 202] scenario name=gpu-tiling-page-0-first-tile phase=start',
+    '[perf 207] raster page=0 kind=gpu-tiling-page-0-first-tile ms=5.0',
+    '[perf 208] scenario name=gpu-tiling-page-0-first-tile phase=validated',
+  ]);
+  final gpuJson = gpuTrace.toJson();
+  final gpuScenarios = _map(gpuJson, 'scenarioMetrics');
+  final gpuPipeline = _map(gpuScenarios, 'gpu-tiling-pipeline-warm');
+  _expectEqual(gpuPipeline['runs'], 3, 'GPU pipeline sample count');
+  _expectEqual(
+    _map(gpuPipeline, 'elapsedMs')['p50'],
+    204.0,
+    'GPU pipeline median',
+  );
+  _expectEqual(
+    summary.patrolPerfScenarioRunShortfalls(
+      gpuJson,
+      const {
+        'gpu-tiling-pipeline-warm': 3,
+        'gpu-tiling-page-0-first-tile': 3,
+      },
+    ),
+    const <String, int>{},
+    'GPU scenarios satisfy the three-run CI contract',
+  );
+  _expectContains(
+    gpuTrace.toHeadlineMarkdown(label: 'macOS Metal GPU'),
+    'Scenario `gpu-tiling-page-0-first-tile` elapsed p50 (3 runs)',
+    'GPU first-tile result reaches the PR headline',
+  );
+
   print('Patrol performance summarizer tests passed');
 }
 


### PR DESCRIPTION
Headline results

- macOS Metal p50: radial shading renders in 18.0 ms on GPU versus 487.0 ms on Canvas (27.1x); exact tiling renders in 10.0 ms versus 305.0 ms (30.5x).
- Android Patrol: `native-mobile-tiles` p50 improves from 4372 ms on `main` to 3038 ms (-30.5%), raster p95 improves 4.1%, all three repetitions validate, and retained-tile structure is unchanged.
- Android stability is restored: zero instrumentation crashes, zero proactive `flutter_gpu` sessions, and native-scenario RSS is 482-493 MB versus 481-491 MB on `main`.
- iOS Patrol is effectively neutral on scenario time (+1.1% p50, +3.0% p95) while scenario raster p95 improves 44.7%; all three repetitions and structural checks validate.
- Exact GPU corpus acceptance expands from 90 to 100 PDF.js pages and from 16 to 18 Ghent pages. Canvas parity is unchanged on the benchmark pages (mean channel difference 0.100 tiling, 0.787 radial).

This is a draft stacked on #748 so its CI can run now. Do not merge it into the temporary base branch; after #748 merges it will be rebased onto `main` and marked ready.

What changed

- Accelerates exact vector tiling cells, axial gradients (including embedded outline text), and nested-circle radial gradients.
- Keeps explicit whole-scene Canvas fallback for unsafe tiling, overprint, unsupported text, non-nested radial geometry, and unsupported transparency.
- Warms shared Impeller pipelines and retained live-page geometry/uploads on desktop only after useful pixels plus a 750 ms quiet window; foreground rendering and parked viewers cancel and restart the delay.
- Keeps Android, iOS, and Fuchsia warm-up on demand by default. Hosts can opt into proactive warm-up explicitly, but mobile no longer creates an idle Impeller context for pages that will immediately fall back to Canvas.
- Adds exact warm-up outcome/cancellation diagnostics and a deterministic required Metal smoke lane.
- Runs tiling and radial GPU measurements three times on macOS Metal, compares PR medians with the latest main artifact, and posts headline numbers before a collapsed details section.

<details>
<summary>Validation and benchmark details</summary>

- Every PR check is green: core tests, browser build/deploy, Android/iOS/macOS Patrol, Metal smoke/performance, and Linux/macOS/Windows GPU packaging.
- Root `fvm dart analyze`: clean.
- Browser unsupported-platform API test: passed.
- `dart_pdf_editor` focused viewer/render scheduling: 128 tests passed.
- Native `flutter_gpu` package: 238 tests passed with three expected environment/opt-in skips.
- Focused native backend/stats: 18 substantive tests passed with one expected no-flags skip.
- GPU corpus: PDF.js accepted=100 rejected=79; Ghent accepted=18 rejected=39. Every accepted page is compared against Canvas; rejections remain intentional fallbacks.
- Android Patrol completed in 12m10s, close to `main` at 11m44s. The prior two attempts crashed every instrumentation process after proactive mobile warm-up raised pressure; the fixed run completed all suites and all three native performance repetitions.
- CI artifacts retain normalized raw traces, JSON summaries, and Markdown reports for macOS Metal plus Android/iOS Patrol comparisons.

</details>
