### PR TITLE
Polish docked panels and Recent PDF handling

### DIFF
--- a/app/lib/doc_scan_io.dart
+++ b/app/lib/doc_scan_io.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_doc_scanner/flutter_doc_scanner.dart';
+import 'package:pdf_document/pdf_document.dart';
 
 import 'pdf_mobile_source.dart' show mobileFileChannel;
 
@@ -28,22 +29,47 @@ class DocumentScanException implements Exception {
       '"$location"';
 }
 
+/// The effective DPI used when captured page images are assembled into a PDF.
+/// ML Kit and VisionKit return print-resolution images; 300 dpi preserves an
+/// A4/Letter-like physical page size instead of treating every pixel as a PDF
+/// point.
+const double scannedDocumentDpi = 300;
+
 /// Launches the platform document scanner and returns the captured pages as a
 /// PDF. Returns null when the user cancels; throws [DocumentScanException] when
-/// a scan completed but its PDF could not be read back.
+/// a captured page could not be read back.
 ///
 /// **One scan session only.** Each `FlutterDocScanner` method launches its own
 /// camera, so calling more than one re-opens the scanner after the user has
-/// already accepted their pages. We ask for the ready-made PDF export and read
-/// it back with [readScannedFile], immediately - ML Kit writes into its own
-/// scratch space and reclaims it once the scanner activity is gone.
-Future<Uint8List?> scanDocumentToPdf() async {
+/// already accepted their pages. We request images exactly once and assemble
+/// the PDF ourselves. In particular, this avoids ML Kit's PDF export, which
+/// fails on some Android devices even though their captured page images are
+/// available.
+Future<Uint8List?> scanDocumentToPdf({FlutterDocScanner? scanner}) async {
   if (!documentScanSupported) return null;
-  final result = await FlutterDocScanner().getScannedDocumentAsPdf();
+  final result =
+      await (scanner ?? FlutterDocScanner()).getScannedDocumentAsImages();
   if (result == null) return null; // user cancelled
-  final bytes = await readScannedFile(result.pdfUri);
-  if (bytes == null) throw DocumentScanException(result.pdfUri);
-  return bytes;
+  return scannedImagesToPdf(result.images);
+}
+
+/// Reads scanner-returned page locations before the platform scanner can
+/// reclaim them and assembles a standalone PDF in capture order.
+@visibleForTesting
+Future<Uint8List> scannedImagesToPdf(
+  List<String> locations, {
+  MethodChannel? channel,
+}) async {
+  if (locations.isEmpty) {
+    throw const DocumentScanException('(scanner returned no pages)');
+  }
+  final images = <Uint8List>[];
+  for (final location in locations) {
+    final bytes = await readScannedFile(location, channel: channel);
+    if (bytes == null) throw DocumentScanException(location);
+    images.add(bytes);
+  }
+  return PdfImageDocument.fromImageBytes(images, dpi: scannedDocumentDpi);
 }
 
 /// Reads a scanner-returned file location.

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -32,6 +32,7 @@ import 'middle_ellipsis_text.dart';
 import 'new_document.dart';
 import 'ocr.dart';
 import 'ocr_status_label.dart';
+import 'open_error.dart';
 import 'pdf_cache.dart';
 import 'print_preview_dialog.dart';
 import 'print_progress_dialog.dart';
@@ -839,15 +840,16 @@ class _EditorScreenState extends State<EditorScreen>
     await _session.save(documents);
   }
 
-  /// Deletes cached mobile snapshots that no Recent entry still references, so
-  /// the private store can't grow without bound as entries roll off the list.
-  /// A no-op on desktop/web (nothing is cached there).
+  /// Deletes private PDF snapshots and first-page thumbnails that no Recent
+  /// entry still references, so local caches cannot grow without bound as
+  /// entries roll off the list.
   void _pruneRecentCache() {
     final keep = {
       for (final entry in _recents.items)
         if (entry.cachePath != null) entry.cachePath!,
     };
     unawaited(pruneCachedPdfs(keep));
+    unawaited(_recentThumbnails.retain(_recents.items));
   }
 
   // --- opening -------------------------------------------------------------
@@ -869,6 +871,17 @@ class _EditorScreenState extends State<EditorScreen>
     AppDevTools.instance
         .addLog('open error: $title - $error', level: DevLogLevel.error);
     _addTab(DocumentTab.error(title: title, error: error));
+  }
+
+  String _openFailureDetail(String title, Object error) {
+    AppDevTools.instance.addLog(
+      'open failure: $title - $error',
+      level: DevLogLevel.error,
+    );
+    return appL10n(context).editorCouldNotOpenDetail(
+      pdfDisplayName(title),
+      openErrorSummary(error),
+    );
   }
 
   void _openHandoff(DocumentHandoff handoff) {
@@ -1167,8 +1180,7 @@ class _EditorScreenState extends State<EditorScreen>
         loading,
         DocumentTab.error(
           title: errorTitle ?? title,
-          error: appL10n(context)
-              .editorCouldNotOpenDetail(errorTitle ?? title, '$e'),
+          error: _openFailureDetail(errorTitle ?? title, e),
         ),
       );
     }
@@ -1243,16 +1255,11 @@ class _EditorScreenState extends State<EditorScreen>
         bookmark: tab.originBookmark,
         cachePath: tab.cachePath,
         into: tab,
-        onOpenFailed: (_) {
-          // Session restoration is best-effort. A source that disappeared
-          // since the previous run should vanish quietly rather than leave a
-          // permanent error tab. `_closeTabs` removes synchronously until its
-          // first await for these clean placeholders, so the fallback's later
-          // replacement sees that the tab is already gone.
-          if (mounted && _tabs.contains(tab)) {
-            unawaited(_closeTabs([tab]));
-          }
-        },
+        // Session restoration is best-effort. A source that disappeared since
+        // the previous run should vanish quietly rather than leave a permanent
+        // error tab. The fallback closes this clean placeholder when the
+        // callback reports that it handled the failure.
+        onOpenFailed: (_) => true,
       );
     });
   }
@@ -1320,7 +1327,7 @@ class _EditorScreenState extends State<EditorScreen>
     String? cachePath,
     int? declaredBytes,
     String? provider,
-    void Function(Object error)? onOpenFailed,
+    bool Function(Object error)? onOpenFailed,
     DocumentTab? into,
   }) async {
     assert((path != null) != (token != null),
@@ -1493,8 +1500,7 @@ class _EditorScreenState extends State<EditorScreen>
         if (index == -1) return;
         setState(() => _tabs[index] = DocumentTab.error(
               title: preview.title,
-              error: appL10n(context)
-                  .editorCouldNotOpenDetail(preview.title, '$error2'),
+              error: _openFailureDetail(preview.title, error2),
             ));
         preview.dispose();
       }
@@ -1545,7 +1551,7 @@ class _EditorScreenState extends State<EditorScreen>
     String? bookmark,
     String? token,
     String? cachePath,
-    void Function(Object error)? onOpenFailed,
+    bool Function(Object error)? onOpenFailed,
   }) async {
     try {
       final bytes =
@@ -1576,13 +1582,17 @@ class _EditorScreenState extends State<EditorScreen>
         }
       }
     } catch (error) {
-      onOpenFailed?.call(error);
       if (!mounted) return;
+      final handled = onOpenFailed?.call(error) ?? false;
+      if (handled) {
+        await _closeTabs([loading]);
+        return;
+      }
       _replaceLoadingTab(
         loading,
         DocumentTab.error(
           title: title,
-          error: appL10n(context).editorCouldNotOpenDetail(title, '$error'),
+          error: _openFailureDetail(title, error),
         ),
       );
     }
@@ -1605,8 +1615,8 @@ class _EditorScreenState extends State<EditorScreen>
         // Older runner without the mobile_file channel - fall through to the
         // copy-based picker below.
       } catch (e) {
-        _openError(
-            l10n.editorOpenFailedTitle, l10n.editorCouldNotOpenSelected('$e'));
+        _openError(l10n.editorOpenFailedTitle,
+            l10n.editorCouldNotOpenSelected(openErrorSummary(e)));
         return;
       }
     }
@@ -1646,8 +1656,8 @@ class _EditorScreenState extends State<EditorScreen>
         }
       }
     } catch (e) {
-      _openError(
-          l10n.editorOpenFailedTitle, l10n.editorCouldNotOpenSelected('$e'));
+      _openError(l10n.editorOpenFailedTitle,
+          l10n.editorCouldNotOpenSelected(openErrorSummary(e)));
     }
   }
 
@@ -2085,7 +2095,9 @@ class _EditorScreenState extends State<EditorScreen>
         onOpenFailed: (_) {
           unawaited(_recents.remove(entry.id));
           _pruneRecentCache();
-          _toast(appL10n(context).editorCouldNotReopen(entry.title));
+          _toast(appL10n(context)
+              .editorCouldNotReopen(pdfDisplayName(entry.title)));
+          return true;
         },
       );
       return;
@@ -2122,14 +2134,14 @@ class _EditorScreenState extends State<EditorScreen>
       await _recents.remove(entry.id);
       _pruneRecentCache();
       if (!mounted) return;
-      _replaceLoadingTab(
-        loading,
-        DocumentTab.error(
-          title: entry.title,
-          error: appL10n(context).editorCouldNotOpenDetail(entry.title, '$e'),
-        ),
+      AppDevTools.instance.addLog(
+        'recent open failed: ${entry.title} - $e',
+        level: DevLogLevel.error,
       );
-      _toast(appL10n(context).editorCouldNotReopen(entry.title));
+      await _closeTabs([loading]);
+      if (!mounted) return;
+      _toast(
+          appL10n(context).editorCouldNotReopen(pdfDisplayName(entry.title)));
     }
   }
 
@@ -2196,8 +2208,8 @@ class _EditorScreenState extends State<EditorScreen>
         _activeIndex = _tabs.length - 1;
       });
     } catch (e) {
-      _openError(
-          l10n.editorCompareFailedTitle, l10n.editorCouldNotOpenSecond('$e'));
+      _openError(l10n.editorCompareFailedTitle,
+          l10n.editorCouldNotOpenSecond(openErrorSummary(e)));
     }
   }
 
@@ -2889,11 +2901,15 @@ class _EditorScreenState extends State<EditorScreen>
     Widget? subtitle,
     TextOverflow? overflow,
     bool middleEllipsis = false,
