### PR TITLE
perf(gpu): mipmap tiled stencil scenes

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Collect worker-decoded images inside retained tiling cells, so bitmap Type 3
+  glyphs keep their image pixels when a command buffer is rebuilt on the UI
+  isolate.
 - Let optional tile backends prepare view-scoped resources and live-page scene
   sessions after first useful pixels and a 750 ms quiet window. Foreground
   rendering cancels and restarts the delay, keeping first paint and immediate

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -469,7 +469,7 @@ class PdfPageRenderer {
   }
 
   /// Gathers every image draw request in [commands], descending into soft-mask
-  /// groups (whose own commands can draw images), in replay order.
+  /// groups and retained tiling cells, in replay order.
   static void collectImageRequests(
       List<PdfRenderCommand> commands, List<PdfImageRequest> out) {
     for (final command in commands) {
@@ -478,6 +478,8 @@ class PdfPageRenderer {
           out.add(request);
         case PdfEndSoftMaskedCommand(:final maskCommands):
           collectImageRequests(maskCommands, out);
+        case PdfDrawTiledCellCommand(:final cellCommands):
+          collectImageRequests(cellCommands, out);
         default:
           break;
       }

--- a/packages/dart_pdf_editor/test/image_stats_test.dart
+++ b/packages/dart_pdf_editor/test/image_stats_test.dart
@@ -1,7 +1,7 @@
 // PdfPageRenderer.decodedImageStats: the diagnostic that counts a worker
-// buffer's decoded images and their total pixels (recursing soft-mask groups),
-// so a slow raster page's cause - one oversized image vs. many capped tiles -
-// is visible in the perf trace.
+// buffer's decoded images and their total pixels (recursing soft-mask groups
+// and retained tiling cells), so a slow raster page's cause - one oversized
+// image vs. many capped tiles - is visible in the perf trace.
 import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -16,8 +16,9 @@ PdfDrawImageCommand _image(int width, int height, {bool decoded = true}) {
     stream: stream,
     transform: PdfMatrix.identity,
     isInline: true,
-    decoded:
-        decoded ? PdfDecodedPixels(Uint8List(width * height * 4), width, height) : null,
+    decoded: decoded
+        ? PdfDecodedPixels(Uint8List(width * height * 4), width, height)
+        : null,
   ));
 }
 
@@ -52,6 +53,17 @@ void main() {
       ),
     ]);
     expect(stats, (2, 3 * 3 + 2 * 2));
