### PR TITLE
perf(gpu): retain deferred image masks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,13 +229,27 @@ jobs:
             local destination_log="$3"
             local cohort="$4"
             local label="$5"
-            local pdf="$6"
-            local repetition="$7"
+            local source_kind="$6"
+            local source="$7"
+            local repetition="$8"
+            local source_env
+            case "$source_kind" in
+              pdf)
+                source_env="PDF_GPU_BENCHMARK_PDF=$source"
+                ;;
+              fixture)
+                source_env="PDF_GPU_BENCHMARK_FIXTURE=$source"
+                ;;
+              *)
+                echo "Unknown Flutter GPU benchmark source kind: $source_kind" >&2
+                return 2
+                ;;
+            esac
             echo "::group::Flutter GPU $cohort $label $repetition"
             (
               cd "$workspace/packages/dart_pdf_editor_flutter_gpu"
               env \
-                PDF_GPU_BENCHMARK_PDF="$pdf" \
+                "$source_env" \
                 PDF_GPU_BENCHMARK_PAGES=0 \
                 PDF_GPU_BENCHMARK_WARMUP=1 \
                 PDF_GPU_BENCHMARK_SCENE_WARMUP=1 \
@@ -254,49 +268,51 @@ jobs:
 
           if [[ -n "$BASE_WORKSPACE" ]]; then
             prime_index=0
-            while read -r label pdf; do
+            while read -r label source_kind source; do
               # The PR worktree already ran gpu_ci_smoke_test.dart. Prime both
               # worktrees here so compilation and Metal driver caches cannot
               # systematically favour the candidate measurements.
               if (( prime_index % 2 == 0 )); then
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" /dev/null \
-                  main "$label" "$pdf" "unmeasured warm-up"
+                  main "$label" "$source_kind" "$source" "unmeasured warm-up"
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" /dev/null \
-                  pr "$label" "$pdf" "unmeasured warm-up"
+                  pr "$label" "$source_kind" "$source" "unmeasured warm-up"
               else
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" /dev/null \
-                  pr "$label" "$pdf" "unmeasured warm-up"
+                  pr "$label" "$source_kind" "$source" "unmeasured warm-up"
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" /dev/null \
-                  main "$label" "$pdf" "unmeasured warm-up"
+                  main "$label" "$source_kind" "$source" "unmeasured warm-up"
               fi
               prime_index=$((prime_index + 1))
             done <<'SCENARIOS'
-          tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
-          radial ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          deferred-mask fixture deferred-mask
           SCENARIOS
           fi
 
           for iteration in 1 2 3 4 5 6; do
-            while read -r label pdf; do
+            while read -r label source_kind source; do
               # Even repetitions run PR first, odd repetitions run main first:
               # each cohort inherits the warmer state exactly three times.
               if [[ -n "$BASE_WORKSPACE" && $((iteration % 2)) == 0 ]]; then
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  pr "$label" "$pdf" "repetition $iteration/6"
+                  pr "$label" "$source_kind" "$source" "repetition $iteration/6"
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
-                  main "$label" "$pdf" "repetition $iteration/6"
+                  main "$label" "$source_kind" "$source" "repetition $iteration/6"
               elif [[ -n "$BASE_WORKSPACE" ]]; then
                 run_case "$BASE_WORKSPACE" "$BASE_COMMIT" "$baseline_log" \
-                  main "$label" "$pdf" "repetition $iteration/6"
+                  main "$label" "$source_kind" "$source" "repetition $iteration/6"
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  pr "$label" "$pdf" "repetition $iteration/6"
+                  pr "$label" "$source_kind" "$source" "repetition $iteration/6"
               else
                 run_case "$GITHUB_WORKSPACE" "$PERF_COMMIT" "$log" \
-                  current "$label" "$pdf" "repetition $iteration/6"
+                  current "$label" "$source_kind" "$source" "repetition $iteration/6"
               fi
             done <<'SCENARIOS'
-          tiling ../../test_corpora/pdfjs/tiling-pattern-box.pdf
-          radial ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
+          deferred-mask fixture deferred-mask
           SCENARIOS
           done
           echo "log=$log" >> "$GITHUB_OUTPUT"
@@ -324,6 +340,8 @@ jobs:
             --require-scenario-runs gpu-radial-page-0-scene-warm=6
             --require-scenario-runs gpu-radial-page-0-first-tile=6
             --require-scenario-runs gpu-radial-page-0-canvas-tile=6
+            --require-scenario-runs gpu-deferred-mask-page-0-first-tile=6
+            --require-scenario-runs gpu-deferred-mask-page-0-canvas-tile=6
           )
           arguments=(
             "$log"

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Render platform-decoded images with deferred `/SMask` companion surfaces on
+  the GPU by caching both textures and combining them in the soft-mask shader.
 - Render tiled stencil images exactly using scene-scoped, hand-built mipmaps.
   Mip levels participate in the shared texture budget and cache identity, and
   worker-reconstructed tiling cells retain their decoded images.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -60,7 +60,9 @@ The current exact subset is solid paths and strokes, embedded-outline text,
 decoded images/image masks, Gouraud meshes, axial gradients, nested-circle
 radial gradients, vector and stencil-image tiling cells, normal blending,
 rectangular and arbitrary path clips, and the common isolated single-image
-soft-mask group.
+soft-mask group. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
+surface also keep their base and mask as separate cached textures and combine
+them in the same shader path.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
 mask case keeps the base and mask as two GPU textures and combines them during

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -171,10 +171,10 @@ Set `PDF_GPU_BENCHMARK_SCENE_WARMUP=1` to additionally compile and submit the
 retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
 markers for each pipeline/scene/tile phase. CI uses those markers to run the
-checked-in tiling-pattern and radial-shading pages six times on macOS Metal,
-compare the exact PR base and candidate on the same runner with balanced
-execution order, and publish both a concise PR headline and a collapsed
-detailed trace.
+checked-in tiling-pattern and radial-shading pages plus the deterministic
+deferred-mask fixture six times on macOS Metal, compare the exact PR base and
+candidate on the same runner with balanced execution order, and publish both a
+concise PR headline and a collapsed detailed trace.
 Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
 a deterministic 1024x768 JPEG under a Flate grayscale soft mask. This fixture
 emits the same first-tile and Canvas scenarios whether the backend accepts the

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -24,7 +24,8 @@ import 'backend_stats.dart';
 /// submit a render pass. No PDF interpretation, path tessellation, image
 /// decode, texture upload, or CPU pixel readback occurs per tile.
 ///
-/// The exact subset includes a common isolated single-image soft-mask group:
+/// The exact subset includes a common isolated single-image soft-mask group
+/// and decoded images whose `/SMask` stayed as a companion GPU surface:
 /// content and mask stay as separate scene-lifetime textures and are combined
 /// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
 /// masks (with rectangular clips additionally using the hardware scissor).
@@ -262,16 +263,6 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         case PdfDrawImageCommand(:final request):
           final image = scene.imageFor(request);
           if (image == null) return 'missing image pixels';
-          // A platform-codec base keeps its /SMask as a companion GPU surface
-          // that only CanvasPdfDevice knows how to compose (dstIn over the
-          // base). This backend uploads one texture per image, so drawing it
-          // here would paint the base opaque - the JPEG's masked-out area is
-          // usually solid black, so a cut-out sticker renders as a black
-          // rectangle (#675). Hand the scene to Canvas until the mask is
-          // uploaded as its own texture.
-          if (pdfGpuSoftMaskOf(image) != null) {
-            return 'deferred image soft mask';
-          }
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
           final gradientReason = run.gradient == null
@@ -1520,8 +1511,6 @@ Future<_GpuDraw> _compileSoftMaskImage(
   );
   textureLeases.add(maskResource);
   final vertices = _imageVertices(spec.content.transform);
-  final inverse = spec.mask.transform.inverted();
-  if (inverse == null) throw StateError('singular soft-mask image transform');
   final contentAlpha = (spec.content.alpha * spec.groupAlpha).clamp(0.0, 1.0);
   final contentTint = spec.content.isStencil
       ? _premul(spec.content.stencilColor, contentAlpha)
@@ -1529,7 +1518,43 @@ Future<_GpuDraw> _compileSoftMaskImage(
   final maskTint = spec.mask.isStencil
       ? _premul(spec.mask.stencilColor, spec.mask.alpha)
       : <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)];
