### PR TITLE
test(perf): add deferred-mask benchmark route

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -169,9 +169,19 @@ Set `PDF_GPU_BENCHMARK_SCENE_WARMUP=1` to additionally compile and submit the
 retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
 markers for each pipeline/scene/tile phase. CI uses those markers to run the
-checked-in tiling-pattern and radial-shading pages three times on macOS Metal,
-compare PR medians with the latest `main` artifact, and publish both a concise
-PR headline and a collapsed detailed trace.
+checked-in tiling-pattern and radial-shading pages six times on macOS Metal,
+compare the exact PR base and candidate on the same runner with balanced
+execution order, and publish both a concise PR headline and a collapsed
+detailed trace.
+Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
+a deterministic 1024x768 JPEG under a Flate grayscale soft mask. This fixture
+emits the same first-tile and Canvas scenarios whether the backend accepts the
+scene or production falls back to Canvas, so a backend-routing change remains
+a like-for-like comparison. Pipeline and scene warm-up scenario markers are
+suppressed for this production-route fixture; the warm-up itself still runs.
+An unmeasured Canvas pass immediately before the Canvas control keeps that
+reference warm on both the accepted and fallback routes without warming the
+cold first-tile measurement.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -8,9 +8,13 @@ import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 const _defaultPages = [27, 30, 29, 32, 31, 34, 37, 39, 28];
 const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
