### PR TITLE
Polish document tabs, toolbar docking, and platform file flows

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -28,6 +28,7 @@ import 'incoming_file.dart';
 import 'keyless_identity_cache.dart';
 import 'keyless_signing.dart';
 import 'l10n/app_l10n.dart';
+import 'middle_ellipsis_text.dart';
 import 'new_document.dart';
 import 'ocr.dart';
 import 'ocr_status_label.dart';
@@ -49,6 +50,7 @@ import 'update_platform.dart';
 import 'web_launch.dart';
 import 'welcome_screen.dart';
 import 'window_support.dart';
+import 'windows_drop_target.dart';
 
 /// Height of the AppBar's browser-style tab strip.
 const double _tabStripHeight = 42;
@@ -2851,6 +2853,13 @@ class _EditorScreenState extends State<EditorScreen>
         _ => false,
       };
 
+  bool get _usesMobileShare =>
+      !kIsWeb &&
+      switch (defaultTargetPlatform) {
+        TargetPlatform.android || TargetPlatform.iOS => true,
+        _ => false,
+      };
+
   double _appMenuItemHeight({bool twoLine = false}) => !_usesCompactAppMenu
       ? kMinInteractiveDimension
       : twoLine
@@ -2879,10 +2888,13 @@ class _EditorScreenState extends State<EditorScreen>
     Widget? trailing,
     Widget? subtitle,
     TextOverflow? overflow,
+    bool middleEllipsis = false,
   }) =>
       ListTile(
         leading: Icon(icon),
-        title: Text(title, overflow: overflow),
+        title: middleEllipsis
+            ? MiddleEllipsisText(title)
+            : Text(title, overflow: overflow),
         subtitle: subtitle,
         trailing: trailing ??
             (shortcut == null
@@ -2970,14 +2982,10 @@ class _EditorScreenState extends State<EditorScreen>
                     title: entry.title.isEmpty
                         ? appL10n(context).editorUntitled
                         : entry.title,
-                    overflow: TextOverflow.ellipsis,
+                    middleEllipsis: true,
                     subtitle: entry.path == null
                         ? null
-                        : Text(
-                            entry.path!,
-                            overflow: TextOverflow.ellipsis,
-                            maxLines: 1,
-                          ),
+                        : MiddleEllipsisText(entry.path!),
                   ),
                 ),
               const PopupMenuDivider(),
@@ -3060,9 +3068,14 @@ class _EditorScreenState extends State<EditorScreen>
             height: _appMenuItemHeight(),
             value: () => _save(tab!, saveAs: true),
             child: _appMenuTile(
-              icon: Icons.save_as_outlined,
-              title: appL10n(context).editorMenuSaveAs,
-              shortcut: _menuShortcut('S', shift: true),
+              icon: _usesMobileShare
+                  ? Icons.share_outlined
+                  : Icons.save_as_outlined,
+              title: _usesMobileShare
+                  ? WidgetsLocalizations.of(context).shareButtonLabel
+                  : appL10n(context).editorMenuSaveAs,
+              shortcut:
+                  _usesMobileShare ? null : _menuShortcut('S', shift: true),
             ),
           ),
           if (_canScan && !_readOnly)
@@ -3176,6 +3189,37 @@ class _EditorScreenState extends State<EditorScreen>
 
   // --- build ---------------------------------------------------------------
 
+  Widget _buildFileDropTarget(Widget child) {
+    void dragDone(DropDoneDetails detail) {
+      setState(() {
+        _dragging = false;
+        _draggingOverThumbnails = false;
+      });
+      unawaited(_onFilesDropped(detail));
+    }
+
+    final handle = _nativeWindowHandle;
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.windows &&
+        handle != null) {
+      return WindowsDropTarget(
+        windowHandle: handle,
+        onDragEntered: (detail) => _onDragMoved(detail.globalPosition),
+        onDragUpdated: (detail) => _onDragMoved(detail.globalPosition),
+        onDragExited: (_) => _onDragEnded(),
+        onDragDone: dragDone,
+        child: child,
+      );
+    }
+    return DropTarget(
+      onDragEntered: (detail) => _onDragMoved(detail.globalPosition),
+      onDragUpdated: (detail) => _onDragMoved(detail.globalPosition),
+      onDragExited: (_) => _onDragEnded(),
+      onDragDone: dragDone,
+      child: child,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final tab = _active;
@@ -3216,72 +3260,60 @@ class _EditorScreenState extends State<EditorScreen>
           const SingleActivator(LogicalKeyboardKey.keyO,
               control: true, shift: true): _openMostRecent,
         },
-        child: DropTarget(
-          onDragEntered: (detail) => _onDragMoved(detail.globalPosition),
-          onDragUpdated: (detail) => _onDragMoved(detail.globalPosition),
-          onDragExited: (_) => _onDragEnded(),
-          onDragDone: (detail) {
-            setState(() {
-              _dragging = false;
-              _draggingOverThumbnails = false;
-            });
-            _onFilesDropped(detail);
-          },
-          child: Builder(builder: (context) {
-            final compactDevTools = _isCompactWidth(context);
-            return Stack(
-              children: [
-                // On wide screens the devtools panel docks beside the body
-                // (like the editor's own sidebars), so the viewer relays out
-                // narrower instead of being overlaid - zoom and scroll
-                // gestures keep their space. On phones there is no room for a
-                // side dock, so it rides up as a bottom sheet instead (below).
-                Positioned.fill(
-                  child: Row(
-                    children: [
-                      Expanded(child: _buildBodyWithDevTools(tab)),
-                      if (_devToolsOpen && kDevToolsEnabled && !compactDevTools)
-                        DevToolsPanel(
-                          onClose: _toggleDevTools,
-                          session: tab?.session,
-                          viewerController: tab?.viewer,
-                          documentTitle: tab?.title,
-                        ),
-                    ],
-                  ),
-                ),
-                // The full-window hint yields to the thumbnails' own
-                // insertion marker once the drag is over a page panel - the
-                // marker already says exactly where the pages will land.
-                if (_dragging && !_draggingOverThumbnails)
-                  Positioned.fill(
-                    child: _DropOverlay(
-                      canInsert: tab?.session != null && !_readOnly,
-                    ),
-                  ),
-                // Phone devtools: a bottom sheet over the viewer. Scrim-less,
-                // so the page underneath still takes gestures (matching the
-                // docked panel, which never blocked the viewer either).
-                if (_devToolsOpen && kDevToolsEnabled && compactDevTools)
-                  Positioned(
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    child: SafeArea(
-                      top: false,
-                      child: DevToolsPanel(
+        child: _buildFileDropTarget(Builder(builder: (context) {
+          final compactDevTools = _isCompactWidth(context);
+          return Stack(
+            children: [
+              // On wide screens the devtools panel docks beside the body
+              // (like the editor's own sidebars), so the viewer relays out
+              // narrower instead of being overlaid - zoom and scroll
+              // gestures keep their space. On phones there is no room for a
+              // side dock, so it rides up as a bottom sheet instead (below).
+              Positioned.fill(
+                child: Row(
+                  children: [
+                    Expanded(child: _buildBodyWithDevTools(tab)),
+                    if (_devToolsOpen && kDevToolsEnabled && !compactDevTools)
+                      DevToolsPanel(
                         onClose: _toggleDevTools,
                         session: tab?.session,
                         viewerController: tab?.viewer,
                         documentTitle: tab?.title,
-                        bottomSheet: true,
                       ),
+                  ],
+                ),
+              ),
+              // The full-window hint yields to the thumbnails' own
+              // insertion marker once the drag is over a page panel - the
+              // marker already says exactly where the pages will land.
+              if (_dragging && !_draggingOverThumbnails)
+                Positioned.fill(
+                  child: _DropOverlay(
+                    canInsert: tab?.session != null && !_readOnly,
+                  ),
+                ),
+              // Phone devtools: a bottom sheet over the viewer. Scrim-less,
+              // so the page underneath still takes gestures (matching the
+              // docked panel, which never blocked the viewer either).
+              if (_devToolsOpen && kDevToolsEnabled && compactDevTools)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: SafeArea(
+                    top: false,
+                    child: DevToolsPanel(
+                      onClose: _toggleDevTools,
+                      session: tab?.session,
+                      viewerController: tab?.viewer,
+                      documentTitle: tab?.title,
+                      bottomSheet: true,
                     ),
                   ),
-              ],
-            );
-          }),
-        ),
+                ),
+            ],
+          );
+        })),
       ),
     );
   }
@@ -3398,6 +3430,10 @@ class _EditorScreenState extends State<EditorScreen>
       onSave: (_) => unawaited(_save(tab)),
       onSaveAs: (_) => unawaited(_save(tab, saveAs: true)),
       showSaveButton: !compact,
+      saveButtonIcon: _usesMobileShare ? Icons.share_outlined : Icons.save_alt,
+      saveButtonLabel: _usesMobileShare
+          ? WidgetsLocalizations.of(context).shareButtonLabel
+          : null,
       // The shell enables Save off its *own* session history, which misses two
       // cases the app knows about. A brand-new untitled document has no on-disk
       // origin yet, so Save (button + Ctrl/⌘+S) stays live even before the
@@ -3480,8 +3516,13 @@ class _EditorScreenState extends State<EditorScreen>
               visualDensity: VisualDensity.compact,
               padding: const EdgeInsets.symmetric(horizontal: 12),
             ),
-            icon: const Icon(Icons.save_alt, size: 18),
-            label: Text(appL10n(context).save),
+            icon: Icon(
+              _usesMobileShare ? Icons.share_outlined : Icons.save_alt,
+              size: 18,
+            ),
+            label: Text(_usesMobileShare
+                ? WidgetsLocalizations.of(context).shareButtonLabel
+                : appL10n(context).save),
             onPressed: () => unawaited(_save(tab!)),
           ),
         ),
