### PR TITLE
Expand exact Flutter GPU blending and vector soft masks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,10 @@ jobs:
             local source="$7"
             local repetition="$8"
             local source_env
+            local route_change=0
+            if [[ "$label" == "vector-mask" ]]; then
+              route_change=1
+            fi
             case "$source_kind" in
               pdf)
                 source_env="PDF_GPU_BENCHMARK_PDF=$source"
@@ -254,6 +258,7 @@ jobs:
                 PDF_GPU_BENCHMARK_WARMUP=1 \
                 PDF_GPU_BENCHMARK_SCENE_WARMUP=1 \
                 PDF_GPU_BENCHMARK_OVERPRINT=0 \
+                PDF_GPU_BENCHMARK_ROUTE_CHANGE="$route_change" \
                 PDF_GPU_BENCHMARK_SCENARIO="$label" \
                 flutter test \
                   --enable-impeller \
@@ -288,6 +293,7 @@ jobs:
           tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
           radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
           deferred-mask fixture deferred-mask
+          vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
           SCENARIOS
           fi
 
@@ -313,6 +319,7 @@ jobs:
           tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
           radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
           deferred-mask fixture deferred-mask
+          vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
           SCENARIOS
           done
           echo "log=$log" >> "$GITHUB_OUTPUT"
@@ -342,6 +349,8 @@ jobs:
             --require-scenario-runs gpu-radial-page-0-canvas-tile=6
             --require-scenario-runs gpu-deferred-mask-page-0-first-tile=6
             --require-scenario-runs gpu-deferred-mask-page-0-canvas-tile=6
+            --require-scenario-runs gpu-vector-mask-page-0-first-tile=6
+            --require-scenario-runs gpu-vector-mask-page-0-canvas-tile=6
           )
           arguments=(
             "$log"

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Render platform-decoded images with deferred `/SMask` companion surfaces on
   the GPU by caching both textures and combining them in the soft-mask shader.
+- Combine a single vector fill with one opaque grayscale image soft mask in a
+  retained stencil pass, while rejecting nested transparency and blend modes.
 - Render tiled stencil images exactly using scene-scoped, hand-built mipmaps.
   Mip levels participate in the shared texture budget and cache identity, and
   worker-reconstructed tiling cells retain their decoded images.

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,7 +5,12 @@
 - Render platform-decoded images with deferred `/SMask` companion surfaces on
   the GPU by caching both textures and combining them in the soft-mask shader.
 - Combine a single vector fill with one opaque grayscale image soft mask in a
-  retained stencil pass, while rejecting nested transparency and blend modes.
+  retained stencil pass. Rectangular vector-mask fills, including alpha or
+  luminosity `/BC` and linearized `/TR`, stay entirely in retained geometry.
+- Render Multiply and Screen exactly with fixed-function blending over the
+  backend's opaque page surface; other blend modes still fall back to Canvas.
+- Warm the nonzero stencil-cover render state used by retained fills, moving
+  its first-use Metal compilation into the existing idle pipeline phase.
 - Render tiled stencil images exactly using scene-scoped, hand-built mipmaps.
   Mip levels participate in the shared texture budget and cache identity, and
   worker-reconstructed tiling cells retain their decoded images.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -58,12 +58,16 @@ compile-time stub and therefore preserves the all-platform host surface.
 
 The current exact subset is solid paths and strokes, embedded-outline text,
 decoded images/image masks, Gouraud meshes, axial gradients, nested-circle
-radial gradients, vector and stencil-image tiling cells, normal blending,
+radial gradients, vector and stencil-image tiling cells, normal/Multiply/Screen
+blending,
 rectangular and arbitrary path clips, and the common isolated single-image
 soft-mask group. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
 surface also keep their base and mask as separate cached textures and combine
 them in the same shader path. A single vector fill can use one opaque grayscale
-image soft mask directly through retained stencil geometry.
+image soft mask directly through retained stencil geometry. Rectangular vector
+soft-mask fills, including alpha or luminosity backdrops and linearized
+transfer functions, are partitioned into constant-mask stencil cover cells and
+need no intermediate texture.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
 mask case keeps the base and mask as two GPU textures and combines them during
@@ -83,10 +87,11 @@ native finalizers; a scene that cannot lease enough geometry also falls back.
 
 After useful page pixels land and foreground work stays quiet for 750 ms, the
 viewer asks the backend to warm its context. The backend submits one transparent
-pixel through each tile pipeline, moving Impeller/driver compilation out of the
-first deep-zoom interaction without delaying initial document paint or
-competing with an immediate scroll. This work is coalesced per native view and
-MSAA mode, even when several readers share the same process.
+pixel through each tile pipeline and the nonzero stencil-cover state used by
+retained fills, moving Impeller/driver compilation out of the first deep-zoom
+interaction without delaying initial document paint or competing with an
+immediate scroll. This work is coalesced per native view and MSAA mode, even
+when several readers share the same process.
 
 Proactive warm-up defaults on for macOS, Windows, and Linux. Android and iOS
 stay on-demand by default because merely creating an Impeller GPU context can
@@ -111,7 +116,8 @@ Clip diagnostics separately report paths compiled and tile-mask rebuilds.
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
-Pages with other transparency groups or soft masks, non-normal blends,
+Pages with other transparency groups or soft masks, blend modes other than
+Multiply and Screen,
 non-nested radial gradients, gradient overprint, unsafe overprint, complex
 clips nested inside the single-image soft-mask shortcut, substituted/stroked
 text, hairlines, or missing image pixels are rejected as a whole rather than
@@ -185,6 +191,9 @@ suppressed for this production-route fixture; the warm-up itself still runs.
 An unmeasured Canvas pass immediately before the Canvas control keeps that
 reference warm on both the accepted and fallback routes without warming the
 cold first-tile measurement.
+Set `PDF_GPU_BENCHMARK_ROUTE_CHANGE=1` for the same normalization when a PDF
+path, rather than the built-in fixture, changes from Canvas fallback to direct
+GPU. CI uses it for the checked-in vector-mask transfer page.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -62,7 +62,8 @@ radial gradients, vector and stencil-image tiling cells, normal blending,
 rectangular and arbitrary path clips, and the common isolated single-image
 soft-mask group. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
 surface also keep their base and mask as separate cached textures and combine
-them in the same shader path.
+them in the same shader path. A single vector fill can use one opaque grayscale
+image soft mask directly through retained stencil geometry.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
 mask case keeps the base and mask as two GPU textures and combines them during

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -29,8 +29,8 @@ import 'backend_stats.dart';
 /// content and mask stay as separate scene-lifetime textures and are combined
 /// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
 /// masks (with rectangular clips additionally using the hardware scissor).
-/// Other isolated groups, non-normal blend modes, complex clips *inside* the
-/// special soft-mask-image shortcut, non-nested radial gradients,
+/// Other isolated groups, blend modes beyond Multiply/Screen, complex clips
+/// *inside* the special soft-mask shortcuts, non-nested radial gradients,
 /// substituted/stroked text, unsafe overprint, or missing image pixels reject
 /// the whole scene.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
@@ -234,7 +234,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       List<_GpuUnit> units,
       bool allowOverprintApproximation) {
     for (final unit in units) {
-      if (unit.blendMode != PdfBlendMode.normal) {
+      if (!_isGpuBlendMode(unit.blendMode)) {
         return 'blend mode ${unit.blendMode.name}';
       }
       final composite = unit.composite;
@@ -249,6 +249,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             if (scene.imageFor(composite.mask) == null) {
               return 'missing soft-mask image pixels';
             }
+          case _SoftMaskVectorFillSpec():
+            break;
         }
         continue;
       }
@@ -307,7 +309,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           if (covered.contains(i)) break;
           return 'unsafe ${command.runtimeType}';
         case PdfSetBlendModeCommand(:final mode):
-          if (mode != PdfBlendMode.normal) return 'blend mode ${mode.name}';
+          if (!_isGpuBlendMode(mode)) return 'blend mode ${mode.name}';
         case PdfSetOverprintCommand(:final fill, :final stroke):
           // Paint units capture their active overprint state above. State
           // changes by themselves do not render anything.
@@ -318,6 +320,11 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     }
     return null;
   }