+    bool hidePdfExtension = false,
   }) =>
       ListTile(
         leading: Icon(icon),
         title: middleEllipsis
-            ? MiddleEllipsisText(title)
+            ? MiddleEllipsisText(
+                title,
+                hidePdfExtension: hidePdfExtension,
+              )
             : Text(title, overflow: overflow),
         subtitle: subtitle,
         trailing: trailing ??
@@ -2983,6 +2999,7 @@ class _EditorScreenState extends State<EditorScreen>
                         ? appL10n(context).editorUntitled
                         : entry.title,
                     middleEllipsis: true,
+                    hidePdfExtension: true,
                     subtitle: entry.path == null
                         ? null
                         : MiddleEllipsisText(entry.path!),
@@ -3377,7 +3394,10 @@ class _EditorScreenState extends State<EditorScreen>
       return _OpeningDocument(title: tab.title);
     }
     if (tab.error != null) {
-      return Center(child: Text(tab.error!, textAlign: TextAlign.center));
+      return _OpenErrorDocument(
+        message: tab.error!,
+        onOpen: _pickAndOpen,
+      );
     }
     if (tab.isComparison) {
       return PdfComparisonView(
@@ -3548,6 +3568,7 @@ class _EditorScreenState extends State<EditorScreen>
     final tab = _active;
     Widget title = MiddleEllipsisText(
       tab?.title.isEmpty ?? true ? appL10n(context).editorUntitled : tab!.title,
+      hidePdfExtension: tab?.title.isNotEmpty ?? false,
     );
     if (_nativeTabDragging && tab?.session != null) {
       title = _buildNativeTabDragSource(tab!, title);
@@ -4006,6 +4027,7 @@ class _EditorScreenState extends State<EditorScreen>
     Widget label() {
       final text = MiddleEllipsisText(
         tab.title.isEmpty ? appL10n(context).editorUntitled : tab.title,
+        hidePdfExtension: tab.title.isNotEmpty,
         style: TextStyle(
           fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
           color:
@@ -4210,6 +4232,7 @@ class _EditorScreenState extends State<EditorScreen>
                   children: [
                     MiddleEllipsisText(
                       tab.title,
+                      hidePdfExtension: true,
                       style: TextStyle(
                         color: overStrip
                             ? scheme.onPrimaryContainer
@@ -4243,6 +4266,44 @@ class _EditorScreenState extends State<EditorScreen>
   }
 }
 
+class _OpenErrorDocument extends StatelessWidget {
+  const _OpenErrorDocument({required this.message, required this.onOpen});
+
+  final String message;
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.file_open_outlined, size: 48, color: scheme.error),
+              const SizedBox(height: 16),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 20),
+              FilledButton.icon(
+                onPressed: onOpen,
+                icon: const Icon(Icons.folder_open),
+                label: Text(appL10n(context).editorOpenPdfNewTab),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _OpeningDocument extends StatelessWidget {
   const _OpeningDocument({required this.title});
 
@@ -4262,7 +4323,7 @@ class _OpeningDocument extends StatelessWidget {
             Text(
               title.isEmpty
                   ? appL10n(context).editorOpeningPdf
-                  : appL10n(context).editorOpeningTitle(title),
+                  : appL10n(context).editorOpeningTitle(pdfDisplayName(title)),
               textAlign: TextAlign.center,
             ),
           ],
@@ -4537,6 +4598,7 @@ class _DesktopTabPreviewCard extends StatelessWidget {
                     tab.title.isEmpty
                         ? appL10n(context).editorUntitled
                         : tab.title,
+                    hidePdfExtension: tab.title.isNotEmpty,
                     key: const ValueKey('tab-hover-preview-title'),
                     style: Theme.of(context).textTheme.labelLarge,
                   ),
@@ -4781,6 +4843,7 @@ class _MobileTabTile extends StatelessWidget {
                       tab.title.isEmpty
                           ? appL10n(context).editorUntitled
                           : tab.title,
+                      hidePdfExtension: tab.title.isNotEmpty,
                       style: TextStyle(
                         fontWeight:
                             selected ? FontWeight.w600 : FontWeight.normal,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1781,11 +1781,9 @@ class _EditorScreenState extends State<EditorScreen>
 
   /// Runs the device scanner. Null means "no pages": cancelled, unavailable, or
   /// failed - a failure has already been logged and toasted by the time this
-  /// returns, so callers just stop.
-  ///
-  /// The toast carries the platform's own reason. "The camera never opened" and
-  /// "the capture couldn't be read back" are different bugs with the same
-  /// symptom, and the message has to say which one happened.
+  /// returns, so callers just stop. Full platform diagnostics stay in DevTools;
+  /// the transient user message never exposes exception types or native error
+  /// plumbing.
   Future<Uint8List?> _runScan() async {
     final scan = _documentScanner;
     if (scan == null || _scanInFlight) return null;
@@ -1795,20 +1793,12 @@ class _EditorScreenState extends State<EditorScreen>
     } catch (e) {
       AppDevTools.instance.addLog('scan failed: $e', level: DevLogLevel.error);
       if (mounted) {
-        _toast(_scanFailureMessage(e), duration: const Duration(seconds: 6));
+        _toast(appL10n(context).editorScanFailed);
       }
       return null;
     } finally {
       _scanInFlight = false;
     }
-  }
-
-  /// The localized "couldn't scan" sentence plus the underlying error, trimmed
-  /// to something a snack bar can hold.
-  String _scanFailureMessage(Object error) {
-    var detail = error.toString();
-    if (detail.length > 140) detail = '${detail.substring(0, 140)}…';
-    return '${appL10n(context).editorScanFailed} $detail';
   }
 
   /// Scans a document with the device camera (mobile/tablet only) and opens

--- a/app/lib/middle_ellipsis_text.dart
+++ b/app/lib/middle_ellipsis_text.dart
@@ -15,15 +15,21 @@ class MiddleEllipsisText extends LeafRenderObjectWidget {
     super.key,
     this.style,
     this.textAlign,
+    this.hidePdfExtension = false,
   });
 
   final String data;
   final TextStyle? style;
   final TextAlign? textAlign;
 
+  /// Hides a trailing `.pdf` (case-insensitively) from the rendered and
+  /// semantic label while retaining [data] as the real filename. Paths, save
+  /// names, and document identities therefore remain untouched.
+  final bool hidePdfExtension;
+
   _MiddleEllipsisConfiguration _configuration(BuildContext context) =>
       _MiddleEllipsisConfiguration(
-        data: data,
+        data: hidePdfExtension ? pdfDisplayName(data) : data,
         style: DefaultTextStyle.of(context).style.merge(style),
         textDirection: Directionality.of(context),
         textScaler: MediaQuery.textScalerOf(context),
@@ -43,6 +49,15 @@ class MiddleEllipsisText extends LeafRenderObjectWidget {
     (renderObject as _RenderMiddleEllipsisText).configuration =
         _configuration(context);
   }
+}
+
+/// The user-facing form of a known PDF filename.
+///
+/// Only the final `.pdf` suffix is removed. Names such as `report.pdf.bak`,
+/// paths, and the underlying document title are otherwise unchanged.
+String pdfDisplayName(String value) {
+  if (value.length <= 4 || !value.toLowerCase().endsWith('.pdf')) return value;
+  return value.substring(0, value.length - 4);
 }
 
 @immutable

--- a/app/lib/open_error.dart
+++ b/app/lib/open_error.dart
@@ -1,0 +1,3 @@
+// Turns platform file-open failures into short user-facing details without
+// leaking an exception class, errno, or a potentially very long local path.
+export 'open_error_stub.dart' if (dart.library.io) 'open_error_io.dart';

--- a/app/lib/open_error_io.dart
+++ b/app/lib/open_error_io.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+/// A concise file-open failure that deliberately omits the source path,
+/// exception type, and errno. The path remains available in diagnostics logs.
+String openErrorSummary(Object error) {
+  if (error is FileSystemException) {
+    final parts = <String>[];
+    final message = error.message.trim();
+    final osMessage = error.osError?.message.trim();
+    if (message.isNotEmpty) parts.add(message);
+    if (osMessage != null &&
+        osMessage.isNotEmpty &&
+        !parts.any((part) => part.toLowerCase() == osMessage.toLowerCase())) {
+      parts.add(osMessage);
+    }
+    if (parts.isNotEmpty) return parts.join(': ');
+  }
+  final text = '$error'.replaceAll(RegExp(r'\s+'), ' ').trim();
+  return text.length <= 180 ? text : '${text.substring(0, 177)}…';
+}

--- a/app/lib/open_error_stub.dart
+++ b/app/lib/open_error_stub.dart
@@ -1,0 +1,5 @@
+/// A concise cross-platform fallback for errors from web/file-provider APIs.
+String openErrorSummary(Object error) {
+  final text = '$error'.replaceAll(RegExp(r'\s+'), ' ').trim();
+  return text.length <= 180 ? text : '${text.substring(0, 177)}…';
+}

--- a/app/lib/print_preview_dialog.dart
+++ b/app/lib/print_preview_dialog.dart
@@ -196,6 +196,7 @@ class _PrintPreviewDialogState extends State<PrintPreviewDialog> {
           Text(l10n.printPreviewTitle),
           MiddleEllipsisText(
             widget.title,
+            hidePdfExtension: true,
             style: theme.textTheme.bodySmall,
           ),
         ],

--- a/app/lib/recent_thumbnail_store.dart
+++ b/app/lib/recent_thumbnail_store.dart
@@ -1,0 +1,8 @@
+// Durable storage for the small first-page images shown by Recent files.
+//
+// Native apps use the application-support directory and the web uses
+// IndexedDB. The bare stub keeps thumbnail rendering functional on targets
+// with neither API; it just cannot retain the result across app launches.
+export 'recent_thumbnail_store_stub.dart'
+    if (dart.library.io) 'recent_thumbnail_store_io.dart'
+    if (dart.library.js_interop) 'recent_thumbnail_store_web.dart';

--- a/app/lib/recent_thumbnail_store_io.dart
+++ b/app/lib/recent_thumbnail_store_io.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+Future<Directory> _thumbnailDir() async {
+  final base = await getApplicationSupportDirectory();
+  final dir = Directory('${base.path}/recent_thumbnails');
+  if (!await dir.exists()) await dir.create(recursive: true);
+  return dir;
+}
+
+Future<Uint8List?> readStoredRecentThumbnail(String key) async {
+  try {
+    final file = File('${(await _thumbnailDir()).path}/$key.thumb');
+    if (!await file.exists()) return null;
+    return await file.readAsBytes();
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> writeStoredRecentThumbnail(String key, Uint8List bytes) async {
+  try {
+    final file = File('${(await _thumbnailDir()).path}/$key.thumb');
+    await file.writeAsBytes(bytes, flush: true);
+  } catch (_) {
+    // A read-only/unavailable support directory only disables persistence;
+    // the in-memory cache still serves the rendered thumbnail this session.
+  }
+}
+
+Future<void> pruneStoredRecentThumbnails(Set<String> keep) async {
+  try {
+    final dir = await _thumbnailDir();
+    await for (final entry in dir.list()) {
+      if (entry is! File || !entry.path.endsWith('.thumb')) continue;
+      final name = entry.uri.pathSegments.last;
+      final key = name.substring(0, name.length - '.thumb'.length);
+      if (keep.contains(key)) continue;
+      try {
+        await entry.delete();
+      } catch (_) {
+        // Best-effort cleanup: a locked or racing cache file can survive.
+      }
+    }
+  } catch (_) {
+    // No writable store - nothing to prune.
+  }
+}

--- a/app/lib/recent_thumbnail_store_stub.dart
+++ b/app/lib/recent_thumbnail_store_stub.dart
@@ -1,0 +1,7 @@
+import 'dart:typed_data';
+
+Future<Uint8List?> readStoredRecentThumbnail(String key) async => null;
+
+Future<void> writeStoredRecentThumbnail(String key, Uint8List bytes) async {}
+
+Future<void> pruneStoredRecentThumbnails(Set<String> keep) async {}

--- a/app/lib/recent_thumbnail_store_web.dart
+++ b/app/lib/recent_thumbnail_store_web.dart
@@ -1,0 +1,59 @@
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+import 'idb_web.dart';
+
+const String _dbName = 'dart_pdf_editor_app.recent_thumbnails';
+const String _storeName = 'thumbnails';
+
+Future<Uint8List?> readStoredRecentThumbnail(String key) async {
+  try {
+    final store = await _store('readonly');
+    return await idbRequest<Uint8List?>(store.get(key.toJS), (result) {
+      if (result == null) return null;
+      return (result as JSUint8Array).toDart;
+    });
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> writeStoredRecentThumbnail(String key, Uint8List bytes) async {
+  try {
+    final store = await _store('readwrite');
+    await idbRequest<void>(store.put(bytes.toJS, key.toJS), (_) {});
+  } catch (_) {
+    // Blocked/private storage only disables persistence for this thumbnail.
+  }
+}
+
+Future<void> pruneStoredRecentThumbnails(Set<String> keep) async {
+  try {
+    final readStore = await _store('readonly');
+    final keys = await idbRequest<List<String>>(
+      readStore.getAllKeys(),
+      (result) => result == null
+          ? const []
+          : [
+              for (final key in (result as JSArray<JSAny?>).toDart)
+                (key! as JSString).toDart,
+            ],
+    );
+    for (final key in keys) {
+      if (keep.contains(key)) continue;
+      final store = await _store('readwrite');
+      await idbRequest<void>(store.delete(key.toJS), (_) {});
+    }
+  } catch (_) {
+    // No writable store - nothing to prune.
+  }
+}
+
+Future<web.IDBDatabase>? _db;
+
+Future<web.IDBObjectStore> _store(String mode) async {
+  final db = await (_db ??= openIdb(_dbName, const [_storeName]));
+  return db.transaction(_storeName.toJS, mode).objectStore(_storeName);
+}

--- a/app/lib/recent_thumbnails.dart
+++ b/app/lib/recent_thumbnails.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:crypto/crypto.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'devtools.dart';
 import 'file_io.dart';
+import 'recent_thumbnail_store.dart';
 import 'recents.dart';
 
 /// Reads a recent entry's bytes from its [RecentFile.readPath]. Mirrors
@@ -14,6 +17,17 @@ import 'recents.dart';
 /// so widget tests can hand back fixture bytes without touching the filesystem.
 typedef RecentBytesReader = Future<Uint8List> Function(String path,
     {String? bookmark});
+
+/// Loads one encoded thumbnail from the app's private persistent store.
+typedef StoredRecentThumbnailReader = Future<Uint8List?> Function(String key);
+
+/// Writes one encoded thumbnail to the app's private persistent store.
+typedef StoredRecentThumbnailWriter = Future<void> Function(
+    String key, Uint8List bytes);
+
+/// Removes persistent thumbnails whose keys are not in the current Recent
+/// list.
+typedef StoredRecentThumbnailPruner = Future<void> Function(Set<String> keep);
 
 /// A rendered first-page thumbnail: the PNG bytes plus the source page's
 /// aspect ratio, so the grid can shape each tile to the real page instead of
@@ -34,24 +48,51 @@ class RecentThumbnail {
 ///
 /// [thumbnailFor] reads an entry's bytes, opens the PDF, and rasterizes its
 /// first page to a [RecentThumbnail] (PNG bytes + page aspect ratio) sized so
-/// its longest side is [longestSide] px, keyed by the entry's [RecentFile.id]
-/// so a welcome-screen rebuild (recents changing, the list scrolling) never
-/// re-renders the same page. Entries with no readable source (a web pick with
-/// no snapshot) or a file that fails to open resolve to null, and the list
-/// falls back to its generic document icon.
+/// its longest side is [longestSide] px. Results are keyed by the entry's
+/// [RecentFile.id], retained in memory, and written to app-private local
+/// storage. A later app launch therefore paints a network/cloud file's cached
+/// thumbnail without opening that source again. Entries with no readable
+/// source (a web pick with no snapshot) or a file that fails to open resolve
+/// to null, and the list falls back to its generic document icon.
 ///
 /// Owned by the editor screen alongside the recents store; lives for the app
 /// session and is bounded to [maxEntries] retained thumbnails.
 class RecentThumbnailCache {
   RecentThumbnailCache({
-    this.readBytes = readPdfAtPath,
+    RecentBytesReader? readBytes,
+    StoredRecentThumbnailReader? readStored,
+    StoredRecentThumbnailWriter? writeStored,
+    StoredRecentThumbnailPruner? pruneStored,
     this.longestSide = 240,
     this.maxEntries = 32,
-  }) : assert(longestSide > 0);
+  })  : readBytes = readBytes ?? readPdfAtPath,
+        // An injected source reader normally supplies fixture bytes. Default
+        // to a matching isolated in-memory-only mode so a developer machine's
+        // persistent cache cannot bypass that fixture and make tests depend on
+        // prior runs. Callers testing persistence inject both layers.
+        readStored = readStored ??
+            (readBytes == null
+                ? readStoredRecentThumbnail
+                : _readNoStoredThumbnail),
+        writeStored = writeStored ??
+            (readBytes == null
+                ? writeStoredRecentThumbnail
+                : _writeNoStoredThumbnail),
+        pruneStored = pruneStored ??
+            (readBytes == null
+                ? pruneStoredRecentThumbnails
+                : _pruneNoStoredThumbnails),
+        assert(longestSide > 0);
 
   /// Reads an entry's bytes. Production reads from disk / the byte-snapshot
   /// store via [readPdfAtPath]; tests inject a fixture reader.
   final RecentBytesReader readBytes;
+
+  /// Reads/writes the durable layer. Injectable so tests can emulate an app
+  /// restart without depending on a platform storage plugin.
+  final StoredRecentThumbnailReader readStored;
+  final StoredRecentThumbnailWriter writeStored;
+  final StoredRecentThumbnailPruner pruneStored;
 
   /// Longest side of a rendered thumbnail, in pixels. The list draws it at
   /// ~40 px and the grid at ~150 px, so a modest raster stays crisp on
@@ -82,7 +123,7 @@ class RecentThumbnailCache {
     }
     final pending = _inflight[key];
     if (pending != null) return pending;
-    final future = _enqueueRender(entry).then((thumb) {
+    final future = _enqueue(() => _loadOrRender(entry)).then((thumb) {
       _inflight.remove(key);
       if (!_disposed) _store(key, thumb);
       return thumb;
@@ -91,13 +132,17 @@ class RecentThumbnailCache {
     return future;
   }
 
-  /// Serializes thumbnail work so a welcome grid cannot hydrate several cloud
-  /// files or spawn several short-lived render isolates at once.
-  Future<RecentThumbnail?> _enqueueRender(RecentFile entry) {
+  /// Drops persistent thumbnails for documents no longer in Recent files.
+  Future<void> retain(Iterable<RecentFile> entries) => pruneStored({
+        for (final entry in entries) _persistentKey(entry.id),
+      });
+
+  Future<RecentThumbnail?> _enqueue(
+      Future<RecentThumbnail?> Function() operation) {
     final result = Completer<RecentThumbnail?>();
     _renderTail = _renderTail.then((_) async {
       try {
-        result.complete(await _render(entry));
+        result.complete(await operation());
       } catch (error, stack) {
         result.completeError(error, stack);
       }
@@ -112,11 +157,41 @@ class RecentThumbnailCache {
     }
   }
 
-  Future<RecentThumbnail?> _render(RecentFile entry) async {
+  Future<RecentThumbnail?> _loadOrRender(RecentFile entry) async {
+    Uint8List? stored;
+    try {
+      stored = await readStored(_persistentKey(entry.id));
+    } catch (_) {
+      // Persistence is an optimization. Fall through to the source whenever
+      // the platform store is unavailable or contains an unreadable entry.
+    }
+    final decoded = stored == null ? null : _decodeThumbnail(stored);
+    if (decoded != null) return decoded;
+
     final path = entry.readPath;
     if (path == null) return null;
     try {
       final bytes = await readBytes(path, bookmark: entry.bookmark);
+      final thumb = await _renderBytes(bytes);
+      if (thumb != null) await _writePersistent(entry.id, thumb);
+      return thumb;
+    } catch (e) {
+      AppDevTools.instance.addLog('recent thumbnail render failed: $e',
+          level: DevLogLevel.error);
+      return null;
+    }
+  }
+
+  Future<void> _writePersistent(String id, RecentThumbnail thumb) async {
+    try {
+      await writeStored(_persistentKey(id), _encodeThumbnail(thumb));
+    } catch (_) {
+      // Keep serving the in-memory thumbnail when durable storage is blocked.
+    }
+  }
+
+  Future<RecentThumbnail?> _renderBytes(Uint8List bytes) async {
+    try {
       final doc = PdfDocument.open(bytes);
       if (doc.pageCount == 0) return null;
       final page = doc.page(0);
@@ -180,4 +255,42 @@ class RecentThumbnailCache {
     _cache.clear();
     _inflight.clear();
   }
+}
+
+Future<Uint8List?> _readNoStoredThumbnail(String key) async => null;
+
+Future<void> _writeNoStoredThumbnail(String key, Uint8List bytes) async {}
+
+Future<void> _pruneNoStoredThumbnails(Set<String> keep) async {}
+
+const _thumbnailMagic = <int>[0x44, 0x50, 0x54, 0x31]; // DPT1
+const _thumbnailHeaderLength = 12;
+
+String _persistentKey(String id) => sha1.convert(utf8.encode(id)).toString();
+
+Uint8List _encodeThumbnail(RecentThumbnail thumbnail) {
+  final bytes = Uint8List(_thumbnailHeaderLength + thumbnail.pngBytes.length);
+  bytes.setRange(0, _thumbnailMagic.length, _thumbnailMagic);
+  ByteData.sublistView(bytes)
+      .setFloat64(4, thumbnail.aspectRatio, Endian.little);
+  bytes.setRange(_thumbnailHeaderLength, bytes.length, thumbnail.pngBytes);
+  return bytes;
+}
+
+RecentThumbnail? _decodeThumbnail(Uint8List bytes) {
+  if (bytes.length <= _thumbnailHeaderLength) return null;
+  for (var i = 0; i < _thumbnailMagic.length; i++) {
+    if (bytes[i] != _thumbnailMagic[i]) return null;
+  }
+  final aspect = ByteData.sublistView(bytes).getFloat64(4, Endian.little);
+  if (!aspect.isFinite || aspect <= 0) return null;
+  final png = Uint8List.sublistView(bytes, _thumbnailHeaderLength);
+  if (png.length < 4 ||
+      png[0] != 0x89 ||
+      png[1] != 0x50 ||
+      png[2] != 0x4E ||
+      png[3] != 0x47) {
+    return null;
+  }
+  return RecentThumbnail(pngBytes: png, aspectRatio: aspect);
 }

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -402,7 +402,10 @@ class _RecentsList extends StatelessWidget {
             width: 48,
             height: 62,
           ),
-          title: MiddleEllipsisText(entry.title),
+          title: MiddleEllipsisText(
+            entry.title,
+            hidePdfExtension: true,
+          ),
           subtitle: entry.path != null
               ? MiddleEllipsisText(entry.path!)
               : entry.isReopenable
@@ -552,6 +555,7 @@ class _RecentGridTile extends StatelessWidget {
               alignment: Alignment.bottomCenter,
               child: MiddleEllipsisText(
                 entry.title,
+                hidePdfExtension: true,
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall,
               ),

--- a/app/test/doc_scan_io_test.dart
+++ b/app/test/doc_scan_io_test.dart
@@ -11,9 +11,37 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_doc_scanner/flutter_doc_scanner.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 import 'package:dart_pdf_editor_app/doc_scan_io.dart';
+
+class _ImageOnlyScanner extends FlutterDocScanner {
+  _ImageOnlyScanner(this.locations);
+
+  final List<String> locations;
+  var imageCalls = 0;
+  var pdfCalls = 0;
+
+  @override
+  Future<ImageScanResult?> getScannedDocumentAsImages({
+    int page = 4,
+    ImageFormat imageFormat = ImageFormat.jpeg,
+    double quality = 0.9,
+    bool useAutomaticSinglePictureProcessing = false,
+  }) async {
+    imageCalls++;
+    return ImageScanResult(images: locations);
+  }
+
+  @override
+  Future<PdfScanResult?> getScannedDocumentAsPdf({int page = 4}) async {
+    pdfCalls++;
+    throw StateError('the plugin PDF route must not be used');
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -57,6 +85,27 @@ void main() {
     // toast, so it has to carry the URI that failed.
     const e = DocumentScanException('content://media/document/1');
     expect(e.toString(), contains('content://media/document/1'));
+  });
+
+  test('scan uses page images once and assembles its own PDF', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final dir = Directory.systemTemp.createTempSync('doc_scan_images_test');
+    try {
+      final first = File('${dir.path}/first.jpg')
+        ..writeAsBytesSync(buildTestJpeg());
+      final second = File('${dir.path}/second.jpg')
+        ..writeAsBytesSync(buildTestJpeg());
+      final scanner = _ImageOnlyScanner([first.path, second.path]);
+
+      final bytes = await scanDocumentToPdf(scanner: scanner);
+      expect(bytes, isNotNull);
+      expect(PdfDocument.open(bytes!).pageCount, 2);
+      expect(scanner.imageCalls, 1);
+      expect(scanner.pdfCalls, 0);
+    } finally {
+      dir.deleteSync(recursive: true);
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   group('readScannedFile', () {
@@ -153,5 +202,19 @@ void main() {
       expect(tokens, isEmpty);
       debugDefaultTargetPlatformOverride = null;
     });
+  });
+
+  test('scannedImagesToPdf reads Android content URIs in page order', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final tokens = mockReadUri(buildTestJpeg());
+
+    final bytes = await scannedImagesToPdf(
+      const ['content://scan/1', 'content://scan/2'],
+      channel: channel,
+    );
+
+    expect(PdfDocument.open(bytes).pageCount, 2);
+    expect(tokens, ['content://scan/1', 'content://scan/2']);
+    debugDefaultTargetPlatformOverride = null;
   });
 }

--- a/app/test/doc_scan_menu_test.dart
+++ b/app/test/doc_scan_menu_test.dart
@@ -152,13 +152,9 @@ void main() {
     await tester.pump(); // reject the future
     await tester.pump(); // show the snack bar
 
-    // The toast carries the platform's own reason after the sentence - which
-    // failure it was is the whole diagnostic value.
-    expect(
-      find.textContaining("Couldn't scan the document."),
-      findsOneWidget,
-    );
-    expect(find.textContaining('scanner unavailable'), findsOneWidget);
+    expect(find.text("Couldn't scan the document."), findsOneWidget);
+    expect(find.textContaining('scanner unavailable'), findsNothing);
+    expect(find.textContaining('StateError'), findsNothing);
     expect(findMiddleEllipsisText('Untitled.pdf'), findsNothing);
   });
 
@@ -179,13 +175,9 @@ void main() {
     await tester.pump(); // reject the future
     await tester.pump(); // show the snack bar
 
-    // The toast carries the platform's own reason after the sentence - which
-    // failure it was is the whole diagnostic value.
-    expect(
-      find.textContaining("Couldn't scan the document."),
-      findsOneWidget,
-    );
-    expect(find.textContaining('scanner unavailable'), findsOneWidget);
+    expect(find.text("Couldn't scan the document."), findsOneWidget);
+    expect(find.textContaining('scanner unavailable'), findsNothing);
+    expect(find.textContaining('StateError'), findsNothing);
   });
 
   testWidgets('a second scan request while one is up is ignored',

--- a/app/test/middle_ellipsis_text_test.dart
+++ b/app/test/middle_ellipsis_text_test.dart
@@ -4,6 +4,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor_app/middle_ellipsis_text.dart';
 
 void main() {
+  test('pdfDisplayName removes only a final PDF extension', () {
+    expect(pdfDisplayName('Drawing.pdf'), 'Drawing');
+    expect(pdfDisplayName('Drawing.PDF'), 'Drawing');
+    expect(pdfDisplayName('Drawing.pdf.bak'), 'Drawing.pdf.bak');
+    expect(pdfDisplayName('.pdf'), '.pdf');
+  });
+
+  testWidgets('can hide the PDF extension without changing the source name',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: SizedBox(
+        width: 300,
+        child: MiddleEllipsisText(
+          'Network drawing.pdf',
+          hidePdfExtension: true,
+        ),
+      ),
+    ));
+
+    final widget =
+        tester.widget<MiddleEllipsisText>(find.byType(MiddleEllipsisText));
+    final render = tester.renderObject(find.byType(MiddleEllipsisText));
+    expect(widget.data, 'Network drawing.pdf');
+    expect((render as dynamic).debugDisplayedText, 'Network drawing');
+  });
+
   testWidgets('keeps both ends of an overflowing file name', (tester) async {
     const name = 'a-very-long-drawing-file-name.pdf';
     await tester.pumpWidget(const MaterialApp(

--- a/app/test/open_error_test.dart
+++ b/app/test/open_error_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/open_error.dart';
+
+void main() {
+  test('filesystem summaries omit exception plumbing and the source path', () {
+    final error = FileSystemException(
+      'Cannot open file',
+      r'C:\Users\ben\OneDrive - Company\Very long folder\drawing.pdf',
+      const OSError('The system cannot find the file specified', 2),
+    );
+
+    final summary = openErrorSummary(error);
+
+    expect(
+        summary, 'Cannot open file: The system cannot find the file specified');
+    expect(summary, isNot(contains(r'C:\Users')));
+    expect(summary, isNot(contains('FileSystemException')));
+    expect(summary, isNot(contains('errno')));
+  });
+}

--- a/app/test/progressive_open_test.dart
+++ b/app/test/progressive_open_test.dart
@@ -248,4 +248,55 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     }
   });
+
+  testWidgets('a missing Recent closes cleanly without exposing its path',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    final missingPath = '${tempDir.path}/network/gone.pdf';
+    try {
+      SharedPreferences.setMockInitialValues({
+        'dart_pdf_editor_app.recents': jsonEncode([
+          {'t': 'gone.pdf', 'p': missingPath, 'o': 1000}
+        ]),
+      });
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+      expect(find.byKey(ValueKey('recent-tile-$missingPath')), findsOneWidget);
+
+      await pump(tester, () async {
+        await tester
+            .tap(find.byKey(ValueKey('recent-tile-thumb-$missingPath')));
+      });
+
+      expect(tabTitle('gone.pdf'), findsNothing);
+      expect(find.textContaining('PathNotFoundException'), findsNothing);
+      expect(find.textContaining(missingPath), findsNothing);
+      expect(find.text('Could not reopen gone'), findsOneWidget);
+      expect(find.byKey(ValueKey('recent-tile-$missingPath')), findsNothing);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('a direct missing-file error is concise and recoverable',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    final missingPath = '${tempDir.path}/network/direct.pdf';
+    try {
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+      await pump(tester, () => openIncoming(tester, missingPath, 'direct.pdf'));
+
+      expect(find.textContaining('Could not open direct'), findsOneWidget);
+      expect(find.textContaining('No such file or directory'), findsOneWidget);
+      expect(find.textContaining('PathNotFoundException'), findsNothing);
+      expect(find.textContaining(missingPath), findsNothing);
+      expect(find.text('Open PDF in a new tab'), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
 }

--- a/app/test/recent_thumbnail_store_io_test.dart
+++ b/app/test/recent_thumbnail_store_io_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:dart_pdf_editor_app/recent_thumbnail_store.dart';
+
+void main() {
+  late Directory root;
+  late PathProviderPlatform originalPathProvider;
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    root = Directory.systemTemp.createTempSync('dartpdf_thumb_store_test');
+    originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _TempPathProvider(root.path);
+  });
+
+  tearDown(() {
+    PathProviderPlatform.instance = originalPathProvider;
+    root.deleteSync(recursive: true);
+  });
+
+  test('writes and reads a thumbnail from application support', () async {
+    final bytes = Uint8List.fromList([1, 2, 3, 4]);
+
+    await writeStoredRecentThumbnail('drawing', bytes);
+
+    expect(await readStoredRecentThumbnail('drawing'), bytes);
+    expect(
+      File('${root.path}/recent_thumbnails/drawing.thumb').existsSync(),
+      isTrue,
+    );
+  });
+
+  test('prunes thumbnails no longer represented by Recent files', () async {
+    await writeStoredRecentThumbnail('keep', Uint8List.fromList([1]));
+    await writeStoredRecentThumbnail('drop', Uint8List.fromList([2]));
+
+    await pruneStoredRecentThumbnails({'keep'});
+
+    expect(await readStoredRecentThumbnail('keep'), [1]);
+    expect(await readStoredRecentThumbnail('drop'), isNull);
+  });
+
+  test('an unavailable support directory degrades to a cache miss', () async {
+    PathProviderPlatform.instance = _BrokenPathProvider();
+
+    await writeStoredRecentThumbnail('drawing', Uint8List.fromList([1]));
+    expect(await readStoredRecentThumbnail('drawing'), isNull);
+    await pruneStoredRecentThumbnails({'drawing'});
+  });
+}
+
+class _TempPathProvider extends PathProviderPlatform {
+  _TempPathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
+
+class _BrokenPathProvider extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationSupportPath() async =>
+      throw MissingPluginException('no path_provider here');
+}

--- a/app/test/recent_thumbnails_test.dart
+++ b/app/test/recent_thumbnails_test.dart
@@ -89,15 +89,58 @@ void main() {
     expect(reads, 1);
   });
 
+  testWidgets('persists a thumbnail across cache instances without rereading',
+      (tester) async {
+    final pdf = PdfBlankDocument.create();
+    final stored = <String, Uint8List>{};
+    var sourceReads = 0;
+
+    RecentThumbnailCache buildCache() => RecentThumbnailCache(
+          readBytes: (path, {bookmark}) async {
+            sourceReads++;
+            return pdf;
+          },
+          readStored: (key) async => stored[key],
+          writeStored: (key, bytes) async {
+            stored[key] = Uint8List.fromList(bytes);
+          },
+          pruneStored: (keep) async {
+            stored.removeWhere((key, _) => !keep.contains(key));
+          },
+        );
+
+    final firstCache = buildCache();
+    late RecentThumbnail first;
+    await tester.runAsync(() async {
+      first = (await firstCache.thumbnailFor(entry(path: r'Z:\a.pdf')))!;
+    });
+    firstCache.dispose();
+    expect(sourceReads, 1);
+    expect(stored, hasLength(1));
+
+    final secondCache = buildCache();
+    addTearDown(secondCache.dispose);
+    late RecentThumbnail second;
+    await tester.runAsync(() async {
+      second = (await secondCache.thumbnailFor(entry(path: r'Z:\a.pdf')))!;
+    });
+
+    expect(sourceReads, 1, reason: 'the network source must not be read again');
+    expect(second.aspectRatio, first.aspectRatio);
+    expect(second.pngBytes, first.pngBytes);
+  });
+
   test('serializes thumbnail reads instead of hydrating recents together',
       () async {
     final first = Completer<Uint8List>();
     final second = Completer<Uint8List>();
     final reads = <String>[];
-    final cache = RecentThumbnailCache(readBytes: (path, {bookmark}) {
-      reads.add(path);
-      return path == '/a.pdf' ? first.future : second.future;
-    });
+    final cache = RecentThumbnailCache(
+        readBytes: (path, {bookmark}) {
+          reads.add(path);
+          return path == '/a.pdf' ? first.future : second.future;
+        },
+        readStored: (_) async => null);
     addTearDown(cache.dispose);
 
     final a = cache.thumbnailFor(entry(path: '/a.pdf'));

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -140,7 +140,7 @@ void main() {
     await tester.pump();
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    expect(find.text('Opening slow.pdf…'), findsOneWidget);
+    expect(find.text('Opening slow…'), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 100));
     expect(find.byType(CircularProgressIndicator), findsNothing);
@@ -413,14 +413,15 @@ void main() {
       find.byKey(const ValueKey('tab-hover-preview-thumbnail')),
     );
     expect(thumbnailSize.width / thumbnailSize.height, closeTo(792 / 612, .01));
-    expect(
-      tester
-          .widget<MiddleEllipsisText>(
-            find.byKey(const ValueKey('tab-hover-preview-title')),
-          )
-          .data,
-      'alpha.pdf',
+    final previewTitle = find.byKey(
+      const ValueKey('tab-hover-preview-title'),
     );
+    final previewTitleWidget = tester.widget<MiddleEllipsisText>(previewTitle);
+    expect(previewTitleWidget.data, 'alpha.pdf');
+    expect(previewTitleWidget.hidePdfExtension, isTrue);
+    // ignore: avoid_dynamic_calls
+    expect((tester.renderObject(previewTitle) as dynamic).debugDisplayedText,
+        'alpha');
     expect(
       tester
           .widget<Text>(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -76,6 +76,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.pageColor = const Color(0xFFFFFFFF),
     this.showAnnotations = true,
     this.dock = PdfPanelDock.left,
+    this.scrollDirection,
     this.resizable = true,
     this.minWidth = 100,
     this.maxWidth = 400,
@@ -106,8 +107,8 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// The viewer to navigate when a thumbnail is tapped.
   final PdfViewerController viewerController;
 
-  /// The default width - a user-dragged width, persisted in
-  /// [PdfEditingPreferences.thumbnailSidebarWidth], wins over it.
+  /// The default dock extent: width at the left/right edges, height at the
+  /// top/bottom edges. A user-dragged persisted extent wins over it.
   final double width;
 
   /// The paper color thumbnails render on - pass the viewer's
@@ -119,13 +120,19 @@ class PdfThumbnailSidebar extends StatefulWidget {
   final bool showAnnotations;
 
   /// Which edge of the viewer the panel docks on; the resize grip rides
-  /// the opposite (inner) edge.
+  /// the opposite (inner) edge. A docked strip scrolls vertically at the
+  /// left/right edges and horizontally at the top/bottom edges.
   final PdfPanelDock dock;
+
+  /// Overrides the page-strip axis. Null follows [dock] for a docked panel
+  /// and stays vertical in bottom-sheet mode. Tabbed top/bottom panels use
+  /// this to retain their dock's horizontal layout inside the shared frame.
+  final Axis? scrollDirection;
 
   /// Whether the inner edge can be dragged to resize the panel.
   final bool resizable;
 
-  /// Clamps for the dragged width.
+  /// Clamps for the dragged dock extent.
   final double minWidth;
   final double maxWidth;
 
@@ -192,6 +199,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   final Map<int, GlobalKey> _tileKeys = {};
 
   PdfSidebarPanelGeometry? _frameGeometry;
+
+  /// The list's current axis and raster width, captured during layout so
+  /// reveal estimates and external-drop hit testing match what is painted.
+  Axis _layoutAxis = Axis.vertical;
+  double? _layoutTileWidth;
 
   int _lastCurrent = 0;
 
@@ -398,6 +410,12 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// clearance.
   double get _tileWidth => _frameWidth - 26 - _extraRightPadding;
 
+  Axis get _requestedScrollAxis =>
+      widget.scrollDirection ??
+      (widget.bottomSheet || widget.dock.isHorizontal
+          ? Axis.vertical
+          : Axis.horizontal);
+
   @override
   void initState() {
     super.initState();
@@ -475,8 +493,10 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       panelContext: context,
       tileKeys: _tileKeys,
       pageCount: widget.controller.document.pageCount,
-      axis: Axis.vertical,
+      axis: _layoutAxis,
       globalPosition: globalPosition,
+      reversed: _layoutAxis == Axis.horizontal &&
+          Directionality.of(context) == TextDirection.rtl,
     );
   }
 
@@ -538,9 +558,9 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     cache.put(key, image);
   }
 
-  /// Scrolls the strip the minimal distance that makes [index]'s tile
-  /// fully visible. Unbuilt tiles get a jump to an estimated offset
-  /// first; the post-frame pass fine-tunes against the real layout.
+  /// Scrolls the strip the minimal distance along its current axis that makes
+  /// [index]'s tile fully visible. Unbuilt tiles get a jump to an estimated
+  /// offset first; the post-frame pass fine-tunes against the real layout.
   void _revealPage(int index) {
     if (_ensureTileVisible(index)) return;
     if (!_scroll.hasClients) return;
@@ -568,11 +588,15 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     return true;
   }
 
-  /// The list offset where [index]'s tile roughly starts, from the same
-  /// layout math the tiles use (12px side padding, 1px border, 4px
-  /// vertical padding, ~28px footer row).
+  /// The list offset where [index]'s tile roughly starts, using the active
+  /// vertical-column or horizontal-strip tile geometry.
   double _estimateOffset(int index) {
-    final thumbWidth = _tileWidth;
+    final thumbWidth = _layoutTileWidth ?? _tileWidth;
+    if (_layoutAxis == Axis.horizontal) {
+      // Every horizontal strip tile has the same outer width: thumbnail
+      // raster width plus the tile chip's 21px horizontal inset.
+      return 8 + index * (thumbWidth + 21);
+    }
     var offset = 8.0; // the list's top padding
     for (var i = 0; i < index; i++) {
       final size = PdfPageRenderer.pageSize(widget.controller.pageAt(i));
@@ -609,37 +633,40 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // persist thumbnails to disk (bound to this document) so a later session
     // opens onto already-rendered pages instead of re-interpreting them
     _cache.disk = widget.rasterCache;
-    // (re)arm the idle background prerender of every page into the shared
-    // cache, at the resolution this strip renders, so the page grid and
-    // scrolling back open onto already-cached thumbnails. A paced loop that
-    // yields to every visible tile, so it never delays one.
-    final pixelWidth =
-        _thumbnailBucket(_tileWidth * MediaQuery.devicePixelRatioOf(context));
-    // ...and hold it off entirely while the viewer is rendering: the warm's
-    // replay/rasterize run on the platform thread, so a lower worker priority
-    // alone still lets it land on the frame the visible page needs (#603).
-    _cache.bindForegroundGate(
-        widget.viewerController.pageRenderActivity, _viewerRenderBusy);
-    if (pdfShouldWarmThumbnails(controller.document.pageCount)) {
-      _cache.setWarm(
-        this,
-        controller.document.pageCount,
-        '$pixelWidth|${widget.pageColor.toARGB32()}|${widget.showAnnotations}',
-        (index) => _warmRender(index, pixelWidth),
-      );
-    } else {
-      // On web, rasterizing even a 128 px thumbnail replays the entire vector
-      // picture through CanvasKit and can monopolize the platform thread for
-      // hundreds of milliseconds. Long documents use on-demand tiles plus
-      // the viewer's already-cached soft previews instead of speculatively
-      // paying that cost for every off-screen page.
-      _cache.clearWarm(this);
+    void configureWarm(double tileWidth) {
+      // (re)arm the idle background prerender at the resolution this layout
+      // uses. Top/bottom docks size tiles from the strip height, so this must
+      // run after that cross-axis extent is known.
+      final pixelWidth =
+          _thumbnailBucket(tileWidth * MediaQuery.devicePixelRatioOf(context));
+      // Hold it off entirely while the viewer is rendering: the warm's
+      // replay/rasterize run on the platform thread, so a lower worker
+      // priority alone still lets it land on the frame the visible page
+      // needs (#603).
       _cache.bindForegroundGate(
           widget.viewerController.pageRenderActivity, _viewerRenderBusy);
+      if (pdfShouldWarmThumbnails(controller.document.pageCount)) {
+        _cache.setWarm(
+          this,
+          controller.document.pageCount,
+          '$pixelWidth|${widget.pageColor.toARGB32()}|${widget.showAnnotations}',
+          (index) => _warmRender(index, pixelWidth),
+        );
+      } else {
+        // Long web documents render visible tiles on demand and reuse the
+        // viewer's soft previews instead of warming every off-screen page.
+        _cache.clearWarm(this);
+        _cache.bindForegroundGate(
+            widget.viewerController.pageRenderActivity, _viewerRenderBusy);
+      }
     }
+
     // pages a shift-click would select from the current hover - painted as
     // a ghost of the selection chip while Shift is held
     final rangePreview = _rangePreview;
+    final scrollAxis = _requestedScrollAxis;
+    final horizontal = scrollAxis == Axis.horizontal;
+    _layoutAxis = scrollAxis;
     // a bottom sheet supplies its own width and resize affordance, so the
     // strip drops the side resize grip; the tile column keeps its preferred
     // width, centered in the wider sheet rather than stretched
@@ -661,61 +688,146 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                 listenable: controller,
                 // the implicit desktop scrollbar is replaced by the
                 // viewer-style bar below
-                builder: (context, _) {
-                  // the tile a paste would land after while the mouse hovers -
-                  // marked with an insertion bar. Computed here, inside the
-                  // controller's builder, so filling/clearing the clipboard
-                  // (a controller notification) re-evaluates it.
-                  final pasteInsertionPage = _pasteInsertionPage;
-                  // ...and the slot an external PDF being dragged over the
-                  // strip would drop into. The marker rides the top edge of
-                  // the tile the pages would land before - or the bottom
-                  // edge of the last tile for a drop past the end.
-                  final dropIndex = widget.fileDropController
-                      ?.indicatorIndexFor(_dropResolver);
-                  final pageCount = controller.document.pageCount;
-                  return Column(
-                    children: [
-                      // page-level file actions sit in a slim header at the top so
-                      // they never collide with the floating editing toolbar (or a
-                      // snackbar) that hugs the bottom of the viewport. The slot is
-                      // a fixed height and always present, so swapping in the bulk-
-                      // action bar when 2+ pages are selected never reflows the
-                      // tiles below (a single selection is just the navigation
-                      // cursor - the per-tile delete handles it).
-                      Padding(
+                builder: (context, _) => LayoutBuilder(
+                  builder: (context, constraints) {
+                    final horizontalGripTop = horizontal &&
+                            !geometry.bottomSheet &&
+                            geometry.showGrip &&
+                            geometry.dock == PdfPanelDock.bottom
+                        ? PdfSidebarResizeGrip.width
+                        : 0.0;
+                    final horizontalGripBottom = horizontal &&
+                            !geometry.bottomSheet &&
+                            geometry.showGrip &&
+                            geometry.dock == PdfPanelDock.top
+                        ? PdfSidebarResizeGrip.width
+                        : 0.0;
+                    final horizontalTopPadding = 8 + horizontalGripTop;
+                    final horizontalBottomPadding =
+                        PdfScrollbar.hitExtent + horizontalGripBottom;
+                    // Side docks size the thumbnail from panel width. A
+                    // top/bottom strip instead uses its available height and
+                    // a portrait-page ratio; landscape pages keep the same
+                    // item width and simply leave more air above/below.
+                    final tileWidth = horizontal
+                        ? math.max(
+                            32.0,
+                            (constraints.maxHeight -
+                                    horizontalTopPadding -
+                                    horizontalBottomPadding -
+                                    33) *
+                                0.75,
+                          )
+                        : _tileWidth;
+                    _layoutTileWidth = tileWidth;
+                    configureWarm(tileWidth);
+                    // the tile a paste would land after while the mouse hovers -
+                    // marked with an insertion bar. Computed here, inside the
+                    // controller's builder, so filling/clearing the clipboard
+                    // (a controller notification) re-evaluates it.
+                    final pasteInsertionPage = _pasteInsertionPage;
+                    // ...and the slot an external PDF being dragged over the
+                    // strip would drop into. The marker rides the top edge of
+                    // the tile the pages would land before - or the bottom
+                    // edge of the last tile for a drop past the end.
+                    final dropIndex = widget.fileDropController
+                        ?.indicatorIndexFor(_dropResolver);
+                    final pageCount = controller.document.pageCount;
+                    final rtl = Directionality.of(context) == TextDirection.rtl;
+                    final showPageActions = widget.onPickPdfToInsert != null ||
+                        widget.onExportPages != null ||
+                        (widget.allowPageEditing &&
+                            controller.hasPageClipboard);
+                    final moveHandle = geometry.moveHandle(
+                      key: const ValueKey('pdf-thumbnail-panel-move'),
+                    );
+                    final closeButton = geometry.closeButton(
+                      key: const ValueKey('pdf-thumbnail-panel-close'),
+                    );
+
+                    final verticalHeader = Padding(
+                      padding: EdgeInsets.fromLTRB(
+                          8 + inset, 2, _extraRightPadding + inset, 2),
+                      child: SizedBox(
+                        height: 36,
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: controller.selectedPageCount > 1
+                                  ? _PageSelectionBar(
+                                      controller: controller,
+                                      allowPageEditing: widget.allowPageEditing,
+                                      onExportPages: widget.onExportPages,
+                                      compact: true,
+                                    )
+                                  : Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            pdfL10n(context).thumbPages,
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .labelMedium,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ),
+                                        if (showPageActions)
+                                          _PageActionsButton(
+                                            controller: controller,
+                                            viewerController:
+                                                widget.viewerController,
+                                            allowPageEditing:
+                                                widget.allowPageEditing,
+                                            onPickPdfToInsert:
+                                                widget.onPickPdfToInsert,
+                                            onExportPages: widget.onExportPages,
+                                          ),
+                                      ],
+                                    ),
+                            ),
+                            if (moveHandle != null) moveHandle,
+                            if (closeButton != null) closeButton,
+                          ],
+                        ),
+                      ),
+                    );
+
+                    // A top/bottom panel is a true strip: its header occupies
+                    // a compact leading cell instead of consuming a row above
+                    // the thumbnails, leaving the full panel height available
+                    // to the horizontal page sequence.
+                    final horizontalHeader = SizedBox(
+                      width: 140,
+                      child: Padding(
                         padding: EdgeInsets.fromLTRB(
-                            8 + inset, 2, _extraRightPadding + inset, 2),
-                        child: SizedBox(
-                          height: 36,
-                          child: Row(
-                            children: [
+                            rtl ? 4 : 8, 8 + horizontalGripTop, rtl ? 8 : 4, 8),
+                        child: Column(
+                          children: [
+                            Row(children: [
                               Expanded(
-                                child: controller.selectedPageCount > 1
-                                    ? _PageSelectionBar(
+                                child: Text(
+                                  pdfL10n(context).thumbPages,
+                                  style:
+                                      Theme.of(context).textTheme.labelMedium,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              if (moveHandle != null) moveHandle,
+                              if (closeButton != null) closeButton,
+                            ]),
+                            Expanded(
+                              child: controller.selectedPageCount > 1
+                                  ? SingleChildScrollView(
+                                      child: _PageSelectionBar(
                                         controller: controller,
                                         allowPageEditing:
                                             widget.allowPageEditing,
                                         onExportPages: widget.onExportPages,
-                                        compact: true,
-                                      )
-                                    : Row(
-                                        children: [
-                                          Expanded(
-                                            child: Text(
-                                              pdfL10n(context).thumbPages,
-                                              style: Theme.of(context)
-                                                  .textTheme
-                                                  .labelMedium,
-                                              overflow: TextOverflow.ellipsis,
-                                            ),
-                                          ),
-                                          if (widget.onPickPdfToInsert !=
-                                                  null ||
-                                              widget.onExportPages != null ||
-                                              (widget.allowPageEditing &&
-                                                  controller.hasPageClipboard))
-                                            _PageActionsButton(
+                                      ),
+                                    )
+                                  : Center(
+                                      child: showPageActions
+                                          ? _PageActionsButton(
                                               controller: controller,
                                               viewerController:
                                                   widget.viewerController,
@@ -725,125 +837,156 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                                   widget.onPickPdfToInsert,
                                               onExportPages:
                                                   widget.onExportPages,
-                                            ),
-                                        ],
-                                      ),
-                              ),
-                              // the drag-to-redock handle and the docked
-                              // strip's close button; a bottom sheet supplies
-                              // its own close in its sheet chrome
-                              if (geometry.moveHandle(
-                                key: const ValueKey('pdf-thumbnail-panel-move'),
-                              )
-                                  case final moveHandle?)
-                                moveHandle,
-                              if (geometry.closeButton(
-                                key:
-                                    const ValueKey('pdf-thumbnail-panel-close'),
-                              )
-                                  case final closeButton?)
-                                closeButton,
-                            ],
-                          ),
-                        ),
-                      ),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: ScrollConfiguration.of(context)
-                              .copyWith(scrollbars: false),
-                          child: ReorderableListView.builder(
-                            scrollController: _scroll,
-                            buildDefaultDragHandles: false,
-                            padding: EdgeInsets.fromLTRB(
-                                inset, 8, _extraRightPadding + inset, 8),
-                            itemCount: controller.document.pageCount,
-                            onReorderStart: (index) =>
-                                setState(() => _reorderPage = index),
-                            onReorderEnd: (_) {
-                              if (mounted) setState(() => _reorderPage = null);
-                            },
-                            proxyDecorator: (child, index, animation) {
-                              final count = controller.isPageSelected(index)
-                                  ? controller.selectedPageCount
-                                  : 1;
-                              return count > 1
-                                  ? _MultiPageDragProxy(
-                                      count: count, child: child)
-                                  : child;
-                            },
-                            onReorderItem: controller.movePage,
-                            itemBuilder: (context, index) {
-                              Widget tile = _PageTile(
-                                key: _tileKeys[index] ??= GlobalKey(),
-                                controller: controller,
-                                viewerController: widget.viewerController,
-                                pageIndex: index,
-                                pageColor: widget.pageColor,
-                                showAnnotations: widget.showAnnotations,
-                                allowPageEditing: widget.allowPageEditing,
-                                onExportPages: widget.onExportPages,
-                                cache: _cache,
-                                tileWidth: _tileWidth,
-                                renderWorker: widget.renderWorker,
-                                inRangePreview: rangePreview.contains(index),
-                                showPasteIndicator: pasteInsertionPage == index,
-                                dropEdge: _tileDropEdge(
-                                  dropIndex,
-                                  index,
-                                  pageCount,
-                                  Axis.vertical,
-                                ),
-                                showPageActions:
-                                    !pdfPanelControlsRevealOnHover() ||
-                                        _hoverPage == index,
-                                onHover: (hovering) =>
-                                    _setHover(index, hovering),
-                                onFocusPage: _focusPage,
-                              );
-                              if (_reorderPage != null &&
-                                  index != _reorderPage &&
-                                  controller.isPageSelected(_reorderPage!) &&
-                                  controller.isPageSelected(index)) {
-                                tile = Opacity(
-                                  key: ValueKey(
-                                      'pdf-thumbnail-reorder-companion-$index'),
-                                  opacity: 0.35,
-                                  child: tile,
-                                );
-                              }
-                              // without the drag listener no reorder can ever start
-                              return widget.allowPageEditing
-                                  ? _ReorderDragStartListener(
-                                      key: ValueKey(index),
-                                      index: index,
-                                      child: tile)
-                                  : KeyedSubtree(
-                                      key: ValueKey(index), child: tile);
-                            },
-                          ),
-                        ),
-                      ),
-                      // a footer to append a blank page; only when the strip
-                      // is editable (a read-only strip is purely navigational)
-                      if (widget.allowPageEditing)
-                        Padding(
-                          padding: EdgeInsets.fromLTRB(
-                              4 + inset, 2, _extraRightPadding + inset, 4),
-                          child: TextButton.icon(
-                            key: const ValueKey('pdf-thumbnail-add-page'),
-                            icon: const Icon(Icons.add, size: 16),
-                            label: Text(pdfL10n(context).thumbAddPage),
-                            style: TextButton.styleFrom(
-                              visualDensity: VisualDensity.compact,
-                              textStyle:
-                                  Theme.of(context).textTheme.labelMedium,
+                                            )
+                                          : const SizedBox.shrink(),
+                                    ),
                             ),
-                            onPressed: () => controller.addBlankPage(),
+                          ],
+                        ),
+                      ),
+                    );
+
+                    Widget tiles = ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(context)
+                          .copyWith(scrollbars: false),
+                      child: ReorderableListView.builder(
+                        scrollDirection: scrollAxis,
+                        scrollController: _scroll,
+                        buildDefaultDragHandles: false,
+                        padding: horizontal
+                            ? EdgeInsets.fromLTRB(
+                                8,
+                                horizontalTopPadding,
+                                8,
+                                horizontalBottomPadding,
+                              )
+                            : EdgeInsets.fromLTRB(
+                                inset, 8, _extraRightPadding + inset, 8),
+                        itemCount: controller.document.pageCount,
+                        onReorderStart: (index) =>
+                            setState(() => _reorderPage = index),
+                        onReorderEnd: (_) {
+                          if (mounted) setState(() => _reorderPage = null);
+                        },
+                        proxyDecorator: (child, index, animation) {
+                          final count = controller.isPageSelected(index)
+                              ? controller.selectedPageCount
+                              : 1;
+                          return count > 1
+                              ? _MultiPageDragProxy(count: count, child: child)
+                              : child;
+                        },
+                        onReorderItem: controller.movePage,
+                        itemBuilder: (context, index) {
+                          Widget tile = _PageTile(
+                            key: _tileKeys[index] ??= GlobalKey(),
+                            controller: controller,
+                            viewerController: widget.viewerController,
+                            pageIndex: index,
+                            pageColor: widget.pageColor,
+                            showAnnotations: widget.showAnnotations,
+                            allowPageEditing: widget.allowPageEditing,
+                            onExportPages: widget.onExportPages,
+                            cache: _cache,
+                            tileWidth: tileWidth,
+                            renderWorker: widget.renderWorker,
+                            scrollAxis: scrollAxis,
+                            reversed: horizontal && rtl,
+                            inRangePreview: rangePreview.contains(index),
+                            showPasteIndicator: pasteInsertionPage == index,
+                            dropEdge: _tileDropEdge(
+                              dropIndex,
+                              index,
+                              pageCount,
+                              scrollAxis,
+                              reversed: horizontal && rtl,
+                            ),
+                            showPageActions: !pdfPanelControlsRevealOnHover() ||
+                                _hoverPage == index,
+                            onHover: (hovering) => _setHover(index, hovering),
+                            onFocusPage: _focusPage,
+                          );
+                          if (horizontal) {
+                            tile = SizedBox(width: tileWidth + 21, child: tile);
+                          }
+                          if (_reorderPage != null &&
+                              index != _reorderPage &&
+                              controller.isPageSelected(_reorderPage!) &&
+                              controller.isPageSelected(index)) {
+                            tile = Opacity(
+                              key: ValueKey(
+                                  'pdf-thumbnail-reorder-companion-$index'),
+                              opacity: 0.35,
+                              child: tile,
+                            );
+                          }
+                          // Without the drag listener no reorder can start.
+                          return widget.allowPageEditing
+                              ? _ReorderDragStartListener(
+                                  key: ValueKey(index),
+                                  index: index,
+                                  child: tile,
+                                )
+                              : KeyedSubtree(key: ValueKey(index), child: tile);
+                        },
+                      ),
+                    );
+                    if (horizontal) {
+                      tiles = Stack(children: [
+                        Positioned.fill(child: tiles),
+                        Positioned(
+                          left: 0,
+                          right: 0,
+                          bottom: horizontalGripBottom,
+                          child: PdfScrollbar(
+                            scroll: _scroll,
+                            axis: Axis.horizontal,
+                            thumbKey:
+                                const ValueKey('pdf-thumbnail-scrollbar-thumb'),
                           ),
                         ),
-                    ],
-                  );
-                },
+                      ]);
+                    }
+
+                    final addPage = TextButton.icon(
+                      key: const ValueKey('pdf-thumbnail-add-page'),
+                      icon: const Icon(Icons.add, size: 16),
+                      label: Text(pdfL10n(context).thumbAddPage),
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        textStyle: Theme.of(context).textTheme.labelMedium,
+                      ),
+                      onPressed: () => controller.addBlankPage(),
+                    );
+
+                    return Flex(
+                      direction: scrollAxis,
+                      children: [
+                        if (horizontal) horizontalHeader else verticalHeader,
+                        Expanded(child: tiles),
+                        // a footer to append a blank page; only when the strip
+                        // is editable (a read-only strip is purely navigational)
+                        if (widget.allowPageEditing)
+                          horizontal
+                              ? SizedBox(
+                                  width: 110,
+                                  child: Padding(
+                                    padding: EdgeInsets.only(
+                                      top: horizontalGripTop,
+                                      bottom: 8,
+                                    ),
+                                    child: Center(child: addPage),
+                                  ),
+                                )
+                              : Padding(
+                                  padding: EdgeInsets.fromLTRB(4 + inset, 2,
+                                      _extraRightPadding + inset, 4),
+                                  child: addPage,
+                                ),
+                      ],
+                    );
+                  },
+                ),
               ),
             ),
           ),
@@ -852,6 +995,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // looks and behaves alike
     final scrollbar = PdfScrollbar(
       scroll: _scroll,
+      axis: scrollAxis,
       thumbKey: const ValueKey('pdf-thumbnail-scrollbar-thumb'),
     );
     // an outline around the whole strip while a file drag hovers it, so the
@@ -878,10 +1022,13 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // the scrollbar pins to the sheet's right edge over the margin
     if (widget.bottomSheet) {
       return LayoutBuilder(builder: (context, constraints) {
-        final inset = math.max(0.0, (constraints.maxWidth - width) / 2);
+        final inset = horizontal
+            ? 0.0
+            : math.max(0.0, (constraints.maxWidth - width) / 2);
         return Stack(children: [
           Positioned.fill(child: buildList(inset)),
-          Positioned(top: 0, bottom: 0, right: 0, child: scrollbar),
+          if (!horizontal)
+            Positioned(top: 0, bottom: 0, right: 0, child: scrollbar),
           if (dropOutline != null) dropOutline,
         ]);
       });
@@ -891,12 +1038,13 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       Positioned.fill(child: buildList(0)),
       // stepped off the resize grip when the grip rides the same
       // (right) edge
-      Positioned(
-        top: 0,
-        bottom: 0,
-        right: geometry.scrollbarInset,
-        child: scrollbar,
-      ),
+      if (!horizontal)
+        Positioned(
+          top: 0,
+          bottom: 0,
+          right: geometry.scrollbarInset,
+          child: scrollbar,
+        ),
       if (dropOutline != null) dropOutline,
     ]);
   }
@@ -1888,6 +2036,7 @@ class _GridPageCell extends StatefulWidget {
   final PdfThumbnailCache cache;
   final double tileWidth;
   final PdfRenderWorker? renderWorker;
+
   final void Function(int pageIndex) onActivatePage;
   final bool dimmed;
   final VoidCallback onDragStarted;
@@ -2137,6 +2286,8 @@ class _PageTile extends StatefulWidget {
     required this.cache,
     required this.tileWidth,
     required this.renderWorker,
+    this.scrollAxis = Axis.vertical,
+    this.reversed = false,
     this.onActivatePage,
     this.activateOnTap = true,
     this.inRangePreview = false,
@@ -2158,15 +2309,22 @@ class _PageTile extends StatefulWidget {
   final double tileWidth;
   final PdfRenderWorker? renderWorker;
 
+  /// The containing strip's scroll axis. Paste markers trail a vertical
+  /// strip at the bottom and a horizontal strip at its reading-order end.
+  final Axis scrollAxis;
+
+  /// Whether the horizontal reading direction runs right-to-left.
+  final bool reversed;
+
   /// Whether a shift-click on this tile would add it to the selection
   /// right now - painted as a faint preview of the selection chip while
   /// the strip's Shift hover is live. Ignored when already [selected].
   final bool inRangePreview;
 
-  /// Whether to paint a paste-insertion bar along this tile's bottom edge:
-  /// the strip sets it on the tile the mouse hovers while the shared page
-  /// clipboard has pages, marking where ⌘/Ctrl+V (or the strip's paste)
-  /// will drop them - right after this page. The grid leaves it false.
+  /// Whether to paint a paste-insertion bar along this tile's trailing edge:
+  /// bottom in a vertical strip, reading-order end in a horizontal one. The
+  /// strip sets it on the hovered tile while the page clipboard has pages,
+  /// marking where ⌘/Ctrl+V (or the strip's paste) will drop them.
   final bool showPasteIndicator;
 
   /// The edge to paint a file-drop insertion marker on while a PDF dragged
@@ -2217,6 +2375,8 @@ class _PageTileState extends State<_PageTile> {
   PdfThumbnailCache get cache => widget.cache;
   double get tileWidth => widget.tileWidth;
   PdfRenderWorker? get renderWorker => widget.renderWorker;
+  Axis get scrollAxis => widget.scrollAxis;
+  bool get reversed => widget.reversed;
   bool get inRangePreview => widget.inRangePreview;
   bool get showPasteIndicator => widget.showPasteIndicator;
   PdfThumbnailDropEdge? get dropEdge => widget.dropEdge;
@@ -2502,17 +2662,20 @@ class _PageTileState extends State<_PageTile> {
     // hovers the strip; it never eats a pointer, so tap/drag still work
     Widget content = tile;
     if (showPasteIndicator) {
+      final horizontal = scrollAxis == Axis.horizontal;
       content = Stack(
         children: [
           content,
           Positioned(
-            left: 0,
-            right: 0,
+            left: horizontal && !reversed ? null : 0,
+            right: horizontal && reversed ? null : 0,
+            top: horizontal ? 0 : null,
             bottom: 0,
             child: IgnorePointer(
               child: _InsertionMarker(
                 key: ValueKey('pdf-thumbnail-paste-indicator-$pageIndex'),
                 color: scheme.primary,
+                axis: horizontal ? Axis.vertical : Axis.horizontal,
               ),
             ),
           ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1345,6 +1345,22 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   // ---- desktop: dock + contextual strip -----------------------------------
 
+  /// The contextual toolbar follows the primary dock: a side dock stacks
+  /// controls vertically, while a top/bottom dock keeps the familiar row.
+  Axis get _stripAxis =>
+      widget.dock.isHorizontal ? Axis.vertical : Axis.horizontal;
+
+  Widget _stripFlex(List<Widget> children) => Flex(
+        direction: _stripAxis,
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: children,
+      );
+
+  Widget _intrinsicStrip(Widget child) => _stripAxis == Axis.horizontal
+      ? IntrinsicHeight(child: child)
+      : IntrinsicWidth(child: child);
+
   Widget _buildDesktop(BuildContext context) {
     final strip = _desktopStrip(context);
     if (widget.dock.isHorizontal) {
@@ -1397,9 +1413,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     return _groupStrip(context, group);
   }
 
-  /// A horizontally-centred floating card. When the controls overflow, the
-  /// controls scroll inside the card so the rounded card edge never gets
-  /// clipped by the viewer or scrollbar gutter.
+  /// A dock-aligned floating card. When the controls overflow, they scroll
+  /// along the toolbar's axis so the rounded card edge never gets clipped by
+  /// the viewer or scrollbar gutter.
   Widget _centeredCard(
     BuildContext context, {
     required Widget child,
@@ -1594,102 +1610,113 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       toolButtons.add(_takeoffButton(context));
     }
 
-    final settings = _groupSettings(context, group);
-    final row = IntrinsicHeight(
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 7, 10, 7),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
-              _StripLabel(
-                group.label(context),
-                hint: group.id == 'markup' &&
-                        !hasTextSelection &&
-                        controller.markupTool == null
-                    ? pdfL10n(context).tbSelectTextForMarkup
-                    : null,
-              ),
-              ...toolButtons,
-            ]),
-          ),
-          if (settings.isNotEmpty) ...[
-            const _StripDivider(),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(10, 7, 12, 7),
-              child: Row(mainAxisSize: MainAxisSize.min, children: settings),
+    final settings = _groupSettings(context, group, axis: _stripAxis);
+    final strip = _intrinsicStrip(
+      _stripFlex([
+        Padding(
+          padding: _stripAxis == Axis.horizontal
+              ? const EdgeInsets.fromLTRB(12, 7, 10, 7)
+              : const EdgeInsets.fromLTRB(7, 12, 7, 10),
+          child: _stripFlex([
+            _StripLabel(
+              group.label(context),
+              axis: _stripAxis,
+              hint: group.id == 'markup' &&
+                      !hasTextSelection &&
+                      controller.markupTool == null
+                  ? pdfL10n(context).tbSelectTextForMarkup
+                  : null,
             ),
-          ],
+            ...toolButtons,
+          ]),
+        ),
+        if (settings.isNotEmpty) ...[
+          _StripDivider(axis: _stripAxis),
+          Padding(
+            padding: _stripAxis == Axis.horizontal
+                ? const EdgeInsets.fromLTRB(10, 7, 12, 7)
+                : const EdgeInsets.fromLTRB(7, 10, 7, 12),
+            child: _stripFlex(settings),
+          ),
         ],
-      ),
+      ]),
     );
-    return _centeredCard(context, padding: EdgeInsets.zero, child: row);
+    return _centeredCard(
+      context,
+      padding: EdgeInsets.zero,
+      scrollDirection: _stripAxis,
+      child: strip,
+    );
   }
 
   /// The settings cluster for the active tool of [group].
-  List<Widget> _groupSettings(BuildContext context, _ToolGroup group) {
+  List<Widget> _groupSettings(
+    BuildContext context,
+    _ToolGroup group, {
+    Axis axis = Axis.horizontal,
+  }) {
     final tool = controller.tool;
     final fields = _groupStyleFields(group);
     switch (group.id) {
       case 'markup':
         return [
           ..._colorCluster(context),
-          if (widget.showColor && widget.showStyle) const _MiniDivider(),
+          if (widget.showColor && widget.showStyle) _MiniDivider(axis: axis),
           _opacitySlider(context),
-          ..._tuneTrailing(context, fields),
+          ..._tuneTrailing(context, fields, axis: axis),
         ];
       case 'draw':
         if (tool == null && viewerController.hasSelection) {
           return [
             ..._colorCluster(context),
-            if (widget.showColor && widget.showStyle) const _MiniDivider(),
+            if (widget.showColor && widget.showStyle) _MiniDivider(axis: axis),
             _opacitySlider(context),
-            ..._tuneTrailing(context, fields),
+            ..._tuneTrailing(context, fields, axis: axis),
           ];
         }
         if (tool == PdfEditTool.eraser) {
           return [
             ..._drawToolExtras(context),
-            ..._tuneTrailing(context, fields),
+            ..._tuneTrailing(context, fields, axis: axis),
           ];
         }
         return [
           ..._colorCluster(context),
-          if (widget.showColor) const _MiniDivider(),
+          if (widget.showColor) _MiniDivider(axis: axis),
           _strokePresets(context),
-          const _MiniDivider(),
+          _MiniDivider(axis: axis),
           _opacitySlider(context),
           ..._drawToolExtras(context),
-          ..._tuneTrailing(context, fields),
+          ..._tuneTrailing(context, fields, axis: axis),
         ];
       case 'shapes':
         return [
           ..._colorCluster(context),
-          if (widget.showColor) const _MiniDivider(),
+          if (widget.showColor) _MiniDivider(axis: axis),
           _strokePresets(context),
-          const _MiniDivider(),
+          _MiniDivider(axis: axis),
           _opacitySlider(context),
-          ..._tuneTrailing(context, fields),
+          ..._tuneTrailing(context, fields, axis: axis),
         ];
       case 'insert':
         return [
           ..._colorCluster(context),
-          if (widget.showColor) const _MiniDivider(),
+          if (widget.showColor) _MiniDivider(axis: axis),
           _opacitySlider(context),
           ..._insertToolExtras(context),
-          ..._tuneTrailing(context, fields),
+          ..._tuneTrailing(context, fields, axis: axis),
         ];
       case 'measure':
         return [
           ..._colorCluster(context),
-          if (widget.showColor) const _MiniDivider(),
+          if (widget.showColor) _MiniDivider(axis: axis),
           _strokePresets(context),
-          const _MiniDivider(),
+          _MiniDivider(axis: axis),
           _scaleChip(context),
-          ..._tuneTrailing(context, fields),
+          ..._tuneTrailing(context, fields, axis: axis),
         ];
       case 'edit':
-        return _editToolExtras(context);
+        return _editToolExtras(context, axis: axis);
       default:
         return const [];
     }
@@ -1754,7 +1781,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// and the redaction apply button (each shows only with its tool armed),
   /// plus the document-wide Flatten action (which moved here from the
   /// dock, gated by [PdfEditingToolbar.showFlatten]).
-  List<Widget> _editToolExtras(BuildContext context) {
+  List<Widget> _editToolExtras(
+    BuildContext context, {
+    Axis axis = Axis.horizontal,
+  }) {
     final tool = controller.tool;
     final flatten = widget.showFlatten
         ? _LabeledToolButton(
@@ -1767,7 +1797,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         : null;
     if (tool == PdfEditTool.form) {
       return [
-        if (flatten != null) ...[flatten, const _MiniDivider()],
+        if (flatten != null) ...[flatten, _MiniDivider(axis: axis)],
         PopupMenuButton<PdfFormFieldKind>(
           key: const ValueKey('pdf-form-field-type'),
           tooltip: pdfL10n(context).tbNewFieldType,
@@ -1809,7 +1839,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     }
     if (tool == PdfEditTool.redact) {
       return [
-        if (flatten != null) ...[flatten, const _MiniDivider()],
+        if (flatten != null) ...[flatten, _MiniDivider(axis: axis)],
         IconButton(
           key: const ValueKey('pdf-apply-redactions'),
           icon: const Icon(Icons.check),
@@ -1833,70 +1863,83 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final settings = <Widget>[
       if (widget.showColor && canRestyle) ..._colorCluster(context),
       if (widget.showColor && canRestyle && widget.showStyle)
-        const _MiniDivider(),
+        _MiniDivider(axis: _stripAxis),
       if (canRestyle) _opacitySlider(context),
-      ..._tuneTrailing(context, _selectionStyleFields()),
+      ..._tuneTrailing(
+        context,
+        _selectionStyleFields(),
+        axis: _stripAxis,
+      ),
     ];
-    final row = IntrinsicHeight(
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 7, 10, 7),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
-              _StripLabel(selectedFieldName == null
+    final strip = _intrinsicStrip(
+      _stripFlex([
+        Padding(
+          padding: _stripAxis == Axis.horizontal
+              ? const EdgeInsets.fromLTRB(12, 7, 10, 7)
+              : const EdgeInsets.fromLTRB(7, 12, 7, 10),
+          child: _stripFlex([
+            _StripLabel(
+              selectedFieldName == null
                   ? pdfL10n(context).tbSelectionCount(
                       controller.selectedAnnotationSlots.length)
-                  : pdfL10n(context).tbFieldNamed(selectedFieldName)),
-              if (selectedFieldName != null)
-                ..._selectedFormFieldActions(context)
-              else
-                IconButton(
-                  icon: const Icon(Icons.delete_outline),
-                  tooltip: pdfL10n(context).tbDeleteAnnotations(
-                      controller.selectedAnnotationSlots.length),
-                  onPressed: controller.deleteSelected,
-                ),
-              if (controller.canCropSelected)
-                IconButton(
-                  key: const ValueKey('pdf-crop-image'),
-                  icon: const Icon(Icons.crop),
-                  tooltip: pdfL10n(context).tbCropImage,
-                  onPressed: controller.beginImageCrop,
-                ),
-              if (controller.canEditSelectedText)
-                IconButton(
-                  key: const ValueKey('pdf-edit-selected-text'),
-                  icon: const Icon(Icons.edit),
-                  tooltip: pdfL10n(context).tbEditAnnotationText,
-                  onPressed: () => _editSelectedText(context),
-                ),
-              if (controller.canRestyleSelectedText)
-                IconButton(
-                  icon: const Icon(Icons.fit_screen),
-                  tooltip: pdfL10n(context).tbAutosizeTextBox,
-                  onPressed: controller.autosizeSelectedTextBox,
-                ),
-            ]),
+                  : pdfL10n(context).tbFieldNamed(selectedFieldName),
+              axis: _stripAxis,
+            ),
+            if (selectedFieldName != null)
+              ..._selectedFormFieldActions(context)
+            else
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: pdfL10n(context).tbDeleteAnnotations(
+                    controller.selectedAnnotationSlots.length),
+                onPressed: controller.deleteSelected,
+              ),
+            if (controller.canCropSelected)
+              IconButton(
+                key: const ValueKey('pdf-crop-image'),
+                icon: const Icon(Icons.crop),
+                tooltip: pdfL10n(context).tbCropImage,
+                onPressed: controller.beginImageCrop,
+              ),
+            if (controller.canEditSelectedText)
+              IconButton(
+                key: const ValueKey('pdf-edit-selected-text'),
+                icon: const Icon(Icons.edit),
+                tooltip: pdfL10n(context).tbEditAnnotationText,
+                onPressed: () => _editSelectedText(context),
+              ),
+            if (controller.canRestyleSelectedText)
+              IconButton(
+                icon: const Icon(Icons.fit_screen),
+                tooltip: pdfL10n(context).tbAutosizeTextBox,
+                onPressed: controller.autosizeSelectedTextBox,
+              ),
+          ]),
+        ),
+        if (controller.canAlignSelected) ...[
+          _StripDivider(axis: _stripAxis),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
+            child: _alignmentCluster(context, axis: _stripAxis),
           ),
-          if (controller.canAlignSelected) ...[
-            const _StripDivider(),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
-              child: _alignmentCluster(context),
-            ),
-          ],
-          if (settings.isNotEmpty) ...[
-            const _StripDivider(),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(10, 7, 12, 7),
-              child: Row(mainAxisSize: MainAxisSize.min, children: settings),
-            ),
-          ],
         ],
-      ),
+        if (settings.isNotEmpty) ...[
+          _StripDivider(axis: _stripAxis),
+          Padding(
+            padding: _stripAxis == Axis.horizontal
+                ? const EdgeInsets.fromLTRB(10, 7, 12, 7)
+                : const EdgeInsets.fromLTRB(7, 10, 7, 12),
+            child: _stripFlex(settings),
+          ),
+        ],
+      ]),
     );
-    return _centeredCard(context, padding: EdgeInsets.zero, child: row);
+    return _centeredCard(
+      context,
+      padding: EdgeInsets.zero,
+      scrollDirection: _stripAxis,
+      child: strip,
+    );
   }
 
   /// The toolbar shown while the interactive image-crop tool is armed: a
@@ -1906,71 +1949,78 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   Widget _cropStrip(BuildContext context) {
     final l10n = pdfL10n(context);
     final hasCrop = controller.selectedAnnotation?.imageStampCrop != null;
-    final row = IntrinsicHeight(
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 7, 4, 7),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
-              _StripLabel(l10n.tbCroppingImage),
-              if (hasCrop)
-                IconButton(
-                  key: const ValueKey('pdf-crop-reset'),
-                  icon: const Icon(Icons.restart_alt),
-                  tooltip: l10n.tbCropReset,
-                  onPressed: () {
-                    controller.cancelImageCrop();
-                    controller.resetSelectedImageCrop();
-                  },
-                ),
-            ]),
-          ),
-          const _StripDivider(),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
-            child: Row(mainAxisSize: MainAxisSize.min, children: [
+    final strip = _intrinsicStrip(
+      _stripFlex([
+        Padding(
+          padding: _stripAxis == Axis.horizontal
+              ? const EdgeInsets.fromLTRB(12, 7, 4, 7)
+              : const EdgeInsets.fromLTRB(7, 12, 7, 4),
+          child: _stripFlex([
+            _StripLabel(l10n.tbCroppingImage, axis: _stripAxis),
+            if (hasCrop)
               IconButton(
-                key: const ValueKey('pdf-crop-cancel-toolbar'),
-                icon: const Icon(Icons.close),
-                tooltip: l10n.tbCropCancel,
-                onPressed: controller.cancelImageCrop,
+                key: const ValueKey('pdf-crop-reset'),
+                icon: const Icon(Icons.restart_alt),
+                tooltip: l10n.tbCropReset,
+                onPressed: () {
+                  controller.cancelImageCrop();
+                  controller.resetSelectedImageCrop();
+                },
               ),
-              IconButton(
-                key: const ValueKey('pdf-crop-apply-toolbar'),
-                icon: const Icon(Icons.check),
-                tooltip: l10n.tbCropApply,
-                onPressed: controller.commitImageCrop,
-              ),
-            ]),
-          ),
-        ],
-      ),
+          ]),
+        ),
+        _StripDivider(axis: _stripAxis),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
+          child: _stripFlex([
+            IconButton(
+              key: const ValueKey('pdf-crop-cancel-toolbar'),
+              icon: const Icon(Icons.close),
+              tooltip: l10n.tbCropCancel,
+              onPressed: controller.cancelImageCrop,
+            ),
+            IconButton(
+              key: const ValueKey('pdf-crop-apply-toolbar'),
+              icon: const Icon(Icons.check),
+              tooltip: l10n.tbCropApply,
+              onPressed: controller.commitImageCrop,
+            ),
+          ]),
+        ),
+      ]),
     );
-    return _centeredCard(context, padding: EdgeInsets.zero, child: row);
+    return _centeredCard(
+      context,
+      padding: EdgeInsets.zero,
+      scrollDirection: _stripAxis,
+      child: strip,
+    );
   }
 
   /// The align/distribute buttons shown while two or more annotations are
   /// selected: edge + centre alignment, then even-spacing distribution
   /// (which needs three, so those disable below that). Each button defers
   /// to [PdfEditingController.alignSelected].
-  Widget _alignmentCluster(BuildContext context) {
+  Widget _alignmentCluster(
+    BuildContext context, {
+    Axis axis = Axis.horizontal,
+  }) {
     final canDistribute = controller.canDistributeSelected;
-    return Row(mainAxisSize: MainAxisSize.min, children: [
+    return Flex(direction: axis, mainAxisSize: MainAxisSize.min, children: [
       _alignButton(PdfAlignment.left, Icons.align_horizontal_left,
           pdfL10n(context).tbAlignLeft),
       _alignButton(PdfAlignment.horizontalCenter, Icons.align_horizontal_center,
           pdfL10n(context).tbAlignHorizontalCenters),
       _alignButton(PdfAlignment.right, Icons.align_horizontal_right,
           pdfL10n(context).tbAlignRight),
-      const _MiniDivider(),
+      _MiniDivider(axis: axis),
       _alignButton(PdfAlignment.top, Icons.align_vertical_top,
           pdfL10n(context).tbAlignTop),
       _alignButton(PdfAlignment.verticalCenter, Icons.align_vertical_center,
           pdfL10n(context).tbAlignVerticalCenters),
       _alignButton(PdfAlignment.bottom, Icons.align_vertical_bottom,
           pdfL10n(context).tbAlignBottom),
-      const _MiniDivider(),
+      _MiniDivider(axis: axis),
       _alignButton(
           PdfAlignment.distributeHorizontal,
           Icons.horizontal_distribute,
@@ -1997,8 +2047,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   /// The strip shown while a page-content element is selected.
   Widget _elementStrip(BuildContext context) {
-    final row = Row(mainAxisSize: MainAxisSize.min, children: [
-      _StripLabel(pdfL10n(context).tbElement),
+    final strip = _stripFlex([
+      _StripLabel(pdfL10n(context).tbElement, axis: _stripAxis),
       IconButton(
         icon: const Icon(Icons.delete_outline),
         tooltip: pdfL10n(context).tbDeleteElement,
@@ -2058,7 +2108,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     return _centeredCard(
       context,
       padding: const EdgeInsets.fromLTRB(12, 7, 12, 7),
-      child: row,
+      scrollDirection: _stripAxis,
+      child: strip,
     );
   }
 
@@ -2278,10 +2329,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     BuildContext context,
     _StyleFields fields, {
     bool compactTrigger = false,
+    Axis axis = Axis.horizontal,
   }) {
     if (!widget.showStyle || fields.isEmpty) return const [];
     return [
-      if (fields.font) const _MiniDivider(),
+      if (fields.font) _MiniDivider(axis: axis),
       _StyleMenu(
         controller: controller,
         palette: widget.palette,
@@ -3058,41 +3110,71 @@ class _NavigationModeGroup extends StatelessWidget {
 
 /// The full-height divider between a strip's tools and settings segments.
 class _StripDivider extends StatelessWidget {
-  const _StripDivider();
+  const _StripDivider({this.axis = Axis.horizontal});
+
+  final Axis axis;
 
   @override
-  Widget build(BuildContext context) => Container(
-        width: 1,
-        margin: const EdgeInsets.symmetric(vertical: 8),
-        color: Theme.of(context).colorScheme.outlineVariant,
-      );
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.outlineVariant;
+    return axis == Axis.horizontal
+        ? Container(
+            width: 1,
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            color: color,
+          )
+        : Container(
+            height: 1,
+            margin: const EdgeInsets.symmetric(horizontal: 8),
+            color: color,
+          );
+  }
 }
 
-/// A short vertical divider between setting clusters within a strip.
+/// A short divider between setting clusters within a strip.
 class _MiniDivider extends StatelessWidget {
-  const _MiniDivider();
+  const _MiniDivider({this.axis = Axis.horizontal});
+
+  final Axis axis;
 
   @override
-  Widget build(BuildContext context) => Container(
-        width: 1,
-        height: 24,
-        margin: const EdgeInsets.symmetric(horizontal: 6),
-        color: Theme.of(context).colorScheme.outlineVariant,
-      );
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.outlineVariant;
+    return axis == Axis.horizontal
+        ? Container(
+            width: 1,
+            height: 24,
+            margin: const EdgeInsets.symmetric(horizontal: 6),
+            color: color,
+          )
+        : Container(
+            width: 24,
+            height: 1,
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            color: color,
+          );
+  }
 }
 
 /// The uppercase group/context label at the left of a contextual strip.
 class _StripLabel extends StatelessWidget {
-  const _StripLabel(this.text, {this.hint});
+  const _StripLabel(
+    this.text, {
+    this.hint,
+    this.axis = Axis.horizontal,
+  });
 
   final String text;
   final String? hint;
+  final Axis axis;
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return Padding(
-      padding: const EdgeInsetsDirectional.only(end: 8, start: 2),
+      padding: axis == Axis.horizontal
+          ? const EdgeInsetsDirectional.only(end: 8, start: 2)
+          : const EdgeInsets.only(bottom: 8, top: 2),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -926,7 +926,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           // thumbnail tiles' delete-button Tooltips) during the enclosing
           // LayoutBuilder's layout pass, which trips a RenderObject mutation
           // assertion. A fresh mount has no such overlay reactivation.
-          PdfThumbnailSidebar thumbnails({required bool bottomSheet}) =>
+          PdfThumbnailSidebar thumbnails({
+            required bool bottomSheet,
+            Axis? scrollDirection,
+          }) =>
               PdfThumbnailSidebar(
                 key: ValueKey(
                     'pdf-shell-thumbnails-${bottomSheet ? 'sheet' : 'docked'}'),
@@ -936,6 +939,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 showAnnotations: prefs.showAnnotations,
                 allowPageEditing: features.pageEditing,
                 dock: prefs.thumbnailSidebarDock,
+                scrollDirection: scrollDirection,
                 bottomSheet: bottomSheet,
                 // the sheet chrome carries its own close button
                 onClose: bottomSheet
@@ -1082,8 +1086,12 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           // a chromeless body for use inside a tab group (the group supplies
           // the frame, tab strip, and close buttons); reuses the panels'
           // bottom-sheet content mode
-          Widget tabBody(PdfDockablePanel p) => switch (p) {
-                PdfDockablePanel.thumbnails => thumbnails(bottomSheet: true),
+          Widget tabBody(PdfDockablePanel p, PdfPanelDock dock) => switch (p) {
+                PdfDockablePanel.thumbnails => thumbnails(
+                    bottomSheet: true,
+                    scrollDirection:
+                        dock.isHorizontal ? Axis.vertical : Axis.horizontal,
+                  ),
                 PdfDockablePanel.search => searchResults(bottomSheet: true),
                 PdfDockablePanel.bookmarks => bookmarks(bottomSheet: true),
                 PdfDockablePanel.annotations => annotations(bottomSheet: true),
@@ -1138,7 +1146,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     for (final m in members)
                       PdfPanelTabEntry(
                         panel: m,
-                        body: tabBody(m),
+                        body: tabBody(m, dock),
                         onClose: closePanel(m),
                       ),
                   ],

--- a/packages/dart_pdf_editor/test/panel_dock_test.dart
+++ b/packages/dart_pdf_editor/test/panel_dock_test.dart
@@ -109,6 +109,61 @@ void main() {
       // its grip is the horizontal (row-resize) variant, not the column one
       expect(find.byKey(const ValueKey('v-grip')), findsOneWidget);
     });
+
+    testWidgets('a top-docked thumbnail strip scrolls pages horizontally',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(8));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+
+      await pump(
+        tester,
+        Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 600,
+            child: PdfThumbnailSidebar(
+              controller: editing,
+              viewerController: viewer,
+              dock: PdfPanelDock.top,
+              width: 180,
+              resizable: false,
+            ),
+          ),
+        ),
+      );
+
+      final list = tester.widget<ReorderableListView>(
+        find.byType(ReorderableListView),
+      );
+      expect(list.scrollDirection, Axis.horizontal);
+      final bar = tester.widget<PdfScrollbar>(
+        find.descendant(
+          of: find.byType(PdfThumbnailSidebar),
+          matching: find.byType(PdfScrollbar),
+        ),
+      );
+      expect(bar.axis, Axis.horizontal);
+
+      final first = tester.getCenter(
+        find.byKey(const ValueKey('pdf-thumbnail-tile-chip-0')),
+      );
+      final second = tester.getCenter(
+        find.byKey(const ValueKey('pdf-thumbnail-tile-chip-1')),
+      );
+      expect(second.dx, greaterThan(first.dx));
+      expect(second.dy, closeTo(first.dy, 0.5));
+
+      final scrollable = find.descendant(
+        of: find.byType(ReorderableListView),
+        matching: find.byType(Scrollable),
+      );
+      await tester.drag(scrollable, const Offset(-240, 0));
+      await tester.pumpAndSettle();
+      expect(tester.state<ScrollableState>(scrollable).position.pixels,
+          greaterThan(0));
+    });
   });
 
   group('drag to redock', () {

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1408,6 +1408,24 @@ void main() {
       ]..sort((a, b) => a.left.compareTo(b.left));
       expect(openRects.last.left, greaterThan(openRects.first.right));
       expect(openRects.first.width, lessThan(openRects.last.width));
+
+      // The contextual (second) toolbar follows the rail instead of opening
+      // as the old horizontal row beside it.
+      final highlight =
+          tester.getCenter(find.byKey(const ValueKey('pdf-markup-highlight')));
+      final underline =
+          tester.getCenter(find.byKey(const ValueKey('pdf-markup-underline')));
+      expect(highlight.dx, closeTo(underline.dx, 0.5));
+      expect(underline.dy, greaterThan(highlight.dy));
+      final contextualScroll = tester.widget<SingleChildScrollView>(
+        find
+            .ancestor(
+              of: find.byKey(const ValueKey('pdf-markup-highlight')),
+              matching: find.byType(SingleChildScrollView),
+            )
+            .first,
+      );
+      expect(contextualScroll.scrollDirection, Axis.vertical);
     });
 
     testWidgets('right toolbar is a vertical rail inside docked panels',


### PR DESCRIPTION
## Summary

- orient the contextual editing toolbar vertically when it is docked on the left or right
- make thumbnail panels horizontal and scrollable when docked on the top or bottom
- handle missing and inaccessible PDFs without exposing raw filesystem exceptions or paths
- persist Recent-file thumbnails locally so network files are not fetched just to rebuild thumbnails
- hide the display-only `.pdf` suffix while preserving the real filename for file operations
- avoid the failing Android scanner PDF-export path by capturing page images once and assembling the PDF locally
- keep raw scanner diagnostics in DevTools instead of leaking plugin exceptions into the toast

Follows #751.

## Testing

- `fvm dart analyze`
- `cd app && fvm flutter test` (500 tests)
- `cd app && fvm flutter test test/doc_scan_io_test.dart test/doc_scan_menu_test.dart` (23 focused tests)
- `cd packages/dart_pdf_editor && fvm flutter test test/panel_dock_test.dart test/pdf_shell_test.dart` (92 tests)