### PR TITLE
ci(perf): compare GPU runs on one host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,34 +187,26 @@ jobs:
           --dart-define PDF_GPU_CI_SMOKE=true
           test/gpu_ci_smoke_test.dart --reporter expanded
 
-      - name: Download latest main Flutter GPU performance baseline
+      - name: Prepare same-host main Flutter GPU baseline
         id: gpu-baseline
         if: github.event_name == 'pull_request'
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          for baseline_run in $(gh run list \
-            --workflow ci.yml \
-            --branch main \
-            --event push \
-            --limit 10 \
-            --json databaseId \
-            --jq '.[].databaseId'); do
-            destination="$RUNNER_TEMP/flutter-gpu-baseline/$baseline_run"
-            if gh run download "$baseline_run" \
-              --name flutter-gpu-performance \
-              --dir "$destination"; then
-              json="$(find "$destination" -name patrol-perf.json -print -quit)"
-              if [[ -n "$json" && -f "$json" ]]; then
-                echo "json=$json" >> "$GITHUB_OUTPUT"
-                echo "Using Flutter GPU baseline from run $baseline_run"
-                exit 0
-              fi
-            fi
-          done
-          echo "::notice::No usable main Flutter GPU artifact is available yet"
+          # A separate workflow artifact can come from a materially faster or
+          # slower macOS host. Keep the exact base revision on this runner so
+          # the comparison isolates code instead of fleet variance.
+          destination="$RUNNER_TEMP/flutter-gpu-main"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git worktree add --detach "$destination" "$BASE_SHA"
+          (
+            cd "$destination"
+            flutter pub get
+          )
+          echo "dir=$destination" >> "$GITHUB_OUTPUT"
+          echo "commit=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Measure Flutter GPU warm-up and first-tile performance
         id: gpu-performance
@@ -222,13 +214,26 @@ jobs:
         shell: bash
         env:
           PERF_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_COMMIT: ${{ steps.gpu-baseline.outputs.commit }}
+          BASE_WORKSPACE: ${{ steps.gpu-baseline.outputs.dir }}
         run: |
           set -euo pipefail
           log="$RUNNER_TEMP/flutter-gpu-performance.log"
+          baseline_log="$RUNNER_TEMP/flutter-gpu-main-performance.log"
           : > "$log"
-          for iteration in 1 2 3; do
-            while read -r label pdf; do
-              echo "::group::Flutter GPU $label repetition $iteration/3"
+          : > "$baseline_log"
+
+          run_case() {
+            local workspace="$1"
+            local commit="$2"
+            local destination_log="$3"
+            local cohort="$4"
+            local label="$5"
+            local pdf="$6"
+            local iteration="$7"
+            echo "::group::Flutter GPU $cohort $label repetition $iteration/3"
+            (
+              cd "$workspace/packages/dart_pdf_editor_flutter_gpu"
               env \
                 PDF_GPU_BENCHMARK_PDF="$pdf" \
                 PDF_GPU_BENCHMARK_PAGES=0 \
@@ -240,17 +245,40 @@ jobs:
                   --enable-impeller \
                   --enable-flutter-gpu \
                   --dart-define PDF_PERF_LOG=true \
-                  --dart-define "PDF_BUILD_COMMIT=$PERF_COMMIT" \
+                  --dart-define "PDF_BUILD_COMMIT=$commit" \
                   test/real_document_benchmark_test.dart \
-                  --reporter expanded \
-                  2>&1 | tee -a "$log"
-              echo "::endgroup::"
+                  --reporter expanded
+            ) 2>&1 | tee -a "$destination_log"
+            echo "::endgroup::"
+          }
+
+          for iteration in 1 2 3; do
+            while read -r label pdf; do
+              # Reverse the order for the middle repetition so neither cohort
+              # always inherits the warmer filesystem/GPU state.
+              if [[ -n "$BASE_WORKSPACE" && "$iteration" == 2 ]]; then
+                run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
+                  pr "$label" "$pdf" "$iteration"
+                run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
+                  main "$label" "$pdf" "$iteration"
+              elif [[ -n "$BASE_WORKSPACE" ]]; then
+                run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
+                  main "$label" "$pdf" "$iteration"
+                run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
+                  pr "$label" "$pdf" "$iteration"
+              else
+                run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
+                  current "$label" "$pdf" "$iteration"
+              fi
             done <<'SCENARIOS'
           tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
           radial ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
           SCENARIOS
           done
           echo "log=$log" >> "$GITHUB_OUTPUT"
