### PR TITLE
Skip definitively failed images on Flutter GPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,8 @@ jobs:
             if [[ "$label" == "vector-mask" ||
                   "$label" == "vector-stack-1" ||
                   "$label" == "vector-stack-2" ||
+                  "$label" == "text-mask-1" ||
+                  "$label" == "text-mask-2" ||
                   "$label" == "hairline" ]]; then
               route_change=1
             fi
@@ -299,6 +301,8 @@ jobs:
           vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
           vector-stack-1 pdf ../../test_corpora/ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf
           vector-stack-2 pdf ../../test_corpora/ghent/1-CMYK/GWG169_Softmasks_Vector_part2_X4.pdf
+          text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
+          text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           fi
@@ -328,6 +332,8 @@ jobs:
           vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
           vector-stack-1 pdf ../../test_corpora/ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf
           vector-stack-2 pdf ../../test_corpora/ghent/1-CMYK/GWG169_Softmasks_Vector_part2_X4.pdf
+          text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
+          text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           done
@@ -364,6 +370,10 @@ jobs:
             --require-scenario-runs gpu-vector-stack-1-page-0-canvas-tile=6
             --require-scenario-runs gpu-vector-stack-2-page-0-first-tile=6
             --require-scenario-runs gpu-vector-stack-2-page-0-canvas-tile=6
+            --require-scenario-runs gpu-text-mask-1-page-0-first-tile=6
+            --require-scenario-runs gpu-text-mask-1-page-0-canvas-tile=6
+            --require-scenario-runs gpu-text-mask-2-page-0-first-tile=6
+            --require-scenario-runs gpu-text-mask-2-page-0-canvas-tile=6
             --require-scenario-runs gpu-hairline-page-0-first-tile=6
             --require-scenario-runs gpu-hairline-page-0-canvas-tile=6
           )

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -67,7 +67,16 @@ class PdfRetainedScene {
     this.commands,
     this._images, [
     this._retainedDecodedRequests,
+    this.imageDecodingAttempted = true,
   ]);
+
+  /// Whether image requests were passed through the decoder for this scene.
+  ///
+  /// When true, a request absent from [imageFor] is definitively undecodable
+  /// and Canvas replay skips it. When false, the scene is a deliberate
+  /// vector-only progressive buffer and a later complete scene may still
+  /// supply the image.
+  final bool imageDecodingAttempted;
 
   /// Scenes holding sheddable spatial metadata (a region index or banded
   /// transcript), weakly held so a coordinated memory-pressure sweep can drop
@@ -418,6 +427,7 @@ class PdfRetainedScene {
       commands,
       images,
       retainedRequests,
+      includeImages,
     );
   }
 

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -185,11 +185,11 @@ Set `PDF_GPU_BENCHMARK_SCENE_WARMUP=1` to additionally compile and submit the
 retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
 markers for each pipeline/scene/tile phase. CI uses those markers to run the
-checked-in tiling-pattern, radial-shading, hairline, vector-mask transfer, and
-GWG168/169 vector soft-mask pages plus the deterministic deferred-mask fixture
-six times on macOS Metal, compare the exact PR base and candidate on the same
-runner with balanced execution order, and publish both a concise PR headline
-and a collapsed detailed trace.
+checked-in tiling-pattern, radial-shading, hairline, vector-mask transfer,
+GWG168/169 vector soft-mask, and GWG1610/1611 text soft-mask pages plus the
+deterministic deferred-mask fixture six times on macOS Metal, compare the exact
+PR base and candidate on the same runner with balanced execution order, and
+publish both a concise PR headline and a collapsed detailed trace.
 Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
 a deterministic 1024x768 JPEG under a Flate grayscale soft mask. This fixture
 emits the same first-tile and Canvas scenarios whether the backend accepts the
@@ -202,7 +202,7 @@ cold first-tile measurement.
 Set `PDF_GPU_BENCHMARK_ROUTE_CHANGE=1` for the same normalization when a PDF
 path, rather than the built-in fixture, changes from Canvas fallback to direct
 GPU. CI uses it for the checked-in vector-mask transfer, hairline, and GWG
-vector soft-mask pages.
+vector/text soft-mask pages.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -291,7 +291,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           break;
         case PdfDrawImageCommand(:final request):
           final image = scene.imageFor(request);
-          if (image == null) return 'missing image pixels';
+          if (image == null && !scene.imageDecodingAttempted) {
+            return 'missing image pixels';
+          }
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
           final reason = _unsupportedTextReason(run);
@@ -3497,7 +3499,7 @@ FutureOr<_GpuDraw?> _compileCommand(
   }
 }
 
