### PR TITLE
Retain exact identity transparency groups on Flutter GPU

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -260,6 +260,10 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             break;
           case _GroupPaintSpec():
             break;
+          case _FlattenGroupSpec():
+            break;
+          case _EmptyGroupSpec():
+            break;
         }
         continue;
       }
@@ -456,6 +460,24 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final List<PdfRenderCommand> commands;
   @override
   final PdfRect? contentClip;
+}
+
+class _FlattenGroupSpec extends _GpuCompositeSpec {
+  const _FlattenGroupSpec(this.paints);
+
+  final List<({int commandIndex, PdfRect? clip})> paints;
+
+  @override
+  PdfRect? get contentClip => null;
+}
+
+class _EmptyGroupSpec extends _GpuCompositeSpec {
+  const _EmptyGroupSpec(this.bounds);
+
+  final PdfRect bounds;
+
+  @override
+  PdfRect? get contentClip => null;
 }
 
 class _SoftMaskImageSpec extends _GpuCompositeSpec {
@@ -705,20 +727,70 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
             initialBlend: capture.blendMode,
           );
           if (parsed.$1 == null) return _GpuUnitBuild(null, parsed.$2);
-          final bounds = capture.bounds;
-          if (bounds != null) {
-            units.add(_GpuUnit(
-              commandIndex: capture.start,
-              endCommandIndex: i,
-              bounds: _inflatePdf(bounds, 2),
-              clip: _withGpuRectClip(capture.clip, parsed.$1!.contentClip),
-              blendMode: capture.blendMode,
-              fillOverprint: capture.fillOverprint,
-              strokeOverprint: capture.strokeOverprint,
-              darken: false,
-              composite: parsed.$1,
-            ));
+          final spec = parsed.$1!;
+          if (spec is _FlattenGroupSpec) {
+            for (final paint in spec.paints) {
+              final paintCommand = commands[paint.commandIndex];
+              final paintClip = _withGpuRectClip(capture.clip, paint.clip);
+              final paintBounds = pdfRenderCommandBounds(paintCommand);
+              final clipped = paintBounds == null || paintClip.empty
+                  ? null
+                  : paintClip.scissor == null
+                      ? paintBounds
+                      : _pdfIntersection(paintClip.scissor, paintBounds);
+              if (clipped == null) continue;
+              units.add(_GpuUnit(
+                commandIndex: paint.commandIndex,
+                endCommandIndex: paint.commandIndex,
+                bounds: _inflatePdf(clipped, 2),
+                clip: paintClip,
+                blendMode: capture.blendMode,
+                fillOverprint: false,
+                strokeOverprint: false,
+                darken: false,
+                hairline: paintCommand is PdfStrokePathCommand &&
+                    paintCommand.stroke.width <= 0,
+              ));
+            }
+            final groupBounds = capture.bounds;
+            if (groupBounds != null) {
+              // Keep the structural Begin/End pair covered for the final
+              // unsupported-command audit. The real paints above retain
+              // their own command indices and clips; this marker compiles to
+              // no draw.
+              units.add(_GpuUnit(
+                commandIndex: capture.start,
+                endCommandIndex: i,
+                bounds: _inflatePdf(groupBounds, 2),
+                clip: capture.clip,
+                blendMode: PdfBlendMode.normal,
+                fillOverprint: false,
+                strokeOverprint: false,
+                darken: false,
+                composite: spec,
+              ));
+            }
+          } else {
+            final bounds =
+                spec is _EmptyGroupSpec ? spec.bounds : capture.bounds;
+            if (bounds != null) {
+              units.add(_GpuUnit(
+                commandIndex: capture.start,
+                endCommandIndex: i,
+                bounds: _inflatePdf(bounds, 2),
+                clip: _withGpuRectClip(capture.clip, spec.contentClip),
+                blendMode: capture.blendMode,
+                fillOverprint: capture.fillOverprint,
+                strokeOverprint: capture.strokeOverprint,
+                darken: false,
+                composite: spec,
+              ));
+            }
           }
+          clip = capture.clip;
+          blend = capture.blendMode;
+          fillOverprint = capture.fillOverprint;
+          strokeOverprint = capture.strokeOverprint;
           composite = null;
         }
       default:
@@ -811,18 +883,30 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     // multi-paint path below is deliberately narrower: alpha-one, normal
     // source-over, non-knockout groups whose isolation layer is an identity.
     PdfDrawImageCommand? content;
-    final paints = <(PdfRenderCommand, PdfRect?, PdfBlendMode, bool)>[];
+    final paints = <(int, PdfRenderCommand, PdfRect?, PdfBlendMode, bool)>[];
     PdfEndSoftMaskedCommand? softEnd;
     var softDepth = 0;
     var softCount = 0;
     PdfRect? clip = initialClip;
     PdfRect? contentClip;
+    var emptyClipOnly = false;
     var fillOverprint = initialFillOverprint;
     var strokeOverprint = initialStrokeOverprint;
     var blend = initialBlend;
+    var invisibleGroupDepth = 0;
     final saved = <(PdfRect?, bool, bool, PdfBlendMode)>[];
     for (var i = start + 1; i < end; i++) {
       final command = commands[i];
+      if (invisibleGroupDepth != 0) {
+        if (command is PdfBeginGroupCommand) invisibleGroupDepth++;
+        if (command is PdfEndGroupCommand) invisibleGroupDepth--;
+        continue;
+      }
+      if (command case PdfBeginGroupCommand(alpha: final groupAlpha)
+          when groupAlpha <= 0) {
+        invisibleGroupDepth = 1;
+        continue;
+      }
       switch (command) {
         case PdfSaveCommand():
           saved.add((clip, fillOverprint, strokeOverprint, blend));
@@ -839,8 +923,14 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           }
           final pathBounds = pdfRenderPathBounds(path);
           final narrowed = _pdfIntersection(clip, pathBounds);
-          if (clip != null && pathBounds != null && narrowed == null) {
-            return (null, 'empty transparency group clip');
+          final degenerate = pathBounds != null &&
+              (pathBounds.right <= pathBounds.left ||
+                  pathBounds.top <= pathBounds.bottom);
+          if (degenerate ||
+              (clip != null && pathBounds != null && narrowed == null)) {
+            emptyClipOnly = true;
+            clip = pathBounds;
+            break;
           }
           clip = narrowed;
         case PdfBeginSoftMaskedCommand():
@@ -850,22 +940,31 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           softDepth--;
           softEnd = command;
         case PdfDrawImageCommand():
+          if (emptyClipOnly) {
+            return (null, 'empty transparency group contains paint');
+          }
           if (softDepth != 1 || content != null) {
             return (null, 'soft-mask group is not a single image');
           }
           content = command;
           contentClip = clip;
         case PdfFillPathCommand():
+          if (emptyClipOnly) {
+            return (null, 'empty transparency group contains paint');
+          }
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfFillPathCommand');
           }
-          paints.add((command, clip, blend, fillOverprint));
+          paints.add((i, command, clip, blend, fillOverprint));
           contentClip = clip;
         case PdfStrokePathCommand():
+          if (emptyClipOnly) {
+            return (null, 'empty transparency group contains paint');
+          }
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfStrokePathCommand');
           }
-          paints.add((command, clip, blend, strokeOverprint));
+          paints.add((i, command, clip, blend, strokeOverprint));
           contentClip = clip;
         case PdfSetBlendModeCommand(:final mode):
           // A one-element group may use any internal blend: with a transparent
@@ -886,22 +985,28 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     if (saved.isNotEmpty) {
       return (null, 'unbalanced transparency group state');
     }