+          if [[ -n "$BASE_WORKSPACE" ]]; then
+            echo "baseline_log=$baseline_log" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Summarize Flutter GPU performance
         if: always()
@@ -263,11 +291,7 @@ jobs:
             log="$RUNNER_TEMP/flutter-gpu-performance.log"
             touch "$log"
           fi
-          arguments=(
-            "$log"
-            --output test-results/gpu
-            --markdown "$GITHUB_STEP_SUMMARY"
-            --label "macOS Metal GPU"
+          requirements=(
             --require-scenario-runs gpu-tiling-pipeline-warm=3
             --require-scenario-runs gpu-tiling-page-0-scene-warm=3
             --require-scenario-runs gpu-tiling-page-0-first-tile=3
@@ -277,8 +301,23 @@ jobs:
             --require-scenario-runs gpu-radial-page-0-first-tile=3
             --require-scenario-runs gpu-radial-page-0-canvas-tile=3
           )
-          baseline="${{ steps.gpu-baseline.outputs.json }}"
-          if [[ -n "$baseline" && -f "$baseline" ]]; then
+          arguments=(
+            "$log"
+            --output test-results/gpu
+            --markdown "$GITHUB_STEP_SUMMARY"
+            --label "macOS Metal GPU"
+            "${requirements[@]}"
+          )
+          baseline_log="${{ steps.gpu-performance.outputs.baseline_log }}"
+          if [[ -n "$baseline_log" && -f "$baseline_log" ]]; then
+            baseline_output="$RUNNER_TEMP/flutter-gpu-main-summary"
+            dart ../../tool/patrol_perf_summary.dart \
+              "$baseline_log" \
+              --output "$baseline_output" \
+              --markdown "$RUNNER_TEMP/flutter-gpu-main.md" \
+              --label "same-host main" \
+              "${requirements[@]}"
+            baseline="$baseline_output/patrol-perf.json"
             arguments+=(--baseline "$baseline")
           fi
           dart ../../tool/patrol_perf_summary.dart "${arguments[@]}"
@@ -345,12 +384,14 @@ jobs:
               ? fs.readFileSync(reportPath, 'utf8').trim()
               : 'No Flutter GPU performance artifact was produced. Open the workflow run for the failing step and raw logs.';
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
+            const baseSha = context.payload.pull_request.base.sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               marker,
               '## Flutter GPU performance',
               '',
               `Automated on macOS Metal for commit \`${sha}\` · [workflow run and downloadable traces](${runUrl})`,
+              `Same-host A/B: base \`${baseSha}\` and PR were alternated on one GitHub runner.`,
               '',
               headline,
               '',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,8 +230,8 @@ jobs:
             local cohort="$4"
             local label="$5"
             local pdf="$6"
-            local iteration="$7"
-            echo "::group::Flutter GPU $cohort $label repetition $iteration/3"
+            local repetition="$7"
+            echo "::group::Flutter GPU $cohort $label $repetition"
             (
               cd "$workspace/packages/dart_pdf_editor_flutter_gpu"
               env \
@@ -252,23 +252,47 @@ jobs:
             echo "::endgroup::"
           }
 
-          for iteration in 1 2 3; do
+          if [[ -n "$BASE_WORKSPACE" ]]; then
+            prime_index=0
             while read -r label pdf; do
-              # Reverse the order for the middle repetition so neither cohort
-              # always inherits the warmer filesystem/GPU state.
-              if [[ -n "$BASE_WORKSPACE" && "$iteration" == 2 ]]; then
+              # The PR worktree already ran gpu_ci_smoke_test.dart. Prime both
+              # worktrees here so compilation and Metal driver caches cannot
+              # systematically favour the candidate measurements.
+              if (( prime_index % 2 == 0 )); then
+                run_case "$BASE_WORKSPACE" "$BASE_COMMIT" /dev/null \
+                  main "$label" "$pdf" "unmeasured warm-up"
+                run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" /dev/null \
+                  pr "$label" "$pdf" "unmeasured warm-up"
+              else
+                run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" /dev/null \
+                  pr "$label" "$pdf" "unmeasured warm-up"
+                run_case "$BASE_WORKSPACE" "$BASE_COMMIT" /dev/null \
+                  main "$label" "$pdf" "unmeasured warm-up"
+              fi
+              prime_index=$((prime_index + 1))
+            done <<'SCENARIOS'
+          tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          radial ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          SCENARIOS
+          fi
+
+          for iteration in 1 2 3 4 5 6; do
+            while read -r label pdf; do
+              # Even repetitions run PR first, odd repetitions run main first:
+              # each cohort inherits the warmer state exactly three times.
+              if [[ -n "$BASE_WORKSPACE" && $((iteration % 2)) == 0 ]]; then
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  pr "$label" "$pdf" "$iteration"
+                  pr "$label" "$pdf" "repetition $iteration/6"
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
-                  main "$label" "$pdf" "$iteration"
+                  main "$label" "$pdf" "repetition $iteration/6"
               elif [[ -n "$BASE_WORKSPACE" ]]; then
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
-                  main "$label" "$pdf" "$iteration"
+                  main "$label" "$pdf" "repetition $iteration/6"
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  pr "$label" "$pdf" "$iteration"
+                  pr "$label" "$pdf" "repetition $iteration/6"
               else
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  current "$label" "$pdf" "$iteration"
+                  current "$label" "$pdf" "repetition $iteration/6"
               fi
             done <<'SCENARIOS'
           tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
@@ -292,14 +316,14 @@ jobs:
             touch "$log"
           fi
           requirements=(
-            --require-scenario-runs gpu-tiling-pipeline-warm=3
-            --require-scenario-runs gpu-tiling-page-0-scene-warm=3
-            --require-scenario-runs gpu-tiling-page-0-first-tile=3
-            --require-scenario-runs gpu-tiling-page-0-canvas-tile=3
-            --require-scenario-runs gpu-radial-pipeline-warm=3
-            --require-scenario-runs gpu-radial-page-0-scene-warm=3
-            --require-scenario-runs gpu-radial-page-0-first-tile=3
-            --require-scenario-runs gpu-radial-page-0-canvas-tile=3
+            --require-scenario-runs gpu-tiling-pipeline-warm=6
+            --require-scenario-runs gpu-tiling-page-0-scene-warm=6
+            --require-scenario-runs gpu-tiling-page-0-first-tile=6
+            --require-scenario-runs gpu-tiling-page-0-canvas-tile=6
+            --require-scenario-runs gpu-radial-pipeline-warm=6
+            --require-scenario-runs gpu-radial-page-0-scene-warm=6
+            --require-scenario-runs gpu-radial-page-0-first-tile=6
+            --require-scenario-runs gpu-radial-page-0-canvas-tile=6
           )
           arguments=(
             "$log"

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -120,8 +120,8 @@ void main(List<String> arguments) {
 /// produce enough complete start/end pairs.
 ///
 /// CI uses this after writing the report artifacts: a flaky Patrol invocation
-/// remains diagnosable, but cannot silently turn a three-sample comparison
-/// into a one- or two-sample result.
+/// remains diagnosable, but cannot silently reduce a repeated comparison to a
+/// sparse result.
 Map<String, int> patrolPerfScenarioRunShortfalls(
   Map<String, Object?> trace,
   Map<String, int> required,
@@ -333,7 +333,7 @@ class PatrolPerfTrace {
   final Map<String, _ScenarioMetrics> _scenarioMetrics;
 
   Map<String, Object?> toJson() => {
-        'schema': 8,
+        'schema': 9,
         'build': buildTag,
         'events': lines.length,
         'journeys': journeys,
@@ -618,6 +618,12 @@ class PatrolPerfComparison {
         ..writeln(
           'Scenario elapsed uses p50 across repeated runs; phase and tail '
           'signals remain p95. Samples (main / PR): $samples.',
+        )
+        ..writeln()
+        ..writeln(
+          'When both cohorts have at least four samples, overlapping '
+          'interquartile ranges are labelled `within run spread` instead '
+          'of showing a misleading percentage.',
         );
       if (sparseSamples) {
         buffer
@@ -661,10 +667,13 @@ class PatrolPerfComparison {
     }
 
     for (final scenario in measuredScenarios) {
-      timingRow(
-        'Scenario ${_code(scenario)} elapsed p50',
-        ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
-      );
+      final path = ['scenarioMetrics', scenario, 'elapsedMs', 'p50'];
+      final before = _jsonNumber(baseline, path);
+      final after = _jsonNumber(current, path);
+      if (before == null && after == null) continue;
+      buffer.writeln('| Scenario ${_code(scenario)} elapsed p50 | '
+          '${_timingText(before)} | ${_timingText(after)} | '
+          '${_scenarioElapsedDelta(baseline, current, scenario)} |');
     }
     timingRow('Jank total p95', const ['jank', 'totalMs', 'p95']);
     timingRow('Reconcile p95', const ['reconciliation', 'elapsedMs', 'p95']);
@@ -713,6 +722,12 @@ class PatrolPerfComparison {
         'Advisory only: timing changes do not fail CI. The baseline is the '
         'newest usable $artifactKind artifact from `Patrol E2E` on `main`.',
       )
+      ..writeln()
+      ..writeln(
+        'Scenario elapsed p50 changes are labelled `within run spread` when '
+        'both cohorts have at least four samples and their interquartile '
+        'ranges overlap.',
+      )
       ..write(
         sameCoverage
             ? ''
@@ -734,11 +749,16 @@ class PatrolPerfComparison {
           '${_numberText(after)} | ${_countDelta(before, after)} |');
     }
 
-    void timingRow(String label, List<String> path) {
+    void timingRow(
+      String label,
+      List<String> path, {
+      String? change,
+    }) {
       final before = _jsonNumber(baseline, path);
       final after = _jsonNumber(current, path);
       buffer.writeln('| $label | ${_timingText(before)} | '
-          '${_timingText(after)} | ${_percentDelta(before, after)} |');
+          '${_timingText(after)} | '
+          '${change ?? _percentDelta(before, after)} |');
     }
 
     countRow('Journey segments', const ['journeys']);
@@ -802,6 +822,7 @@ class PatrolPerfComparison {
       timingRow(
         'Scenario $scenario elapsed p50',
         ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
+        change: _scenarioElapsedDelta(baseline, current, scenario),
       );
       timingRow(
         'Scenario $scenario elapsed p95',
@@ -935,6 +956,9 @@ class _ScenarioMetrics {
   Map<String, Object?> toJson() => {
         'runs': elapsedMs.length,
         'elapsedMs': _distribution(elapsedMs),
+        // Retain the small per-scenario sample set so PR comparisons can
+        // distinguish a shifted distribution from overlapping runner noise.
+        'elapsedSamplesMs': List<double>.unmodifiable(elapsedMs),
         'jank': {
           'count': jankTotalMs.length,
           'totalMs': _distribution(jankTotalMs),
@@ -1329,7 +1353,62 @@ Set<String> _jsonMapKeys(Object? root, List<String> path) {
       : const {};
 }
 
-typedef _GpuTileSpeedup = ({double firstTileMs, double canvasTileMs});
+List<double> _jsonNumberList(Object? root, List<String> path) {
+  Object? value = root;
+  for (final part in path) {
+    if (value is! Map || !value.containsKey(part)) return const [];
+    value = value[part];
+  }
+  if (value is! List) return const [];
+  return [
+    for (final item in value)
+      if (item is num) item.toDouble(),
+  ];
+}
+
+String _scenarioElapsedDelta(
+  Object? baseline,
+  Object? current,
+  String scenario,
+) {
+  final before = _jsonNumber(
+    baseline,
+    ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
+  );
+  final after = _jsonNumber(
+    current,
+    ['scenarioMetrics', scenario, 'elapsedMs', 'p50'],
+  );
+  final beforeSamples = _jsonNumberList(
+    baseline,
+    ['scenarioMetrics', scenario, 'elapsedSamplesMs'],
+  );
+  final afterSamples = _jsonNumberList(
+    current,
+    ['scenarioMetrics', scenario, 'elapsedSamplesMs'],
+  );
+  if (_interquartileRangesOverlap(beforeSamples, afterSamples)) {
+    return 'within run spread';
+  }
+  return _percentDelta(before, after);
+}
+
+bool _interquartileRangesOverlap(List<double> a, List<double> b) {
+  if (a.length < 4 || b.length < 4) return false;
+  final sortedA = List<double>.of(a)..sort();
+  final sortedB = List<double>.of(b)..sort();
+  final aLow = _percentile(sortedA, 0.25);
+  final aHigh = _percentile(sortedA, 0.75);
+  final bLow = _percentile(sortedB, 0.25);
+  final bHigh = _percentile(sortedB, 0.75);
+  return aLow <= bHigh && bLow <= aHigh;
+}
+
+typedef _GpuTileSpeedup = ({
+  double firstTileMs,
+  double canvasTileMs,
+  double? pairedSpeedup,
+});
 
 Map<String, _GpuTileSpeedup> _gpuTileSpeedups(Object? trace) {
   const suffix = '-first-tile';
@@ -1348,9 +1427,27 @@ Map<String, _GpuTileSpeedup> _gpuTileSpeedups(Object? trace) {
       ['scenarioMetrics', '$prefix-canvas-tile', 'elapsedMs', 'p50'],
     );
     if (firstTile == null || canvasTile == null || firstTile <= 0) continue;
+    final firstTileSamples = _jsonNumberList(
+      trace,
+      ['scenarioMetrics', scenario, 'elapsedSamplesMs'],
+    );
+    final canvasTileSamples = _jsonNumberList(
+      trace,
+      ['scenarioMetrics', '$prefix-canvas-tile', 'elapsedSamplesMs'],
+    );
+    final pairedRatios = <double>[];
+    if (firstTileSamples.length == canvasTileSamples.length) {
+      for (var i = 0; i < firstTileSamples.length; i++) {
+        final first = firstTileSamples[i];
+        if (first > 0) pairedRatios.add(canvasTileSamples[i] / first);
+      }
+    }
+    final sortedRatios = List<double>.of(pairedRatios)..sort();
     result[prefix.substring('gpu-'.length).replaceAll('-', ' ')] = (
       firstTileMs: firstTile.toDouble(),
       canvasTileMs: canvasTile.toDouble(),
+      pairedSpeedup:
+          sortedRatios.isEmpty ? null : _percentile(sortedRatios, 0.50),
     );
   }
   return result;
@@ -1369,7 +1466,7 @@ String? _gpuTileSpeedupHeadline(
 
   String speedup(_GpuTileSpeedup? value) => value == null
       ? 'n/a'
-      : '${(value.canvasTileMs / value.firstTileMs).toStringAsFixed(1)}×';
+      : '${(value.pairedSpeedup ?? value.canvasTileMs / value.firstTileMs).toStringAsFixed(1)}×';
 
   if (baseline != null) {
     final values = workloads.map(

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -37,7 +37,7 @@ void main() {
     '[perf 90] scenario name=heavy-document phase=validated',
   ]);
   final json = trace.toJson();
-  _expectEqual(json['schema'], 8, 'schema');
+  _expectEqual(json['schema'], 9, 'schema');
 
   final workerPhases = _map(_map(json, 'webWorker'), 'phases');
   _expectEqual(workerPhases['count'], 2, 'worker phase count');
@@ -354,6 +354,11 @@ void main() {
     const {'p50': 200.0, 'p95': 300.0, 'max': 300.0},
     'repeated scenario distribution',
   );
+  _expectEqual(
+    (repeatedScenario['elapsedSamplesMs'] as List).join(', '),
+    '100.0, 300.0, 200.0',
+    'repeated scenario raw sample order',
+  );
   _expectContains(
     repeatedTrace.toHeadlineMarkdown(),
     '| Scenario `repeatable` elapsed p50 (3 runs) | 200.0 ms |',
@@ -372,6 +377,50 @@ void main() {
     repeatedComparison,
     'fewer than three samples',
     'repeated comparison is not sparse',
+  );
+  final overlapBaseline = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] build commit=overlap-base-1',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 110] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-base-2',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 120] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-base-3',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 130] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-base-4',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 140] scenario name=overlap phase=validated',
+  ]).toJson();
+  final overlapCurrent = summary.PatrolPerfTrace.parse(const [
+    '[perf 0] build commit=overlap-current-1',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 115] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-current-2',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 125] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-current-3',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 135] scenario name=overlap phase=validated',
+    '[perf 0] build commit=overlap-current-4',
+    '[perf 10] scenario name=overlap phase=start',
+    '[perf 145] scenario name=overlap phase=validated',
+  ]).toJson();
+  final overlapComparison = summary.PatrolPerfComparison(
+    baseline: overlapBaseline,
+    current: overlapCurrent,
+  );
+  _expectContains(
+    overlapComparison.toHeadlineMarkdown(),
+    '| Scenario `overlap` elapsed p50 | 120.0 ms | 125.0 ms | '
+        'within run spread |',
+    'overlapping scenario distributions are not presented as a regression',
+  );
+  _expectContains(
+    overlapComparison.toMarkdown(),
+    '| Scenario overlap elapsed p50 | 120.0 ms | 125.0 ms | '
+        'within run spread |',
+    'detailed comparison uses the same noise label',
   );
   final repetitionTransitionComparison = summary.PatrolPerfComparison(
     baseline: const {
@@ -479,7 +528,7 @@ void main() {
   );
   _expectContains(
     gpuTrace.toHeadlineMarkdown(label: 'macOS Metal GPU'),
-    '**GPU first tile vs Canvas (p50):** `tiling page 0` **58.3×** '
+    '**GPU first tile vs Canvas (p50):** `tiling page 0` **56.7×** '
         '(6.0 ms vs 350.0 ms).',
     'GPU speedup leads the PR headline',
   );
@@ -489,7 +538,7 @@ void main() {
       current: gpuJson,
     ).toHeadlineMarkdown(label: 'macOS Metal GPU'),
     '**GPU first tile vs Canvas (p50, main → PR):** '
-        '`tiling page 0` **58.3× → 58.3×**.',
+        '`tiling page 0` **56.7× → 56.7×**.',
     'GPU main comparison leads the PR headline',
   );
 


### PR DESCRIPTION
## Summary

- benchmark the exact PR base SHA and candidate on the same macOS runner
- warm both cohorts, then collect six samples per scenario with a balanced 3/3 execution order
- build the comparison baseline from the same-host raw log
- retain raw scenario samples, use paired-run GPU/Canvas speedups, and label overlapping interquartile ranges as within run spread
- keep the headline comparison visible and the full trace under a details disclosure

## Why

PR #750 exposed a false cross-host regression: unchanged PDF decode, scene recording, and Canvas controls slowed by roughly 50% on different GitHub runners. A single artifact from another machine allowed host and order variance to dominate the code change.

## Validation

- final same-host report: all eight unchanged scenario distributions overlap; no measured regression
- radial GPU advantage: 36.5x to 41.8x; tiling: 36.1x to 33.7x
- workflow YAML parses successfully
- embedded prepare, measure, and summarize scripts pass bash syntax validation
- fvm dart tool/patrol_perf_summary_test.dart
- fvm dart analyze
- git diff --check