-Future<_GpuDraw> _compileImageCommand(
+Future<_GpuDraw?> _compileImageCommand(
     gpu.GpuContext context,
     _GpuGeometryArena geometry,
     PdfRetainedScene scene,
@@ -3506,7 +3508,8 @@ Future<_GpuDraw> _compileImageCommand(
     _GpuImageCache imageCache,
     List<_GpuImageTexture> textureLeases,
     {required bool mipmapImages}) async {
-  final image = scene.imageFor(request)!;
+  final image = scene.imageFor(request);
+  if (image == null) return null;
   final maskImage = pdfGpuSoftMaskOf(image);
   final resource = await imageCache.acquire(
     context,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -256,6 +256,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             break;
           case _SoftMaskGradientFillSpec():
             break;
+          case _SoftMaskTextSpec():
+            if (scene.imageFor(composite.mask) == null) {
+              return 'missing soft-mask image pixels';
+            }
+            final reason = _unsupportedTextReason(composite.content.run);
+            if (reason != null) return reason;
+          case _SoftMaskGradientTextSpec():
+            final reason = _unsupportedTextReason(composite.content.run);
+            if (reason != null) return reason;
           case _GroupFillSpec():
             break;
           case _GroupStrokeSpec():
@@ -285,18 +294,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           if (image == null) return 'missing image pixels';
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
-          final gradientReason = run.gradient == null
-              ? null
-              : _gradientUnsupportedReason(run.gradient!, run.fillAlpha);
-          final textReasons = <String>[
-            if (run.glyphs == null) 'missing glyph outlines',
-            if (!run.fill) 'fill disabled',
-            if (gradientReason != null) gradientReason,
-            if (run.strokeColor != null) 'stroke',
-          ];
-          if (textReasons.isNotEmpty) {
-            return 'unsupported text: ${textReasons.join(', ')}';
-          }
+          final reason = _unsupportedTextReason(run);
+          if (reason != null) return reason;
         case PdfFillPathGradientCommand():
           final reason =
               _gradientUnsupportedReason(command.gradient, command.alpha);
@@ -479,6 +478,7 @@ class _FlattenSoftMaskPaint {
     required this.clip,
     required this.blendMode,
     this.composite,
+    this.pathClip,
   });
 
   final int commandIndex;
@@ -487,6 +487,7 @@ class _FlattenSoftMaskPaint {
   final PdfRect clip;
   final PdfBlendMode blendMode;
   final _GpuCompositeSpec? composite;
+  final PdfPath? pathClip;
 }
 
 class _SoftMaskImageSpec extends _GpuCompositeSpec {
@@ -567,6 +568,44 @@ class _SoftMaskGradientFillSpec extends _GpuCompositeSpec {
   });
 
   final PdfFillPathCommand content;
+  final PdfFillPathGradientCommand mask;
+  @override
+  final PdfRect? contentClip;
+  final bool luminosity;
+}
+
+class _SoftMaskTextSpec extends _GpuCompositeSpec {
+  const _SoftMaskTextSpec({
+    required this.content,
+    required this.mask,
+    required this.contentClip,
+    required this.maskClip,
+    required this.luminosity,
+    required this.backdropLuminance,
+    required this.transferScale,
+    required this.transferOffset,
+  });
+
+  final PdfDrawTextCommand content;
+  final PdfImageRequest mask;
+  @override
+  final PdfRect? contentClip;
+  final PdfRect? maskClip;
+  final bool luminosity;
+  final double backdropLuminance;
+  final double transferScale;
+  final double transferOffset;
+}
+
+class _SoftMaskGradientTextSpec extends _GpuCompositeSpec {
+  const _SoftMaskGradientTextSpec({
+    required this.content,
+    required this.mask,
+    required this.contentClip,
+    required this.luminosity,
+  });
+
+  final PdfDrawTextCommand content;
   final PdfFillPathGradientCommand mask;
   @override
   final PdfRect? contentClip;
@@ -754,11 +793,20 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
           final spec = parsed.$1!;
           if (spec is _FlattenSoftMaskSpec) {
             for (final paint in spec.paints) {
+              var paintClip = _withGpuRectClip(capture.clip, paint.clip);
+              final pathClip = paint.pathClip;
+              if (pathClip != null) {
+                paintClip = _pushGpuClip(
+                  paintClip,
+                  pathClip,
+                  PdfFillRule.nonzero,
+                );
+              }
               units.add(_GpuUnit(
                 commandIndex: paint.commandIndex,
                 endCommandIndex: paint.endCommandIndex,
                 bounds: _inflatePdf(paint.bounds, 2),
-                clip: _withGpuRectClip(capture.clip, paint.clip),
+                clip: paintClip,
                 blendMode: paint.blendMode,
                 fillOverprint: false,
                 strokeOverprint: false,
@@ -1057,12 +1105,23 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       initialBlend: initialBlend,
     );
     if (flattened != null) return (flattened, null);
+    final textStack = _parseOpaqueTextMaskStack(
+      commands,
+      start,
+      end,
+      endCommand,
+      initialClip: initialClip,
+      initialFillOverprint: initialFillOverprint,
+      initialStrokeOverprint: initialStrokeOverprint,
+      initialBlend: initialBlend,
+    );
+    if (textStack != null) return (textStack, null);
     final maskCommands = endCommand.maskCommands;
     final luminosity = endCommand.luminosity;
     final backdropLuminance = endCommand.backdropLuminance;
     final transferScale = endCommand.transferScale;
     final transferOffset = endCommand.transferOffset;
-    PdfFillPathCommand? content;
+    PdfRenderCommand? content;
     PdfRect? clip = initialClip;
     PdfRect? contentClip;
     final saved = <PdfRect?>[];
@@ -1079,9 +1138,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             return (null, 'non-rectangular soft-mask fill clip');
           }
           clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
-        case PdfFillPathCommand():
+        case PdfFillPathCommand() || PdfDrawTextCommand():
           if (content != null) {
-            return (null, 'soft-mask group has multiple vector fills');
+            return (null, 'soft-mask group has multiple paints');
           }
           content = command;
           contentClip = clip;
@@ -1127,15 +1186,27 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         if (contentBounds != null &&
             maskBounds != null &&
             _pdfContains(maskBounds, contentBounds)) {
-          return (
-            _SoftMaskGradientFillSpec(
-              content: content,
-              mask: gradient,
-              contentClip: contentClip,
-              luminosity: luminosity,
-            ),
-            null,
-          );
+          return switch (content) {
+            PdfFillPathCommand fill => (
+                _SoftMaskGradientFillSpec(
+                  content: fill,
+                  mask: gradient,
+                  contentClip: contentClip,
+                  luminosity: luminosity,
+                ),
+                null,
+              ),
+            PdfDrawTextCommand text => (
+                _SoftMaskGradientTextSpec(
+                  content: text,
+                  mask: gradient,
+                  contentClip: contentClip,
+                  luminosity: luminosity,
+                ),
+                null,
+              ),
+            _ => (null, 'unsupported gradient soft-mask content'),
+          };
         }
       }
       final vectorMask = _vectorMaskFills(maskCommands);
@@ -1144,6 +1215,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       if (![backdropLuminance, transferScale, transferOffset]
           .every((value) => value.isFinite)) {
         return (null, 'invalid vector soft-mask transfer');
+      }
+      if (content is! PdfFillPathCommand) {
+        return (null, 'unsupported vector soft-mask text');
       }
       return (
         _SoftMaskVectorFillSpec(
@@ -1165,19 +1239,35 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     if (maskDictionary['SMask'] != null || maskDictionary['Mask'] != null) {
       return (null, 'transparent soft-mask fill image');
     }
-    return (
-      _SoftMaskFillSpec(
-        content: content,
-        mask: mask.request,
-        contentClip: contentClip,
-        maskClip: maskState.$2,
-        luminosity: luminosity,
-        backdropLuminance: backdropLuminance,
-        transferScale: transferScale,
-        transferOffset: transferOffset,
-      ),
-      null,
-    );
+    return switch (content) {
+      PdfFillPathCommand fill => (
+          _SoftMaskFillSpec(
+            content: fill,
+            mask: mask.request,
+            contentClip: contentClip,
+            maskClip: maskState.$2,
+            luminosity: luminosity,
+            backdropLuminance: backdropLuminance,
+            transferScale: transferScale,
+            transferOffset: transferOffset,
+          ),
+          null,
+        ),
+      PdfDrawTextCommand text => (
+          _SoftMaskTextSpec(
+            content: text,
+            mask: mask.request,
+            contentClip: contentClip,
+            maskClip: maskState.$2,
+            luminosity: luminosity,
+            backdropLuminance: backdropLuminance,
+            transferScale: transferScale,
+            transferOffset: transferOffset,
+          ),
+          null,
+        ),
+      _ => (null, 'unsupported image soft-mask content'),
+    };
   }
   return (null, 'unsupported composite ${commands[start].runtimeType}');
 }
@@ -1187,7 +1277,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
 /// by image-masked fills blended onto that base. Because the base is opaque,
 /// each nested blend sees exactly the same backdrop whether it is evaluated
 /// inside the isolated source layer or directly after the base. The outer
-/// mask then reduces to a rectangular clip.
+/// mask then reduces to a retained path stencil (a rectangle stays a cheap
+/// scissor).
 ///
 /// Every condition below is part of that proof. General nested masks, partial
 /// bases, non-binary masks, and non-Normal outer composites continue through
@@ -1208,17 +1299,23 @@ _FlattenSoftMaskSpec? _parseOpaqueVectorMaskStack(
       outerEnd.transferOffset != 0) {
     return null;
   }
-  final vectorMask = _vectorMaskFills(outerEnd.maskCommands).$1;
-  if (vectorMask == null || vectorMask.length != 1) return null;
-  final mask = vectorMask.single;
+  final maskState = _singleMaskPath(outerEnd.maskCommands);
+  final mask = maskState.$1;
+  if (mask == null) return null;
   final maskIsOpaque = mask.alpha == 1 &&
       (!outerEnd.luminosity ||
           (mask.color.red == 1 &&
               mask.color.green == 1 &&
               mask.color.blue == 1));
   if (!maskIsOpaque) return null;
-  final visibleMask = _pdfIntersection(initialClip, mask.rect);
+  final maskBounds = pdfRenderCommandBounds(mask);
+  var visibleMask = _pdfIntersection(initialClip, maskState.$2);
+  visibleMask = _pdfIntersection(visibleMask, maskBounds);
   if (visibleMask == null) return null;
+  final rectangularMask =
+      FlutterGpuTileRasterBackend._isAxisAlignedRect(mask.path);
+  if (!rectangularMask && mask.rule != PdfFillRule.nonzero) return null;
+  final pathClip = rectangularMask ? null : mask.path;
 
   var clip = initialClip;
   var blend = initialBlend;
@@ -1268,15 +1365,17 @@ _FlattenSoftMaskSpec? _parseOpaqueVectorMaskStack(
       case PdfSetOverprintCommand(:final fill, :final stroke):
         fillOverprint = fill;
         strokeOverprint = stroke;
-      case PdfFillPathCommand(:final path, :final alpha):
-        if (hasOpaqueBase ||
-            alpha != 1 ||
-            blend != PdfBlendMode.normal ||
-            !FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+      case PdfFillPathCommand(:final path, :final rule, :final alpha):
+        if (hasOpaqueBase || alpha != 1 || blend != PdfBlendMode.normal) {
           return null;
         }
         final bounds = _pdfIntersection(clip, pdfRenderPathBounds(path));
-        if (bounds == null || !_pdfContains(bounds, visibleMask)) return null;
+        final matchingMask = rectangularMask
+            ? bounds != null && _pdfContains(bounds, visibleMask)
+            : rule == mask.rule && _samePathGeometry(path, mask.path);
+        if (bounds == null || !matchingMask) {
+          return null;
+        }
         hasOpaqueBase = true;
         paints.add(_FlattenSoftMaskPaint(
           commandIndex: i,
@@ -1284,6 +1383,7 @@ _FlattenSoftMaskSpec? _parseOpaqueVectorMaskStack(
           bounds: visibleMask,
           clip: visibleMask,
           blendMode: PdfBlendMode.normal,
+          pathClip: pathClip,
         ));
       case PdfBeginSoftMaskedCommand():
         if (!hasOpaqueBase) return null;
@@ -1314,6 +1414,7 @@ _FlattenSoftMaskSpec? _parseOpaqueVectorMaskStack(
             clip: paintClip!,
             blendMode: blend,
             composite: parsed,
+            pathClip: pathClip,
           ));
         }
         nestedMasks++;
@@ -1329,6 +1430,220 @@ _FlattenSoftMaskSpec? _parseOpaqueVectorMaskStack(
   }
   if (saved.isNotEmpty || !hasOpaqueBase || nestedMasks == 0) return null;
   return _FlattenSoftMaskSpec(List.unmodifiable(paints));
+}
+
+/// Text inner-shadow/glow effects in the GWG suite use the same exact shape
+/// as the vector stack above: an opaque text base, one image-masked fill, then
+/// an opaque white copy of the same text as the outer luminosity mask. The
+/// common text outline is an exact retained stencil, so no offscreen group or
+/// rasterized glyph mask is needed.
+_FlattenSoftMaskSpec? _parseOpaqueTextMaskStack(
+  List<PdfRenderCommand> commands,
+  int start,
+  int end,
+  PdfEndSoftMaskedCommand outerEnd, {
+  required PdfRect? initialClip,
+  required bool initialFillOverprint,
+  required bool initialStrokeOverprint,
+  required PdfBlendMode initialBlend,
+}) {
+  if (!outerEnd.luminosity ||
+      initialBlend != PdfBlendMode.normal ||
+      outerEnd.backdropLuminance != 0 ||
+      outerEnd.transferScale != 1 ||
+      outerEnd.transferOffset != 0) {
+    return null;
+  }
+  final maskState = _singleMaskText(outerEnd.maskCommands);
+  final mask = maskState.$1;
+  if (mask == null ||
+      mask.run.color.red != 1 ||
+      mask.run.color.green != 1 ||
+      mask.run.color.blue != 1 ||
+      mask.run.fillAlpha != 1 ||
+      _unsupportedTextReason(mask.run) != null) {
+    return null;
+  }
+  final maskPath = _textPath(mask.run);
+  final maskBounds = pdfRenderCommandBounds(mask);
+  var visibleMask = _pdfIntersection(initialClip, maskState.$2);
+  visibleMask = _pdfIntersection(visibleMask, maskBounds);
+  if (maskPath == null || visibleMask == null) return null;
+
+  var clip = initialClip;
+  var blend = initialBlend;
+  var fillOverprint = initialFillOverprint;
+  var strokeOverprint = initialStrokeOverprint;
+  final saved = <(PdfRect?, PdfBlendMode, bool, bool)>[];
+  final paints = <_FlattenSoftMaskPaint>[];
+  PdfDrawTextCommand? base;
+  var nestedMasks = 0;
+
+  int? nestedEnd(int nestedStart) {
+    var depth = 1;
+    for (var i = nestedStart + 1; i < end; i++) {
+      switch (commands[i]) {
+        case PdfBeginSoftMaskedCommand():
+          depth++;
+        case PdfEndSoftMaskedCommand():
+          depth--;
+          if (depth == 0) return i;
+        case PdfBeginGroupCommand() || PdfEndGroupCommand():
+          return null;
+        default:
+          break;
+      }
+    }
+    return null;
+  }
+
+  for (var i = start + 1; i < end; i++) {
+    final command = commands[i];
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, blend, fillOverprint, strokeOverprint));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return null;
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        blend = restored.$2;
+        fillOverprint = restored.$3;
+        strokeOverprint = restored.$4;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) return null;
+        clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (clip == null) return null;
+      case PdfSetBlendModeCommand(:final mode):
+        blend = mode;
+      case PdfSetOverprintCommand(:final fill, :final stroke):
+        fillOverprint = fill;
+        strokeOverprint = stroke;
+      case PdfDrawTextCommand():
+        if (base != null ||
+            blend != PdfBlendMode.normal ||
+            command.run.fillAlpha != 1 ||
+            _unsupportedTextReason(command.run) != null ||
+            !_sameTextGeometry(command, mask)) {
+          return null;
+        }
+        final bounds = _pdfIntersection(
+          _pdfIntersection(clip, visibleMask),
+          pdfRenderCommandBounds(command),
+        );
+        if (bounds == null) return null;
+        base = command;
+        paints.add(_FlattenSoftMaskPaint(
+          commandIndex: i,
+          endCommandIndex: i,
+          bounds: bounds,
+          clip: visibleMask,
+          blendMode: PdfBlendMode.normal,
+          pathClip: maskPath,
+        ));
+      case PdfBeginSoftMaskedCommand():
+        if (base == null) return null;
+        final nestedStop = nestedEnd(i);
+        if (nestedStop == null ||
+            commands[nestedStop] is! PdfEndSoftMaskedCommand) {
+          return null;
+        }
+        final parsed = _parseComposite(
+          commands,
+          i,
+          nestedStop,
+          initialClip: clip,
+          initialFillOverprint: fillOverprint,
+          initialStrokeOverprint: strokeOverprint,
+          initialBlend: blend,
+        ).$1;
+        if (parsed is! _SoftMaskFillSpec) return null;
+        final bounds = _pdfIntersection(
+          _pdfIntersection(
+            _pdfIntersection(clip, parsed.contentClip),
+            visibleMask,
+          ),
+          pdfRenderCommandBounds(parsed.content),
+        );
+        if (bounds != null) {
+          paints.add(_FlattenSoftMaskPaint(
+            commandIndex: i,
+            endCommandIndex: nestedStop,
+            bounds: bounds,
+            clip: visibleMask,
+            blendMode: blend,
+            composite: parsed,
+            pathClip: maskPath,
+          ));
+        }
+        nestedMasks++;
+        i = nestedStop;
+      case PdfBeginGroupCommand() || PdfEndGroupCommand():
+        return null;
+      default:
+        if (pdfRenderCommandBounds(command) != null) return null;
+    }
+  }
+  if (saved.isNotEmpty || base == null || nestedMasks != 1) return null;
+  return _FlattenSoftMaskSpec(List.unmodifiable(paints));
+}
+
+bool _sameTextGeometry(PdfDrawTextCommand a, PdfDrawTextCommand b) {
+  final left = _textSubpaths(a.run), right = _textSubpaths(b.run);
+  return left != null && right != null && _sameSubpaths(left, right);
+}
+
+bool _samePathGeometry(PdfPath a, PdfPath b) => _sameSubpaths(
+      flattenPath(a, PdfMatrix.identity, tolerance: 0.01),
+      flattenPath(b, PdfMatrix.identity, tolerance: 0.01),
+    );
+
+bool _sameSubpaths(List<FlatSubpath> left, List<FlatSubpath> right) {
+  if (left.length != right.length) return false;
+  for (var i = 0; i < left.length; i++) {
+    final l = left[i], r = right[i];
+    if (l.closed != r.closed || l.points.length != r.points.length) {
+      return false;
+    }
+    for (var j = 0; j < l.points.length; j++) {
+      if ((l.points[j] - r.points[j]).abs() > 0.001) return false;
+    }
+  }
+  return true;
+}
+
+PdfPath? _textPath(PdfTextRun run) {
+  final glyphs = run.glyphs;
+  if (glyphs == null) return null;
+  final segments = <PdfPathSegment>[];
+  for (final glyph in glyphs) {
+    final outline = glyph.outline;
+    if (outline == null) continue;
+    final transform = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+        .concat(run.transform);
+    final cursor = outline.cursor();
+    while (cursor.moveNext()) {
+      segments.add(switch (cursor.verb) {
+        PdfPathVerb.moveTo => PdfMoveTo(
+            transform.transformX(cursor.x1, cursor.y1),
+            transform.transformY(cursor.x1, cursor.y1),
+          ),
+        PdfPathVerb.lineTo => PdfLineTo(
+            transform.transformX(cursor.x1, cursor.y1),
+            transform.transformY(cursor.x1, cursor.y1),
+          ),
+        PdfPathVerb.cubicTo => PdfCubicTo(
+            transform.transformX(cursor.x1, cursor.y1),
+            transform.transformY(cursor.x1, cursor.y1),
+            transform.transformX(cursor.x2, cursor.y2),
+            transform.transformY(cursor.x2, cursor.y2),
+            transform.transformX(cursor.x3, cursor.y3),
+            transform.transformY(cursor.x3, cursor.y3),
+          ),
+        PdfPathVerb.close => const PdfClosePath(),
+      });
+    }
+  }
+  return segments.isEmpty ? null : PdfPath(List.unmodifiable(segments));
 }
 
 // Adjacent form transforms in real PDFs can serialize the same intended edge