-  final maskClip = spec.maskClip ??
+  final info = _softMaskInfo(
+    context,
+    maskTransform: spec.mask.transform,
+    contentTint: contentTint,
+    maskTint: maskTint,
+    contentStencil: spec.content.isStencil,
+    maskStencil: spec.mask.isStencil,
+    luminosity: spec.luminosity,
+    backdropLuminance: spec.backdropLuminance,
+    transferScale: spec.transferScale,
+    transferOffset: spec.transferOffset,
+    maskClip: spec.maskClip,
+  );
+  return _SoftMaskDraw(
+    geometry.add(vertices.bytes, vertices.length ~/ 4),
+    contentResource.texture,
+    maskResource.texture,
+    info,
+  );
+}
+
+gpu.BufferView _softMaskInfo(
+  gpu.GpuContext context, {
+  required PdfMatrix maskTransform,
+  required List<double> contentTint,
+  required List<double> maskTint,
+  required bool contentStencil,
+  required bool maskStencil,
+  required bool luminosity,
+  required double backdropLuminance,
+  required double transferScale,
+  required double transferOffset,
+  PdfRect? maskClip,
+}) {
+  final inverse = maskTransform.inverted();
+  if (inverse == null) throw StateError('singular soft-mask image transform');
+  final clip = maskClip ??
       const PdfRect(-1000000000, -1000000000, 1000000000, 1000000000);
   final values = Float32List(36)
     ..setRange(0, 16, <double>[
@@ -1553,32 +1578,27 @@ Future<_GpuDraw> _compileSoftMaskImage(
     ..setRange(16, 20, contentTint)
     ..setRange(20, 24, maskTint)
     ..setRange(24, 28, <double>[
-      spec.content.isStencil ? 1 : 0,
-      spec.mask.isStencil ? 1 : 0,
-      spec.luminosity ? 1 : 0,
-      spec.luminosity ? spec.backdropLuminance : 0,
+      contentStencil ? 1 : 0,
+      maskStencil ? 1 : 0,
+      luminosity ? 1 : 0,
+      luminosity ? backdropLuminance : 0,
     ])
     ..setRange(28, 32, <double>[
-      spec.transferScale,
-      spec.transferOffset,
+      transferScale,
+      transferOffset,
       0,
       0,
     ])
     ..setRange(32, 36, <double>[
-      maskClip.left,
-      maskClip.bottom,
-      maskClip.right,
-      maskClip.top,
+      clip.left,
+      clip.bottom,
+      clip.right,
+      clip.top,
     ]);
-  return _SoftMaskDraw(
-    geometry.add(vertices.bytes, vertices.length ~/ 4),
-    contentResource.texture,
-    maskResource.texture,
-    gpu.BufferView(
-      context.createDeviceBufferWithCopy(ByteData.sublistView(values)),
-      offsetInBytes: 0,
-      lengthInBytes: values.lengthInBytes,
-    ),
+  return gpu.BufferView(
+    context.createDeviceBufferWithCopy(ByteData.sublistView(values)),
+    offsetInBytes: 0,
+    lengthInBytes: values.lengthInBytes,
   );
 }
 
@@ -1591,6 +1611,8 @@ class _GpuImageTexture {
   int leases = 0;
   bool cacheable = true;
 }
+
+enum _GpuTexturePlane { deferredSoftMask }
 
 class _GpuTextureKey {
   const _GpuTextureKey(
@@ -1634,12 +1656,27 @@ class _GpuImageCache {
   final Set<_GpuImageTexture> _detached = Set.identity();
   int _bytes = 0;
 
-  Future<_GpuImageTexture> acquire(gpu.GpuContext context,
-      PdfImageRequest request, ui.Image image, FlutterGpuTileBackendStats stats,
-      {required bool mipmapped}) async {
+  Future<_GpuImageTexture> acquire(
+          gpu.GpuContext context,
+          PdfImageRequest request,
+          ui.Image image,
+          FlutterGpuTileBackendStats stats,
+          {required bool mipmapped}) =>
+      acquireSurface(
+        context,
+        pdfImageContentKey(request),
+        image,
+        stats,
+        decoded: request.decoded,
+        mipmapped: mipmapped,
+      );
+
+  Future<_GpuImageTexture> acquireSurface(gpu.GpuContext context,
+      Object content, ui.Image image, FlutterGpuTileBackendStats stats,
+      {PdfDecodedPixels? decoded, required bool mipmapped}) async {
     final key = _GpuTextureKey(
       context,
-      pdfImageContentKey(request),
+      content,
       image.width,
       image.height,
       mipmapped,
@@ -1666,7 +1703,7 @@ class _GpuImageCache {
       context,
       image,
       stats,
-      decoded: request.decoded,
+      decoded: decoded,
       mipLevelCount: mipLevelCount,
     )
       ..leases = 1;
@@ -1943,6 +1980,7 @@ Future<_GpuDraw> _compileImageCommand(
     List<_GpuImageTexture> textureLeases,
     {required bool mipmapImages}) async {
   final image = scene.imageFor(request)!;
+  final maskImage = pdfGpuSoftMaskOf(image);
   final resource = await imageCache.acquire(
     context,
     request,
@@ -1955,6 +1993,36 @@ Future<_GpuDraw> _compileImageCommand(
   final tint = request.isStencil
       ? _premul(request.stencilColor, request.alpha)
       : <double>[0, 0, 0, request.alpha];
+  if (maskImage != null) {
+    final maskResource = await imageCache.acquireSurface(
+      context,
+      (pdfImageContentKey(request), _GpuTexturePlane.deferredSoftMask),
+      maskImage,
+      stats,
+      mipmapped: mipmapImages,
+    );
+    textureLeases.add(maskResource);
+    // Platform-codec `/SMask` companions are opaque grayscale surfaces. The
+    // PDF alpha is their gray sample (Canvas applies red-to-alpha), so the
+    // luminosity branch of the existing soft-mask shader is the exact match.
+    return _SoftMaskDraw(
+      geometry.add(vertices.bytes, 6),
+      resource.texture,
+      maskResource.texture,
+      _softMaskInfo(
+        context,
+        maskTransform: request.transform,
+        contentTint: tint,
+        maskTint: const [0, 0, 0, 1],
+        contentStencil: request.isStencil,
+        maskStencil: false,
+        luminosity: true,
+        backdropLuminance: 0,
+        transferScale: 1,
+        transferOffset: 0,
+      ),
+    );
+  }
   final info = Float32List(8)
     ..setRange(0, 4, tint)
     ..[4] = request.isStencil ? 1 : 0;
@@ -2802,6 +2870,7 @@ class _GpuEncoder {
     final sampler = gpu.SamplerOptions(
       minFilter: gpu.MinMagFilter.linear,
       magFilter: gpu.MinMagFilter.linear,
+      mipFilter: gpu.MipFilter.linear,
     );
     pass
       ..setColorBlendEquation(_srcOver)

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1025,7 +1025,7 @@ void main() {
     });
   });
 
-  testWidgets('an image whose /SMask stayed a companion surface falls back',
+  testWidgets('an image whose /SMask stayed a companion surface renders',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -1033,10 +1033,10 @@ void main() {
         return;
       }
       // A non-CMYK JPEG decodes through the platform codec, which keeps a
-      // simple grayscale /SMask as a companion `ui.Image` that only
-      // CanvasPdfDevice knows how to compose. This backend uploads one texture
-      // per image, so it must decline the scene rather than paint the base
-      // opaque - the JPEG's masked-out area is solid black (#675).
+      // simple grayscale /SMask as a companion `ui.Image`. The GPU backend
+      // keeps both surfaces as separate cached textures and combines them in
+      // one shader pass; painting only the base would leave the JPEG opaque
+      // and regress the black-rectangle failure from #675.
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final scene = await PdfRetainedScene.fromCommands(page, [
         PdfDrawImageCommand(PdfImageRequest(
@@ -1046,8 +1046,24 @@ void main() {
       ]);
       addTearDown(scene.dispose);
       final backend = FlutterGpuTileRasterBackend();
-      expect(backend.createSession(scene), isNull);
-      expect(backend.stats.lastRejection, contains('soft mask'));
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(0, 0, 200, 200);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(2));
+      expect(backend.stats.texturesUploaded, 2);
+      expect(backend.stats.textureBytes, 8192,
+          reason: '32x32 RGBA base plus its 32x32 RGBA mask');
     });
   });
 }


### PR DESCRIPTION
## Summary

- keep platform-decoded JPEGs with companion `/SMask` surfaces on the Flutter GPU path
- cache the base and mask as separate retained textures and combine them through the existing soft-mask shader
- reuse the soft-mask uniform builder across retained groups and deferred image masks
- add the deterministic deferred-mask fixture to the balanced six-run same-host Metal comparison

## Validation

- `fvm dart analyze`
- `fvm flutter test` in `packages/dart_pdf_editor_flutter_gpu`
- focused Metal backend suite: 18 passed, 1 expected non-GPU-context skip
- Metal corpus parity: 218 passed; acceptance totals remain PDF.js 101/78 and Ghent 19/38
- exact local benchmark route: `firstRoute=flutter_gpu`, 2 texture uploads, 0 raster fallbacks, 0.492/255 mean Canvas difference
- performance summarizer tests
- workflow YAML parse check

The local benchmark is a route/correctness smoke, not the performance conclusion. CI runs the exact base and candidate six times on one macOS Metal host with balanced ordering and will publish the comparison.