+
+  static bool _isGpuBlendMode(PdfBlendMode mode) =>
+      mode == PdfBlendMode.normal ||
+      mode == PdfBlendMode.multiply ||
+      mode == PdfBlendMode.screen;
 
   static bool _isAxisAlignedRect(PdfPath path) {
     final subs = flattenPath(path, PdfMatrix.identity);
@@ -451,6 +458,35 @@ class _SoftMaskFillSpec extends _SoftMaskSpec {
   final double backdropLuminance;
   final double transferScale;
   final double transferOffset;
+}
+
+class _SoftMaskVectorFillSpec extends _SoftMaskSpec {
+  const _SoftMaskVectorFillSpec({
+    required this.content,
+    required this.maskFills,
+    required this.contentClip,
+    required this.luminosity,
+    required this.backdropLuminance,
+    required this.transferScale,
+    required this.transferOffset,
+  });
+
+  final PdfFillPathCommand content;
+  final List<_VectorMaskFill> maskFills;
+  @override
+  final PdfRect? contentClip;
+  final bool luminosity;
+  final double backdropLuminance;
+  final double transferScale;
+  final double transferOffset;
+}
+
+class _VectorMaskFill {
+  const _VectorMaskFill(this.rect, this.color, this.alpha);
+
+  final PdfRect rect;
+  final PdfColor color;
+  final double alpha;
 }
 
 class _GpuCommandBuild {
@@ -817,12 +853,19 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           }
           content = command;
           contentClip = clip;
-        case PdfSetBlendModeCommand(:final mode):
-          if (mode != PdfBlendMode.normal) {
-            return (null, 'soft-mask fill blend mode ${mode.name}');
-          }
-        case PdfSetOverprintCommand(:final fill, :final stroke):
-          if (fill || stroke) return (null, 'soft-mask fill overprint');
+        case PdfSetBlendModeCommand():
+          // This shortcut accepts exactly one painted element in the isolated
+          // soft-mask capture. Every PDF blend function reduces to the source
+          // when the backdrop alpha is zero, so the active blend mode cannot
+          // affect that element's captured pixels. The completed masked layer
+          // is then composited normally, matching CanvasPdfDevice's two-layer
+          // beginSoftMasked/endSoftMasked sequence.
+          break;
+        case PdfSetOverprintCommand():
+          // Like blend modes above, overprint has no backdrop colorants to
+          // preserve inside this isolated, initially transparent capture.
+          // With one painted fill it therefore reduces to the same source.
+          break;
         default:
           if (pdfRenderCommandBounds(command) != null) {
             return (null, 'soft-mask fill contains ${command.runtimeType}');
@@ -834,7 +877,27 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     final maskState = _singleMaskImage(maskCommands);
     final mask = maskState.$1;
-    if (mask == null) return (null, maskState.$3);
+    if (mask == null) {
+      final vectorMask = _vectorMaskFills(maskCommands);
+      final maskFills = vectorMask.$1;
+      if (maskFills == null) return (null, vectorMask.$2 ?? maskState.$3);
+      if (![backdropLuminance, transferScale, transferOffset]
+          .every((value) => value.isFinite)) {
+        return (null, 'invalid vector soft-mask transfer');
+      }
+      return (
+        _SoftMaskVectorFillSpec(
+          content: content,
+          maskFills: maskFills,
+          contentClip: contentClip,
+          luminosity: luminosity,
+          backdropLuminance: backdropLuminance,
+          transferScale: transferScale,
+          transferOffset: transferOffset,
+        ),
+        null,
+      );
+    }
     if (mask.request.isStencil) {
       return (null, 'stencil soft-mask fill image');
     }
@@ -894,6 +957,64 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
   if (saved.isNotEmpty) return (null, null, 'unbalanced mask image state');
   if (image == null) return (null, null, 'mask has no image');
   return (image, clip, null);
+}
+
+(List<_VectorMaskFill>?, String?) _vectorMaskFills(
+    List<PdfRenderCommand> commands) {
+  const maxFills = 32;
+  final fills = <_VectorMaskFill>[];
+  PdfRect? clip;
+  var clipEmpty = false;
+  final saved = <(PdfRect?, bool)>[];
+  for (final command in commands) {
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, clipEmpty));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return (null, 'unbalanced vector mask state');
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        clipEmpty = restored.$2;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+          return (null, 'non-rectangular vector mask clip');
+        }
+        if (clipEmpty) continue;
+        final narrowed = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (narrowed == null) {
+          clipEmpty = true;
+        } else {
+          clip = narrowed;
+        }
+      case PdfFillPathCommand(
+          :final path,
+          :final color,
+          :final alpha,
+        ):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+          return (null, 'non-rectangular vector mask fill');
+        }
+        if (clipEmpty) continue;
+        final rect = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (rect != null) fills.add(_VectorMaskFill(rect, color, alpha));
+        if (fills.length > maxFills) {
+          return (null, 'vector mask fill count exceeds GPU cap');
+        }
+      case PdfSetBlendModeCommand(:final mode):
+        if (mode != PdfBlendMode.normal) {
+          return (null, 'vector mask blend mode ${mode.name}');
+        }
+      case PdfSetOverprintCommand(:final fill, :final stroke):
+        if (fill || stroke) return (null, 'vector mask overprint');
+      default:
+        if (pdfRenderCommandBounds(command) != null) {
+          return (null, 'vector mask contains ${command.runtimeType}');
+        }
+    }
+  }
+  if (saved.isNotEmpty) return (null, 'unbalanced vector mask state');
+  if (fills.isEmpty) return (null, 'vector mask has no fills');
+  return (List.unmodifiable(fills), null);
 }
 
 List<_GpuUnit> _selectGpuUnits(
@@ -1287,6 +1408,8 @@ class _CompiledScene {
                 textureLeases,
                 mipmapImages: mipmapImages,
               ),
+            _SoftMaskVectorFillSpec spec =>
+              _compileSoftMaskVectorFill(geometry, spec),
           };
         }
         if (draw != null) draws[unit.commandIndex] = draw;