@@ -1438,22 +1753,115 @@ bool _pdfContains(PdfRect outer, PdfRect inner) =>
   return (gradient, bounds, null);
 }
 
+(PdfDrawTextCommand?, PdfRect?, String?) _singleMaskText(
+    List<PdfRenderCommand> commands) {
+  PdfDrawTextCommand? text;
+  PdfRect? textClip;
+  PdfRect? clip;
+  var blend = PdfBlendMode.normal;
+  final saved = <(PdfRect?, PdfBlendMode)>[];
+  for (final command in commands) {
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, blend));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return (null, null, 'unbalanced mask text state');
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        blend = restored.$2;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+          return (null, null, 'non-rectangular mask text clip');
+        }
+        clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+      case PdfDrawTextCommand():
+        if (text != null) return (null, null, 'mask contains multiple texts');
+        if (blend != PdfBlendMode.normal) {
+          return (null, null, 'mask text blend mode ${blend.name}');
+        }
+        text = command;
+        textClip = clip;
+      case PdfSetBlendModeCommand(:final mode):
+        blend = mode;
+      case PdfSetOverprintCommand():
+        // A single mask element has no prior colorants to preserve.
+        break;
+      default:
+        if (pdfRenderCommandBounds(command) != null) {
+          return (null, null, 'mask contains ${command.runtimeType}');
+        }
+    }
+  }
+  if (saved.isNotEmpty) return (null, null, 'unbalanced mask text state');
+  if (text == null) return (null, null, 'mask has no text');
+  return (text, textClip, null);
+}
+
+(PdfFillPathCommand?, PdfRect?, String?) _singleMaskPath(
+    List<PdfRenderCommand> commands) {
+  PdfFillPathCommand? fill;
+  PdfRect? fillClip;
+  PdfRect? clip;
+  var blend = PdfBlendMode.normal;
+  final saved = <(PdfRect?, PdfBlendMode)>[];
+  for (final command in commands) {
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, blend));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return (null, null, 'unbalanced mask path state');
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        blend = restored.$2;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+          return (null, null, 'non-rectangular mask path clip');
+        }
+        clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+      case PdfFillPathCommand():
+        if (fill != null) return (null, null, 'mask contains multiple paths');
+        if (blend != PdfBlendMode.normal) {
+          return (null, null, 'mask path blend mode ${blend.name}');
+        }
+        fill = command;
+        fillClip = clip;
+      case PdfSetBlendModeCommand(:final mode):
+        blend = mode;
+      case PdfSetOverprintCommand():
+        // A single mask element has no prior colorants to preserve.
+        break;
+      default:
+        if (pdfRenderCommandBounds(command) != null) {
+          return (null, null, 'mask contains ${command.runtimeType}');
+        }
+    }
+  }
+  if (saved.isNotEmpty) return (null, null, 'unbalanced mask path state');
+  if (fill == null) return (null, null, 'mask has no path');
+  return (fill, fillClip, null);
+}
+
 (List<_VectorMaskFill>?, String?) _vectorMaskFills(
     List<PdfRenderCommand> commands) {
   const maxFills = 32;
   final fills = <_VectorMaskFill>[];
   PdfRect? clip;
   var clipEmpty = false;
-  final saved = <(PdfRect?, bool)>[];
+  var fillOverprint = false;
+  var strokeOverprint = false;
+  var overprintedFills = 0;
+  final saved = <(PdfRect?, bool, bool, bool)>[];
   for (final command in commands) {
     switch (command) {
       case PdfSaveCommand():
-        saved.add((clip, clipEmpty));
+        saved.add((clip, clipEmpty, fillOverprint, strokeOverprint));
       case PdfRestoreCommand():
         if (saved.isEmpty) return (null, 'unbalanced vector mask state');
         final restored = saved.removeLast();
         clip = restored.$1;
         clipEmpty = restored.$2;
+        fillOverprint = restored.$3;
+        strokeOverprint = restored.$4;
       case PdfClipPathCommand(:final path):
         if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
           return (null, 'non-rectangular vector mask clip');
@@ -1476,6 +1884,7 @@ bool _pdfContains(PdfRect outer, PdfRect inner) =>
         if (clipEmpty) continue;
         final rect = _pdfIntersection(clip, pdfRenderPathBounds(path));
         if (rect != null) fills.add(_VectorMaskFill(rect, color, alpha));
+        if (fillOverprint) overprintedFills++;
         if (fills.length > maxFills) {
           return (null, 'vector mask fill count exceeds GPU cap');
         }
@@ -1484,7 +1893,8 @@ bool _pdfContains(PdfRect outer, PdfRect inner) =>
           return (null, 'vector mask blend mode ${mode.name}');
         }
       case PdfSetOverprintCommand(:final fill, :final stroke):
-        if (fill || stroke) return (null, 'vector mask overprint');
+        fillOverprint = fill;
+        strokeOverprint = stroke;
       default:
         if (pdfRenderCommandBounds(command) != null) {
           return (null, 'vector mask contains ${command.runtimeType}');
@@ -1493,6 +1903,12 @@ bool _pdfContains(PdfRect outer, PdfRect inner) =>
   }
   if (saved.isNotEmpty) return (null, 'unbalanced vector mask state');
   if (fills.isEmpty) return (null, 'vector mask has no fills');
+  // Overprint has nothing to preserve for the only painted element in a
+  // fresh mask group. With multiple fills it can change their interaction,
+  // so that shape remains on Canvas.
+  if (overprintedFills > 0 && fills.length > 1) {
+    return (null, 'multi-fill vector mask overprint');
+  }
   return (List.unmodifiable(fills), null);
 }
 
@@ -1645,6 +2061,20 @@ String? _gradientUnsupportedReason(PdfGradient gradient, double alpha) {
     previous = stop;
   }
   return null;
+}
+
+String? _unsupportedTextReason(PdfTextRun run) {
+  if (run.invisible) return null;
+  final gradientReason = run.gradient == null
+      ? null
+      : _gradientUnsupportedReason(run.gradient!, run.fillAlpha);
+  final reasons = <String>[
+    if (run.glyphs == null) 'missing glyph outlines',
+    if (!run.fill) 'fill disabled',
+    if (gradientReason != null) gradientReason,
+    if (run.strokeColor != null) 'stroke',
+  ];
+  return reasons.isEmpty ? null : 'unsupported text: ${reasons.join(', ')}';
 }
 
 bool _commandNeedsDarken(
@@ -1922,6 +2352,18 @@ class _CompiledScene {
               _compileSoftMaskVectorFill(geometry, spec),
             _SoftMaskGradientFillSpec spec =>
               _compileSoftMaskGradientFill(geometry, spec),
+            _SoftMaskTextSpec spec => await _compileSoftMaskText(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                mipmapImages: mipmapImages,
+              ),
+            _SoftMaskGradientTextSpec spec =>
+              _compileSoftMaskGradientText(geometry, spec),
           };
         }
         if (draw != null) draws[unit.commandIndex] = draw;