+  });
+
+  test('descends into retained tiling cells without counting repeats', () {
+    final stats = PdfPageRenderer.decodedImageStats([
+      PdfDrawTiledCellCommand(
+        [_image(4, 3)],
+        Float64List.fromList([0, 10, 20]),
+        Float64List.fromList([0, 0, 0]),
+      ),
+    ]);
+    expect(stats, (1, 4 * 3));
   });
 
   test('an image-free buffer reports zero', () {

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Render tiled stencil images exactly using scene-scoped, hand-built mipmaps.
+  Mip levels participate in the shared texture budget and cache identity, and
+  worker-reconstructed tiling cells retain their decoded images.
 - Warm every tile shader with a one-pixel idle submission, shared per Impeller
   context and MSAA mode, then compile and submit each live page's retained
   scene at one-pixel scale. Both passes wait for useful pixels plus a 750 ms

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -58,8 +58,9 @@ compile-time stub and therefore preserves the all-platform host surface.
 
 The current exact subset is solid paths and strokes, embedded-outline text,
 decoded images/image masks, Gouraud meshes, axial gradients, nested-circle
-radial gradients, vector tiling cells, normal blending, rectangular and
-arbitrary path clips, and the common isolated single-image soft-mask group.
+radial gradients, vector and stencil-image tiling cells, normal blending,
+rectangular and arbitrary path clips, and the common isolated single-image
+soft-mask group.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
 mask case keeps the base and mask as two GPU textures and combines them during
@@ -108,10 +109,10 @@ instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
 Pages with other transparency groups or soft masks, non-normal blends,
-non-nested radial gradients, gradient overprint, stencil-image tiling cells,
-unsafe overprint, complex clips nested inside the single-image soft-mask
-shortcut, substituted/stroked text, hairlines, or missing image pixels are
-rejected as a whole rather than approximated.
+non-nested radial gradients, gradient overprint, unsafe overprint, complex
+clips nested inside the single-image soft-mask shortcut, substituted/stroked
+text, hairlines, or missing image pixels are rejected as a whole rather than
+approximated.
 `allowOverprintApproximation` exists only for controlled experiments and
 defaults to false.
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -30,8 +30,8 @@ import 'backend_stats.dart';
 /// masks (with rectangular clips additionally using the hardware scissor).
 /// Other isolated groups, non-normal blend modes, complex clips *inside* the
 /// special soft-mask-image shortcut, non-nested radial gradients,
-/// substituted/stroked text, stencil-image tiling cells, unsafe overprint, or
-/// missing image pixels reject the whole scene.
+/// substituted/stroked text, unsafe overprint, or missing image pixels reject
+/// the whole scene.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -209,6 +209,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       return _FlutterGpuTileSession(
         scene: scene,
         commands: commands,
+        mipmapImages: commandBuild.mipmapImages,
         context: context,
         pipelines: _GpuPipelines.instance(context),
         units: units,
@@ -426,10 +427,15 @@ class _SoftMaskImageSpec {
 }
 
 class _GpuCommandBuild {
-  const _GpuCommandBuild(this.commands, this.rejection);
+  const _GpuCommandBuild(
+    this.commands,
+    this.rejection, {
+    required this.mipmapImages,
+  });
 
   final List<PdfRenderCommand>? commands;
   final String? rejection;
+  final bool mipmapImages;
 }
 
 /// Expands retained tiling cells once for the GPU scene.
@@ -444,7 +450,7 @@ class _GpuCommandBuild {
 _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
   const maxExpandedCommands = 1000000;
   var hasTiledCell = false;
-  String? tiledRejection;
+  var mipmapImages = false;
 
   int count(List<PdfRenderCommand> commands, Set<Object> active,
       {bool inTiledCell = false}) {
@@ -470,11 +476,11 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
         if (inTiledCell &&
             command is PdfDrawImageCommand &&
             command.request.isStencil) {
-          // Type 3 bitmap glyphs are retained as one-repeat tiling cells.
-          // Linear texture sampling does not yet match Canvas closely enough
-          // on the Ghent font grid, so do not let flattening accidentally
-          // promote those pages into the exact GPU subset.
-          tiledRejection ??= 'unsupported tiled stencil image';
+          // Canvas uses FilterQuality.medium for every image on the page.
+          // Once a retained bitmap-font cell needs minification, match that
+          // sampling mode for the whole GPU scene; mixing base-only and
+          // mipmapped images on the same Ghent page is measurably less exact.
+          mipmapImages = true;
         }
         total++;
       }
@@ -488,14 +494,14 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
   }
 
   final expandedCount = count(source, Set<Object>.identity());
-  if (!hasTiledCell) return _GpuCommandBuild(source, null);
-  if (tiledRejection != null) {
-    return _GpuCommandBuild(null, tiledRejection);
+  if (!hasTiledCell) {
+    return _GpuCommandBuild(source, null, mipmapImages: false);
   }
   if (expandedCount > maxExpandedCommands) {
     return const _GpuCommandBuild(
       null,
       'expanded tiling cells exceed GPU command cap',
+      mipmapImages: false,
     );
   }
 
@@ -526,9 +532,14 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
     return const _GpuCommandBuild(
       null,
       'expanded tiling cells exceed GPU command cap',
+      mipmapImages: false,
     );
   }
-  return _GpuCommandBuild(List.unmodifiable(expanded), null);
+  return _GpuCommandBuild(
+    List.unmodifiable(expanded),
+    null,
+    mipmapImages: mipmapImages,
+  );
 }
 
 _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
@@ -939,6 +950,7 @@ class _FlutterGpuTileSession
   _FlutterGpuTileSession({
     required this.scene,
     required this.commands,
+    required this.mipmapImages,
     required this.context,
     required this.pipelines,
     required this.units,
@@ -951,6 +963,7 @@ class _FlutterGpuTileSession
   @override
   final PdfRetainedScene scene;
   final List<PdfRenderCommand> commands;
+  final bool mipmapImages;
 
   // This backend already returns a final GPU texture for every raster call.
   // Slab splitting would queue another texture-to-texture copy per tile; those
@@ -985,6 +998,7 @@ class _FlutterGpuTileSession
         stats,
         imageCache,
         geometryPool,
+        mipmapImages: mipmapImages,
       ).then((compiled) {
         if (_disposed) {
           compiled.dispose();
@@ -1119,14 +1133,14 @@ class _CompiledScene {
   });
 
   static Future<_CompiledScene> build(
-    PdfRetainedScene scene,
-    List<PdfRenderCommand> commands,
-    gpu.GpuContext context,
-    List<_GpuUnit> units,
-    FlutterGpuTileBackendStats stats,
-    _GpuImageCache imageCache,
-    _GpuGeometryPool geometryPool,
-  ) async {
+      PdfRetainedScene scene,
+      List<PdfRenderCommand> commands,
+      gpu.GpuContext context,
+      List<_GpuUnit> units,
+      FlutterGpuTileBackendStats stats,
+      _GpuImageCache imageCache,
+      _GpuGeometryPool geometryPool,
+      {required bool mipmapImages}) async {
     final clock = Stopwatch()..start();
     final draws = <int, _GpuDraw>{};
     final clipDraws = Map<_GpuClipNode, _GpuClipDraw>.identity();
@@ -1151,6 +1165,7 @@ class _CompiledScene {
             stats,
             imageCache,
             textureLeases,
+            mipmapImages: mipmapImages,
           );
           draw = pending is Future<_GpuDraw?> ? await pending : pending;
         } else {
@@ -1162,6 +1177,7 @@ class _CompiledScene {
             stats,
             imageCache,
             textureLeases,
+            mipmapImages: mipmapImages,
           );
         }
         if (draw != null) draws[unit.commandIndex] = draw;
@@ -1477,21 +1493,31 @@ _SolidDraw _paperDraw(_GpuGeometryArena geometry, PdfRetainedScene scene) {
 }
 
 Future<_GpuDraw> _compileSoftMaskImage(
-  gpu.GpuContext context,
-  _GpuGeometryArena geometry,
-  PdfRetainedScene scene,
-  _SoftMaskImageSpec spec,
-  FlutterGpuTileBackendStats stats,
-  _GpuImageCache imageCache,
-  List<_GpuImageTexture> textureLeases,
-) async {
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    _SoftMaskImageSpec spec,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
   final contentImage = scene.imageFor(spec.content)!;
   final maskImage = scene.imageFor(spec.mask)!;
-  final contentResource =
-      await imageCache.acquire(context, spec.content, contentImage, stats);
+  final contentResource = await imageCache.acquire(
+    context,
+    spec.content,
+    contentImage,
+    stats,
+    mipmapped: mipmapImages,
+  );
   textureLeases.add(contentResource);
-  final maskResource =
-      await imageCache.acquire(context, spec.mask, maskImage, stats);
+  final maskResource = await imageCache.acquire(
+    context,
+    spec.mask,
+    maskImage,
+    stats,
+    mipmapped: mipmapImages,
+  );
   textureLeases.add(maskResource);
   final vertices = _imageVertices(spec.content.transform);
   final inverse = spec.mask.transform.inverted();
@@ -1557,21 +1583,28 @@ Future<_GpuDraw> _compileSoftMaskImage(
 }
 
 class _GpuImageTexture {
-  _GpuImageTexture(this.texture, this.width, this.height);
+  _GpuImageTexture(this.texture, this.width, this.height, this.bytes);
   final gpu.Texture texture;
   final int width;
   final int height;
+  final int bytes;
   int leases = 0;
   bool cacheable = true;
-  int get bytes => width * height * 4;
 }
 
 class _GpuTextureKey {
-  const _GpuTextureKey(this.context, this.content, this.width, this.height);
+  const _GpuTextureKey(
+    this.context,
+    this.content,
+    this.width,
+    this.height,
+    this.mipmapped,
+  );
   final gpu.GpuContext context;
   final Object content;
   final int width;
   final int height;
+  final bool mipmapped;
 
   @override
   bool operator ==(Object other) =>
@@ -1579,11 +1612,17 @@ class _GpuTextureKey {
       identical(other.context, context) &&
       other.content == content &&
       other.width == width &&
-      other.height == height;
+      other.height == height &&
+      other.mipmapped == mipmapped;
 
   @override
-  int get hashCode =>
-      Object.hash(identityHashCode(context), content, width, height);
+  int get hashCode => Object.hash(
+        identityHashCode(context),
+        content,
+        width,
+        height,
+        mipmapped,
+      );
 }
 
 class _GpuImageCache {
@@ -1595,14 +1634,16 @@ class _GpuImageCache {
   final Set<_GpuImageTexture> _detached = Set.identity();
   int _bytes = 0;
 
-  Future<_GpuImageTexture> acquire(
-    gpu.GpuContext context,
-    PdfImageRequest request,
-    ui.Image image,
-    FlutterGpuTileBackendStats stats,
-  ) async {
+  Future<_GpuImageTexture> acquire(gpu.GpuContext context,
+      PdfImageRequest request, ui.Image image, FlutterGpuTileBackendStats stats,
+      {required bool mipmapped}) async {
     final key = _GpuTextureKey(
-        context, pdfImageContentKey(request), image.width, image.height);
+      context,
+      pdfImageContentKey(request),
+      image.width,
+      image.height,
+      mipmapped,
+    );
     final hit = _entries.remove(key);
     if (hit != null) {
       _entries[key] = hit;
@@ -1613,7 +1654,9 @@ class _GpuImageCache {
       return hit;
     }
     stats.textureCacheMisses++;
-    final bytes = image.width * image.height * 4;
+    final mipLevelCount =
+        mipmapped ? gpu.Texture.fullMipCount(image.width, image.height) : 1;
+    final bytes = _textureBytes(image.width, image.height, mipLevelCount);
     if (maxBytes > 0 && !_makeRoom(bytes, stats)) {
       stats.textureBudgetFallbacks++;
       throw StateError('GPU texture budget exceeded: need $bytes bytes, '
@@ -1624,6 +1667,7 @@ class _GpuImageCache {
       image,
       stats,
       decoded: request.decoded,
+      mipLevelCount: mipLevelCount,
     )
       ..leases = 1;
     _bytes += uploaded.bytes;
@@ -1706,7 +1750,7 @@ FloatBuilder _imageVertices(PdfMatrix transform) {
 
 Future<_GpuImageTexture> _uploadImageTexture(
     gpu.GpuContext context, ui.Image image, FlutterGpuTileBackendStats stats,
-    {PdfDecodedPixels? decoded}) async {
+    {PdfDecodedPixels? decoded, required int mipLevelCount}) async {
   final ByteData bytes;
   if (decoded != null &&
       decoded.width == image.width &&
@@ -1726,21 +1770,57 @@ Future<_GpuImageTexture> _uploadImageTexture(
     image.width,
     image.height,
     format: gpu.PixelFormat.r8g8b8a8UNormInt,
+    mipLevelCount: mipLevelCount,
   );
   texture.overwrite(bytes);
+  var width = image.width;
+  var height = image.height;
+  var level =
+      bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes);
+  for (var mip = 1; mip < mipLevelCount; mip++) {
+    level = _downsampleRgba(level, width, height);
+    width = math.max(1, width ~/ 2);
+    height = math.max(1, height ~/ 2);
+    texture.overwrite(ByteData.sublistView(level), mipLevel: mip);
+  }
   stats.texturesUploaded++;
-  return _GpuImageTexture(texture, image.width, image.height);
+  return _GpuImageTexture(
+    texture,
+    image.width,
+    image.height,
+    _textureBytes(image.width, image.height, mipLevelCount),
+  );
+}
+
+int _textureBytes(int width, int height, int mipLevelCount) {
+  var bytes = 0;
+  for (var mip = 0; mip < mipLevelCount; mip++) {
+    bytes += width * height * 4;
+    width = math.max(1, width ~/ 2);
+    height = math.max(1, height ~/ 2);
+  }
+  return bytes;
+}
+
+Uint8List _downsampleRgba(Uint8List source, int width, int height) {
+  final nextWidth = math.max(1, width ~/ 2);
+  final nextHeight = math.max(1, height ~/ 2);
+  return downsamplePdfDecodedPixels(
+    PdfDecodedPixels(source, width, height),
+    nextWidth,
+    nextHeight,
+  ).rgba;
 }
 
 FutureOr<_GpuDraw?> _compileCommand(
-  gpu.GpuContext context,
-  _GpuGeometryArena geometry,
-  PdfRetainedScene scene,
-  PdfRenderCommand command,
-  FlutterGpuTileBackendStats stats,
-  _GpuImageCache imageCache,
-  List<_GpuImageTexture> textureLeases,
-) async {
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    PdfRenderCommand command,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
   switch (command) {
     case PdfFillPathCommand(
         :final path,
@@ -1846,6 +1926,7 @@ FutureOr<_GpuDraw?> _compileCommand(
         stats,
         imageCache,
         textureLeases,
+        mipmapImages: mipmapImages,
       );
     default:
       return null;
@@ -1853,16 +1934,22 @@ FutureOr<_GpuDraw?> _compileCommand(
 }
 
 Future<_GpuDraw> _compileImageCommand(
-  gpu.GpuContext context,
-  _GpuGeometryArena geometry,
-  PdfRetainedScene scene,
-  PdfImageRequest request,
-  FlutterGpuTileBackendStats stats,
-  _GpuImageCache imageCache,
-  List<_GpuImageTexture> textureLeases,
-) async {
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    PdfImageRequest request,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
   final image = scene.imageFor(request)!;
-  final resource = await imageCache.acquire(context, request, image, stats);
+  final resource = await imageCache.acquire(
+    context,
+    request,
+    image,
+    stats,
+    mipmapped: mipmapImages,
+  );
   textureLeases.add(resource);
   final vertices = _imageVertices(request.transform);
   final tint = request.isStencil
@@ -2702,6 +2789,7 @@ class _GpuEncoder {
         sampler: gpu.SamplerOptions(
           minFilter: gpu.MinMagFilter.linear,
           magFilter: gpu.MinMagFilter.linear,
+          mipFilter: gpu.MipFilter.linear,
         ),
       );
     _drawBuffer(vertices);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -913,47 +913,6 @@ void main() {
       expect(backend.stats.lastRejection,
           'unsupported non-nested radial gradient');
 
-      final stencilSource = _decodedImage(
-        Uint8List.fromList([
-          0,
-          0,
-          0,
-          255,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          0,
-          255,
-        ]),
-        const PdfMatrix(40, 0, 0, 40, 100, 100),
-        'tiled-stencil',
-      ).request;
-      final tiledStencil = await PdfRetainedScene.fromCommands(page, [
-        PdfDrawTiledCellCommand(
-          [
-            PdfDrawImageCommand(PdfImageRequest(
-              stream: stencilSource.stream,
-              transform: stencilSource.transform,
-              isStencil: true,
-              stencilColor: const PdfColor(0.1, 0.2, 0.8),
-              decoded: stencilSource.decoded,
-            )),
-          ],
-          Float64List.fromList([0]),
-          Float64List.fromList([0]),
-        ),
-      ]);
-      addTearDown(tiledStencil.dispose);
-      expect(backend.createSession(tiledStencil), isNull);
-      expect(backend.stats.lastRejection, 'unsupported tiled stencil image');
-
       final nonRectClip = await PdfRetainedScene.fromCommands(page, [
         const PdfSaveCommand(),
         PdfClipPathCommand(
@@ -987,6 +946,82 @@ void main() {
       }
       expect(difference / a.length, lessThan(3),
           reason: 'arbitrary PDF clips should use the exact stencil route');
+    });
+  });
+
+  testWidgets('tiled stencil images use scene-wide mipmaps', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const sourceSize = 64;
+      final pixels = Uint8List(sourceSize * sourceSize * 4);
+      for (var y = 0; y < sourceSize; y++) {
+        for (var x = 0; x < sourceSize; x++) {
+          final offset = 4 * (y * sourceSize + x);
+          final on = ((x ~/ 2 + y ~/ 2).isEven) ? 255 : 0;
+          pixels[offset] = on;
+          pixels[offset + 1] = on;
+          pixels[offset + 2] = on;
+          pixels[offset + 3] = on;
+        }
+      }
+      final stream = CosStream(
+        CosDictionary({
+          'Identity': CosString.fromText('minified-tiled-stencil'),
+          'Width': const CosInteger(sourceSize),
+          'Height': const CosInteger(sourceSize),
+        }),
+        Uint8List(0),
+      );
+      final origins = Float64List.fromList([
+        for (var y = 0; y < 10; y++)
+          for (var x = 0; x < 10; x++) x * 9.0,
+      ]);
+      final originsY = Float64List.fromList([
+        for (var y = 0; y < 10; y++)
+          for (var x = 0; x < 10; x++) y * 9.0,
+      ]);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfDrawTiledCellCommand(
+            [
+              PdfDrawImageCommand(PdfImageRequest(
+                stream: stream,
+                transform: const PdfMatrix(8, 0, 0, 8, 10, 10),
+                isStencil: true,
+                stencilColor: const PdfColor(0.1, 0.2, 0.8),
+                decoded: PdfDecodedPixels(pixels, sourceSize, sourceSize),
+              )),
+            ],
+            origins,
+            originsY,
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(0, 0, 110, 110);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(16));
+      expect(backend.stats.textureBytes, 21840,
+          reason: '64x64 RGBA plus every mip level flutter_gpu supports');
     });
   });
 


### PR DESCRIPTION
## Summary

- make retained tiled stencil-image cells eligible for exact Flutter GPU rendering
- build scene-wide RGBA mipmaps when minified stencil cells need Canvas-equivalent filtering
- include mip levels in texture cache identity and byte-budget accounting
- retain worker-decoded images nested inside tiling cells

## Validation

- `fvm flutter test --enable-impeller --enable-flutter-gpu test/flutter_gpu_tile_backend_test.dart`
- `fvm flutter test --enable-impeller --enable-flutter-gpu test/gpu_corpus_test.dart`
  - PDF.js: **101 accepted / 78 rejected** (was 100 / 79)
  - Ghent: **19 accepted / 38 rejected** (was 18 / 39)
- `fvm flutter test test/image_stats_test.dart`
- `fvm dart analyze`

Unsupported pages still fall back to Canvas rather than being approximated.