+const _deferredMaskFixture = 'deferred-mask';
 
 bool _gpuAvailable() {
   try {
@@ -83,13 +87,67 @@ double _meanDiff(ByteData a, ByteData b) {
   return total / aa.length;
 }
 
+Uint8List _deferredMaskDocument() {
+  const width = 1024, height = 768;
+  final source = img.Image(width: width, height: height, numChannels: 3);
+  img.fill(source, color: img.ColorRgb8(38, 112, 168));
+  final jpeg = Uint8List.fromList(img.encodeJpg(source, quality: 82));
+  return buildSyntheticRasterUnderlaySheet(
+    underlays: [
+      PdfUnderlaySpec(width: width, height: height, payload: jpeg),
+    ],
+    layers: 4,
+    ops: 200,
+    pageW: 612,
+    pageH: 792,
+  );
+}
+
+Uint8List _benchmarkDocumentBytes(String? path, String? fixture) {
+  if (path != null && fixture != null) {
+    throw ArgumentError(
+      'Set either PDF_GPU_BENCHMARK_PDF or PDF_GPU_BENCHMARK_FIXTURE, not both',
+    );
+  }
+  if (path != null) return File(path).readAsBytesSync();
+  return switch (fixture) {
+    _deferredMaskFixture => _deferredMaskDocument(),
+    null => throw ArgumentError(
+        'Set PDF_GPU_BENCHMARK_PDF or PDF_GPU_BENCHMARK_FIXTURE',
+      ),
+    _ => throw ArgumentError('Unknown PDF_GPU_BENCHMARK_FIXTURE: $fixture'),
+  };
+}
+
 void main() {
   if (_buildCommit.isNotEmpty) PdfPerfLog.buildTag = 'commit=$_buildCommit';
 
+  testWidgets('deferred-mask fixture keeps its companion image surface',
+      (tester) async {
+    await tester.runAsync(() async {
+      final document = PdfDocument.open(_deferredMaskDocument());
+      final scene = await PdfRetainedScene.record(document.page(0));
+      try {
+        final request = scene.commands
+            .whereType<PdfDrawImageCommand>()
+            .map((command) => command.request)
+            .single;
+        final image = scene.imageFor(request);
+        expect(image, isNotNull);
+        expect(pdfGpuSoftMaskOf(image!), isNotNull);
+      } finally {
+        scene.dispose();
+      }
+    });
+  });
+
   testWidgets('real document: cold scene plus two 512px LoDs', (tester) async {
     final path = Platform.environment['PDF_GPU_BENCHMARK_PDF'];
-    if (path == null) {
-      markTestSkipped('set PDF_GPU_BENCHMARK_PDF');
+    final fixture = Platform.environment['PDF_GPU_BENCHMARK_FIXTURE']?.trim();
+    if (path == null && (fixture == null || fixture.isEmpty)) {
+      markTestSkipped(
+        'set PDF_GPU_BENCHMARK_PDF or PDF_GPU_BENCHMARK_FIXTURE',
+      );
       return;
     }
     await tester.runAsync(() async {
@@ -97,7 +155,11 @@ void main() {
         markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
         return;
       }
-      final document = PdfDocument.open(File(path).readAsBytesSync());
+      final fixtureName = fixture == null || fixture.isEmpty ? null : fixture;
+      final document = PdfDocument.open(
+        _benchmarkDocumentBytes(path, fixtureName),
+      );
+      final productionRoute = fixtureName == _deferredMaskFixture;
       final configuredPages =
           Platform.environment['PDF_GPU_BENCHMARK_PAGES']?.trim();
       final scenarioLabel =
@@ -120,7 +182,9 @@ void main() {
         allowOverprintApproximation: approximateOverprint,
       );
       if (Platform.environment['PDF_GPU_BENCHMARK_WARMUP'] == '1') {
-        final scenario = _scenarioName(scenarioLabel, 'pipeline-warm');
+        final scenario = productionRoute
+            ? null
+            : _scenarioName(scenarioLabel, 'pipeline-warm');
         _startScenario(scenario);
         final warmUp = Stopwatch()..start();
         await backend.warmUp();
@@ -145,16 +209,62 @@ void main() {
         );
         record.stop();
         try {
+          final size = scene.pageSize;
+          final center = Offset(size.width / 2, size.height / 2);
+          const lod1 = 1.0;
+          final region1 = Rect.fromCenter(
+            center: center,
+            width: math.min(size.width, 512 / lod1),
+            height: math.min(size.height, 512 / lod1),
+          );
           final session = backend.createSession(scene);
           if (session == null) {
+            final firstScenario = _scenarioName(
+              scenarioLabel,
+              'first-tile',
+              page: pageIndex,
+            );
+            _startScenario(firstScenario);
+            final fallback = await _render(
+              () => scene.rasterizeRegion(region1, pixelRatio: lod1),
+              pngPath: output == null
+                  ? null
+                  : '$output/page-$pageIndex-fallback.png',
+            );
+            _finishScenario(firstScenario, fallback.$1, page: pageIndex);
+            if (productionRoute) {
+              // The fallback itself warmed Canvas. Repeat the unmeasured pass
+              // so both routes take one explicit warm-up immediately before
+              // the measured Canvas control below.
+              await _render(
+                () => scene.rasterizeRegion(region1, pixelRatio: lod1),
+              );
+            }
+            final canvasScenario = _scenarioName(
+              scenarioLabel,
+              'canvas-tile',
+              page: pageIndex,
+            );
+            _startScenario(canvasScenario);
+            final canvas = await _render(
+              () => scene.rasterizeRegion(region1, pixelRatio: lod1),
+              pngPath:
+                  output == null ? null : '$output/page-$pageIndex-canvas.png',
+            );
+            _finishScenario(canvasScenario, canvas.$1, page: pageIndex);
+            peakRss = math.max(peakRss, ProcessInfo.currentRss);
             rows.add('page=$pageIndex recordUs=${record.elapsedMicroseconds} '
                 'decodeUs=${(timing.decodeMs * 1000).round()} '
                 'gpu=rejected reason=${backend.stats.lastRejection} '
+                'firstRoute=canvas-fallback firstUs=${fallback.$1} '
+                'canvasUs=${canvas.$1} '
+                'meanDiff=${_meanDiff(fallback.$2, canvas.$2).toStringAsFixed(3)} '
                 'commands=${scene.commands.length}');
             continue;
           }
           try {
             if (Platform.environment['PDF_GPU_BENCHMARK_SCENE_WARMUP'] == '1' &&
+                !productionRoute &&
                 session is PdfTileRasterWarmUp) {
               final scenario = _scenarioName(
                 scenarioLabel,
@@ -169,14 +279,6 @@ void main() {
               print('REAL_GPU_BENCHMARK sceneWarmUpUs=$elapsedUs');
               _finishScenario(scenario, elapsedUs, page: pageIndex);
             }
-            final size = scene.pageSize;
-            final center = Offset(size.width / 2, size.height / 2);
-            final lod1 = 1.0;
-            final region1 = Rect.fromCenter(
-              center: center,
-              width: math.min(size.width, 512 / lod1),
-              height: math.min(size.height, 512 / lod1),
-            );
             try {
               final coldScenario = _scenarioName(
                 scenarioLabel,
@@ -190,6 +292,14 @@ void main() {
                     output == null ? null : '$output/page-$pageIndex-gpu.png',
               );
               _finishScenario(coldScenario, coldGpu.$1, page: pageIndex);
+              if (productionRoute) {
+                // A GPU first tile does not warm Canvas. Keep the reference
+                // control comparable with the fallback route without moving
+                // this work into the cold production-settle scenario.
+                await _render(
+                  () => scene.rasterizeRegion(region1, pixelRatio: lod1),
+                );
+              }
               final canvasScenario = _scenarioName(
                 scenarioLabel,
                 'canvas-tile',
@@ -219,6 +329,7 @@ void main() {
               peakRss = math.max(peakRss, ProcessInfo.currentRss);
               rows.add('page=$pageIndex recordUs=${record.elapsedMicroseconds} '
                   'decodeUs=${(timing.decodeMs * 1000).round()} '
+                  'firstRoute=flutter_gpu '
                   'gpuColdUs=${coldGpu.$1} gpuWarmUs=${warmGpu.$1} '
                   'canvasUs=${warmCanvas.$1} '
                   'meanDiff=${_meanDiff(coldGpu.$2, warmCanvas.$2).toStringAsFixed(3)}');

--- a/tool/patrol_perf_summary.dart
+++ b/tool/patrol_perf_summary.dart
@@ -1466,13 +1466,13 @@ String? _gpuTileSpeedupHeadline(
 
   String speedup(_GpuTileSpeedup? value) => value == null
       ? 'n/a'
-      : '${(value.pairedSpeedup ?? value.canvasTileMs / value.firstTileMs).toStringAsFixed(1)}×';
+      : '${_ratioText(value.pairedSpeedup ?? value.canvasTileMs / value.firstTileMs)}×';
 
   if (baseline != null) {
     final values = workloads.map(
         (workload) => '${_code(workload)} **${speedup(before[workload])} → '
             '${speedup(after[workload])}**');
-    return '**GPU first tile vs Canvas (p50, main → PR):** '
+    return '**First tile vs Canvas (p50, main → PR):** '
         '${values.join('; ')}.';
   }
 
@@ -1482,8 +1482,11 @@ String? _gpuTileSpeedupHeadline(
         '(${_formatMs(value.firstTileMs)} vs '
         '${_formatMs(value.canvasTileMs)})';
   });
-  return '**GPU first tile vs Canvas (p50):** ${values.join('; ')}.';
+  return '**First tile vs Canvas (p50):** ${values.join('; ')}.';
 }
+
+String _ratioText(double value) =>
+    value < 1 ? value.toStringAsFixed(2) : value.toStringAsFixed(1);
 
 bool _sameMapKeys(Map<String, int> a, Map<String, int> b) =>
     a.length == b.length && a.keys.every(b.containsKey);

--- a/tool/patrol_perf_summary_test.dart
+++ b/tool/patrol_perf_summary_test.dart
@@ -528,7 +528,7 @@ void main() {
   );
   _expectContains(
     gpuTrace.toHeadlineMarkdown(label: 'macOS Metal GPU'),
-    '**GPU first tile vs Canvas (p50):** `tiling page 0` **56.7×** '
+    '**First tile vs Canvas (p50):** `tiling page 0` **56.7×** '
         '(6.0 ms vs 350.0 ms).',
     'GPU speedup leads the PR headline',
   );
@@ -537,9 +537,32 @@ void main() {
       baseline: gpuJson,
       current: gpuJson,
     ).toHeadlineMarkdown(label: 'macOS Metal GPU'),
-    '**GPU first tile vs Canvas (p50, main → PR):** '
+    '**First tile vs Canvas (p50, main → PR):** '
         '`tiling page 0` **56.7× → 56.7×**.',
     'GPU main comparison leads the PR headline',
+  );
+  final fallbackGpuJson = <String, Object?>{
+    'scenarios': <String, int>{},
+    'scenarioMetrics': <String, Object?>{
+      'gpu-masked-page-0-first-tile': {
+        'runs': 4,
+        'elapsedMs': {'p50': 200.0},
+        'elapsedSamplesMs': [200.0, 200.0, 200.0, 200.0],
+      },
+      'gpu-masked-page-0-canvas-tile': {
+        'runs': 4,
+        'elapsedMs': {'p50': 20.0},
+        'elapsedSamplesMs': [20.0, 20.0, 20.0, 20.0],
+      },
+    },
+  };
+  _expectContains(
+    summary.PatrolPerfComparison(
+      baseline: fallbackGpuJson,
+      current: fallbackGpuJson,
+    ).toHeadlineMarkdown(label: 'macOS Metal GPU'),
+    '`masked page 0` **0.10× → 0.10×**',
+    'sub-one first-tile ratios keep enough precision',
   );
 
   print('Patrol performance summarizer tests passed');


### PR DESCRIPTION
## Summary

- add a deterministic 1024x768 JPEG-under-Flate-soft-mask benchmark fixture
- emit identical first-tile and Canvas scenarios whether production selects GPU or Canvas fallback
- suppress setup scenario markers for this route so backend acceptance cannot change coverage
- warm Canvas outside the measured control on both routes while keeping first-tile settle cold
- preserve sub-1x first-tile ratios at two decimals in performance headlines
- update the benchmark documentation for six-run same-host comparisons

## Why

The next GPU optimization changes deferred image masks from a whole-scene Canvas fallback to two retained GPU textures. Its benchmark must land first so both the base and candidate use exactly the same fixture, route logic, scenario names, and Canvas-control state.

## Validation

- fvm dart tool/patrol_perf_summary_test.dart
- fvm dart analyze
- complete dart_pdf_editor_flutter_gpu test suite
- focused benchmark-harness Flutter test
- Metal baseline: deferred image soft mask rejection, Canvas fallback, pixel-identical control
- temporary future-candidate integration: GPU accepted, two textures uploaded, mean pixel difference 0.49/255
- corrected local sample: cold settle 280 ms Canvas fallback to 111 ms GPU; warmed Canvas controls 21 ms and 17 ms
- git diff --check