@@ -3505,9 +3546,8 @@ class _EditorScreenState extends State<EditorScreen>
   Widget _buildTabsTitle() {
     if (!_isCompactWidth(context)) return _buildTabStrip();
     final tab = _active;
-    Widget title = Text(
+    Widget title = MiddleEllipsisText(
       tab?.title.isEmpty ?? true ? appL10n(context).editorUntitled : tab!.title,
-      overflow: TextOverflow.ellipsis,
     );
     if (_nativeTabDragging && tab?.session != null) {
       title = _buildNativeTabDragSource(tab!, title);
@@ -3964,9 +4004,8 @@ class _EditorScreenState extends State<EditorScreen>
     // so the label keeps room; the active tab always keeps it.
     final showClose = selected || width >= _tabCloseHideWidth;
     Widget label() {
-      final text = Text(
+      final text = MiddleEllipsisText(
         tab.title.isEmpty ? appL10n(context).editorUntitled : tab.title,
-        overflow: TextOverflow.ellipsis,
         style: TextStyle(
           fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
           color:
@@ -4169,10 +4208,8 @@ class _EditorScreenState extends State<EditorScreen>
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
+                    MiddleEllipsisText(
                       tab.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: overStrip
                             ? scheme.onPrimaryContainer
@@ -4496,13 +4533,11 @@ class _DesktopTabPreviewCard extends StatelessWidget {
                     child: Icon(Icons.circle, size: 8, color: scheme.primary),
                   ),
                 Expanded(
-                  child: Text(
+                  child: MiddleEllipsisText(
                     tab.title.isEmpty
                         ? appL10n(context).editorUntitled
                         : tab.title,
                     key: const ValueKey('tab-hover-preview-title'),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.labelLarge,
                   ),
                 ),
@@ -4742,12 +4777,10 @@ class _MobileTabTile extends StatelessWidget {
                       child: Icon(Icons.circle, size: 8, color: scheme.primary),
                     ),
                   Expanded(
-                    child: Text(
+                    child: MiddleEllipsisText(
                       tab.title.isEmpty
                           ? appL10n(context).editorUntitled
                           : tab.title,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         fontWeight:
                             selected ? FontWeight.w600 : FontWeight.normal,

--- a/app/lib/middle_ellipsis_text.dart
+++ b/app/lib/middle_ellipsis_text.dart
@@ -1,0 +1,236 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show SemanticsConfiguration;
+
+/// A single-line text label that removes characters from its centre when it
+/// does not fit.
+///
+/// File names benefit from middle truncation because it keeps both the
+/// identifying start of the name and its extension visible. Flutter's stock
+/// [TextOverflow.ellipsis] only truncates the end.
+class MiddleEllipsisText extends LeafRenderObjectWidget {
+  const MiddleEllipsisText(
+    this.data, {
+    super.key,
+    this.style,
+    this.textAlign,
+  });
+
+  final String data;
+  final TextStyle? style;
+  final TextAlign? textAlign;
+
+  _MiddleEllipsisConfiguration _configuration(BuildContext context) =>
+      _MiddleEllipsisConfiguration(
+        data: data,
+        style: DefaultTextStyle.of(context).style.merge(style),
+        textDirection: Directionality.of(context),
+        textScaler: MediaQuery.textScalerOf(context),
+        locale: Localizations.maybeLocaleOf(context),
+        textAlign: textAlign ?? TextAlign.start,
+      );
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderMiddleEllipsisText(_configuration(context));
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    RenderObject renderObject,
+  ) {
+    (renderObject as _RenderMiddleEllipsisText).configuration =
+        _configuration(context);
+  }
+}
+
+@immutable
+class _MiddleEllipsisConfiguration {
+  const _MiddleEllipsisConfiguration({
+    required this.data,
+    required this.style,
+    required this.textDirection,
+    required this.textScaler,
+    required this.locale,
+    required this.textAlign,
+  });
+
+  final String data;
+  final TextStyle style;
+  final TextDirection textDirection;
+  final TextScaler textScaler;
+  final Locale? locale;
+  final TextAlign textAlign;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _MiddleEllipsisConfiguration &&
+      data == other.data &&
+      style == other.style &&
+      textDirection == other.textDirection &&
+      textScaler == other.textScaler &&
+      locale == other.locale &&
+      textAlign == other.textAlign;
+
+  @override
+  int get hashCode => Object.hash(
+        data,
+        style,
+        textDirection,
+        textScaler,
+        locale,
+        textAlign,
+      );
+}
+
+class _RenderMiddleEllipsisText extends RenderBox {
+  _RenderMiddleEllipsisText(this._configuration);
+
+  _MiddleEllipsisConfiguration _configuration;
+  TextPainter? _painter;
+  String _displayedText = '';
+
+  set configuration(_MiddleEllipsisConfiguration value) {
+    if (value == _configuration) return;
+    final semanticsChanged = value.data != _configuration.data ||
+        value.textDirection != _configuration.textDirection;
+    _configuration = value;
+    markNeedsLayout();
+    if (semanticsChanged) markNeedsSemanticsUpdate();
+  }
+
+  // Read dynamically by the focused widget test without making the render
+  // implementation part of the app's public API.
+  String get debugDisplayedText => _displayedText;
+
+  TextPainter _textPainter(String text) => TextPainter(
+        text: TextSpan(text: text, style: _configuration.style),
+        textDirection: _configuration.textDirection,
+        textScaler: _configuration.textScaler,
+        locale: _configuration.locale,
+        textAlign: _configuration.textAlign,
+        maxLines: 1,
+      );
+
+  double _naturalWidth(String text) {
+    final painter = _textPainter(text)..layout();
+    final width = painter.width;
+    painter.dispose();
+    return width;
+  }
+
+  @override
+  void performLayout() {
+    final natural = _textPainter(_configuration.data)..layout();
+    final naturalSize = natural.size;
+    final availableWidth = constraints.constrainWidth(naturalSize.width);
+    _displayedText = naturalSize.width <= availableWidth
+        ? _configuration.data
+        : _middleEllipsize(
+            _configuration.data,
+            (candidate) => _naturalWidth(candidate) <= availableWidth,
+          );
+    natural.dispose();
+
+    _painter?.dispose();
+    _painter = _textPainter(_displayedText)
+      ..layout(minWidth: availableWidth, maxWidth: availableWidth);
+    size = constraints.constrain(Size(naturalSize.width, naturalSize.height));
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    _painter!.paint(context.canvas, offset);
+  }
+
+  @override
+  bool hitTestSelf(Offset position) => true;
+
+  @override
+  double computeMinIntrinsicWidth(double height) =>
+      _naturalWidth(_configuration.data);
+
+  @override
+  double computeMaxIntrinsicWidth(double height) =>
+      _naturalWidth(_configuration.data);
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    final painter = _textPainter(_configuration.data)..layout();
+    final height = painter.height;
+    painter.dispose();
+    return height;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) =>
+      computeMinIntrinsicHeight(width);
+
+  @override
+  double? computeDistanceToActualBaseline(TextBaseline baseline) =>
+      _painter!.computeDistanceToActualBaseline(baseline);
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config
+      ..isSemanticBoundary = true
+      ..label = _configuration.data
+      ..textDirection = _configuration.textDirection;
+  }
+
+  @override
+  void dispose() {
+    _painter?.dispose();
+    super.dispose();
+  }
+}
+
+String _middleEllipsize(
+  String value,
+  bool Function(String candidate) fits,
+) {
+  if (fits(value)) return value;
+  const ellipsis = '…';
+  if (!fits(ellipsis)) return '';
+
+  final characters = value.runes.toList(growable: false);
+  final lastDot = value.lastIndexOf('.');
+  final extensionLength = lastDot > 0 && lastDot < value.length - 1
+      ? value.substring(lastDot).runes.length
+      : 0;
+  // For file names, keep the complete extension whenever it can fit. This is
+  // the useful part of Finder-style middle truncation: `drawing…ing.pdf` is
+  // still recognisable as a PDF, unlike `drawing…pdf` or an end ellipsis.
+  final minimumSuffix = extensionLength > 0 &&
+          fits(ellipsis +
+              String.fromCharCodes(
+                characters.skip(characters.length - extensionLength),
+              ))
+      ? extensionLength
+      : 0;
+  var low = 0;
+  var high = characters.length;
+  var best = ellipsis;
+  while (low <= high) {
+    final kept = (low + high) ~/ 2;
+    // Keep one extra character at the end when the split is uneven: for file
+    // names this makes extensions slightly more resilient at very small widths.
+    final suffixCount = math.min(
+      kept,
+      math.max(minimumSuffix, (kept + 1) ~/ 2),
+    );
+    final prefixCount = kept - suffixCount;
+    final candidate = String.fromCharCodes(characters.take(prefixCount)) +
+        ellipsis +
+        String.fromCharCodes(characters.skip(characters.length - suffixCount));
+    if (fits(candidate)) {
+      best = candidate;
+      low = kept + 1;
+    } else {
+      high = kept - 1;
+    }
+  }
+  return best;
+}

--- a/app/lib/print_preview_dialog.dart
+++ b/app/lib/print_preview_dialog.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'l10n/app_l10n.dart';
+import 'middle_ellipsis_text.dart';
 import 'l10n/app_localizations.dart';
 
 /// Which pages a print job covers, as chosen in the preview.
@@ -157,8 +158,8 @@ class _PrintPreviewDialogState extends State<PrintPreviewDialog> {
   void _step(int delta) {
     final pages = _pages;
     if (pages.isEmpty) return;
-    setState(() =>
-        _previewSlot = (_previewSlot + delta).clamp(0, pages.length - 1));
+    setState(
+        () => _previewSlot = (_previewSlot + delta).clamp(0, pages.length - 1));
   }
 
   void _print() {
@@ -175,9 +176,8 @@ class _PrintPreviewDialogState extends State<PrintPreviewDialog> {
     final l10n = appL10n(context);
     final theme = Theme.of(context);
     final pages = _pages;
-    final previewPage = pages.isEmpty
-        ? null
-        : pages[_previewSlot.clamp(0, pages.length - 1)];
+    final previewPage =
+        pages.isEmpty ? null : pages[_previewSlot.clamp(0, pages.length - 1)];
 
     // The dialog is desktop-first (it only opens where the OS print flow has
     // no preview of its own), but stay inside a small window rather than
@@ -194,11 +194,9 @@ class _PrintPreviewDialogState extends State<PrintPreviewDialog> {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(l10n.printPreviewTitle),
-          Text(
+          MiddleEllipsisText(
             widget.title,
             style: theme.textTheme.bodySmall,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),
@@ -386,9 +384,8 @@ class _PagePreviewState extends State<_PagePreview> {
         // Annotations print (the vector encoder keeps them), so preview them.
         final image = await PdfPageRenderer.renderImage(
           page,
-          pixelRatio: size.width <= 0
-              ? 1.0
-              : (pixelWidth / size.width).clamp(0.2, 4.0),
+          pixelRatio:
+              size.width <= 0 ? 1.0 : (pixelWidth / size.width).clamp(0.2, 4.0),
         );
         if (!mounted || token != _token) {
           image.dispose();
@@ -437,9 +434,8 @@ class _PagePreviewState extends State<_PagePreview> {
       }
       return Center(
         child: AspectRatio(
-          aspectRatio: _pageSize.height <= 0
-              ? 1
-              : _pageSize.width / _pageSize.height,
+          aspectRatio:
+              _pageSize.height <= 0 ? 1 : _pageSize.width / _pageSize.height,
           child: DecoratedBox(
             decoration: BoxDecoration(
               color: const Color(0xFFFFFFFF),

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'app_info.dart';
 import 'l10n/app_l10n.dart';
+import 'middle_ellipsis_text.dart';
 import 'recent_thumbnails.dart';
 import 'recents.dart';
 
@@ -401,10 +402,9 @@ class _RecentsList extends StatelessWidget {
             width: 48,
             height: 62,
           ),
-          title:
-              Text(entry.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+          title: MiddleEllipsisText(entry.title),
           subtitle: entry.path != null
-              ? Text(entry.path!, maxLines: 1, overflow: TextOverflow.ellipsis)
+              ? MiddleEllipsisText(entry.path!)
               : entry.isReopenable
                   // Mobile: reopens from a private snapshot, so no path to
                   // show and no re-pick needed.
@@ -550,10 +550,8 @@ class _RecentGridTile extends StatelessWidget {
             height: _twoLineHeight(context, theme.textTheme.bodySmall),
             child: Align(
               alignment: Alignment.bottomCenter,
-              child: Text(
+              child: MiddleEllipsisText(
                 entry.title,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall,
               ),

--- a/app/lib/windows_drop_target.dart
+++ b/app/lib/windows_drop_target.dart
@@ -1,0 +1,184 @@
+import 'dart:async' show unawaited;
+
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+const _channel = MethodChannel('dev.milanko.dartpdf/windows_drop');
+
+enum _WindowsDropEventKind { entered, updated, exited, dropped }
+
+class _WindowsDropEvent {
+  const _WindowsDropEvent(this.kind, this.position, this.paths);
+
+  final _WindowsDropEventKind kind;
+  final Offset position;
+  final List<String> paths;
+}
+
+typedef _WindowsDropListener = void Function(_WindowsDropEvent event);
+
+/// Routes the engine-scoped Windows channel to the Flutter view whose HWND
+/// received the native OLE drop. `desktop_drop` cannot do this itself because
+/// it registers only against the registrar's implicit view; DartPDF's
+/// multi-window runner intentionally has no such view.
+class _WindowsDropRouter {
+  _WindowsDropRouter._() {
+    _channel.setMethodCallHandler(_handleCall);
+  }
+
+  static final instance = _WindowsDropRouter._();
+
+  final Map<int, Set<_WindowsDropListener>> _listeners = {};
+
+  void attach(int handle, _WindowsDropListener listener) {
+    final listeners = _listeners.putIfAbsent(handle, () => {});
+    final first = listeners.isEmpty;
+    listeners.add(listener);
+    if (first) {
+      unawaited(_channel.invokeMethod<void>(
+          'register', <String, Object>{'handle': handle}).catchError((_) {}));
+    }
+  }
+
+  void detach(int handle, _WindowsDropListener listener) {
+    final listeners = _listeners[handle];
+    if (listeners == null) return;
+    listeners.remove(listener);
+    if (listeners.isNotEmpty) return;
+    _listeners.remove(handle);
+    unawaited(_channel.invokeMethod<void>(
+        'unregister', <String, Object>{'handle': handle}).catchError((_) {}));
+  }
+
+  Future<void> _handleCall(MethodCall call) async {
+    final args = call.arguments;
+    if (args is! Map) return;
+    final handle = args['handle'];
+    if (handle is! int) return;
+    final listeners = _listeners[handle];
+    if (listeners == null || listeners.isEmpty) return;
+    final x = args['x'];
+    final y = args['y'];
+    final position = Offset(
+      x is num ? x.toDouble() : 0,
+      y is num ? y.toDouble() : 0,
+    );
+    final paths = switch (args['paths']) {
+      final List values => values.whereType<String>().toList(growable: false),
+      _ => const <String>[],
+    };
+    final kind = switch (call.method) {
+      'entered' => _WindowsDropEventKind.entered,
+      'updated' => _WindowsDropEventKind.updated,
+      'exited' => _WindowsDropEventKind.exited,
+      'performOperation' => _WindowsDropEventKind.dropped,
+      _ => null,
+    };
+    if (kind == null) return;
+    final event = _WindowsDropEvent(kind, position, paths);
+    for (final listener in List<_WindowsDropListener>.of(listeners)) {
+      listener(event);
+    }
+  }
+}
+
+/// A per-native-window counterpart to [DropTarget] for DartPDF's Windows
+/// multi-window runner.
+///
+/// The native bridge includes the receiving HWND with each event, so a drop in
+/// one window cannot accidentally notify the identically-positioned body of a
+/// second window.
+class WindowsDropTarget extends StatefulWidget {
+  const WindowsDropTarget({
+    super.key,
+    required this.windowHandle,
+    required this.child,
+    this.onDragEntered,
+    this.onDragUpdated,
+    this.onDragExited,
+    this.onDragDone,
+  });
+
+  final int windowHandle;
+  final Widget child;
+  final OnDragCallback<DropEventDetails>? onDragEntered;
+  final OnDragCallback<DropEventDetails>? onDragUpdated;
+  final OnDragCallback<DropEventDetails>? onDragExited;
+  final OnDragDoneCallback? onDragDone;
+
+  @override
+  State<WindowsDropTarget> createState() => _WindowsDropTargetState();
+}
+
+class _WindowsDropTargetState extends State<WindowsDropTarget> {
+  bool _inside = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _WindowsDropRouter.instance.attach(widget.windowHandle, _onEvent);
+  }
+
+  @override
+  void didUpdateWidget(WindowsDropTarget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.windowHandle == widget.windowHandle) return;
+    _WindowsDropRouter.instance.detach(oldWidget.windowHandle, _onEvent);
+    _WindowsDropRouter.instance.attach(widget.windowHandle, _onEvent);
+    _inside = false;
+  }
+
+  void _onEvent(_WindowsDropEvent event) {
+    if (!mounted) return;
+    final box = context.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return;
+    final ratio = MediaQuery.devicePixelRatioOf(context);
+    final global = event.position / ratio;
+    final local = box.globalToLocal(global);
+    final inBounds = box.paintBounds.contains(local);
+    final details = DropEventDetails(
+      localPosition: local,
+      globalPosition: global,
+    );
+    switch (event.kind) {
+      case _WindowsDropEventKind.entered:
+        if (!inBounds) return;
+        _inside = true;
+        widget.onDragEntered?.call(details);
+      case _WindowsDropEventKind.updated:
+        if (inBounds) {
+          if (!_inside) {
+            _inside = true;
+            widget.onDragEntered?.call(details);
+          } else {
+            widget.onDragUpdated?.call(details);
+          }
+        } else if (_inside) {
+          _inside = false;
+          widget.onDragExited?.call(details);
+        }
+      case _WindowsDropEventKind.exited:
+        if (!_inside) return;
+        _inside = false;
+        widget.onDragExited?.call(details);
+      case _WindowsDropEventKind.dropped:
+        if (!_inside || !inBounds) return;
+        _inside = false;
+        widget.onDragDone?.call(DropDoneDetails(
+          files: [for (final path in event.paths) DropItemFile(path)],
+          localPosition: local,
+          globalPosition: global,
+        ));
+    }
+  }
+
+  @override
+  void dispose() {
+    _WindowsDropRouter.instance.detach(widget.windowHandle, _onEvent);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/app/test/doc_scan_menu_test.dart
+++ b/app/test/doc_scan_menu_test.dart
@@ -20,6 +20,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -72,7 +74,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // A brand-new untitled tab now holds the scan.
-    expect(find.text('Untitled.pdf'), findsOneWidget);
+    expect(findMiddleEllipsisText('Untitled.pdf'), findsOneWidget);
   });
 
   testWidgets('no Insert scan entry without a document open', (tester) async {
@@ -131,7 +133,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // No document was created; the welcome screen is still up.
-    expect(find.text('Untitled.pdf'), findsNothing);
+    expect(findMiddleEllipsisText('Untitled.pdf'), findsNothing);
     expect(find.byType(PdfEditorView), findsNothing);
   });
 
@@ -157,7 +159,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.textContaining('scanner unavailable'), findsOneWidget);
-    expect(find.text('Untitled.pdf'), findsNothing);
+    expect(findMiddleEllipsisText('Untitled.pdf'), findsNothing);
   });
 
   testWidgets('a failing Insert scan toasts instead of throwing',

--- a/app/test/drop_insert_test.dart
+++ b/app/test/drop_insert_test.dart
@@ -11,6 +11,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+import 'test_finders.dart';
+
 // These tests exercise the *branching* a drop takes - show the open/insert
 // dialog when a document is open, and route to the right action - by driving
 // the desktop_drop channel directly. They deliberately do not read real files:
@@ -83,7 +85,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   testWidgets('dropping onto an open document offers open or insert',

--- a/app/test/middle_ellipsis_text_test.dart
+++ b/app/test/middle_ellipsis_text_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/middle_ellipsis_text.dart';
+
+void main() {
+  testWidgets('keeps both ends of an overflowing file name', (tester) async {
+    const name = 'a-very-long-drawing-file-name.pdf';
+    await tester.pumpWidget(const MaterialApp(
+      home: Center(
+        child: SizedBox(
+          width: 110,
+          child: MiddleEllipsisText(name, style: TextStyle(fontSize: 14)),
+        ),
+      ),
+    ));
+
+    final render = tester.renderObject(find.byType(MiddleEllipsisText));
+    // ignore: avoid_dynamic_calls
+    final rendered = (render as dynamic).debugDisplayedText as String;
+    expect(rendered, isNot(name));
+    expect(rendered, contains('…'));
+    expect(rendered, startsWith('a'));
+    expect(rendered, endsWith('.pdf'));
+  });
+
+  testWidgets('leaves a fitting file name unchanged', (tester) async {
+    const name = 'drawing.pdf';
+    await tester.pumpWidget(const MaterialApp(
+      home: Center(
+        child: SizedBox(
+          width: 300,
+          child: MiddleEllipsisText(name, style: TextStyle(fontSize: 14)),
+        ),
+      ),
+    ));
+
+    final render = tester.renderObject(find.byType(MiddleEllipsisText));
+    // ignore: avoid_dynamic_calls
+    expect((render as dynamic).debugDisplayedText, name);
+  });
+}

--- a/app/test/multi_window_test.dart
+++ b/app/test/multi_window_test.dart
@@ -21,6 +21,8 @@ import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 import 'package:dart_pdf_editor_app/window_support.dart';
 
+import 'test_finders.dart';
+
 // flutter_test cannot create real desktop windows. These tests pin the public
 // app-side seam instead: feature visibility, shortcuts, lossless handoff,
 // failure safety, process-service isolation, and the native close handshake.
@@ -62,7 +64,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   Future<void> rightClickTab(WidgetTester tester, String name) async {

--- a/app/test/new_document_test.dart
+++ b/app/test/new_document_test.dart
@@ -5,6 +5,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -63,7 +65,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('new-document-create')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Untitled.pdf'), findsWidgets);
+    expect(findMiddleEllipsisText('Untitled.pdf'), findsWidgets);
     final view = tester.widget<PdfEditorView>(find.byType(PdfEditorView));
     final page = view.controller!.document.page(0);
     expect(page.mediaBox.width, 792);
@@ -84,7 +86,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('new-document-create')));
     await tester.pumpAndSettle();
 
-    expect(find.text('Untitled.pdf'), findsOneWidget);
-    expect(find.text('Untitled 2.pdf'), findsOneWidget);
+    expect(findMiddleEllipsisText('Untitled.pdf'), findsOneWidget);
+    expect(findMiddleEllipsisText('Untitled 2.pdf'), findsOneWidget);
   });
 }

--- a/app/test/progressive_open_test.dart
+++ b/app/test/progressive_open_test.dart
@@ -18,6 +18,8 @@ import 'package:dart_pdf_editor_app/devtools.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
   late Directory tempDir;
@@ -42,7 +44,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   Future<void> pump(WidgetTester tester, Future<void> Function() action) async {

--- a/app/test/recent_menu_test.dart
+++ b/app/test/recent_menu_test.dart
@@ -8,6 +8,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -86,7 +88,7 @@ void main() {
       await tester.tap(find.text('Open Recent'));
       await tester.pumpAndSettle();
       final recentItemFinder = find.ancestor(
-        of: find.text('alpha.pdf'),
+        of: findMiddleEllipsisText('alpha.pdf'),
         matching: find.byType(PopupMenuItem<VoidCallback>),
       );
       final recentItem = tester.widget<PopupMenuItem<VoidCallback>>(
@@ -141,8 +143,8 @@ void main() {
     await tester.tap(find.text('Open Recent'));
     await tester.pumpAndSettle();
 
-    expect(find.text('alpha.pdf'), findsWidgets);
-    expect(find.text('beta.pdf'), findsWidgets);
+    expect(findMiddleEllipsisText('alpha.pdf'), findsWidgets);
+    expect(findMiddleEllipsisText('beta.pdf'), findsWidgets);
     expect(
       find.byKey(const ValueKey('view-all-recent-files')),
       findsOneWidget,

--- a/app/test/save_shortcuts_test.dart
+++ b/app/test/save_shortcuts_test.dart
@@ -11,6 +11,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/file_io.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -144,8 +146,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(saveAsCalls, 1);
-      expect(find.text('Renamed.pdf'), findsWidgets);
-      expect(find.text('Original.pdf'), findsNothing);
+      expect(findMiddleEllipsisText('Renamed.pdf'), findsWidgets);
+      expect(findMiddleEllipsisText('Original.pdf'), findsNothing);
       final continued =
           tester.widget<PdfEditorView>(find.byType(PdfEditorView));
       expect(continued.documentId, 'Renamed.pdf');

--- a/app/test/session_restore_test.dart
+++ b/app/test/session_restore_test.dart
@@ -17,6 +17,8 @@ import 'package:dart_pdf_editor_app/session_store.dart';
 import 'package:dart_pdf_editor_app/unsaved_changes.dart';
 import 'package:dart_pdf_editor_app/welcome_screen.dart';
 
+import 'test_finders.dart';
+
 class _FakeFileSelector extends fs.FileSelectorPlatform {
   _FakeFileSelector(this.files);
 
@@ -85,7 +87,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   // The editor never settles (it keeps rasterizing), and restore performs real
@@ -347,9 +349,14 @@ void main() {
     expect(tester.getCenter(tabTitle('b.pdf')).dx,
         lessThan(tester.getCenter(tabTitle('clicked.pdf')).dx));
     // ...and stays the document on screen.
-    expect(tester.widget<Text>(tabTitle('clicked.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('clicked.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
-    expect(tester.widget<Text>(tabTitle('b.pdf')).style?.fontWeight,
+    expect(
+        tester.widget<MiddleEllipsisText>(tabTitle('b.pdf')).style?.fontWeight,
         FontWeight.normal);
   });
 
@@ -373,7 +380,8 @@ void main() {
     expect(find.byTooltip('Close tab'), findsNWidgets(2)); // no duplicate tab
     expect(tester.getCenter(tabTitle('b.pdf')).dx,
         lessThan(tester.getCenter(tabTitle('a.pdf')).dx));
-    expect(tester.widget<Text>(tabTitle('a.pdf')).style?.fontWeight,
+    expect(
+        tester.widget<MiddleEllipsisText>(tabTitle('a.pdf')).style?.fontWeight,
         FontWeight.w600);
   });
 }

--- a/app/test/tab_drag_test.dart
+++ b/app/test/tab_drag_test.dart
@@ -11,6 +11,8 @@ import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/tab_drag.dart';
 import 'package:dart_pdf_editor_app/window_support.dart';
 
+import 'test_finders.dart';
+
 class _FakeLocator implements TabDropLocator {
   TabDropLocation? location;
   Object? failure;
@@ -92,6 +94,11 @@ DocumentHandoff _handoff([String title = 'dragged.pdf']) {
 }
 
 void main() {
+  Finder tabLabel(String title) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: findMiddleEllipsisText(title),
+      );
+
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('native locator sends window handles and decodes the local point',
@@ -169,10 +176,7 @@ void main() {
     await tester.pump();
 
     expect(
-      find.descendant(
-        of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text('dragged.pdf'),
-      ),
+      tabLabel('dragged.pdf'),
       findsOneWidget,
     );
     expect(source.tabs, isEmpty);
@@ -204,10 +208,7 @@ void main() {
     );
     await tester.pump();
     expect(
-      find.descendant(
-        of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text('compact.pdf'),
-      ),
+      tabLabel('compact.pdf'),
       findsOneWidget,
     );
     expect(compactSource.tabs, isEmpty);
@@ -220,10 +221,7 @@ void main() {
         DocumentTab.error(title: 'incoming.pdf', error: 'fixture');
     incomingSource.tabs.add(incomingTab);
     coordinator.register(incomingSource);
-    final firstTabBefore = tester.getCenter(find.descendant(
-      of: find.byKey(const ValueKey('tab-strip')),
-      matching: find.text('dragged.pdf'),
-    ));
+    final firstTabBefore = tester.getCenter(tabLabel('dragged.pdf'));
     final targetListRect =
         tester.getRect(find.byKey(const ValueKey('tab-strip')));
     locator.location = TabDropLocation(
@@ -256,12 +254,7 @@ void main() {
     expect(tester.getTopLeft(destinationFeedback).dx,
         greaterThan(feedbackLeft + 20));
     expect(
-      tester
-          .getCenter(find.descendant(
-            of: find.byKey(const ValueKey('tab-strip')),
-            matching: find.text('dragged.pdf'),
-          ))
-          .dx,
+      tester.getCenter(tabLabel('dragged.pdf')).dx,
       greaterThan(firstTabBefore.dx + 100),
     );
     coordinator.cancel(incomingToken);
@@ -276,14 +269,8 @@ void main() {
     // the coordinator. Dragging the second tab before the first is the
     // regression for replacing the ReorderableListView handle with a plain
     // Draggable without restoring same-strip routing.
-    final compactLabel = find.descendant(
-      of: find.byKey(const ValueKey('tab-strip')),
-      matching: find.text('compact.pdf'),
-    );
-    final draggedLabel = find.descendant(
-      of: find.byKey(const ValueKey('tab-strip')),
-      matching: find.text('dragged.pdf'),
-    );
+    final compactLabel = tabLabel('compact.pdf');
+    final draggedLabel = tabLabel('dragged.pdf');
     final firstRect = tester.getRect(draggedLabel);
     final firstCenterBeforeReorder = tester.getCenter(draggedLabel);
     final tabListRect = tester.getRect(find.byKey(const ValueKey('tab-strip')));
@@ -350,10 +337,7 @@ void main() {
       localPoint: Offset(40, 20),
     );
     for (final title in ['compact.pdf', 'dragged.pdf']) {
-      final label = find.descendant(
-        of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(title),
-      );
+      final label = tabLabel(title);
       final move = await tester.startGesture(
         tester.getCenter(label),
         kind: PointerDeviceKind.mouse,

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
+import 'package:dart_pdf_editor_app/middle_ellipsis_text.dart';
 
 void main() {
   late PdfEditingPreferences prefs;
@@ -67,9 +68,13 @@ void main() {
   // The tab title within the strip (scoped to the tab-strip ReorderableListView
   // so it never matches the AppBar's active-document title nor the thumbnail
   // sidebar's own reorderable list in the body).
+  Finder middleText(String name) => find.byWidgetPredicate(
+        (widget) => widget is MiddleEllipsisText && widget.data == name,
+      );
+
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: middleText(name),
       );
 
   // Right-clicks the tab labelled [name] to open its context menu.
@@ -102,7 +107,7 @@ void main() {
   Finder gridTile(String name) => find.ancestor(
         of: find.descendant(
           of: find.byKey(const ValueKey('desktop-tabs-grid')),
-          matching: find.text(name),
+          matching: middleText(name),
         ),
         matching: find.byKey(const ValueKey('mobile-tab-tile')),
       );
@@ -162,6 +167,20 @@ void main() {
       findsOneWidget,
     );
     expect(find.byKey(const ValueKey('mobile-app-save')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile-app-save')),
+        matching: find.text('Share'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile-app-save')),
+        matching: find.byIcon(Icons.share_outlined),
+      ),
+      findsOneWidget,
+    );
     expect(find.byKey(const ValueKey('pdf-shell-save')), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('mobile-tabs-button')));
@@ -173,19 +192,58 @@ void main() {
     expect(
       find.descendant(
         of: find.byKey(const ValueKey('mobile-tabs-grid')),
-        matching: find.text('alpha.pdf'),
+        matching: middleText('alpha.pdf'),
       ),
       findsOneWidget,
     );
     expect(
       find.descendant(
         of: find.byKey(const ValueKey('mobile-tabs-grid')),
-        matching: find.text('beta.pdf'),
+        matching: middleText('beta.pdf'),
       ),
       findsOneWidget,
     );
     expect(find.byKey(const ValueKey('mobile-tabs-open')), findsOneWidget);
   });
+
+  testWidgets('wide mobile save affordance is labelled Share', (tester) async {
+    setDesktopSize(tester);
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'alpha.pdf');
+
+    final save = find.byKey(const ValueKey('pdf-shell-save'));
+    expect(save, findsOneWidget);
+    expect(
+      find.descendant(of: save, matching: find.text('Share')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: save, matching: find.byIcon(Icons.share_outlined)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+    'narrow desktop keeps the Save affordance',
+    (tester) async {
+      await setMobileSize(tester);
+      await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      await tester.pump();
+      await openTab(tester, 'alpha.pdf');
+
+      final save = find.byKey(const ValueKey('mobile-app-save'));
+      expect(
+        find.descendant(of: save, matching: find.text('Save')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: save, matching: find.byIcon(Icons.save_alt)),
+        findsOneWidget,
+      );
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.windows),
+  );
 
   testWidgets('desktop tab strip opens the preview grid in a dialog',
       (tester) async {
@@ -229,12 +287,16 @@ void main() {
     expect(find.byKey(const ValueKey('desktop-tabs-open')), findsOneWidget);
 
     await tester.tap(
-      find.descendant(of: grid, matching: find.text('alpha.pdf')),
+      find.descendant(of: grid, matching: middleText('alpha.pdf')),
     );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('desktop-tabs-dialog')), findsNothing);
-    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('alpha.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
   });
 
@@ -260,7 +322,7 @@ void main() {
     final grid = find.byKey(const ValueKey('desktop-tabs-grid'));
     Finder previewFor(String title) {
       final tile = find.ancestor(
-        of: find.descendant(of: grid, matching: find.text(title)),
+        of: find.descendant(of: grid, matching: middleText(title)),
         matching: find.byKey(const ValueKey('mobile-tab-tile')),
       );
       return find.descendant(
@@ -297,7 +359,7 @@ void main() {
         )
         .first;
     Finder tile(String title) => find.ancestor(
-          of: find.descendant(of: grid, matching: find.text(title)),
+          of: find.descendant(of: grid, matching: middleText(title)),
           matching: find.byKey(const ValueKey('mobile-tab-tile')),
         );
     expect(tester.widget<GridView>(grid).scrollCacheExtent, isNotNull);
@@ -352,15 +414,19 @@ void main() {
     );
     expect(thumbnailSize.width / thumbnailSize.height, closeTo(792 / 612, .01));
     expect(
-      tester.widget<Text>(
-        find.byKey(const ValueKey('tab-hover-preview-title')),
-      ).data,
+      tester
+          .widget<MiddleEllipsisText>(
+            find.byKey(const ValueKey('tab-hover-preview-title')),
+          )
+          .data,
       'alpha.pdf',
     );
     expect(
-      tester.widget<Text>(
-        find.byKey(const ValueKey('tab-hover-preview-page')),
-      ).data,
+      tester
+          .widget<Text>(
+            find.byKey(const ValueKey('tab-hover-preview-page')),
+          )
+          .data,
       'Page 1',
     );
     await tester.pump();
@@ -519,7 +585,11 @@ void main() {
 
     expect(tabTitle('gamma.pdf'), findsNothing);
     // beta is now the rightmost survivor and becomes active.
-    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('beta.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
   });
 
@@ -531,7 +601,11 @@ void main() {
     await openTab(tester, 'alpha.pdf', path: '/docs/alpha.pdf');
     await openTab(tester, 'beta.pdf', path: '/docs/beta.pdf');
     // beta was opened last, so it is the active tab.
-    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('beta.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
 
     // The OS hands us alpha a second time (another "open with" of the same
@@ -542,9 +616,17 @@ void main() {
     // No duplicate tab, and alpha is now focused rather than re-loaded.
     expect(tabTitle('alpha.pdf'), findsOneWidget);
     expect(find.byTooltip('Close tab'), findsNWidgets(2));
-    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('alpha.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
-    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('beta.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.normal);
   });
 }

--- a/app/test/tabs_reorder_test.dart
+++ b/app/test/tabs_reorder_test.dart
@@ -9,6 +9,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+import 'test_finders.dart';
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -42,7 +44,7 @@ void main() {
   // sidebar's own reorderable list in the body).
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   testWidgets('tabs render in a reorderable strip', (tester) async {
@@ -96,9 +98,17 @@ void main() {
     // Both tabs survive and beta is still the active document (its tab keeps
     // the selected weight while alpha reverts to normal).
     expect(find.byTooltip('Close tab'), findsNWidgets(2));
-    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('beta.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.w600);
-    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+    expect(
+        tester
+            .widget<MiddleEllipsisText>(tabTitle('alpha.pdf'))
+            .style
+            ?.fontWeight,
         FontWeight.normal);
   });
 }

--- a/app/test/tabs_sizing_test.dart
+++ b/app/test/tabs_sizing_test.dart
@@ -9,6 +9,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+import 'test_finders.dart';
+
 /// Chrome-style tab sizing: tabs share the strip equally and shrink as more
 /// open, and closing while the pointer is over the strip holds the surviving
 /// tabs' width until the pointer leaves.
@@ -47,7 +49,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   // The tab's coloured Material (nearest Material ancestor of its title); its

--- a/app/test/test_finders.dart
+++ b/app/test/test_finders.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/middle_ellipsis_text.dart';
+export 'package:dart_pdf_editor_app/middle_ellipsis_text.dart'
+    show MiddleEllipsisText;
+
+/// Finds the filename widget by its complete source value, regardless of the
+/// centre-ellipsized text currently painted for its layout width.
+Finder findMiddleEllipsisText(String value) => find.byWidgetPredicate(
+      (widget) => widget is MiddleEllipsisText && widget.data == value,
+    );

--- a/app/test/unsaved_changes_recovery_test.dart
+++ b/app/test/unsaved_changes_recovery_test.dart
@@ -14,6 +14,8 @@ import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/file_io.dart';
 import 'package:dart_pdf_editor_app/unsaved_changes.dart';
 
+import 'test_finders.dart';
+
 /// The editor half of crash recovery: what the user sees on the launch after
 /// the app went away with unsaved work.
 void main() {
@@ -28,7 +30,7 @@ void main() {
 
   Finder tabTitle(String name) => find.descendant(
         of: find.byKey(const ValueKey('tab-strip')),
-        matching: find.text(name),
+        matching: findMiddleEllipsisText(name),
       );
 
   /// The dirty dot the tab strip paints beside an edited document.
@@ -157,9 +159,9 @@ void main() {
   });
 
   /// The live edit session behind the one open tab.
-  PdfEditingController sessionOf(WidgetTester tester) => tester
-      .widget<PdfViewer>(find.byType(PdfViewer).first)
-      .editing as PdfEditingController;
+  PdfEditingController sessionOf(WidgetTester tester) =>
+      tester.widget<PdfViewer>(find.byType(PdfViewer).first).editing
+          as PdfEditingController;
 
   testWidgets('backgrounding the app mirrors edits it has not written yet',
       (tester) async {

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -11,6 +11,8 @@ import 'package:dart_pdf_editor_app/recent_thumbnails.dart';
 import 'package:dart_pdf_editor_app/recents.dart';
 import 'package:dart_pdf_editor_app/welcome_screen.dart';
 
+import 'test_finders.dart';
+
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
@@ -339,8 +341,8 @@ void main() {
     expect(lThumb.center.dy, moreOrLessEquals(pThumb.center.dy, epsilon: 0.5));
 
     // The titles share one bottom baseline despite the differing thumbnails.
-    final pTitle = tester.getRect(find.text('portrait.pdf'));
-    final lTitle = tester.getRect(find.text('landscape.pdf'));
+    final pTitle = tester.getRect(findMiddleEllipsisText('portrait.pdf'));
+    final lTitle = tester.getRect(findMiddleEllipsisText('landscape.pdf'));
     expect(lTitle.bottom, moreOrLessEquals(pTitle.bottom, epsilon: 0.5));
   });
 

--- a/app/test/windows_drop_target_test.dart
+++ b/app/test/windows_drop_target_test.dart
@@ -1,0 +1,98 @@
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/windows_drop_target.dart';
+
+void main() {
+  const channel = MethodChannel('dev.milanko.dartpdf/windows_drop');
+  const codec = StandardMethodCodec();
+
+  testWidgets('routes a native drop to its registered window', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final registrations = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (call) async {
+        registrations.add(call);
+        return true;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null));
+
+    DropDoneDetails? dropped;
+    await tester.pumpWidget(MaterialApp(
+      home: WindowsDropTarget(
+        windowHandle: 42,
+        onDragDone: (details) => dropped = details,
+        child: const SizedBox.expand(),
+      ),
+    ));
+    await tester.pump();
+    expect(registrations.single.method, 'register');
+
+    Future<void> send(String method, {List<String>? paths}) async {
+      final message = codec.encodeMethodCall(MethodCall(method, {
+        'handle': 42,
+        'x': 100.0,
+        'y': 120.0,
+        if (paths != null) 'paths': paths,
+      }));
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        channel.name,
+        message,
+        (_) {},
+      );
+      await tester.pump();
+    }
+
+    await send('entered');
+    await send('performOperation', paths: [r'C:\drawings\plan.pdf']);
+
+    expect(dropped, isNotNull);
+    expect(dropped!.files.single.path, endsWith(r'plan.pdf'));
+    expect(dropped!.globalPosition, const Offset(100, 120));
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+    expect(registrations.last.method, 'unregister');
+  });
+
+  testWidgets('ignores events addressed to another window', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => true);
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null));
+
+    var drops = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: WindowsDropTarget(
+        windowHandle: 7,
+        onDragDone: (_) => drops++,
+        child: const SizedBox.expand(),
+      ),
+    ));
+    await tester.pump();
+
+    for (final method in ['entered', 'performOperation']) {
+      final message = codec.encodeMethodCall(MethodCall(method, {
+        'handle': 8,
+        'x': 100.0,
+        'y': 120.0,
+        'paths': [r'C:\other.pdf'],
+      }));
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        channel.name,
+        message,
+        (_) {},
+      );
+    }
+    await tester.pump();
+    expect(drops, 0);
+  });
+}

--- a/app/windows/runner/CMakeLists.txt
+++ b/app/windows/runner/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(${BINARY_NAME} WIN32
   "native_print.cpp"
   "platform_channels.cpp"
   "utils.cpp"
+  "windows_drop.cpp"
   "win32_window.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
   "Runner.rc"

--- a/app/windows/runner/platform_channels.cpp
+++ b/app/windows/runner/platform_channels.cpp
@@ -12,6 +12,7 @@
 #include "file_dialogs.h"
 #include "image_clipboard.h"
 #include "utils.h"
+#include "windows_drop.h"
 
 namespace {
 
@@ -143,6 +144,8 @@ DartPdfPlatformChannels::DartPdfPlatformChannels(
 DartPdfPlatformChannels::~DartPdfPlatformChannels() = default;
 
 void DartPdfPlatformChannels::Register(flutter::BinaryMessenger* messenger) {
+  windows_drop_service_ =
+      std::make_unique<DartPdfWindowsDropService>(messenger);
   incoming_channel_ =
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
           messenger, kIncomingChannelName,

--- a/app/windows/runner/platform_channels.h
+++ b/app/windows/runner/platform_channels.h
@@ -13,6 +13,8 @@
 #include "file_dialogs.h"
 #include "native_print.h"
 
+class DartPdfWindowsDropService;
+
 // Engine-scoped DartPDF services shared by the normal single-view runner and
 // Flutter's experimental engine-owned multi-window bootstrap.
 class DartPdfPlatformChannels {
@@ -44,6 +46,7 @@ class DartPdfPlatformChannels {
       native_print_channel_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       file_dialog_channel_;
+  std::unique_ptr<DartPdfWindowsDropService> windows_drop_service_;
   NativePrinter native_printer_;
 };
 

--- a/app/windows/runner/windows_drop.cpp
+++ b/app/windows/runner/windows_drop.cpp
@@ -1,0 +1,219 @@
+#include "windows_drop.h"
+
+#include <flutter/standard_method_codec.h>
+#include <ole2.h>
+#include <shellapi.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "utils.h"
+
+namespace {
+
+constexpr char kWindowsDropChannelName[] =
+    "dev.milanko.dartpdf/windows_drop";
+
+const flutter::EncodableValue* Lookup(const flutter::EncodableMap& map,
+                                      const char* key) {
+  auto it = map.find(flutter::EncodableValue(key));
+  return it == map.end() ? nullptr : &it->second;
+}
+
+std::optional<int64_t> Integer(const flutter::EncodableValue& value) {
+  if (const auto* number = std::get_if<int64_t>(&value)) return *number;
+  if (const auto* number = std::get_if<int32_t>(&value)) return *number;
+  return std::nullopt;
+}
+
+flutter::EncodableMap EventPayload(HWND window, POINTL point) {
+  POINT client{point.x, point.y};
+  ::ScreenToClient(window, &client);
+  return flutter::EncodableMap{
+      {flutter::EncodableValue("handle"),
+       flutter::EncodableValue(
+           static_cast<int64_t>(reinterpret_cast<intptr_t>(window)))},
+      {flutter::EncodableValue("x"),
+       flutter::EncodableValue(static_cast<double>(client.x))},
+      {flutter::EncodableValue("y"),
+       flutter::EncodableValue(static_cast<double>(client.y))},
+  };
+}
+
+}  // namespace
+
+class DartPdfWindowsDropTarget : public IDropTarget {
+ public:
+  DartPdfWindowsDropTarget(
+      HWND window,
+      flutter::MethodChannel<flutter::EncodableValue>* channel)
+      : window_(window), channel_(channel) {}
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void** object) override {
+    if (object == nullptr) return E_INVALIDARG;
+    if (iid == IID_IUnknown || iid == IID_IDropTarget) {
+      *object = static_cast<IDropTarget*>(this);
+      AddRef();
+      return S_OK;
+    }
+    *object = nullptr;
+    return E_NOINTERFACE;
+  }
+
+  ULONG STDMETHODCALLTYPE AddRef() override {
+    return static_cast<ULONG>(::InterlockedIncrement(&references_));
+  }
+
+  ULONG STDMETHODCALLTYPE Release() override {
+    const LONG references = ::InterlockedDecrement(&references_);
+    if (references == 0) delete this;
+    return static_cast<ULONG>(references);
+  }
+
+  HRESULT STDMETHODCALLTYPE DragEnter(IDataObject* data,
+                                      DWORD /*key_state*/,
+                                      POINTL point,
+                                      DWORD* effect) override {
+    last_point_ = point;
+    SetEffect(data, effect);
+    Invoke("entered", EventPayload(window_, point));
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE DragOver(DWORD /*key_state*/,
+                                     POINTL point,
+                                     DWORD* effect) override {
+    last_point_ = point;
+    if (effect != nullptr) *effect = DROPEFFECT_COPY;
+    Invoke("updated", EventPayload(window_, point));
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE DragLeave() override {
+    Invoke("exited", EventPayload(window_, last_point_));
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE Drop(IDataObject* data,
+                                 DWORD /*key_state*/,
+                                 POINTL point,
+                                 DWORD* effect) override {
+    last_point_ = point;
+    flutter::EncodableMap payload = EventPayload(window_, point);
+    flutter::EncodableList paths;
+    FORMATETC format{CF_HDROP, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL};
+    STGMEDIUM medium{};
+    if (data != nullptr && data->QueryGetData(&format) == S_OK &&
+        data->GetData(&format, &medium) == S_OK) {
+      HDROP drop = static_cast<HDROP>(::GlobalLock(medium.hGlobal));
+      if (drop != nullptr) {
+        const UINT count = ::DragQueryFileW(drop, 0xFFFFFFFF, nullptr, 0);
+        for (UINT index = 0; index < count; ++index) {
+          const UINT length = ::DragQueryFileW(drop, index, nullptr, 0);
+          std::wstring path(static_cast<size_t>(length) + 1, L'\0');
+          const UINT copied =
+              ::DragQueryFileW(drop, index, path.data(), length + 1);
+          path.resize(copied);
+          if (!path.empty()) {
+            paths.emplace_back(Utf8FromUtf16(path.c_str()));
+          }
+        }
+        ::GlobalUnlock(medium.hGlobal);
+      }
+      ::ReleaseStgMedium(&medium);
+    }
+    payload[flutter::EncodableValue("paths")] =
+        flutter::EncodableValue(std::move(paths));
+    if (effect != nullptr) *effect = DROPEFFECT_COPY;
+    Invoke("performOperation", std::move(payload));
+    return S_OK;
+  }
+
+ private:
+  ~DartPdfWindowsDropTarget() = default;
+
+  static void SetEffect(IDataObject* data, DWORD* effect) {
+    if (effect == nullptr) return;
+    FORMATETC format{CF_HDROP, nullptr, DVASPECT_CONTENT, -1, TYMED_HGLOBAL};
+    *effect = data != nullptr && data->QueryGetData(&format) == S_OK
+                  ? DROPEFFECT_COPY
+                  : DROPEFFECT_NONE;
+  }
+
+  void Invoke(const char* method, flutter::EncodableMap payload) {
+    channel_->InvokeMethod(
+        method,
+        std::make_unique<flutter::EncodableValue>(std::move(payload)));
+  }
+
+  HWND window_;
+  flutter::MethodChannel<flutter::EncodableValue>* channel_;
+  LONG references_ = 1;
+  POINTL last_point_{};
+};
+
+DartPdfWindowsDropService::DartPdfWindowsDropService(
+    flutter::BinaryMessenger* messenger) {
+  // RegisterDragDrop requires OLE initialization in addition to the runner's
+  // regular COM initialization. Balance S_OK and S_FALSE alike per the API.
+  ole_initialized_ = SUCCEEDED(::OleInitialize(nullptr));
+  channel_ = std::make_unique<
+      flutter::MethodChannel<flutter::EncodableValue>>(
+      messenger, kWindowsDropChannelName,
+      &flutter::StandardMethodCodec::GetInstance());
+  channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+        const auto* handle_value =
+            args == nullptr ? nullptr : Lookup(*args, "handle");
+        const auto handle =
+            handle_value == nullptr ? std::nullopt : Integer(*handle_value);
+        if (!handle.has_value()) {
+          result->Error("bad_args", "A native window handle is required");
+          return;
+        }
+        const HWND window = reinterpret_cast<HWND>(
+            static_cast<intptr_t>(*handle));
+        if (call.method_name() == "register") {
+          result->Success(flutter::EncodableValue(Register(window)));
+        } else if (call.method_name() == "unregister") {
+          Unregister(window);
+          result->Success();
+        } else {
+          result->NotImplemented();
+        }
+      });
+}
+
+DartPdfWindowsDropService::~DartPdfWindowsDropService() {
+  while (!targets_.empty()) Unregister(targets_.begin()->first);
+  if (ole_initialized_) ::OleUninitialize();
+}
+
+bool DartPdfWindowsDropService::Register(HWND window) {
+  if (window == nullptr || !::IsWindow(window)) return false;
+  if (targets_.find(window) != targets_.end()) return true;
+  auto* target = new DartPdfWindowsDropTarget(window, channel_.get());
+  const HRESULT result = ::RegisterDragDrop(window, target);
+  if (FAILED(result)) {
+    target->Release();
+    return false;
+  }
+  targets_.emplace(window, target);
+  return true;
+}
+
+void DartPdfWindowsDropService::Unregister(HWND window) {
+  const auto found = targets_.find(window);
+  if (found == targets_.end()) return;
+  ::RevokeDragDrop(window);
+  found->second->Release();
+  targets_.erase(found);
+}

--- a/app/windows/runner/windows_drop.h
+++ b/app/windows/runner/windows_drop.h
@@ -1,0 +1,35 @@
+#ifndef RUNNER_WINDOWS_DROP_H_
+#define RUNNER_WINDOWS_DROP_H_
+
+#include <flutter/binary_messenger.h>
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+#include <windows.h>
+
+#include <map>
+#include <memory>
+
+class DartPdfWindowsDropTarget;
+
+// Per-HWND OLE file-drop registration for Flutter's engine-owned regular
+// windows. The desktop_drop plugin can only discover an implicit registrar
+// view, which does not exist in DartPDF's multi-window bootstrap.
+class DartPdfWindowsDropService {
+ public:
+  explicit DartPdfWindowsDropService(flutter::BinaryMessenger* messenger);
+  ~DartPdfWindowsDropService();
+
+  DartPdfWindowsDropService(const DartPdfWindowsDropService&) = delete;
+  DartPdfWindowsDropService& operator=(const DartPdfWindowsDropService&) =
+      delete;
+
+ private:
+  bool Register(HWND window);
+  void Unregister(HWND window);
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+  std::map<HWND, DartPdfWindowsDropTarget*> targets_;
+  bool ole_initialized_ = false;
+};
+
+#endif  // RUNNER_WINDOWS_DROP_H_

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -104,6 +104,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   PdfPanelDock _bookmarkSidebarDock = PdfPanelDock.left;
   PdfPanelDock _annotationSidebarDock = PdfPanelDock.right;
   PdfPanelDock _propertiesPanelDock = PdfPanelDock.right;
+  PdfPanelDock _toolbarDock = PdfPanelDock.bottom;
   // Tab-group membership: panels sharing the same dock AND the same group id
   // render as one tabbed panel; a panel alone in its group is a standalone
   // side-by-side panel. The default id is each panel's own enum index, so
@@ -290,6 +291,7 @@ class PdfEditingPreferences extends ChangeNotifier {
           _readDock(store, 'annotationSidebarDock', _annotationSidebarDock);
       _propertiesPanelDock =
           _readDock(store, 'propertiesPanelDock', _propertiesPanelDock);
+      _toolbarDock = _readDock(store, 'toolbarDock', _toolbarDock);
       for (final p in PdfDockablePanel.values) {
         _panelGroups[p] =
             store.getInt('${_prefix}panelGroup.${p.name}') ?? _panelGroups[p]!;
@@ -1261,6 +1263,17 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _propertiesPanelDock) return;
     _propertiesPanelDock = value;
     _setDock('propertiesPanelDock', value);
+  }
+
+  /// Which edge the floating editing toolbar is attached to. Persisted so a
+  /// dragged toolbar returns to the same edge in later sessions. Compact
+  /// layouts still use their fixed bottom bar regardless of this preference.
+  PdfPanelDock get toolbarDock => _toolbarDock;
+
+  set toolbarDock(PdfPanelDock value) {
+    if (value == _toolbarDock) return;
+    _toolbarDock = value;
+    _setDock('toolbarDock', value);
   }
 
   /// The dock a specific [panel] is attached to, keyed by identity - the

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -336,6 +336,10 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   }
 
   Map<ShortcutActivator, VoidCallback> get _keyboardShortcuts => {
+        const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
+            widget.controller.selectAllPages,
+        const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+            widget.controller.selectAllPages,
         const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
             _moveKeyboardSelection(-1),
         const SingleActivator(LogicalKeyboardKey.arrowDown): () =>
@@ -1492,6 +1496,10 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
   }
 
   Map<ShortcutActivator, VoidCallback> _keyboardShortcuts(int columns) => {
+        const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
+            widget.controller.selectAllPages,
+        const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+            widget.controller.selectAllPages,
         const SingleActivator(LogicalKeyboardKey.arrowLeft): () =>
             _moveKeyboardSelection(-1),
         const SingleActivator(LogicalKeyboardKey.arrowRight): () =>

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3220,24 +3220,33 @@ class _GroupChip extends StatelessWidget {
                 : _compact
                     ? const EdgeInsets.symmetric(horizontal: 10)
                     : const EdgeInsets.fromLTRB(12, 0, 14, 0),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
-              if (vertical)
-                Icon(icon, size: 19, color: fg, semanticLabel: label)
-              else if (_toolsHandle && !_compact) ...[
-                Text(label,
-                    style: TextStyle(
-                        fontWeight: FontWeight.w600, fontSize: 14, color: fg)),
-                const SizedBox(width: 6),
-                Icon(icon, size: 18, color: fg),
-              ] else if (!_toolsHandle) ...[
-                Icon(icon, size: 19, color: fg),
-                const SizedBox(width: 8),
-                Text(label,
-                    style: TextStyle(
-                        fontWeight: FontWeight.w600, fontSize: 14, color: fg)),
-              ] else
-                Icon(icon, size: 18, color: fg, semanticLabel: label),
-            ]),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment:
+                  vertical ? MainAxisAlignment.center : MainAxisAlignment.start,
+              children: [
+                if (vertical)
+                  Icon(icon, size: 19, color: fg, semanticLabel: label)
+                else if (_toolsHandle && !_compact) ...[
+                  Text(label,
+                      style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                          color: fg)),
+                  const SizedBox(width: 6),
+                  Icon(icon, size: 18, color: fg),
+                ] else if (!_toolsHandle) ...[
+                  Icon(icon, size: 19, color: fg),
+                  const SizedBox(width: 8),
+                  Text(label,
+                      style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                          color: fg)),
+                ] else
+                  Icon(icon, size: 18, color: fg, semanticLabel: label),
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -26,6 +26,7 @@ import 'editing_fonts.dart';
 import 'editing_form_style.dart';
 import 'editing_value_field.dart';
 import 'editing_measure.dart';
+import 'editing_panel.dart';
 import 'editing_takeoff.dart';
 import 'line_style.dart';
 import 'editing_signature.dart';
@@ -87,6 +88,8 @@ class PdfEditingToolbar extends StatefulWidget {
     this.showStyle = true,
     this.showFlatten = true,
     this.showColorProcessing = true,
+    this.dock = PdfPanelDock.bottom,
+    this.compact,
     this.cardAlignment = Alignment.center,
     this.leading = const [],
     this.trailing = const [],
@@ -191,6 +194,21 @@ class PdfEditingToolbar extends StatefulWidget {
 
   /// Whether the Edit group includes the colour-processing action.
   final bool showColorProcessing;
+
+  /// The edge this toolbar is docked to.
+  ///
+  /// Left and right docks render the primary controls as a vertical rail,
+  /// with any contextual strip opening inward. Top and bottom docks retain
+  /// the standard horizontal layout. Compact/mobile mode remains horizontal.
+  final PdfPanelDock dock;
+
+  /// Overrides the width-based compact/mobile layout decision.
+  ///
+  /// Drop-in shells set this from the whole window width so docked panels
+  /// cannot accidentally turn a desktop toolbar into the phone bar by
+  /// narrowing only the viewer region. Null keeps the standalone toolbar's
+  /// automatic behavior.
+  final bool? compact;
 
   /// Alignment of the floating desktop cards within the width supplied by
   /// the host. The drop-in editor uses this when the toolbar is docked to the
@@ -1310,10 +1328,15 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         child: ListenableBuilder(
           listenable: Listenable.merge([controller, viewerController]),
           builder: (context, _) => LayoutBuilder(
-            builder: (context, constraints) =>
-                constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint
-                    ? _buildMobile(context, width: constraints.maxWidth)
-                    : _buildDesktop(context),
+            builder: (context, constraints) {
+              final compact = widget.compact ??
+                  (!widget.dock.isHorizontal &&
+                      constraints.maxWidth <
+                          PdfEditingToolbar.mobileBreakpoint);
+              return compact
+                  ? _buildMobile(context, width: constraints.maxWidth)
+                  : _buildDesktop(context);
+            },
           ),
         ),
       ),
@@ -1324,6 +1347,28 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   Widget _buildDesktop(BuildContext context) {
     final strip = _desktopStrip(context);
+    if (widget.dock.isHorizontal) {
+      final rail = _dock(context);
+      final children = <Widget>[
+        if (widget.dock == PdfPanelDock.right && strip != null) ...[
+          Flexible(child: strip),
+          const SizedBox(width: 8),
+        ],
+        rail,
+        if (widget.dock == PdfPanelDock.left && strip != null) ...[
+          const SizedBox(width: 8),
+          Flexible(child: strip),
+        ],
+      ];
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(8, 14, 8, 14),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: children,
+        ),
+      );
+    }
     return Padding(
       padding: const EdgeInsets.fromLTRB(14, 8, 14, 10),
       child: Column(
@@ -1359,17 +1404,20 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     BuildContext context, {
     required Widget child,
     EdgeInsetsGeometry padding = const EdgeInsets.all(8),
+    Axis scrollDirection = Axis.horizontal,
   }) {
     return LayoutBuilder(
       builder: (context, constraints) => Align(
         alignment: widget.cardAlignment,
         child: Container(
           key: const ValueKey('pdf-editing-toolbar-card'),
-          constraints: BoxConstraints(maxWidth: constraints.maxWidth),
+          constraints: scrollDirection == Axis.horizontal
+              ? BoxConstraints(maxWidth: constraints.maxWidth)
+              : BoxConstraints(maxHeight: constraints.maxHeight),
           decoration: _cardDecoration(context),
           clipBehavior: Clip.antiAlias,
           child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
+            scrollDirection: scrollDirection,
             child: Padding(
               padding: padding,
               child: child,
@@ -1404,75 +1452,84 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   }
 
   Widget _dock(BuildContext context) {
+    final axis = widget.dock.isHorizontal ? Axis.vertical : Axis.horizontal;
     final groups = _visibleGroups;
     final showNavigationModes = groups.any((group) => group.id == 'select');
     final editingGroups =
         groups.where((group) => group.id != 'select').toList(growable: false);
-    final row = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (final builder in widget.leading)
-          builder(context, controller, viewerController),
-        if (widget.leading.isNotEmpty) const _DockDivider(),
-        if (widget.showUndoRedo) ...[
-          IconButton(
-            key: const ValueKey('pdf-undo'),
-            icon: const Icon(Icons.undo),
-            tooltip: pdfL10n(context).tbUndoShortcut,
-            onPressed: controller.canUndo ? controller.undo : null,
-          ),
-          IconButton(
-            key: const ValueKey('pdf-redo'),
-            icon: const Icon(Icons.redo),
-            tooltip: pdfL10n(context).tbRedoShortcut,
-            onPressed: controller.canRedo ? controller.redo : null,
-          ),
-          const _DockDivider(),
-        ],
-        if (showNavigationModes) ...[
-          _NavigationModeGroup(
-            handLabel: pdfL10n(context).tbNameHand,
-            selectLabel: _entryTip(context, _groups.first.tools.single),
-            handActive: controller.isHandMode,
-            selectActive: controller.tool == PdfEditTool.select,
-            onHand: _activateHandMode,
-            onSelect: _activateSelectMode,
-          ),
-          if (editingGroups.isNotEmpty ||
-              widget.onSave != null ||
-              widget.trailing.isNotEmpty)
-            const _DockDivider(),
-        ],
-        for (final group in editingGroups)
-          _GroupChip(
-            key: ValueKey('pdf-group-${group.id}'),
-            group: group,
-            active: _openGroup?.id == group.id,
-            onTap: () => _openGroupTap(group),
-          ),
-        // Flatten now lives in the Edit group's strip, not the dock.
-        // Save stays available for standalone hosts, but the drop-in
-        // shells hide it here and surface it in their header (near Open).
-        if (widget.onSave != null) ...[
-          const _DockDivider(),
-          IconButton(
-            icon: const Icon(Icons.save_alt),
-            tooltip: pdfL10n(context).tbSaveShortcut,
-            // disabled while the document matches what was opened - there's
-            // nothing to write until an edit bumps the revision cursor
-            onPressed: controller.isModified
-                ? () => widget.onSave!(controller.bytes)
-                : null,
-          ),
-        ],
-        if (widget.trailing.isNotEmpty) ...[
-          const _DockDivider(),
-          for (final builder in widget.trailing)
-            builder(context, controller, viewerController),
-        ],
+    final children = <Widget>[
+      for (final builder in widget.leading)
+        builder(context, controller, viewerController),
+      if (widget.leading.isNotEmpty) _DockDivider(axis: axis),
+      if (widget.showUndoRedo) ...[
+        IconButton(
+          key: const ValueKey('pdf-undo'),
+          icon: const Icon(Icons.undo),
+          tooltip: pdfL10n(context).tbUndoShortcut,
+          onPressed: controller.canUndo ? controller.undo : null,
+        ),
+        IconButton(
+          key: const ValueKey('pdf-redo'),
+          icon: const Icon(Icons.redo),
+          tooltip: pdfL10n(context).tbRedoShortcut,
+          onPressed: controller.canRedo ? controller.redo : null,
+        ),
+        _DockDivider(axis: axis),
       ],
+      if (showNavigationModes) ...[
+        _NavigationModeGroup(
+          axis: axis,
+          handLabel: pdfL10n(context).tbNameHand,
+          selectLabel: _entryTip(context, _groups.first.tools.single),
+          handActive: controller.isHandMode,
+          selectActive: controller.tool == PdfEditTool.select,
+          onHand: _activateHandMode,
+          onSelect: _activateSelectMode,
+        ),
+        if (editingGroups.isNotEmpty ||
+            widget.onSave != null ||
+            widget.trailing.isNotEmpty)
+          _DockDivider(axis: axis),
+      ],
+      for (final group in editingGroups)
+        _GroupChip(
+          key: ValueKey('pdf-group-${group.id}'),
+          group: group,
+          active: _openGroup?.id == group.id,
+          vertical: axis == Axis.vertical,
+          onTap: () => _openGroupTap(group),
+        ),
+      // Flatten now lives in the Edit group's strip, not the dock.
+      // Save stays available for standalone hosts, but the drop-in
+      // shells hide it here and surface it in their header (near Open).
+      if (widget.onSave != null) ...[
+        _DockDivider(axis: axis),
+        IconButton(
+          icon: const Icon(Icons.save_alt),
+          tooltip: pdfL10n(context).tbSaveShortcut,
+          // disabled while the document matches what was opened - there's
+          // nothing to write until an edit bumps the revision cursor
+          onPressed: controller.isModified
+              ? () => widget.onSave!(controller.bytes)
+              : null,
+        ),
+      ],
+      if (widget.trailing.isNotEmpty) ...[
+        _DockDivider(axis: axis),
+        for (final builder in widget.trailing)
+          builder(context, controller, viewerController),
+      ],
+    ];
+    final dock = Flex(
+      direction: axis,
+      mainAxisSize: MainAxisSize.min,
+      children: children,
     );
-    return _centeredCard(context, child: row);
+    return _centeredCard(
+      context,
+      child: dock,
+      scrollDirection: axis,
+    );
   }
 
   /// The tools-left / settings-right card for an open [group].
@@ -2892,23 +2949,36 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   }
 }
 
-/// A thin vertical divider between dock clusters.
+/// A thin divider between dock clusters, perpendicular to the dock [axis].
 class _DockDivider extends StatelessWidget {
-  const _DockDivider();
+  const _DockDivider({this.axis = Axis.horizontal});
+
+  final Axis axis;
 
   @override
-  Widget build(BuildContext context) => Container(
-        width: 1,
-        height: 26,
-        margin: const EdgeInsets.symmetric(horizontal: 4),
-        color: Theme.of(context).colorScheme.outlineVariant,
-      );
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.outlineVariant;
+    return axis == Axis.horizontal
+        ? Container(
+            width: 1,
+            height: 26,
+            margin: const EdgeInsets.symmetric(horizontal: 4),
+            color: color,
+          )
+        : Container(
+            width: 26,
+            height: 1,
+            margin: const EdgeInsets.symmetric(vertical: 4),
+            color: color,
+          );
+  }
 }
 
 /// The two mutually exclusive navigation modes, kept in one compact control
 /// so they read differently from the editing-tool group chips beside them.
 class _NavigationModeGroup extends StatelessWidget {
   const _NavigationModeGroup({
+    this.axis = Axis.horizontal,
     required this.handLabel,
     required this.selectLabel,
     required this.handActive,
@@ -2917,6 +2987,7 @@ class _NavigationModeGroup extends StatelessWidget {
     required this.onSelect,
   });
 
+  final Axis axis;
   final String handLabel;
   final String selectLabel;
   final bool handActive;
@@ -2932,7 +3003,7 @@ class _NavigationModeGroup extends StatelessWidget {
       color: Colors.transparent,
       shape: StadiumBorder(side: BorderSide(color: scheme.outline)),
       clipBehavior: Clip.antiAlias,
-      child: Row(mainAxisSize: MainAxisSize.min, children: [
+      child: Flex(direction: axis, mainAxisSize: MainAxisSize.min, children: [
         _button(
           key: const ValueKey('pdf-mode-hand'),
           icon: Icons.pan_tool_alt,
@@ -2941,7 +3012,9 @@ class _NavigationModeGroup extends StatelessWidget {
           onPressed: onHand,
           scheme: scheme,
         ),
-        Container(width: 1, height: 24, color: scheme.outlineVariant),
+        axis == Axis.horizontal
+            ? Container(width: 1, height: 24, color: scheme.outlineVariant)
+            : Container(width: 24, height: 1, color: scheme.outlineVariant),
         _button(
           // Preserve the established key for host and package widget tests.
           key: const ValueKey('pdf-group-select'),
@@ -3099,6 +3172,7 @@ class _GroupChip extends StatelessWidget {
     required this.group,
     required this.active,
     required this.onTap,
+    this.vertical = false,
   })  : _toolsHandle = false,
         _compact = false;
 
@@ -3109,13 +3183,15 @@ class _GroupChip extends StatelessWidget {
   })  : group = null,
         active = true,
         _toolsHandle = true,
-        _compact = compact;
+        _compact = compact,
+        vertical = false;
 
   final _ToolGroup? group;
   final bool active;
   final VoidCallback onTap;
   final bool _toolsHandle;
   final bool _compact;
+  final bool vertical;
 
   @override
   Widget build(BuildContext context) {
@@ -3125,48 +3201,52 @@ class _GroupChip extends StatelessWidget {
     final label =
         _toolsHandle ? pdfL10n(context).tbTools : group!.label(context);
     final icon = _toolsHandle ? Icons.keyboard_arrow_up : group!.icon;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 3),
-      child: Material(
-        color: on ? scheme.primary.withValues(alpha: 0.15) : Colors.transparent,
-        shape: StadiumBorder(
-          side: BorderSide(
-            color: on ? scheme.primary.withValues(alpha: 0.55) : scheme.outline,
-          ),
+    final chip = Material(
+      color: on ? scheme.primary.withValues(alpha: 0.15) : Colors.transparent,
+      shape: StadiumBorder(
+        side: BorderSide(
+          color: on ? scheme.primary.withValues(alpha: 0.55) : scheme.outline,
         ),
-        child: InkWell(
-          customBorder: const StadiumBorder(),
-          onTap: onTap,
-          child: SizedBox(
-            height: 40,
-            child: Padding(
-              padding: _compact
-                  ? const EdgeInsets.symmetric(horizontal: 10)
-                  : const EdgeInsets.fromLTRB(12, 0, 14, 0),
-              child: Row(mainAxisSize: MainAxisSize.min, children: [
-                if (_toolsHandle && !_compact) ...[
-                  Text(label,
-                      style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          fontSize: 14,
-                          color: fg)),
-                  const SizedBox(width: 6),
-                  Icon(icon, size: 18, color: fg),
-                ] else if (!_toolsHandle) ...[
-                  Icon(icon, size: 19, color: fg),
-                  const SizedBox(width: 8),
-                  Text(label,
-                      style: TextStyle(
-                          fontWeight: FontWeight.w600,
-                          fontSize: 14,
-                          color: fg)),
-                ] else
-                  Icon(icon, size: 18, color: fg, semanticLabel: label),
-              ]),
-            ),
+      ),
+      child: InkWell(
+        customBorder: const StadiumBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: vertical ? 40 : null,
+          height: 40,
+          child: Padding(
+            padding: vertical
+                ? EdgeInsets.zero
+                : _compact
+                    ? const EdgeInsets.symmetric(horizontal: 10)
+                    : const EdgeInsets.fromLTRB(12, 0, 14, 0),
+            child: Row(mainAxisSize: MainAxisSize.min, children: [
+              if (vertical)
+                Icon(icon, size: 19, color: fg, semanticLabel: label)
+              else if (_toolsHandle && !_compact) ...[
+                Text(label,
+                    style: TextStyle(
+                        fontWeight: FontWeight.w600, fontSize: 14, color: fg)),
+                const SizedBox(width: 6),
+                Icon(icon, size: 18, color: fg),
+              ] else if (!_toolsHandle) ...[
+                Icon(icon, size: 19, color: fg),
+                const SizedBox(width: 8),
+                Text(label,
+                    style: TextStyle(
+                        fontWeight: FontWeight.w600, fontSize: 14, color: fg)),
+              ] else
+                Icon(icon, size: 18, color: fg, semanticLabel: label),
+            ]),
           ),
         ),
       ),
+    );
+    return Padding(
+      padding: vertical
+          ? const EdgeInsets.symmetric(vertical: 3)
+          : const EdgeInsets.symmetric(horizontal: 3),
+      child: vertical ? Tooltip(message: label, child: chip) : chip,
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -87,6 +87,7 @@ class PdfEditingToolbar extends StatefulWidget {
     this.showStyle = true,
     this.showFlatten = true,
     this.showColorProcessing = true,
+    this.cardAlignment = Alignment.center,
     this.leading = const [],
     this.trailing = const [],
   });
@@ -190,6 +191,11 @@ class PdfEditingToolbar extends StatefulWidget {
 
   /// Whether the Edit group includes the colour-processing action.
   final bool showColorProcessing;
+
+  /// Alignment of the floating desktop cards within the width supplied by
+  /// the host. The drop-in editor uses this when the toolbar is docked to the
+  /// left or right edge. Compact/mobile mode ignores it.
+  final AlignmentGeometry cardAlignment;
 
   /// Custom widgets shown before the stock dock controls. Builders run
   /// inside the toolbar's listenable rebuild, so they can reflect
@@ -1356,6 +1362,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   }) {
     return LayoutBuilder(
       builder: (context, constraints) => Align(
+        alignment: widget.cardAlignment,
         child: Container(
           key: const ValueKey('pdf-editing-toolbar-card'),
           constraints: BoxConstraints(maxWidth: constraints.maxWidth),

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -133,7 +133,7 @@ class PdfEditorFeatures {
   /// The annotation properties panel and its toggle.
   final bool propertiesPanel;
 
-  /// The bottom editing toolbar.
+  /// The floating, edge-dockable editing toolbar.
   final bool toolbar;
 
   /// The toolbar's text-markup buttons (highlight, underline...).
@@ -224,6 +224,8 @@ class PdfEditorView extends StatefulWidget {
     this.onSave,
     this.onSaveAs,
     this.showSaveButton = true,
+    this.saveButtonIcon = Icons.save_alt,
+    this.saveButtonLabel,
     this.alwaysAllowSave = false,
     this.onDocumentChanged,
     this.onPickPdfToInsert,
@@ -315,6 +317,8 @@ class PdfEditorView extends StatefulWidget {
     this.onSave,
     this.onSaveAs,
     this.showSaveButton = true,
+    this.saveButtonIcon = Icons.save_alt,
+    this.saveButtonLabel,
     this.alwaysAllowSave = false,
     this.onDocumentChanged,
     this.onPickPdfToInsert,
@@ -459,6 +463,13 @@ class PdfEditorView extends StatefulWidget {
   /// save affordance while still keeping [onSave] and the keyboard
   /// shortcut active.
   final bool showSaveButton;
+
+  /// Icon used by the stock save affordance. A mobile host whose save flow
+  /// opens the platform share sheet can pass [Icons.share_outlined].
+  final IconData saveButtonIcon;
+
+  /// Optional replacement for the localized stock "Save" label.
+  final String? saveButtonLabel;
 
   /// Keeps Save (the button and ⌘S / Ctrl+S) enabled even when the
   /// document has no unsaved edits. Hosts set this for a document that has
@@ -762,6 +773,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         onSave: complete ? widget.onSave : null,
         onSaveAs: complete ? widget.onSaveAs : null,
         showSaveButton: widget.showSaveButton,
+        saveButtonIcon: widget.saveButtonIcon,
+        saveButtonLabel: widget.saveButtonLabel,
         alwaysAllowSave: complete && widget.alwaysAllowSave,
         onDocumentChanged: complete ? widget.onDocumentChanged : null,
         onPickPdfToInsert: complete ? widget.onPickPdfToInsert : null,
@@ -1225,7 +1238,19 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     showStyle: features.styleControls,
                     showFlatten: features.flatten,
                     showColorProcessing: features.colorProcessing,
-                    leading: widget.toolbarLeading,
+                    cardAlignment: switch (prefs.toolbarDock) {
+                      PdfPanelDock.left => Alignment.centerLeft,
+                      PdfPanelDock.right => Alignment.centerRight,
+                      PdfPanelDock.top ||
+                      PdfPanelDock.bottom =>
+                        Alignment.center,
+                    },
+                    leading: [
+                      if (!dockToolbar)
+                        (context, controller, viewer) =>
+                            const PdfToolbarMoveHandle(),
+                      ...widget.toolbarLeading,
+                    ],
                     trailing: widget.toolbarTrailing,
                   );
           final viewOptionsControl = PdfShellControlItem(
@@ -1373,8 +1398,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         visualDensity: VisualDensity.compact,
                         padding: const EdgeInsets.symmetric(horizontal: 12),
                       ),
-                      icon: const Icon(Icons.save_alt, size: 18),
-                      label: Text(pdfL10n(context).save),
+                      icon: Icon(widget.saveButtonIcon, size: 18),
+                      label:
+                          Text(widget.saveButtonLabel ?? pdfL10n(context).save),
                       onPressed: _canSave ? _save : null,
                     ),
                 ],
@@ -1395,8 +1421,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   if (widget.onSave != null && widget.showSaveButton)
                     PdfShellControlItem(
                       key: const ValueKey('pdf-shell-save'),
-                      icon: Icons.save_alt,
-                      label: pdfL10n(context).save,
+                      icon: widget.saveButtonIcon,
+                      label: widget.saveButtonLabel ?? pdfL10n(context).save,
                       enabled: _canSave,
                       onPressed: _save,
                     ),
@@ -1492,7 +1518,11 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 // (see dockToolbar) so its solid bar never hides the page
                 floatingToolbar:
                     toolbar != null && !dockToolbar ? toolbar : null,
+                floatingToolbarDock: prefs.toolbarDock,
                 dockedToolbar: toolbar != null && dockToolbar ? toolbar : null,
+                onToolbarDock: toolbar != null && !dockToolbar
+                    ? (dock) => prefs.toolbarDock = dock
+                    : null,
               ),
             ),
           ]);

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1238,6 +1238,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     showStyle: features.styleControls,
                     showFlatten: features.flatten,
                     showColorProcessing: features.colorProcessing,
+                    dock: prefs.toolbarDock,
+                    compact: dockToolbar,
                     cardAlignment: switch (prefs.toolbarDock) {
                       PdfPanelDock.left => Alignment.centerLeft,
                       PdfPanelDock.right => Alignment.centerRight,
@@ -1477,7 +1479,11 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         // contextual strip, so the last page can move fully
                         // clear of the controls instead of being trapped
                         // underneath them.
-                        trailingPadding: showToolbar && !dockToolbar ? 144 : 0,
+                        trailingPadding: showToolbar &&
+                                !dockToolbar &&
+                                prefs.toolbarDock == PdfPanelDock.bottom
+                            ? 144
+                            : 0,
                         pageLayout: widget.pageLayout,
                         initialFit: widget.initialFit,
                         toolShortcuts: _toolShortcuts,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -112,11 +112,17 @@ class PdfShellPanelLayout extends StatefulWidget {
 }
 
 class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
-  bool _dragging = false;
+  bool _draggingPanel = false;
+  bool _draggingToolbar = false;
 
-  void _setDragging(bool value) {
-    if (_dragging == value) return;
-    setState(() => _dragging = value);
+  void _setPanelDragging(bool value) {
+    if (_draggingPanel == value) return;
+    setState(() => _draggingPanel = value);
+  }
+
+  void _setToolbarDragging(bool value) {
+    if (_draggingToolbar == value) return;
+    setState(() => _draggingToolbar = value);
   }
 
   Widget _floatingToolbarOverlay() {
@@ -143,6 +149,13 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       children: [
         widget.viewer,
         if (widget.floatingToolbar != null) _floatingToolbarOverlay(),
+        // The toolbar itself docks to the viewer, inward of any panels. Its
+        // drag targets use that exact same rectangle so the preview and the
+        // eventual dock location cannot disagree.
+        if (widget.onToolbarDock != null && _draggingToolbar)
+          Positioned.fill(
+            child: _PanelDropZones(onToolbarDock: widget.onToolbarDock),
+          ),
       ],
     );
     final row = Row(children: [
@@ -163,15 +176,13 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       ...widget.overlays,
       if (widget.bottomSheets.isNotEmpty)
         pdfShellBottomSheets(widget.bottomSheets),
-      // the redock drop zones sit above everything while a panel is being
-      // dragged, so a panel can be dropped onto any edge - even over the
-      // toolbar or another panel
-      if ((widget.onPanelDock != null || widget.onToolbarDock != null) &&
-          _dragging)
+      // Panel targets stay shell-relative: panels really do dock outside the
+      // viewer and may be dropped over another panel. Toolbar targets are
+      // instead mounted in the viewer Stack above.
+      if (widget.onPanelDock != null && _draggingPanel)
         Positioned.fill(
           child: _PanelDropZones(
             onPanelDock: widget.onPanelDock,
-            onToolbarDock: widget.onToolbarDock,
           ),
         ),
     ]);
@@ -184,15 +195,15 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       // the panels below read this to drive the drag: their move handles
       // toggle the drop zones on and off.
       result = PdfPanelDragScope(
-        onDragStarted: () => _setDragging(true),
-        onDragEnded: () => _setDragging(false),
+        onDragStarted: () => _setPanelDragging(true),
+        onDragEnded: () => _setPanelDragging(false),
         child: result,
       );
     }
     if (widget.onToolbarDock != null) {
       result = PdfToolbarDragScope(
-        onDragStarted: () => _setDragging(true),
-        onDragEnded: () => _setDragging(false),
+        onDragStarted: () => _setToolbarDragging(true),
+        onDragEnded: () => _setToolbarDragging(false),
         child: result,
       );
     }

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -94,8 +92,8 @@ class PdfShellPanelLayout extends StatefulWidget {
   /// A toolbar that floats over the content area.
   final Widget? floatingToolbar;
 
-  /// The edge the floating toolbar is attached to. Top/bottom use the full
-  /// width; left/right use a centred shelf aligned to that side.
+  /// The edge the floating toolbar is attached to, within the viewer region.
+  /// The toolbar therefore stays inward of any docked panels.
   final PdfPanelDock floatingToolbarDock;
 
   /// A toolbar that consumes layout space below the content area.
@@ -128,26 +126,30 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       PdfPanelDock.bottom =>
         Positioned(left: 0, right: 0, bottom: 0, child: toolbar),
       PdfPanelDock.left || PdfPanelDock.right => Positioned.fill(
-          child: LayoutBuilder(builder: (context, constraints) {
-            final width = math.min(constraints.maxWidth, 900.0);
-            return Align(
-              alignment: widget.floatingToolbarDock == PdfPanelDock.left
-                  ? Alignment.centerLeft
-                  : Alignment.centerRight,
-              child: SizedBox(width: width, child: toolbar),
-            );
-          }),
+          child: Align(
+            alignment: widget.floatingToolbarDock == PdfPanelDock.left
+                ? Alignment.centerLeft
+                : Alignment.centerRight,
+            child: toolbar,
+          ),
         ),
     };
   }
 
   @override
   Widget build(BuildContext context) {
+    final viewer = Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.viewer,
+        if (widget.floatingToolbar != null) _floatingToolbarOverlay(),
+      ],
+    );
     final row = Row(children: [
       ...widget.leadingPanels,
       Expanded(
         key: const ValueKey('pdf-shell-viewer'),
-        child: widget.viewer,
+        child: viewer,
       ),
       ...widget.trailingPanels,
     ]);
@@ -159,7 +161,6 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
     final content = Stack(children: [
       Positioned.fill(child: stacked),
       ...widget.overlays,
-      if (widget.floatingToolbar != null) _floatingToolbarOverlay(),
       if (widget.bottomSheets.isNotEmpty)
         pdfShellBottomSheets(widget.bottomSheets),
       // the redock drop zones sit above everything while a panel is being

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
@@ -62,8 +63,10 @@ class PdfShellPanelLayout extends StatefulWidget {
     this.bottomSheets = const [],
     this.overlays = const [],
     this.floatingToolbar,
+    this.floatingToolbarDock = PdfPanelDock.bottom,
     this.dockedToolbar,
     this.onPanelDock,
+    this.onToolbarDock,
   });
 
   /// The page viewer, reflow view, or other primary document surface.
@@ -91,12 +94,20 @@ class PdfShellPanelLayout extends StatefulWidget {
   /// A toolbar that floats over the content area.
   final Widget? floatingToolbar;
 
+  /// The edge the floating toolbar is attached to. Top/bottom use the full
+  /// width; left/right use a centred shelf aligned to that side.
+  final PdfPanelDock floatingToolbarDock;
+
   /// A toolbar that consumes layout space below the content area.
   final Widget? dockedToolbar;
 
   /// Redocks the given panel to the dropped-on edge. Null disables the
   /// drag-to-redock affordance (panels then show no move handle).
   final void Function(PdfDockablePanel panel, PdfPanelDock dock)? onPanelDock;
+
+  /// Redocks the floating editing toolbar to the dropped-on edge. Null keeps
+  /// the toolbar fixed and hides its edge drop zones.
+  final ValueChanged<PdfPanelDock>? onToolbarDock;
 
   @override
   State<PdfShellPanelLayout> createState() => _PdfShellPanelLayoutState();
@@ -108,6 +119,26 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
   void _setDragging(bool value) {
     if (_dragging == value) return;
     setState(() => _dragging = value);
+  }
+
+  Widget _floatingToolbarOverlay() {
+    final toolbar = widget.floatingToolbar!;
+    return switch (widget.floatingToolbarDock) {
+      PdfPanelDock.top => Positioned(left: 0, right: 0, top: 0, child: toolbar),
+      PdfPanelDock.bottom =>
+        Positioned(left: 0, right: 0, bottom: 0, child: toolbar),
+      PdfPanelDock.left || PdfPanelDock.right => Positioned.fill(
+          child: LayoutBuilder(builder: (context, constraints) {
+            final width = math.min(constraints.maxWidth, 900.0);
+            return Align(
+              alignment: widget.floatingToolbarDock == PdfPanelDock.left
+                  ? Alignment.centerLeft
+                  : Alignment.centerRight,
+              child: SizedBox(width: width, child: toolbar),
+            );
+          }),
+        ),
+    };
   }
 
   @override
@@ -128,21 +159,19 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
     final content = Stack(children: [
       Positioned.fill(child: stacked),
       ...widget.overlays,
-      if (widget.floatingToolbar != null)
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: 0,
-          child: widget.floatingToolbar!,
-        ),
+      if (widget.floatingToolbar != null) _floatingToolbarOverlay(),
       if (widget.bottomSheets.isNotEmpty)
         pdfShellBottomSheets(widget.bottomSheets),
       // the redock drop zones sit above everything while a panel is being
       // dragged, so a panel can be dropped onto any edge - even over the
       // toolbar or another panel
-      if (widget.onPanelDock != null && _dragging)
+      if ((widget.onPanelDock != null || widget.onToolbarDock != null) &&
+          _dragging)
         Positioned.fill(
-          child: _PanelDropZones(onPanelDock: widget.onPanelDock!),
+          child: _PanelDropZones(
+            onPanelDock: widget.onPanelDock,
+            onToolbarDock: widget.onToolbarDock,
+          ),
         ),
     ]);
 
@@ -159,6 +188,13 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
         child: result,
       );
     }
+    if (widget.onToolbarDock != null) {
+      result = PdfToolbarDragScope(
+        onDragStarted: () => _setDragging(true),
+        onDragEnded: () => _setDragging(false),
+        child: result,
+      );
+    }
     return result;
   }
 }
@@ -166,9 +202,10 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
 /// The four edge drop targets shown while a panel is being dragged. Dropping
 /// the panel onto one redocks it to that edge.
 class _PanelDropZones extends StatelessWidget {
-  const _PanelDropZones({required this.onPanelDock});
+  const _PanelDropZones({this.onPanelDock, this.onToolbarDock});
 
-  final void Function(PdfDockablePanel panel, PdfPanelDock dock) onPanelDock;
+  final void Function(PdfDockablePanel panel, PdfPanelDock dock)? onPanelDock;
+  final ValueChanged<PdfPanelDock>? onToolbarDock;
 
   @override
   Widget build(BuildContext context) {
@@ -185,15 +222,22 @@ class _PanelDropZones extends StatelessWidget {
           top: 0,
           bottom: 0,
           width: bandW,
-          child: _DropTarget(dock: PdfPanelDock.left, onPanelDock: onPanelDock),
+          child: _DropTarget(
+            dock: PdfPanelDock.left,
+            onPanelDock: onPanelDock,
+            onToolbarDock: onToolbarDock,
+          ),
         ),
         Positioned(
           right: 0,
           top: 0,
           bottom: 0,
           width: bandW,
-          child:
-              _DropTarget(dock: PdfPanelDock.right, onPanelDock: onPanelDock),
+          child: _DropTarget(
+            dock: PdfPanelDock.right,
+            onPanelDock: onPanelDock,
+            onToolbarDock: onToolbarDock,
+          ),
         ),
         // top/bottom bands inset horizontally so they never overlap the
         // left/right bands at the corners
@@ -202,15 +246,22 @@ class _PanelDropZones extends StatelessWidget {
           right: bandW,
           top: 0,
           height: bandH,
-          child: _DropTarget(dock: PdfPanelDock.top, onPanelDock: onPanelDock),
+          child: _DropTarget(
+            dock: PdfPanelDock.top,
+            onPanelDock: onPanelDock,
+            onToolbarDock: onToolbarDock,
+          ),
         ),
         Positioned(
           left: bandW,
           right: bandW,
           bottom: 0,
           height: bandH,
-          child:
-              _DropTarget(dock: PdfPanelDock.bottom, onPanelDock: onPanelDock),
+          child: _DropTarget(
+            dock: PdfPanelDock.bottom,
+            onPanelDock: onPanelDock,
+            onToolbarDock: onToolbarDock,
+          ),
         ),
       ]);
     });
@@ -218,10 +269,15 @@ class _PanelDropZones extends StatelessWidget {
 }
 
 class _DropTarget extends StatelessWidget {
-  const _DropTarget({required this.dock, required this.onPanelDock});
+  const _DropTarget({
+    required this.dock,
+    this.onPanelDock,
+    this.onToolbarDock,
+  });
 
   final PdfPanelDock dock;
-  final void Function(PdfDockablePanel panel, PdfPanelDock dock) onPanelDock;
+  final void Function(PdfDockablePanel panel, PdfPanelDock dock)? onPanelDock;
+  final ValueChanged<PdfPanelDock>? onToolbarDock;
 
   IconData get _icon => switch (dock) {
         PdfPanelDock.left => Icons.west,
@@ -233,9 +289,20 @@ class _DropTarget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    return DragTarget<PdfDockablePanel>(
-      onWillAcceptWithDetails: (_) => true,
-      onAcceptWithDetails: (details) => onPanelDock(details.data, dock),
+    return DragTarget<Object>(
+      onWillAcceptWithDetails: (details) => switch (details.data) {
+        PdfDockablePanel() => onPanelDock != null,
+        PdfToolbarDragData() => onToolbarDock != null,
+        _ => false,
+      },
+      onAcceptWithDetails: (details) {
+        switch (details.data) {
+          case final PdfDockablePanel panel:
+            onPanelDock?.call(panel, dock);
+          case PdfToolbarDragData():
+            onToolbarDock?.call(dock);
+        }
+      },
       builder: (context, candidate, rejected) {
         final active = candidate.isNotEmpty;
         return AnimatedContainer(
@@ -262,6 +329,86 @@ class _DropTarget extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// Drag payload for the floating editing toolbar's move handle.
+class PdfToolbarDragData {
+  const PdfToolbarDragData();
+}
+
+/// Ambient wiring used by [PdfToolbarMoveHandle] to reveal the shell's edge
+/// drop zones while the floating toolbar is being moved.
+class PdfToolbarDragScope extends InheritedWidget {
+  const PdfToolbarDragScope({
+    super.key,
+    required this.onDragStarted,
+    required this.onDragEnded,
+    required super.child,
+  });
+
+  final VoidCallback onDragStarted;
+  final VoidCallback onDragEnded;
+
+  static PdfToolbarDragScope? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<PdfToolbarDragScope>();
+
+  @override
+  bool updateShouldNotify(PdfToolbarDragScope oldWidget) => false;
+}
+
+/// Compact grab handle injected into the stock floating editing toolbar.
+class PdfToolbarMoveHandle extends StatelessWidget {
+  const PdfToolbarMoveHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = PdfToolbarDragScope.maybeOf(context);
+    if (scope == null) return const SizedBox.shrink();
+    final scheme = Theme.of(context).colorScheme;
+    final handle = MouseRegion(
+      cursor: SystemMouseCursors.move,
+      child: Tooltip(
+        message: pdfL10n(context).panelDragToMovePanel,
+        child: SizedBox.square(
+          dimension: 40,
+          child: Icon(
+            Icons.drag_indicator,
+            size: 18,
+            color: scheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+    return Draggable<Object>(
+      key: const ValueKey('pdf-toolbar-move'),
+      data: const PdfToolbarDragData(),
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      onDragStarted: scope.onDragStarted,
+      onDragEnd: (_) => scope.onDragEnded(),
+      onDraggableCanceled: (_, __) => scope.onDragEnded(),
+      feedback: Material(
+        color: Colors.transparent,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: scheme.primaryContainer,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.2),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Icon(Icons.build_outlined,
+              size: 18, color: scheme.onPrimaryContainer),
+        ),
+      ),
+      childWhenDragging: Opacity(opacity: 0.3, child: handle),
+      child: handle,
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -11,6 +11,7 @@ import 'editing/editing_preferences.dart';
 import 'editing/tool_shortcuts.dart';
 import 'l10n/pdf_l10n.dart';
 import 'pdf_viewer.dart';
+import 'scrollbar.dart';
 import 'search_field_style.dart';
 
 /// Shared header chrome for the drop-in shells (PdfReader and
@@ -131,13 +132,21 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       PdfPanelDock.top => Positioned(left: 0, right: 0, top: 0, child: toolbar),
       PdfPanelDock.bottom =>
         Positioned(left: 0, right: 0, bottom: 0, child: toolbar),
-      PdfPanelDock.left || PdfPanelDock.right => Positioned.fill(
+      PdfPanelDock.left => Positioned.fill(
           child: Align(
-            alignment: widget.floatingToolbarDock == PdfPanelDock.left
-                ? Alignment.centerLeft
-                : Alignment.centerRight,
+            alignment: Alignment.centerLeft,
             child: toolbar,
           ),
+        ),
+      // The viewer's vertical scrollbar owns this right-edge hit gutter.
+      // Keep the toolbar visually docked beside it without intercepting
+      // scrollbar hover, taps, or drags.
+      PdfPanelDock.right => Positioned(
+          left: 0,
+          right: PdfScrollbar.hitExtent,
+          top: 0,
+          bottom: 0,
+          child: Align(alignment: Alignment.centerRight, child: toolbar),
         ),
     };
   }

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -106,6 +107,33 @@ void main() {
       }
       expect(PdfThumbnailSidebar.debugRasterizations, target);
     }
+
+    testWidgets('Ctrl+A selects every page in the sidebar', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      expect(editing.selectedPages, [1]);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(editing.selectedPages, [0, 1, 2, 3]);
+      await tester.pump(const Duration(seconds: 2));
+    });
 
     testWidgets('an edit re-renders only the page it touched', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(3));

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -34,6 +34,7 @@ void main() {
       a.stampDateFormat = PdfStampDateFormat.dayMonthYear;
       a.stampTimeFormat = PdfStampTimeFormat.twelveHourSeconds;
       a.locale = const Locale('es');
+      a.toolbarDock = PdfPanelDock.right;
       await pumpEventQueue(); // let the unawaited writes land
 
       final b = PdfEditingPreferences();
@@ -60,6 +61,7 @@ void main() {
       expect(b.stampDateFormat, PdfStampDateFormat.dayMonthYear);
       expect(b.stampTimeFormat, PdfStampTimeFormat.twelveHourSeconds);
       expect(b.locale, const Locale('es'));
+      expect(b.toolbarDock, PdfPanelDock.right);
     });
 
     test('locale persists as a BCP-47 tag and restores script/region subtags',

--- a/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
@@ -123,6 +123,23 @@ void main() {
       await drain(tester);
     });
 
+    testWidgets('Ctrl+A selects every page in the grid', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 5);
+
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      expect(refs.editing.selectedPages, [1]);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(refs.editing.selectedPages, [0, 1, 2, 3, 4]);
+      await drain(tester);
+    });
+
     testWidgets('the size slider changes the tile-width preference',
         (tester) async {
       wideScreen(tester);

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1309,6 +1309,43 @@ void main() {
       expect(viewer.pageColor, const Color(0xFFEEF7EE));
     });
 
+    testWidgets('floating toolbar can be dragged to another edge',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          preferences: prefs,
+        ),
+      );
+
+      expect(prefs.toolbarDock, PdfPanelDock.bottom);
+      final handle = find.byKey(const ValueKey('pdf-toolbar-move'));
+      expect(handle, findsOneWidget);
+      final gesture = await tester.startGesture(
+        tester.getCenter(handle),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(12, 0));
+      await tester.pump();
+
+      final top = find.byKey(const ValueKey('pdf-shell-dropzone-top'));
+      expect(top, findsOneWidget);
+      await gesture.moveTo(tester.getCenter(top));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(prefs.toolbarDock, PdfPanelDock.top);
+      final card = find.byKey(const ValueKey('pdf-editing-toolbar-card'));
+      expect(tester.getTopLeft(card).dy, lessThan(140));
+    });
+
     testWidgets('view options show page color hex and current author',
         (tester) async {
       final prefs = PdfEditingPreferences();

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1437,6 +1437,13 @@ void main() {
         tester.getRect(card).right,
         lessThanOrEqualTo(tester.getRect(annotations).left + 0.5),
       );
+      final viewerRect = tester.getRect(
+        find.byKey(const ValueKey('pdf-shell-viewer')),
+      );
+      expect(
+        viewerRect.right - tester.getRect(card).right,
+        greaterThanOrEqualTo(PdfScrollbar.hitExtent - 0.5),
+      );
 
       final markup =
           tester.getCenter(find.byKey(const ValueKey('pdf-group-markup')));

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1336,6 +1336,19 @@ void main() {
 
       final top = find.byKey(const ValueKey('pdf-shell-dropzone-top'));
       expect(top, findsOneWidget);
+      final viewerRect = tester.getRect(
+        find.byKey(const ValueKey('pdf-shell-viewer')),
+      );
+      final leftTarget = tester.getRect(
+        find.byKey(const ValueKey('pdf-shell-dropzone-left')),
+      );
+      final rightTarget = tester.getRect(
+        find.byKey(const ValueKey('pdf-shell-dropzone-right')),
+      );
+      expect(viewerRect.left, greaterThan(100));
+      expect(leftTarget.left, greaterThanOrEqualTo(viewerRect.left));
+      expect(rightTarget.right, lessThanOrEqualTo(viewerRect.right));
+      expect(tester.getRect(top).top, greaterThanOrEqualTo(viewerRect.top));
       await gesture.moveTo(tester.getCenter(top));
       await tester.pump();
       await gesture.up();
@@ -1378,6 +1391,11 @@ void main() {
           tester.getCenter(find.byKey(const ValueKey('pdf-group-draw')));
       expect((markup.dx - draw.dx).abs(), lessThan(0.5));
       expect(draw.dy, greaterThan(markup.dy));
+      final markupIcon = tester.getCenter(find.descendant(
+        of: find.byKey(const ValueKey('pdf-group-markup')),
+        matching: find.byIcon(Icons.edit_note),
+      ));
+      expect(markupIcon.dx, closeTo(markup.dx, 0.1));
 
       await tester.tap(find.byKey(const ValueKey('pdf-group-markup')),
           kind: PointerDeviceKind.mouse);

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1346,6 +1346,100 @@ void main() {
       expect(tester.getTopLeft(card).dy, lessThan(140));
     });
 
+    testWidgets('left toolbar is a vertical rail inside docked panels',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      prefs.toolbarDock = PdfPanelDock.left;
+
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          preferences: prefs,
+        ),
+      );
+
+      final card = find.byKey(const ValueKey('pdf-editing-toolbar-card'));
+      final pages = find.byType(PdfThumbnailSidebar);
+      expect(card, findsOneWidget);
+      expect(pages, findsOneWidget);
+      expect(
+        tester.getRect(card).left,
+        greaterThanOrEqualTo(tester.getRect(pages).right - 0.5),
+      );
+
+      final markup =
+          tester.getCenter(find.byKey(const ValueKey('pdf-group-markup')));
+      final draw =
+          tester.getCenter(find.byKey(const ValueKey('pdf-group-draw')));
+      expect((markup.dx - draw.dx).abs(), lessThan(0.5));
+      expect(draw.dy, greaterThan(markup.dy));
+
+      await tester.tap(find.byKey(const ValueKey('pdf-group-markup')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      final openCards = find.byKey(const ValueKey('pdf-editing-toolbar-card'));
+      expect(openCards, findsNWidgets(2));
+      final openRects = [
+        for (final element in openCards.evaluate())
+          tester.getRect(find.byElementPredicate((e) => identical(e, element))),
+      ]..sort((a, b) => a.left.compareTo(b.left));
+      expect(openRects.last.left, greaterThan(openRects.first.right));
+      expect(openRects.first.width, lessThan(openRects.last.width));
+    });
+
+    testWidgets('right toolbar is a vertical rail inside docked panels',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      prefs.showThumbnailSidebar = false;
+      prefs.showAnnotationSidebar = true;
+      prefs.toolbarDock = PdfPanelDock.right;
+
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          preferences: prefs,
+        ),
+      );
+
+      final card = find.byKey(const ValueKey('pdf-editing-toolbar-card'));
+      final annotations = find.byType(PdfAnnotationSidebar);
+      expect(card, findsOneWidget);
+      expect(annotations, findsOneWidget);
+      expect(
+        tester.getRect(card).right,
+        lessThanOrEqualTo(tester.getRect(annotations).left + 0.5),
+      );
+
+      final markup =
+          tester.getCenter(find.byKey(const ValueKey('pdf-group-markup')));
+      final draw =
+          tester.getCenter(find.byKey(const ValueKey('pdf-group-draw')));
+      expect((markup.dx - draw.dx).abs(), lessThan(0.5));
+      expect(draw.dy, greaterThan(markup.dy));
+
+      await tester.tap(find.byKey(const ValueKey('pdf-group-markup')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      final openCards = find.byKey(const ValueKey('pdf-editing-toolbar-card'));
+      expect(openCards, findsNWidgets(2));
+      final openRects = [
+        for (final element in openCards.evaluate())
+          tester.getRect(find.byElementPredicate((e) => identical(e, element))),
+      ]..sort((a, b) => a.left.compareTo(b.left));
+      expect(openRects.first.right, lessThan(openRects.last.left));
+      expect(openRects.last.width, lessThan(openRects.first.width));
+    });
+
     testWidgets('view options show page color hex and current author',
         (tester) async {
       final prefs = PdfEditingPreferences();


### PR DESCRIPTION
## Summary

- add Ctrl/Cmd+A selection across thumbnail sidebar and grid views
- restore Windows file dropping under the engine-owned multi-window runner with per-HWND OLE targets
- use extension-preserving middle ellipsis for tabs, recents, paths, and print titles
- make the floating editing toolbar draggable to all four edges and persist its dock
- present the mobile save flow as Share while retaining desktop Save behavior

## Affected packages

- [ ] pdf_cos
- [ ] pdf_document
- [ ] pdf_graphics
- [x] dart_pdf_editor
- [ ] pdf_test_fixtures
- [x] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] fvm flutter pub get
- [x] fvm dart analyze
- [ ] cd packages/pdf_cos && fvm dart test
- [ ] cd packages/pdf_document && fvm dart test
- [ ] cd packages/pdf_graphics && fvm dart test
- [ ] cd packages/dart_pdf_editor && fvm flutter test
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

Focused dart_pdf_editor tests passed (122 tests). The complete app test suite passed (489 tests). The Windows native runner cannot be compiled on this macOS host; its Dart channel and per-window routing are covered by widget tests and the native lifecycle was audited statically.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

No PDF rendering output changes; existing programmatic fixtures cover the affected UI paths.

## Compatibility checklist

- [x] No dart:ui or Flutter imports outside packages/dart_pdf_editor.
- [x] No dart:io imports added in any lib directory.
- [x] Layering is preserved: pdf_cos <- pdf_document <- pdf_graphics <- dart_pdf_editor.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The Windows bridge is engine-scoped and routes native drag events by HWND, avoiding the implicit Flutter view assumption that broke after the multi-window bootstrap.