+    if (invisibleGroupDepth != 0) {
+      return (null, 'unbalanced invisible transparency group');
+    }
+    if (emptyClipOnly && softCount == 0 && paints.isEmpty && content == null) {
+      return (_EmptyGroupSpec(clip!), null);
+    }
     if (softCount == 0 && softDepth == 0 && paints.length == 1) {
       final paint = paints.single;
-      if (paint.$4) {
+      if (paint.$5) {
         return (
           null,
-          paint.$1 is PdfStrokePathCommand
+          paint.$2 is PdfStrokePathCommand
               ? 'transparency-group stroke overprint'
               : 'transparency-group fill overprint',
         );
       }
-      return switch (paint.$1) {
+      return switch (paint.$2) {
         PdfFillPathCommand content => (
             _GroupFillSpec(
               content: content,
               groupAlpha: alpha,
-              contentClip: paint.$2,
+              contentClip: paint.$3,
             ),
             null,
           ),
@@ -909,7 +1014,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             _GroupStrokeSpec(
               content: content,
               groupAlpha: alpha,
-              contentClip: paint.$2,
+              contentClip: paint.$3,
             ),
             null,
           ),
@@ -917,19 +1022,39 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       };
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
-      final commonClip = paints.first.$2;
+      final commonClip = paints.first.$3;
+      var overlaps = false;
+      final occupied = <PdfRect>[];
+      for (final paint in paints) {
+        final bounds = _pdfIntersection(
+          pdfRenderCommandBounds(paint.$2),
+          paint.$3,
+        );
+        if (bounds == null) continue;
+        if (occupied.any((other) => _pdfIntersection(other, bounds) != null)) {
+          overlaps = true;
+          break;
+        }
+        occupied.add(bounds);
+      }
       if (alpha != 1 ||
           knockout ||
-          initialBlend != PdfBlendMode.normal ||
-          paints.any((paint) =>
-              paint.$3 != PdfBlendMode.normal ||
-              paint.$4 ||
-              !_samePdfRect(paint.$2, commonClip))) {
+          paints.any((paint) => paint.$4 != PdfBlendMode.normal || paint.$5) ||
+          (initialBlend != PdfBlendMode.normal && overlaps)) {
         return (null, 'non-identity multi-paint transparency group');
+      }
+      if (paints.any((paint) => !_samePdfRect(paint.$3, commonClip))) {
+        return (
+          _FlattenGroupSpec(List.unmodifiable([
+            for (final paint in paints)
+              (commandIndex: paint.$1, clip: paint.$3),
+          ])),
+          null,
+        );
       }
       return (
         _GroupPaintSpec(
-          commands: List.unmodifiable([for (final paint in paints) paint.$1]),
+          commands: List.unmodifiable([for (final paint in paints) paint.$2]),
           contentClip: commonClip,
         ),
         null,
@@ -1555,6 +1680,8 @@ class _CompiledScene {
             _GroupFillSpec spec => _compileGroupFill(geometry, spec),
             _GroupStrokeSpec spec => _compileGroupStroke(geometry, spec),
             _GroupPaintSpec spec => _compileGroupPaint(geometry, spec),
+            _FlattenGroupSpec() => null,
+            _EmptyGroupSpec() => null,
             _SoftMaskImageSpec spec => await _compileSoftMaskImage(
                 context,
                 geometry,

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -915,6 +915,67 @@ void main() {
     });
   });
 
+  testWidgets('empty clipped transparency groups remain no-ops',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(20, 80, 180, 240),
+          const PdfColor(0.1, 0.7, 0.25),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(1),
+        PdfClipPathCommand(_rect(80, 100, 80, 220), PdfFillRule.nonzero),
+        const PdfEndGroupCommand(),
+        PdfFillPathCommand(
+          _rect(210, 80, 370, 240),
+          const PdfColor(0.75, 0.2, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(0, 60, 400, 200);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(1));
+      expect(backend.stats.lastTileRoute, 'flutter_gpu');
+
+      final painted = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(1),
+        PdfClipPathCommand(_rect(80, 100, 80, 220), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(60, 90, 100, 230),
+          const PdfColor(0.8, 0.2, 0.1),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(painted.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(painted), isNull);
+      expect(conservative.stats.lastRejection, contains('contains paint'));
+    });
+  });
+
   testWidgets('isolated single-fill groups preserve clip blend and alpha',
       (tester) async {
     await tester.runAsync(() async {
@@ -943,6 +1004,12 @@ void main() {
         ),
         const PdfRestoreCommand(),
         const PdfEndGroupCommand(),
+        PdfFillPathCommand(
+          _rect(175, 120, 215, 220),
+          const PdfColor(0.85, 0.65, 0.2),
+          PdfFillRule.nonzero,
+          0.75,
+        ),
         const PdfSetBlendModeCommand(PdfBlendMode.normal),
       ]);
       addTearDown(scene.dispose);
@@ -1064,6 +1131,88 @@ void main() {
         difference += (a[i] - b[i]).abs();
       }
       expect(difference / a.length, lessThan(4));
+    });
+  });
+
+  testWidgets('disjoint group paints retain their outer blend and clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(20, 80, 380, 260),
+          const PdfColor(0.35, 0.65, 0.85),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(1),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(40, 100, 170, 240), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(30, 90, 180, 250),
+          const PdfColor(0.9, 0.3, 0.2),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        const PdfRestoreCommand(),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(220, 100, 350, 240), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(210, 90, 360, 250),
+          const PdfColor(0.25, 0.85, 0.35),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfRestoreCommand(),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.75);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.75);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(2));
+      expect(backend.stats.lastTileRoute, 'flutter_gpu');
+
+      final overlapping = await PdfRetainedScene.fromCommands(page, [
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(1),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfFillPathCommand(
+          _rect(40, 100, 220, 260),
+          const PdfColor(0.9, 0.3, 0.2),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        PdfFillPathCommand(
+          _rect(160, 120, 340, 280),
+          const PdfColor(0.25, 0.85, 0.35),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(overlapping.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(overlapping), isNull);
+      expect(conservative.stats.lastRejection, contains('non-identity'));
     });
   });
 