@@ -2401,6 +2843,57 @@ Future<_GpuDraw> _compileSoftMaskFill(
   );
 }
 
+Future<_GpuDraw> _compileSoftMaskText(
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    _SoftMaskTextSpec spec,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
+  final maskImage = scene.imageFor(spec.mask)!;
+  final maskResource = await imageCache.acquire(
+    context,
+    spec.mask,
+    maskImage,
+    stats,
+    mipmapped: mipmapImages,
+  );
+  textureLeases.add(maskResource);
+  final subpaths = _textSubpaths(spec.content.run)!;
+  final stencil = _stencilGeometry(geometry, subpaths);
+  if (stencil == null) throw StateError('empty soft-mask text outline');
+  final bounds = stencil.$2;
+  final cover = _imageVertices(PdfMatrix(
+    bounds.right - bounds.left,
+    0,
+    0,
+    bounds.top - bounds.bottom,
+    bounds.left,
+    bounds.bottom,
+  ));
+  return _SoftMaskFillDraw(
+    stencil.$1,
+    geometry.add(cover.bytes, cover.length ~/ 4),
+    PdfFillRule.nonzero,
+    maskResource.texture,
+    _softMaskInfo(
+      context,
+      maskTransform: spec.mask.transform,
+      contentTint: _premul(spec.content.run.color, spec.content.run.fillAlpha),
+      maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
+      contentStencil: true,
+      maskStencil: false,
+      luminosity: spec.luminosity,
+      backdropLuminance: spec.backdropLuminance,
+      transferScale: spec.transferScale,
+      transferOffset: spec.transferOffset,
+      maskClip: spec.maskClip,
+    ),
+  );
+}
+
 _GpuDraw? _compileSoftMaskGradientFill(
   _GpuGeometryArena geometry,
   _SoftMaskGradientFillSpec spec,
@@ -2427,6 +2920,32 @@ _GpuDraw? _compileSoftMaskGradientFill(
       return _premul(
         spec.content.color,
         (spec.content.alpha * mask).clamp(0.0, 1.0),
+      );
+    },
+  );
+}
+
+_GpuDraw? _compileSoftMaskGradientText(
+  _GpuGeometryArena geometry,
+  _SoftMaskGradientTextSpec spec,
+) {
+  final maskAlpha = spec.mask.alpha.clamp(0.0, 1.0);
+  return _compileGradientSubpaths(
+    geometry,
+    _textSubpaths(spec.content.run)!,
+    PdfFillRule.nonzero,
+    spec.mask.gradient,
+    1,
+    vertexColor: (maskColor) {
+      final mask = spec.luminosity
+          ? (0.2126 * maskColor.red +
+                  0.7152 * maskColor.green +
+                  0.0722 * maskColor.blue) *
+              maskAlpha
+          : maskAlpha;
+      return _premul(
+        spec.content.run.color,
+        (spec.content.run.fillAlpha * mask).clamp(0.0, 1.0),
       );
     },
   );
@@ -2878,6 +3397,27 @@ _GpuDraw? _compileStroke(
   return _stencilDraw(geometry, rings, color, alpha, PdfFillRule.nonzero, true);
 }
 
+List<FlatSubpath>? _textSubpaths(PdfTextRun run) {
+  final glyphs = run.glyphs;
+  if (glyphs == null) return null;
+  final subpaths = <FlatSubpath>[];
+  for (final glyph in glyphs) {
+    final outline = glyph.outline;
+    if (outline == null) continue;
+    final transform = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+        .concat(run.transform);
+    for (final sub in FlattenedOutline.of(outline).subpaths) {
+      final mapped = Float64List(sub.points.length);
+      for (var i = 0; i < sub.points.length; i += 2) {
+        mapped[i] = transform.transformX(sub.points[i], sub.points[i + 1]);
+        mapped[i + 1] = transform.transformY(sub.points[i], sub.points[i + 1]);
+      }
+      subpaths.add(FlatSubpath(mapped, closed: sub.closed));
+    }
+  }
+  return subpaths;
+}
+
 FutureOr<_GpuDraw?> _compileCommand(
     gpu.GpuContext context,
     _GpuGeometryArena geometry,
@@ -2913,22 +3453,7 @@ FutureOr<_GpuDraw?> _compileCommand(
       return _compileStroke(geometry, command);
     case PdfDrawTextCommand(:final run):
       if (run.invisible) return null;
-      final subs = <FlatSubpath>[];
-      for (final glyph in run.glyphs!) {
-        final outline = glyph.outline;
-        if (outline == null) continue;
-        final transform = PdfMatrix.translation(glyph.offset, glyph.offsetY)
-            .concat(run.transform);
-        for (final sub in FlattenedOutline.of(outline).subpaths) {
-          final mapped = Float64List(sub.points.length);
-          for (var i = 0; i < sub.points.length; i += 2) {
-            mapped[i] = transform.transformX(sub.points[i], sub.points[i + 1]);
-            mapped[i + 1] =
-                transform.transformY(sub.points[i], sub.points[i + 1]);
-          }
-          subs.add(FlatSubpath(mapped, closed: sub.closed));
-        }
-      }
+      final subs = _textSubpaths(run)!;
       final gradient = run.gradient;
       if (gradient != null) {
         return _compileGradientSubpaths(

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -53,6 +53,37 @@ PdfDrawImageCommand _decodedImage(
   ));
 }
 
+PdfDrawTextCommand _outlinedText({
+  required PdfMatrix transform,
+  required PdfColor color,
+  double alpha = 1,
+  PdfColor? strokeColor,
+}) =>
+    PdfDrawTextCommand(PdfTextRun(
+      text: 'A',
+      transform: transform,
+      color: color,
+      width: 1,
+      glyphs: const [
+        PdfGlyphPlacement(
+          offset: 0,
+          text: 'A',
+          outline: PdfPath([
+            PdfMoveTo(0.05, 0),
+            PdfLineTo(0.5, 1),
+            PdfLineTo(0.95, 0),
+            PdfLineTo(0.7, 0),
+            PdfLineTo(0.6, 0.3),
+            PdfLineTo(0.4, 0.3),
+            PdfLineTo(0.3, 0),
+            PdfClosePath(),
+          ]),
+        ),
+      ],
+      fillAlpha: alpha,
+      strokeColor: strokeColor,
+    ));
+
 void main() {
   testWidgets('unavailable context declines without affecting the host',
       (tester) async {
@@ -1515,6 +1546,342 @@ void main() {
       expect(difference / a.length, lessThan(6));
       expect(backend.stats.lastTileRoute, 'flutter_gpu');
       expect(backend.stats.texturesUploaded, 0);
+    });
+  });
+
+  testWidgets('image and axial masks retain outlined text', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final imageMask = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          0,
+          0,
+          0,
+          255,
+        ]),
+        const PdfMatrix(612, 0, 0, 792, 0, 0),
+        'outlined-text-mask',
+      );
+      const gradient = PdfGradient(
+        isRadial: false,
+        coords: [0, 0, 1, 0],
+        colors: [PdfColor(0, 0, 0), PdfColor(1, 1, 1)],
+        stops: [0, 1],
+        transform: PdfMatrix(612, 0, 0, 792, 0, 0),
+      );
+      final scene = await PdfRetainedScene.fromCommands(
+          page,
+          [
+            const PdfBeginSoftMaskedCommand(),
+            _outlinedText(
+              transform: const PdfMatrix(120, 0, 0, 120, 70, 100),
+              color: const PdfColor(0.1, 0.55, 0.9),
+            ),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [imageMask],
+            ),
+            const PdfBeginSoftMaskedCommand(),
+            _outlinedText(
+              transform: const PdfMatrix(120, 0, 0, 120, 300, 100),
+              color: const PdfColor(0.9, 0.2, 0.45),
+            ),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [
+                PdfFillPathGradientCommand(
+                  _rect(0, 0, 612, 792),
+                  PdfFillRule.nonzero,
+                  gradient,
+                  1,
+                ),
+              ],
+            ),
+          ],
+          retainDecodedPixels: true);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(50, 550, 500, 170);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(6));
+      expect(backend.stats.texturesUploaded, 1);
+
+      final stroked = await PdfRetainedScene.fromCommands(
+          page,
+          [
+            const PdfBeginSoftMaskedCommand(),
+            _outlinedText(
+              transform: const PdfMatrix(120, 0, 0, 120, 70, 100),
+              color: const PdfColor(0.1, 0.55, 0.9),
+              strokeColor: const PdfColor(0, 0, 0),
+            ),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [imageMask],
+            ),
+          ],
+          retainDecodedPixels: true);
+      addTearDown(stroked.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(stroked), isNull);
+      expect(conservative.stats.lastRejection, contains('stroke'));
+    });
+  });
+
+  testWidgets('matched text masks flatten one nested image-masked fill',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      PdfDrawImageCommand maskImage(String key) => _decodedImage(
+            Uint8List.fromList([
+              0,
+              0,
+              0,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              0,
+              0,
+              0,
+              255,
+            ]),
+            const PdfMatrix(180, 0, 0, 180, 80, 100),
+            key,
+          );
+      const textTransform = PdfMatrix(180, 0, 0, 180, 80, 100);
+      List<PdfRenderCommand> commands(
+              PdfMatrix outerMaskTransform, String key) =>
+          [
+            const PdfBeginSoftMaskedCommand(),
+            _outlinedText(
+              transform: textTransform,
+              color: const PdfColor(0.95, 0.75, 0.1),
+            ),
+            const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+            const PdfBeginSoftMaskedCommand(),
+            PdfFillPathCommand(
+              _rect(60, 80, 280, 320),
+              const PdfColor(0.15, 0.15, 0.15),
+              PdfFillRule.nonzero,
+              0.7,
+            ),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [maskImage(key)],
+            ),
+            const PdfSetBlendModeCommand(PdfBlendMode.normal),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [
+                _outlinedText(
+                  transform: outerMaskTransform,
+                  color: const PdfColor(1, 1, 1),
+                ),
+              ],
+            ),
+          ];
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        commands(textTransform, 'nested-text-mask'),
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(50, 450, 260, 280);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      // The retained stencil intersects coverage per MSAA sample; Canvas
+      // resolves the source layer before applying the identical mask. Their
+      // edge pixels differ slightly, while the continuous PDF geometry and
+      // every fully covered sample are identical.
+      expect(difference / a.length, lessThan(12));
+
+      final unmatched = await PdfRetainedScene.fromCommands(
+        page,
+        commands(
+          const PdfMatrix(180, 0, 0, 180, 84, 100),
+          'unmatched-text-mask',
+        ),
+        retainDecodedPixels: true,
+      );
+      addTearDown(unmatched.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(unmatched), isNull);
+      expect(conservative.stats.lastRejection, contains('multiple paints'));
+    });
+  });
+
+  testWidgets('matched path masks retain nested fills and reject mismatches',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final shape = PdfPath([
+        const PdfMoveTo(80, 100),
+        const PdfLineTo(180, 300),
+        const PdfLineTo(280, 100),
+        const PdfLineTo(220, 160),
+        const PdfLineTo(140, 160),
+        const PdfClosePath(),
+      ]);
+      final shifted = PdfPath([
+        const PdfMoveTo(84, 100),
+        const PdfLineTo(184, 300),
+        const PdfLineTo(284, 100),
+        const PdfLineTo(224, 160),
+        const PdfLineTo(144, 160),
+        const PdfClosePath(),
+      ]);
+      PdfDrawImageCommand maskImage(String key) => _decodedImage(
+            Uint8List.fromList([
+              0,
+              0,
+              0,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              255,
+              0,
+              0,
+              0,
+              255,
+            ]),
+            const PdfMatrix(220, 0, 0, 220, 70, 90),
+            key,
+          );
+      List<PdfRenderCommand> commands(PdfPath maskPath, String key) => [
+            const PdfBeginSoftMaskedCommand(),
+            PdfFillPathCommand(
+              shape,
+              const PdfColor(0.2, 0.65, 0.9),
+              PdfFillRule.nonzero,
+              1,
+            ),
+            const PdfSetBlendModeCommand(PdfBlendMode.screen),
+            const PdfBeginSoftMaskedCommand(),
+            PdfFillPathCommand(
+              _rect(60, 80, 300, 320),
+              const PdfColor(0.9, 0.3, 0.15),
+              PdfFillRule.nonzero,
+              0.8,
+            ),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [maskImage(key)],
+            ),
+            const PdfSetBlendModeCommand(PdfBlendMode.normal),
+            PdfEndSoftMaskedCommand(
+              luminosity: true,
+              backdrop: page.cropBox,
+              maskCommands: [
+                const PdfSetOverprintCommand(
+                  fill: true,
+                  stroke: false,
+                  mode: 1,
+                ),
+                PdfFillPathCommand(
+                  maskPath,
+                  const PdfColor(1, 1, 1),
+                  PdfFillRule.nonzero,
+                  1,
+                ),
+              ],
+            ),
+          ];
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        commands(shape, 'matched-path-mask'),
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(50, 450, 260, 280);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      // Same per-sample stencil-vs-intermediate-resolution edge difference as
+      // the matched text-mask case above.
+      expect(difference / a.length, lessThan(12));
+
+      final unmatched = await PdfRetainedScene.fromCommands(
+        page,
+        commands(shifted, 'unmatched-path-mask'),
+        retainDecodedPixels: true,
+      );
+      addTearDown(unmatched.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(unmatched), isNull);
+      expect(conservative.stats.lastRejection, contains('multiple paints'));
     });
   });
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2031,6 +2031,62 @@ void main() {
     });
   });
 