@@ -1492,7 +1615,9 @@ class _CompiledScene {
     for (final unit in selected) {
       final draw = draws[unit.commandIndex];
       if (draw == null) continue;
-      encoder.setClip(unit.clip);
+      encoder
+        ..setClip(unit.clip)
+        ..setBlendMode(unit.blendMode);
       draw.encode(encoder);
     }
     stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
@@ -1710,6 +1835,99 @@ Future<_GpuDraw> _compileSoftMaskFill(
       maskClip: spec.maskClip,
     ),
   );
+}
+
+_GpuDraw? _compileSoftMaskVectorFill(
+    _GpuGeometryArena geometry, _SoftMaskVectorFillSpec spec) {
+  final subpaths = flattenPath(
+    spec.content.path,
+    PdfMatrix.identity,
+    tolerance: 0.01,
+  );
+  final stencil = _stencilGeometry(geometry, subpaths);
+  if (stencil == null) return null;
+  final pathBounds = stencil.$2;
+  final bounds = _pdfIntersection(
+    PdfRect(
+      pathBounds.left,
+      pathBounds.bottom,
+      pathBounds.right,
+      pathBounds.top,
+    ),
+    spec.contentClip,
+  );
+  if (bounds == null) return null;
+
+  final xs = <double>{bounds.left, bounds.right};
+  final ys = <double>{bounds.bottom, bounds.top};
+  for (final fill in spec.maskFills) {
+    final rect = _pdfIntersection(bounds, fill.rect);
+    if (rect == null) continue;
+    xs
+      ..add(rect.left)
+      ..add(rect.right);
+    ys
+      ..add(rect.bottom)
+      ..add(rect.top);
+  }
+  final orderedX = xs.toList()..sort();
+  final orderedY = ys.toList()..sort();
+  final cells = (orderedX.length - 1) * (orderedY.length - 1);
+  final cover = FloatBuilder(math.max(36, cells * 36));
+  for (var yi = 0; yi + 1 < orderedY.length; yi++) {
+    final bottom = orderedY[yi], top = orderedY[yi + 1];
+    if (top <= bottom) continue;
+    for (var xi = 0; xi + 1 < orderedX.length; xi++) {
+      final left = orderedX[xi], right = orderedX[xi + 1];
+      if (right <= left) continue;
+      final mask = _vectorMaskValue(
+        spec,
+        (left + right) / 2,
+        (bottom + top) / 2,
+      );
+      final color = _premul(
+        spec.content.color,
+        (spec.content.alpha * mask).clamp(0.0, 1.0),
+      );
+      for (final (x, y) in <(double, double)>[
+        (left, bottom),
+        (right, bottom),
+        (right, top),
+        (left, bottom),
+        (right, top),
+        (left, top),
+      ]) {
+        cover.add6(x, y, color[0], color[1], color[2], color[3]);
+      }
+    }
+  }
+  return _StencilDraw(
+    stencil.$1,
+    geometry.add(cover.bytes, cover.length ~/ 6),
+    spec.content.rule,
+    false,
+  );
+}
+
+double _vectorMaskValue(_SoftMaskVectorFillSpec spec, double x, double y) {
+  var alpha = spec.luminosity ? 1.0 : 0.0;
+  var red = spec.luminosity ? spec.backdropLuminance : 0.0;
+  var green = red, blue = red;
+  for (final fill in spec.maskFills) {
+    final rect = fill.rect;
+    if (x < rect.left || x > rect.right || y < rect.bottom || y > rect.top) {
+      continue;
+    }
+    final sourceAlpha = fill.alpha.clamp(0.0, 1.0);
+    final inverse = 1 - sourceAlpha;
+    red = fill.color.red * sourceAlpha + red * inverse;
+    green = fill.color.green * sourceAlpha + green * inverse;
+    blue = fill.color.blue * sourceAlpha + blue * inverse;
+    alpha = sourceAlpha + alpha * inverse;
+  }
+  final value =
+      spec.luminosity ? 0.2126 * red + 0.7152 * green + 0.0722 * blue : alpha;
+  return (value * spec.transferScale + spec.transferOffset).clamp(0.0, 1.0);
 }
 
 gpu.BufferView _softMaskInfo(
@@ -2826,10 +3044,26 @@ class _GpuEncoder {
   int _activeClipBit = 0;
   int clipMaskRebuilds = 0;
   bool? _separateVertexCountApi;
+  gpu.ColorBlendEquation _paintBlend = _srcOver;
 
   static final _srcOver = gpu.ColorBlendEquation(
     sourceColorBlendFactor: gpu.BlendFactor.one,
     destinationColorBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
+    sourceAlphaBlendFactor: gpu.BlendFactor.one,
+    destinationAlphaBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
+  );
+  // The page paper makes the destination beneath every supported primitive
+  // opaque. Under that invariant PDF Multiply and Screen each reduce to one
+  // exact fixed-function equation, with no destination-texture readback.
+  static final _multiply = gpu.ColorBlendEquation(
+    sourceColorBlendFactor: gpu.BlendFactor.destinationColor,
+    destinationColorBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
+    sourceAlphaBlendFactor: gpu.BlendFactor.one,
+    destinationAlphaBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
+  );
+  static final _screen = gpu.ColorBlendEquation(
+    sourceColorBlendFactor: gpu.BlendFactor.oneMinusDestinationColor,
+    destinationColorBlendFactor: gpu.BlendFactor.one,
     sourceAlphaBlendFactor: gpu.BlendFactor.one,
     destinationAlphaBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
   );
@@ -2839,6 +3073,14 @@ class _GpuEncoder {
     sourceAlphaBlendFactor: gpu.BlendFactor.zero,
     destinationAlphaBlendFactor: gpu.BlendFactor.one,
   );
+
+  void setBlendMode(PdfBlendMode mode) {
+    _paintBlend = switch (mode) {
+      PdfBlendMode.multiply => _multiply,
+      PdfBlendMode.screen => _screen,
+      _ => _srcOver,
+    };
+  }
 
   void setClip(_GpuClipState clip) {
     if (identical(_clipState, clip)) return;
@@ -2924,7 +3166,7 @@ class _GpuEncoder {
   void solid(_GpuBuffer vertices) {
     _defaultStencil();
     pass
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
     _drawBuffer(vertices);
@@ -2936,7 +3178,7 @@ class _GpuEncoder {
         rule: rule, union: union, requiredClipBit: _activeClipBit);
     pass
       ..setStencilReference(0)
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..setStencilConfig(gpu.StencilConfig(
         compareFunction: gpu.CompareFunction.notEqual,
         depthStencilPassOperation: gpu.StencilOperation.zero,
@@ -2958,7 +3200,7 @@ class _GpuEncoder {
     );
     pass
       ..setStencilReference(0)
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..setStencilConfig(gpu.StencilConfig(
         compareFunction: gpu.CompareFunction.notEqual,
         depthStencilPassOperation: gpu.StencilOperation.zero,
@@ -3034,7 +3276,7 @@ class _GpuEncoder {
   void texture(_GpuBuffer vertices, gpu.Texture texture, gpu.BufferView info) {
     _defaultStencil();
     pass
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..bindPipeline(pipelines.texture)
       ..bindUniform(pipelines.textureTransform, transform)
       ..bindUniform(pipelines.textureInfo, info)
@@ -3060,7 +3302,7 @@ class _GpuEncoder {
       mipFilter: gpu.MipFilter.linear,
     );
     pass
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..bindPipeline(pipelines.softMask)
       ..bindUniform(pipelines.softMaskTransform, transform)
       ..bindUniform(pipelines.softMaskInfo, info)
@@ -3087,7 +3329,7 @@ class _GpuEncoder {
     );
     pass
       ..setStencilReference(0)
-      ..setColorBlendEquation(_srcOver)
+      ..setColorBlendEquation(_paintBlend)
       ..setStencilConfig(gpu.StencilConfig(
         compareFunction: gpu.CompareFunction.notEqual,
         depthStencilPassOperation: gpu.StencilOperation.zero,
@@ -3371,15 +3613,36 @@ class _GpuPipelines {
       ..setColorBlendEnable(true)
       ..setStencilReference(0)
       ..setColorBlendEquation(_GpuEncoder._noWrite)
-      ..setStencilConfig(gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.always,
-        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-        readMask: 0,
-        writeMask: _GpuEncoder._pathMask,
-      ))
+      ..setStencilConfig(
+          gpu.StencilConfig(
+            compareFunction: gpu.CompareFunction.always,
+            depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
+            readMask: 0,
+            writeMask: _GpuEncoder._pathMask,
+          ),
+          targetFace: gpu.StencilFace.front)
+      ..setStencilConfig(
+          gpu.StencilConfig(
+            compareFunction: gpu.CompareFunction.always,
+            depthStencilPassOperation: gpu.StencilOperation.decrementWrap,
+            readMask: 0,
+            writeMask: _GpuEncoder._pathMask,
+          ),
+          targetFace: gpu.StencilFace.back)
       ..bindPipeline(stencil)
       ..bindUniform(stencilTransform, transform);
     _warmUpDraw(pass, stencilVertices, 3);
+    pass
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.notEqual,
+        depthStencilPassOperation: gpu.StencilOperation.zero,
+        readMask: _GpuEncoder._pathMask,
+        writeMask: _GpuEncoder._pathMask,
+      ))
+      ..bindPipeline(solid)
+      ..bindUniform(solidTransform, transform)
+      ..setColorBlendEquation(_GpuEncoder._srcOver);
+    _warmUpDraw(pass, solidVertices, 3);
     pass
       ..setColorBlendEquation(_GpuEncoder._srcOver)
       ..setStencilConfig(gpu.StencilConfig(
@@ -3387,9 +3650,7 @@ class _GpuPipelines {
         depthStencilPassOperation: gpu.StencilOperation.keep,
         readMask: 0,
         writeMask: 0,
-      ))
-      ..bindPipeline(solid)
-      ..bindUniform(solidTransform, transform);
+      ));
     _warmUpDraw(pass, solidVertices, 3);
     pass
       ..bindPipeline(texture)

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -239,9 +239,16 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       }
       final composite = unit.composite;
       if (composite != null) {
-        if (scene.imageFor(composite.content) == null ||
-            scene.imageFor(composite.mask) == null) {
-          return 'missing soft-mask image pixels';
+        switch (composite) {
+          case _SoftMaskImageSpec():
+            if (scene.imageFor(composite.content) == null ||
+                scene.imageFor(composite.mask) == null) {
+              return 'missing soft-mask image pixels';
+            }
+          case _SoftMaskFillSpec():
+            if (scene.imageFor(composite.mask) == null) {
+              return 'missing soft-mask image pixels';
+            }
         }
         continue;
       }
@@ -350,7 +357,7 @@ class _GpuUnit {
   final bool fillOverprint;
   final bool strokeOverprint;
   final bool darken;
-  final _SoftMaskImageSpec? composite;
+  final _SoftMaskSpec? composite;
 }
 
 /// One immutable graphics-state clip. Rectangles only narrow [scissor]; every
@@ -393,7 +400,12 @@ class _CompositeCapture {
   PdfRect? bounds;
 }
 
-class _SoftMaskImageSpec {
+sealed class _SoftMaskSpec {
+  const _SoftMaskSpec();
+  PdfRect? get contentClip;
+}
+
+class _SoftMaskImageSpec extends _SoftMaskSpec {
   const _SoftMaskImageSpec({
     required this.content,
     required this.mask,
@@ -409,6 +421,30 @@ class _SoftMaskImageSpec {
   final PdfImageRequest content;
   final PdfImageRequest mask;
   final double groupAlpha;
+  @override
+  final PdfRect? contentClip;
+  final PdfRect? maskClip;
+  final bool luminosity;
+  final double backdropLuminance;
+  final double transferScale;
+  final double transferOffset;
+}
+
+class _SoftMaskFillSpec extends _SoftMaskSpec {
+  const _SoftMaskFillSpec({
+    required this.content,
+    required this.mask,
+    required this.contentClip,
+    required this.maskClip,
+    required this.luminosity,
+    required this.backdropLuminance,
+    required this.transferScale,
+    required this.transferOffset,
+  });
+
+  final PdfFillPathCommand content;
+  final PdfImageRequest mask;
+  @override
   final PdfRect? contentClip;
   final PdfRect? maskClip;
   final bool luminosity;
@@ -669,7 +705,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       : _GpuClipState(narrowed, state.node);
 }
 
-(_SoftMaskImageSpec?, String?) _parseSoftMaskImage(
+(_SoftMaskSpec?, String?) _parseSoftMaskImage(
   List<PdfRenderCommand> commands,
   int start,
   int end, {
@@ -746,6 +782,76 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         backdropLuminance: softEnd.backdropLuminance,
         transferScale: softEnd.transferScale,
         transferOffset: softEnd.transferOffset,
+      ),
+      null,
+    );
+  }
+  final endCommand = commands[end];
+  if (commands[start] is PdfBeginSoftMaskedCommand &&
+      endCommand is PdfEndSoftMaskedCommand) {
+    final maskCommands = endCommand.maskCommands;
+    final luminosity = endCommand.luminosity;
+    final backdropLuminance = endCommand.backdropLuminance;
+    final transferScale = endCommand.transferScale;
+    final transferOffset = endCommand.transferOffset;
+    PdfFillPathCommand? content;
+    PdfRect? clip = initialClip;
+    PdfRect? contentClip;
+    final saved = <PdfRect?>[];
+    for (var i = start + 1; i < end; i++) {
+      final command = commands[i];
+      switch (command) {
+        case PdfSaveCommand():
+          saved.add(clip);
+        case PdfRestoreCommand():
+          if (saved.isEmpty) return (null, 'unbalanced soft-mask fill state');
+          clip = saved.removeLast();
+        case PdfClipPathCommand(:final path):
+          if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+            return (null, 'non-rectangular soft-mask fill clip');
+          }
+          clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        case PdfFillPathCommand():
+          if (content != null) {
+            return (null, 'soft-mask group has multiple vector fills');
+          }
+          content = command;
+          contentClip = clip;
+        case PdfSetBlendModeCommand(:final mode):
+          if (mode != PdfBlendMode.normal) {
+            return (null, 'soft-mask fill blend mode ${mode.name}');
+          }
+        case PdfSetOverprintCommand(:final fill, :final stroke):
+          if (fill || stroke) return (null, 'soft-mask fill overprint');
+        default:
+          if (pdfRenderCommandBounds(command) != null) {
+            return (null, 'soft-mask fill contains ${command.runtimeType}');
+          }
+      }
+    }
+    if (saved.isNotEmpty || content == null) {
+      return (null, 'unsupported soft-mask fill group');
+    }
+    final maskState = _singleMaskImage(maskCommands);
+    final mask = maskState.$1;
+    if (mask == null) return (null, maskState.$3);
+    if (mask.request.isStencil) {
+      return (null, 'stencil soft-mask fill image');
+    }
+    final maskDictionary = mask.request.stream.dictionary;
+    if (maskDictionary['SMask'] != null || maskDictionary['Mask'] != null) {
+      return (null, 'transparent soft-mask fill image');
+    }
+    return (
+      _SoftMaskFillSpec(
+        content: content,
+        mask: mask.request,
+        contentClip: contentClip,
+        maskClip: maskState.$2,
+        luminosity: luminosity,
+        backdropLuminance: backdropLuminance,
+        transferScale: transferScale,
+        transferOffset: transferOffset,
       ),
       null,
     );
@@ -1160,16 +1266,28 @@ class _CompiledScene {
           );
           draw = pending is Future<_GpuDraw?> ? await pending : pending;
         } else {
-          draw = await _compileSoftMaskImage(
-            context,
-            geometry,
-            scene,
-            unit.composite!,
-            stats,
-            imageCache,
-            textureLeases,
-            mipmapImages: mipmapImages,
-          );
+          draw = switch (unit.composite!) {
+            _SoftMaskImageSpec spec => await _compileSoftMaskImage(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                mipmapImages: mipmapImages,
+              ),
+            _SoftMaskFillSpec spec => await _compileSoftMaskFill(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                mipmapImages: mipmapImages,
+              ),
+          };
         }
         if (draw != null) draws[unit.commandIndex] = draw;
       }
@@ -1536,6 +1654,61 @@ Future<_GpuDraw> _compileSoftMaskImage(
     contentResource.texture,
     maskResource.texture,
     info,
+  );
+}
+
+Future<_GpuDraw> _compileSoftMaskFill(
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    _SoftMaskFillSpec spec,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
+  final maskImage = scene.imageFor(spec.mask)!;
+  final maskResource = await imageCache.acquire(
+    context,
+    spec.mask,
+    maskImage,
+    stats,
+    mipmapped: mipmapImages,
+  );
+  textureLeases.add(maskResource);
+  final subpaths = flattenPath(
+    spec.content.path,
+    PdfMatrix.identity,
+    tolerance: 0.01,
+  );
+  final stencil = _stencilGeometry(geometry, subpaths);
+  if (stencil == null) throw StateError('empty soft-mask fill path');
+  final bounds = stencil.$2;
+  final cover = _imageVertices(PdfMatrix(
+    bounds.right - bounds.left,
+    0,
+    0,
+    bounds.top - bounds.bottom,
+    bounds.left,
+    bounds.bottom,
+  ));
+  return _SoftMaskFillDraw(
+    stencil.$1,
+    geometry.add(cover.bytes, cover.length ~/ 4),
+    spec.content.rule,
+    maskResource.texture,
+    _softMaskInfo(
+      context,
+      maskTransform: spec.mask.transform,
+      contentTint: _premul(spec.content.color, spec.content.alpha),
+      maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
+      contentStencil: true,
+      maskStencil: false,
+      luminosity: spec.luminosity,
+      backdropLuminance: spec.backdropLuminance,
+      transferScale: spec.transferScale,
+      transferOffset: spec.transferOffset,
+      maskClip: spec.maskClip,
+    ),
   );
 }
 
@@ -2601,6 +2774,20 @@ class _SoftMaskDraw implements _GpuDraw {
       encoder.softMask(vertices, contentTexture, maskTexture, info);
 }
 
+class _SoftMaskFillDraw implements _GpuDraw {
+  const _SoftMaskFillDraw(
+      this.fan, this.cover, this.rule, this.maskTexture, this.info);
+  final _GpuBuffer fan;
+  final _GpuBuffer cover;
+  final PdfFillRule rule;
+  final gpu.Texture maskTexture;
+  final gpu.BufferView info;
+
+  @override
+  void encode(_GpuEncoder encoder) =>
+      encoder.softMaskFill(fan, cover, rule, maskTexture, info);
+}
+
 class _GpuEncoder {
   _GpuEncoder({
     required this.pass,
@@ -2883,6 +3070,44 @@ class _GpuEncoder {
           sampler: sampler);
     _drawBuffer(vertices);
     pass.clearBindings();
+  }
+
+  void softMaskFill(_GpuBuffer fan, _GpuBuffer cover, PdfFillRule rule,
+      gpu.Texture maskTexture, gpu.BufferView info) {
+    _accumulateStencil(
+      fan,
+      rule: rule,
+      union: false,
+      requiredClipBit: _activeClipBit,
+    );
+    final sampler = gpu.SamplerOptions(
+      minFilter: gpu.MinMagFilter.linear,
+      magFilter: gpu.MinMagFilter.linear,
+      mipFilter: gpu.MipFilter.linear,
+    );
+    pass
+      ..setStencilReference(0)
+      ..setColorBlendEquation(_srcOver)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.notEqual,
+        depthStencilPassOperation: gpu.StencilOperation.zero,
+        stencilFailureOperation: gpu.StencilOperation.keep,
+        readMask: _pathMask,
+        writeMask: _pathMask,
+      ))
+      ..bindPipeline(pipelines.softMask)
+      ..bindUniform(pipelines.softMaskTransform, transform)
+      ..bindUniform(pipelines.softMaskInfo, info)
+      // The normal grayscale mask texture has opaque alpha. Binding it as the
+      // content sample too lets contentStencil supply the solid fill color,
+      // while the second lookup still evaluates the PDF mask luminance/alpha.
+      ..bindTexture(pipelines.softMaskContentSampler, maskTexture,
+          sampler: sampler)
+      ..bindTexture(pipelines.softMaskMaskSampler, maskTexture,
+          sampler: sampler);
+    _drawBuffer(cover);
+    pass.clearBindings();
+    _clearStencil(_pathMask);
   }
 
   // flutter_gpu is experimental. Flutter 3.47 split vertex count out of

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -879,6 +879,76 @@ void main() {
     });
   });
 
+  testWidgets('single vector fills use an image soft mask directly',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final mask = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+        ]),
+        const PdfMatrix(180, 0, 0, 180, 50, 100),
+        'vector-mask',
+      );
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(50, 100, 230, 280),
+            const PdfColor(0.1, 0.7, 0.25),
+            PdfFillRule.nonzero,
+            0.8,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: [mask],
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(40, 90, 200, 200);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(8));
+      expect(backend.stats.texturesUploaded, 1);
+      expect(backend.stats.textureDirectUploads, 1);
+      expect(mask.request.decoded, isNull);
+    });
+  });
+
   testWidgets('unsupported pages are rejected instead of approximated',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -241,6 +241,59 @@ void main() {
     });
   });
 