### PR DESCRIPTION
## Headline

- **PDF.js GPU acceptance:** **107/72 -> 108/71**; `quadpoints.pdf` now stays retained.
- **Same-host first tile p50:** **355.0 ms -> 348.3 ms (-1.9%)** across six alternating runs, with non-overlapping run spread.
- **Retained warm tile:** **46.1 ms Canvas -> 13.0 ms GPU (-71.8%)**.
- **Correctness:** real-page mean channel difference **0.186/255**; full refreshed Metal corpus **218/218 passed**.
- **Ghent:** remains **35/22** against the newly merged GWG baseline.

<details>
<summary>Implementation and validation details</summary>

### What changed

- Flattens alpha-one, non-knockout identity transparency groups into their exact retained paint units.
- Preserves each paint's rectangular clip and the group's outer blend mode.
- Allows a non-Normal outer blend only when conservative clipped paint bounds are disjoint; overlapping groups remain on Canvas.
- Treats zero-alpha nested groups as exact no-ops.
- Retains truly empty, degenerate-clipped transparency groups as no-op structural markers.
- Restores the captured clip and graphics-state routing after a group closes.

### Safety boundaries

- Any paint after an empty/degenerate clip rejects the GPU route.
- Alpha, knockout, internal blend, overprint, or overlapping non-Normal cases reject conservatively.
- `knockout_isolated_overlap.pdf` remains rejected as a non-identity group.

### Validation

- `fvm dart analyze`: no issues.
- Full Metal-enabled package suite: **250 passed, 3 expected skips**.
- Full refreshed corpus: **218/218 passed**.
- Corpus acceptance:
  - PDF.js: **107 accepted / 72 fallback -> 108 / 71**
  - Ghent: **35 / 22 -> 35 / 22**
- Six alternating same-host `quadpoints.pdf` runs:
  - Canvas-fallback first tile median: **355.0 ms**
  - retained GPU cold tile median: **348.3 ms**
  - standalone Canvas median: **46.1 ms**
  - retained GPU warm median: **13.0 ms**
- Dedicated Metal tests cover exact empty-group no-ops, rejection when a degenerate clip is followed by paint, varying per-paint clips, outer blend preservation, and conservative overlap rejection.

</details>

Independent of #758. Advances #682.