+  testWidgets('failed image decodes are exact no-ops, not progressive gaps',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final request = PdfImageRequest(
+        stream: CosStream(
+          CosDictionary({
+            'Subtype': const CosName('Image'),
+            'Width': const CosInteger(2),
+            'Height': const CosInteger(2),
+            'BitsPerComponent': const CosInteger(8),
+            'ColorSpace': const CosName('DeviceRGB'),
+            'Filter': const CosName('UnsupportedDecode'),
+          }),
+          Uint8List.fromList([1, 2, 3]),
+        ),
+        transform: const PdfMatrix(140, 0, 0, 140, 50, 50),
+      );
+      final command = PdfDrawImageCommand(request);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [command],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      expect(scene.imageDecodingAttempted, isTrue);
+      expect(scene.imageFor(request), isNull);
+
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(0, 0, 240, 240);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      expect(await _pixels(actual), await _pixels(expected));
+
+      final progressive = await PdfRetainedScene.fromCommands(
+        page,
+        [command],
+        includeImages: false,
+      );
+      addTearDown(progressive.dispose);
+      expect(progressive.imageDecodingAttempted, isFalse);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(progressive), isNull);
+      expect(conservative.stats.lastRejection, 'missing image pixels');
+    });
+  });
+
   testWidgets('an image whose /SMask stayed a companion surface renders',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

PDF.js GPU coverage increases from 107 accepted / 72 fallback pages to 108 / 71 with exact Canvas parity; refreshed Ghent remains 39 / 18. A definitively failed image decode now stays the same transparent no-op Canvas already renders instead of forcing the whole page off Flutter GPU.

This is stacked on #762 and will be rebased after the prerequisite GPU PRs merge.

## What changed

- record whether a retained scene actually attempted image decoding
- compile a decoder-attempted missing image as a no-op
- continue rejecting deliberate vector-only progressive scenes, where image pixels may arrive in a replacement scene
- cover both states plus pixel parity in a Metal regression test

<details>
<summary>Validation details</summary>

- `fvm flutter test --enable-impeller --enable-flutter-gpu`: 254 passed, 3 intentional skips
- refreshed Ghent corpus: 39 accepted / 18 rejected
- PDF.js GPU corpus: 108 accepted / 71 rejected
- `fvm dart analyze`: clean
- `git diff --check`: clean

</details>