+  testWidgets('Multiply and Screen use exact opaque-page blend equations',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      for (final mode in [PdfBlendMode.multiply, PdfBlendMode.screen]) {
+        final scene = await PdfRetainedScene.fromCommands(page, [
+          PdfFillPathCommand(
+            _rect(50, 100, 350, 400),
+            const PdfColor(0.16, 0.52, 0.82),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          PdfSetBlendModeCommand(mode),
+          PdfFillPathCommand(
+            _rect(140, 180, 310, 350),
+            const PdfColor(0.88, 0.26, 0.12),
+            PdfFillRule.nonzero,
+            0.63,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        ]);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull,
+            reason: '${mode.name}: ${backend.stats.lastRejection}');
+        const region = Rect.fromLTWH(40, 90, 320, 320);
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session!.rasterizeRegion(
+          region,
+          pixelRatio: 1.5,
+        );
+        try {
+          final a = await _pixels(expected), b = await _pixels(actual);
+          var difference = 0;
+          for (var i = 0; i < a.length; i++) {
+            difference += (a[i] - b[i]).abs();
+          }
+          expect(difference / a.length, lessThan(3),
+              reason: '${mode.name} must agree with Canvas');
+        } finally {
+          expected.dispose();
+          actual.dispose();
+          session.dispose();
+          scene.dispose();
+        }
+      }
+    });
+  });
+
   testWidgets('tiling cells expand once and preserve painter order',
       (tester) async {
     await tester.runAsync(() async {
@@ -913,6 +966,8 @@ void main() {
         page,
         [
           const PdfBeginSoftMaskedCommand(),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          const PdfSetOverprintCommand(fill: true, stroke: true, mode: 1),
           PdfFillPathCommand(
             _rect(50, 100, 230, 280),
             const PdfColor(0.1, 0.7, 0.25),
@@ -946,6 +1001,95 @@ void main() {
       expect(backend.stats.texturesUploaded, 1);
       expect(backend.stats.textureDirectUploads, 1);
       expect(mask.request.decoded, isNull);
+    });
+  });
+
+  testWidgets('rectangular vector masks retain backdrop and transfer values',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final cases = <({bool luminosity, List<PdfRenderCommand> mask})>[
+        (
+          luminosity: false,
+          mask: [
+            PdfClipPathCommand(
+              _rect(90, 150, 240, 300),
+              PdfFillRule.nonzero,
+            ),
+            PdfFillPathCommand(
+              _rect(60, 120, 270, 330),
+              const PdfColor(1, 1, 1),
+              PdfFillRule.nonzero,
+              1,
+            ),
+          ],
+        ),
+        (
+          luminosity: true,
+          mask: [
+            PdfFillPathCommand(
+              _rect(90, 150, 165, 300),
+              const PdfColor(0, 0, 0),
+              PdfFillRule.nonzero,
+              1,
+            ),
+            PdfFillPathCommand(
+              _rect(165, 150, 240, 300),
+              const PdfColor(1, 1, 1),
+              PdfFillRule.nonzero,
+              1,
+            ),
+          ],
+        ),
+      ];
+      for (final testCase in cases) {
+        final scene = await PdfRetainedScene.fromCommands(page, [
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(50, 100, 280, 350),
+            const PdfColor(0.2, 0.6, 0.9),
+            PdfFillRule.nonzero,
+            0.85,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: testCase.luminosity,
+            backdrop: page.cropBox,
+            maskCommands: testCase.mask,
+            backdropLuminance: 0.6,
+            transferScale: 0.5,
+            transferOffset: 0.25,
+          ),
+        ]);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        const region = Rect.fromLTWH(40, 90, 250, 270);
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session!.rasterizeRegion(
+          region,
+          pixelRatio: 1.5,
+        );
+        try {
+          final a = await _pixels(expected), b = await _pixels(actual);
+          var difference = 0;
+          for (var i = 0; i < a.length; i++) {
+            difference += (a[i] - b[i]).abs();
+          }
+          expect(difference / a.length, lessThan(4),
+              reason: testCase.luminosity ? 'luminosity mask' : 'alpha mask');
+          expect(backend.stats.texturesUploaded, 0,
+              reason: 'solid vector masks need no retained image surface');
+        } finally {
+          expected.dispose();
+          actual.dispose();
+          session.dispose();
+          scene.dispose();
+        }
+      }
     });
   });
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -159,7 +159,8 @@ void main() {
       final document = PdfDocument.open(
         _benchmarkDocumentBytes(path, fixtureName),
       );
-      final productionRoute = fixtureName == _deferredMaskFixture;
+      final productionRoute = fixtureName == _deferredMaskFixture ||
+          Platform.environment['PDF_GPU_BENCHMARK_ROUTE_CHANGE'] == '1';
       final configuredPages =
           Platform.environment['PDF_GPU_BENCHMARK_PAGES']?.trim();
       final scenarioLabel =


### PR DESCRIPTION
## Headline

**Vector-mask first tile vs main: 46.2 ms direct GPU vs 175.8 ms Canvas fallback on the same Mac (73.7% faster).** After desktop scene preparation the interaction tile is 4.8 ms. The broader stencil-state pipeline warm-up moves about 53 ms into the existing idle phase (275 ms vs 222 ms locally).

PDF.js direct-GPU coverage moves from **101 accepted / 78 rejected** to **106 / 73**. Ghent remains **19 / 38**. All 218 corpus cases pass and the representative vector-mask page differs from Canvas by a mean **1.323 / 255**.

## What changed

- render Multiply and Screen exactly with fixed-function blending over the opaque page surface;
- retain a single vector fill under an opaque grayscale image mask;
- retain rectangular alpha/luminosity vector masks, including `/BC` and linearized `/TR`, as constant-mask stencil cover cells with no texture or readback;
- warm the real nonzero stencil-cover state during the existing idle pipeline pass;
- add a balanced six-run main-vs-PR Metal scenario for the route change.

Canvas remains the fallback for other blend modes, nested/multiple transparency groups, unsafe overprint, missing pixels, substituted text, and unsupported mask geometry.

<details>
<summary>Validation details</summary>

- `fvm dart analyze`
- full `dart_pdf_editor_flutter_gpu` Metal suite: 244 passed, 3 skipped
- focused backend suite: 21 passed, 1 expected no-context skip
- full GPU corpus: 218 passed
- PDF.js: 106 accepted / 73 conservative fallbacks
- Ghent: 19 accepted / 38 conservative fallbacks
- same-host local route comparison:
  - main: first Canvas fallback 175.767 ms; warm Canvas 5.452 ms
  - candidate: first direct GPU 46.220 ms; warm GPU 4.706 ms; warm Canvas 5.234 ms
  - prepared candidate: scene warm 48.489 ms; first interaction tile 4.754 ms
  - visual mean difference 1.323 / 255
  - candidate uses 0 image uploads and 0 readbacks for the vector-mask case

</details>

Advances #682 without weakening per-scene correctness fallback.
