### PR TITLE
perf(gpu): retain fallback annotation text

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Treat C1 controls as non-rendering glyph placements in the exact native
+  outline seam, matching Flutter shaping while preserving their PDF advances.
 - Retain stroke-only and fill-plus-stroke outline text, including page-space
   alpha and zero-width hairlines, by reusing the exact path stroke pipeline.
   Filled glyphs keep the analytic atlas while their stroke overlays in painter

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next
 
+- Render overlapping Normal paints in isolated transparency groups into a
+  shader-readable tile attachment, then apply group alpha and outer blend once
+  when sampling it into the page pass.
+- Elide zero-alpha and zero-area transparency groups before GPU auditing;
+  their composite alpha or form BBox clip makes all nested paints exact
+  no-ops.
+- Retain non-Normal transparency groups whose padded fill bounds are provably
+  disjoint, preserving exact outer blending without an offscreen surface.
 - Treat C1 controls as non-rendering glyph placements in the exact native
   outline seam, matching Flutter shaping while preserving their PDF advances.
 - Retain stroke-only and fill-plus-stroke outline text, including page-space

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -33,12 +33,12 @@ import 'text_outliner.dart';
 /// content and mask stay as separate scene-lifetime textures and are combined
 /// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
 /// masks (with rectangular clips additionally using the hardware scissor).
-/// Other isolated groups, blend modes beyond Multiply/Screen, complex clips
-/// *inside* the special soft-mask shortcuts, non-nested radial gradients,
-/// unresolved substituted text, stroked text, unsafe overprint, or missing
-/// image pixels reject the whole scene. Zero-width PDF hairlines are expanded
-/// at tile submission time so they remain exactly one device pixel at every
-/// level of detail.
+/// Knockout/non-isolated groups, isolated groups with non-Normal internal
+/// paints, blend modes beyond Multiply/Screen, complex clips *inside* the
+/// special soft-mask shortcuts, non-nested radial gradients, unresolved
+/// substituted text, unsafe overprint, or missing image pixels reject the
+/// whole scene. Zero-width PDF hairlines are expanded at tile submission time
+/// so they remain exactly one device pixel at every level of detail.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -492,10 +492,16 @@ class _GroupStrokeSpec extends _GpuCompositeSpec {
 class _GroupPaintSpec extends _GpuCompositeSpec {
   const _GroupPaintSpec({
     required this.commands,
+    required this.paintClips,
     required this.contentClip,
+    this.groupAlpha = 1,
+    this.offscreen = false,
   });
 
   final List<PdfRenderCommand> commands;
+  final List<PdfRect?> paintClips;
+  final double groupAlpha;
+  final bool offscreen;
   @override
   final PdfRect? contentClip;
 }
@@ -766,6 +772,7 @@ PdfTextRun? _tryOutlineGpuText(
 /// compact transcript for unbounded GPU geometry.
 _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
   const maxExpandedCommands = 1000000;
+  source = _dropInvisibleGroups(source);
   var hasTiledCell = false;
   var mipmapImages = false;
 
@@ -857,6 +864,45 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
     null,
     mipmapImages: mipmapImages,
   );
+}
+
+/// Removes transparency groups whose alpha is zero or whose declared
+/// device-space bounds have no area.
+///
+/// A form group is clipped to its BBox before any content paints. A collapsed
+/// BBox therefore contributes no samples regardless of nested commands,
+/// blend modes, masks, or overprint state; group alpha zero has the same
+/// result after compositing. Dropping the balanced transcript is exact and
+/// avoids rejecting an otherwise GPU-safe page for unreachable content.
+List<PdfRenderCommand> _dropInvisibleGroups(List<PdfRenderCommand> commands) {
+  List<PdfRenderCommand>? rewritten;
+  for (var index = 0; index < commands.length; index++) {
+    final command = commands[index];
+    if (command case PdfBeginGroupCommand(:final alpha, :final bounds)
+        when alpha <= 0 ||
+            (bounds != null &&
+                (bounds.right <= bounds.left || bounds.top <= bounds.bottom))) {
+      var depth = 1;
+      var end = index + 1;
+      for (; end < commands.length && depth > 0; end++) {
+        switch (commands[end]) {
+          case PdfBeginGroupCommand():
+            depth++;
+          case PdfEndGroupCommand():
+            depth--;
+          default:
+            break;
+        }
+      }
+      if (depth == 0) {
+        rewritten ??= List<PdfRenderCommand>.of(commands.take(index));
+        index = end - 1;
+        continue;
+      }
+    }
+    rewritten?.add(command);
+  }
+  return rewritten == null ? commands : List.unmodifiable(rewritten);
 }
 
 _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
@@ -1100,7 +1146,12 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
   PdfBlendMode initialBlend = PdfBlendMode.normal,
 }) {
   if (commands[start]
-      case PdfBeginGroupCommand(:final alpha, :final knockout)) {
+      case PdfBeginGroupCommand(
+        :final alpha,
+        :final knockout,
+        :final isolated,
+        :final backdropColor,
+      )) {
     if (commands[end] is! PdfEndGroupCommand) {
       return (null, 'unsupported composite nesting');
     }
@@ -1109,7 +1160,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     // multi-paint path below is deliberately narrower: alpha-one, normal
     // source-over, non-knockout groups whose isolation layer is an identity.
     PdfDrawImageCommand? content;
-    final paints = <(int, PdfRenderCommand, PdfRect?, PdfBlendMode, bool)>[];
+    final paints = <(int?, PdfRenderCommand, PdfRect?, PdfBlendMode, bool)>[];
     PdfEndSoftMaskedCommand? softEnd;
     var softDepth = 0;
     var softCount = 0;
@@ -1200,7 +1251,70 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         case PdfSetOverprintCommand(:final fill, :final stroke):
           fillOverprint = fill;
           strokeOverprint = stroke;
-        case PdfBeginGroupCommand() || PdfEndGroupCommand():
+        case PdfBeginGroupCommand(:final backdropColor):
+          if (blend != PdfBlendMode.normal ||
+              fillOverprint ||
+              strokeOverprint ||
+              backdropColor != null) {
+            return (null, 'nested image group');
+          }
+          final nestedEnd = _matchingGroupEnd(commands, i, end);
+          if (nestedEnd == null) return (null, 'nested image group');
+          final nested = _parseComposite(
+            commands,
+            i,
+            nestedEnd,
+            initialClip: clip,
+            initialFillOverprint: false,
+            initialStrokeOverprint: false,
+            initialBlend: PdfBlendMode.normal,
+          );
+          final nestedSpec = nested.$1;
+          switch (nestedSpec) {
+            case _GroupFillSpec(:final content, :final groupAlpha):
+              paints.add((
+                null,
+                PdfFillPathCommand(
+                  content.path,
+                  content.color,
+                  content.rule,
+                  (content.alpha * groupAlpha).clamp(0.0, 1.0),
+                ),
+                nestedSpec.contentClip,
+                PdfBlendMode.normal,
+                false,
+              ));
+            case _GroupStrokeSpec(:final content, :final groupAlpha):
+              paints.add((
+                null,
+                PdfStrokePathCommand(
+                  content.path,
+                  content.color,
+                  content.stroke,
+                  (content.alpha * groupAlpha).clamp(0.0, 1.0),
+                ),
+                nestedSpec.contentClip,
+                PdfBlendMode.normal,
+                false,
+              ));
+            case _GroupPaintSpec(:final commands, :final paintClips)
+                when !nestedSpec.offscreen:
+              for (var nestedIndex = 0;
+                  nestedIndex < commands.length;
+                  nestedIndex++) {
+                paints.add((
+                  null,
+                  commands[nestedIndex],
+                  paintClips[nestedIndex],
+                  PdfBlendMode.normal,
+                  false,
+                ));
+              }
+            default:
+              return (null, nested.$2 ?? 'nested image group');
+          }
+          i = nestedEnd;
+        case PdfEndGroupCommand():
           return (null, 'nested image group');
         default:
           if (pdfRenderCommandBounds(command) != null) {
@@ -1227,6 +1341,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               : 'transparency-group fill overprint',
         );
       }
+      if (backdropColor != null) {
+        return (null, 'non-identity single-paint transparency group');
+      }
       return switch (paint.$2) {
         PdfFillPathCommand content => (
             _GroupFillSpec(
@@ -1249,39 +1366,51 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
       final commonClip = paints.first.$3;
-      var overlaps = false;
-      final occupied = <PdfRect>[];
-      for (final paint in paints) {
-        final bounds = _pdfIntersection(
-          pdfRenderCommandBounds(paint.$2),
-          paint.$3,
-        );
-        if (bounds == null) continue;
-        if (occupied.any((other) => _pdfIntersection(other, bounds) != null)) {
-          overlaps = true;
-          break;
-        }
-        occupied.add(bounds);
-      }
-      if (alpha != 1 ||
-          knockout ||
-          paints.any((paint) => paint.$4 != PdfBlendMode.normal || paint.$5) ||
-          (initialBlend != PdfBlendMode.normal && overlaps)) {
+      final compatiblePaints =
+          paints.every((paint) => paint.$4 == PdfBlendMode.normal && !paint.$5);
+      final commonPaintClip =
+          paints.every((paint) => _samePdfRect(paint.$3, commonClip));
+      final disjointOuterBlend = initialBlend != PdfBlendMode.normal &&
+          _areDisjointFills([
+            for (final paint in paints)
+              (paint.$2, paint.$3, paint.$4, paint.$5),
+          ]);
+      final canFlatten = alpha == 1 &&
+          !knockout &&
+          backdropColor == null &&
+          compatiblePaints &&
+          (initialBlend == PdfBlendMode.normal || disjointOuterBlend);
+      final canRenderOffscreen =
+          isolated && !knockout && backdropColor == null && compatiblePaints;
+      if (!canFlatten && !canRenderOffscreen) {
         return (null, 'non-identity multi-paint transparency group');
       }
-      if (paints.any((paint) => !_samePdfRect(paint.$3, commonClip))) {
+      if (canFlatten &&
+          !commonPaintClip &&
+          paints.every((paint) => paint.$1 != null)) {
         return (
           _FlattenGroupSpec(List.unmodifiable([
             for (final paint in paints)
-              (commandIndex: paint.$1, clip: paint.$3),
+              (commandIndex: paint.$1!, clip: paint.$3),
           ])),
           null,
         );
       }
+      // Synthesized paints from a nested group no longer have source command
+      // indices, so they cannot use [_FlattenGroupSpec]'s per-command clips.
+      // Retaining those clips in an offscreen pass is exact only for an
+      // isolated group; an unisolated group must keep seeing the page
+      // backdrop between paints.
+      if (canFlatten && !commonPaintClip && !canRenderOffscreen) {
+        return (null, 'nested group has distinct paint clips');
+      }
       return (
         _GroupPaintSpec(
           commands: List.unmodifiable([for (final paint in paints) paint.$2]),
-          contentClip: commonClip,
+          paintClips: List.unmodifiable([for (final paint in paints) paint.$3]),
+          contentClip: canFlatten && commonPaintClip ? commonClip : null,
+          groupAlpha: alpha,
+          offscreen: !canFlatten || !commonPaintClip,
         ),
         null,
       );
@@ -1489,6 +1618,52 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     };
   }
   return (null, 'unsupported composite ${commands[start].runtimeType}');
+}
+
+/// Whether a multi-paint group can apply its outer blend per paint without
+/// changing the result.
+///
+/// Disjoint fills never contribute to the same destination sample, so
+/// compositing their transparent group once is identical to compositing each
+/// fill directly. The two-point padding is deliberately conservative around
+/// antialiased path edges; overlapping, touching, stroked, or unbounded paints
+/// stay on the exact Canvas layer path.
+bool _areDisjointFills(
+  List<(PdfRenderCommand, PdfRect?, PdfBlendMode, bool)> paints,
+) {
+  final bounds = <PdfRect>[];
+  for (final paint in paints) {
+    if (paint.$1 is! PdfFillPathCommand) return false;
+    final commandBounds = pdfRenderCommandBounds(paint.$1);
+    final clipped = _pdfIntersection(commandBounds, paint.$2);
+    if (clipped == null) return false;
+    final padded = _inflatePdf(clipped, 2);
+    if (bounds.any((other) => _pdfIntersection(other, padded) != null)) {
+      return false;
+    }
+    bounds.add(padded);
+  }
+  return true;
+}
+
+int? _matchingGroupEnd(
+  List<PdfRenderCommand> commands,
+  int start,
+  int outerEnd,
+) {
+  var depth = 1;
+  for (var index = start + 1; index < outerEnd; index++) {
+    switch (commands[index]) {
+      case PdfBeginGroupCommand():
+        depth++;
+      case PdfEndGroupCommand():
+        depth--;
+        if (depth == 0) return index;
+      default:
+        break;
+    }
+  }
+  return null;
 }
 
 /// Flattens one narrow nested-mask shape without allocating an offscreen
@@ -2759,46 +2934,215 @@ class _CompiledScene {
       format: context.defaultStencilFormat,
       sampleCount: multisampled ? 4 : 1,
     );
-    final commandBuffer = context.createCommandBuffer();
-    final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
-      colorAttachments: [
-        gpu.ColorAttachment(
-          texture: color,
-          resolveTexture: multisampled ? resolve : null,
-          clearValue: vm.Vector4(0, 0, 0, 0),
-          storeAction: multisampled
-              ? gpu.StoreAction.multisampleResolve
-              : gpu.StoreAction.store,
-        ),
-      ],
-      depthStencilAttachment: gpu.DepthStencilAttachment(
-        texture: stencil,
-        stencilClearValue: 0,
-      ),
-    ));
-    pass
-      ..setCullMode(gpu.CullMode.none)
-      ..setWindingOrder(gpu.WindingOrder.counterClockwise)
-      ..setPrimitiveType(gpu.PrimitiveType.triangle)
-      ..setStencilReference(0)
-      ..setColorBlendEnable(true);
-
     final transient = context.createHostBuffer();
-    final transform = transient.emplace(
-      _tileTransform(pageToRaster, region, pixelRatio, width, height),
+
+    gpu.RenderPass createPass(
+      gpu.CommandBuffer commandBuffer,
+      gpu.Texture target,
+      gpu.Texture stencilTarget, {
+      gpu.Texture? resolveTarget,
+    }) {
+      final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
+        colorAttachments: [
+          gpu.ColorAttachment(
+            texture: target,
+            resolveTexture: resolveTarget,
+            clearValue: vm.Vector4(0, 0, 0, 0),
+            storeAction: resolveTarget == null
+                ? gpu.StoreAction.store
+                : gpu.StoreAction.multisampleResolve,
+          ),
+        ],
+        depthStencilAttachment: gpu.DepthStencilAttachment(
+          texture: stencilTarget,
+          stencilClearValue: 0,
+        ),
+      ));
+      return pass
+        ..setCullMode(gpu.CullMode.none)
+        ..setWindingOrder(gpu.WindingOrder.counterClockwise)
+        ..setPrimitiveType(gpu.PrimitiveType.triangle)
+        ..setStencilReference(0)
+        ..setColorBlendEnable(true);
+    }
+
+    _GpuEncoder encoderFor(
+      gpu.RenderPass pass, {
+      required Rect targetRegion,
+      required int targetWidth,
+      required int targetHeight,
+    }) =>
+        _GpuEncoder(
+          pass: pass,
+          pipelines: pipelines,
+          transform: transient.emplace(_tileTransform(
+            pageToRaster,
+            targetRegion,
+            pixelRatio,
+            targetWidth,
+            targetHeight,
+          )),
+          pageToRaster: pageToRaster,
+          region: targetRegion,
+          pixelRatio: pixelRatio,
+          width: targetWidth,
+          height: targetHeight,
+          clipDraws: clipDraws,
+          stencilClear: paper.vertices,
+          emplaceTransient: transient.emplace,
+        );
+
+    Rect groupRegionFor(_GpuUnit unit, _OffscreenGroupDraw draw) {
+      final hairlinePadding = math.max(
+        0.0,
+        0.5 / _pageDeviceScale(pageToRaster, pixelRatio) - 2,
+      );
+      final extraPadding = math.max(draw.extraPadding, hairlinePadding);
+      final bounds = extraPadding == 0
+          ? unit.bounds
+          : _inflatePdf(unit.bounds, extraPadding);
+      final points = <(double, double)>[
+        (bounds.left, bounds.bottom),
+        (bounds.right, bounds.bottom),
+        (bounds.right, bounds.top),
+        (bounds.left, bounds.top),
+      ];
+      var left = double.infinity, top = double.infinity;
+      var right = double.negativeInfinity, bottom = double.negativeInfinity;
+      for (final (x, y) in points) {
+        final rx = pageToRaster.transformX(x, y);
+        final ry = pageToRaster.transformY(x, y);
+        if (rx < left) left = rx;
+        if (rx > right) right = rx;
+        if (ry < top) top = ry;
+        if (ry > bottom) bottom = ry;
+      }
+      left = math.max(
+          region.left,
+          region.left +
+              (((left - region.left) * pixelRatio).floor() / pixelRatio));
+      top = math.max(
+          region.top,
+          region.top +
+              (((top - region.top) * pixelRatio).floor() / pixelRatio));
+      right = math.min(
+          region.right,
+          region.left +
+              (((right - region.left) * pixelRatio).ceil() / pixelRatio));
+      bottom = math.min(
+          region.bottom,
+          region.top +
+              (((bottom - region.top) * pixelRatio).ceil() / pixelRatio));
+      return Rect.fromLTRB(left, top, right, bottom);
+    }
+
+    final groupPlans = <(_GpuUnit, _OffscreenGroupDraw, Rect, int, int, int)>[];
+    var offscreenBytes = 0;
+    for (final unit in selected) {
+      final draw = draws[unit.commandIndex];
+      if (draw is! _OffscreenGroupDraw) continue;
+      final groupRegion = groupRegionFor(unit, draw);
+      final groupWidth =
+          (groupRegion.width * pixelRatio).ceil().clamp(1, width);
+      final groupHeight =
+          (groupRegion.height * pixelRatio).ceil().clamp(1, height);
+      // Resolve RGBA + stencil is about 8 B/px. A 4x attachment adds four
+      // samples of each; 40 B/px is deliberately conservative across backend
+      // stencil formats. Bound all live intermediates so a pathological page
+      // falls back instead of multiplying a deep-zoom tile into an OOM.
+      final estimatedBytes = groupWidth * groupHeight * (multisampled ? 40 : 8);
+      offscreenBytes += estimatedBytes;
+      if (offscreenBytes > (256 << 20)) {
+        stats.offscreenGroupBudgetFallbacks++;
+        throw StateError('offscreen group tiles exceed 256 MiB');
+      }
+      groupPlans.add((
+        unit,
+        draw,
+        groupRegion,
+        groupWidth,
+        groupHeight,
+        estimatedBytes,
+      ));
+    }
+
+    final groupTextures = <int, (gpu.Texture, Rect)>{};
+    final retainedGroupTextures = <gpu.Texture>[];
+    for (final plan in groupPlans) {
+      final (unit, draw, groupRegion, groupWidth, groupHeight, estimatedBytes) =
+          plan;
+      final groupResolve = context.createTexture(
+        gpu.StorageMode.devicePrivate,
+        groupWidth,
+        groupHeight,
+        format: context.defaultColorFormat,
+      );
+      final groupColor = multisampled
+          ? context.createTexture(
+              gpu.StorageMode.deviceTransient,
+              groupWidth,
+              groupHeight,
+              format: context.defaultColorFormat,
+              sampleCount: 4,
+            )
+          : groupResolve;
+      final groupStencil = context.createTexture(
+        gpu.StorageMode.deviceTransient,
+        groupWidth,
+        groupHeight,
+        format: context.defaultStencilFormat,
+        sampleCount: multisampled ? 4 : 1,
+      );
+      final groupAttachments = <gpu.Texture>[
+        groupResolve,
+        if (multisampled) groupColor,
+        groupStencil,
+      ];
+      retainedGroupTextures.addAll(groupAttachments);
+      final groupCommandBuffer = context.createCommandBuffer();
+      final groupEncoder = encoderFor(
+        createPass(
+          groupCommandBuffer,
+          groupColor,
+          groupStencil,
+          resolveTarget: multisampled ? groupResolve : null,
+        ),
+        targetRegion: groupRegion,
+        targetWidth: groupWidth,
+        targetHeight: groupHeight,
+      );
+      groupEncoder.setBlendMode(PdfBlendMode.normal);
+      for (final paint in draw.paints) {
+        groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
+        paint.$1.encode(groupEncoder);
+      }
+      stats.clipMaskRebuilds += groupEncoder.clipMaskRebuilds;
+      groupCommandBuffer.submit(completionCallback: (_) {
+        // The page completion owns the same textures on the success path.
+        // This independent capture also fences them if a later allocation or
+        // the final page submission throws after this pass was queued.
+        groupAttachments.length;
+      });
+      stats
+        ..offscreenGroupPasses += 1
+        ..offscreenGroupAllocatedBytes += estimatedBytes;
+      groupTextures[unit.commandIndex] = (groupResolve, groupRegion);
+    }
+    stats.peakOffscreenGroupBytes =
+        math.max(stats.peakOffscreenGroupBytes, offscreenBytes);
+
+    final commandBuffer = context.createCommandBuffer();
+    final pass = createPass(
+      commandBuffer,
+      color,
+      stencil,
+      resolveTarget: multisampled ? resolve : null,
     );
-    final encoder = _GpuEncoder(
-      pass: pass,
-      pipelines: pipelines,
-      transform: transform,
-      pageToRaster: pageToRaster,
-      region: region,
-      pixelRatio: pixelRatio,
-      width: width,
-      height: height,
-      clipDraws: clipDraws,
-      stencilClear: paper.vertices,
-      emplaceTransient: transient.emplace,
+    final encoder = encoderFor(
+      pass,
+      targetRegion: region,
+      targetWidth: width,
+      targetHeight: height,
     );
     encoder
       ..setClip(_rootGpuClip)
@@ -2809,7 +3153,12 @@ class _CompiledScene {
       encoder
         ..setClip(unit.clip)
         ..setBlendMode(unit.blendMode);
-      draw.encode(encoder);
+      if (draw is _OffscreenGroupDraw) {
+        final group = groupTextures[unit.commandIndex]!;
+        encoder.tileTexture(group.$1, group.$2, draw.alpha);
+      } else {
+        draw.encode(encoder);
+      }
     }
     stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
     final submit = Stopwatch()..start();
@@ -2823,14 +3172,19 @@ class _CompiledScene {
       );
     try {
       commandBuffer.submit(
-        completionCallback: (success) => _completeSubmission(
-          success,
-          completion,
-          tracePage,
-          width,
-          height,
-          selected.length,
-        ),
+        completionCallback: (success) {
+          // Keep every intermediate attachment alive until the command buffer
+          // has finished sampling it into the page target.
+          retainedGroupTextures.length;
+          _completeSubmission(
+            success,
+            completion,
+            tracePage,
+            width,
+            height,
+            selected.length,
+          );
+        },
       );
     } catch (_) {
       _inFlight--;
@@ -2999,8 +3353,18 @@ _GpuDraw? _compileGroupStroke(
     );
 
 _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
-  final draws = <_GpuDraw>[];
-  for (final command in spec.commands) {
+  final draws = <(_GpuDraw, PdfRect?)>[];
+  var paintPadding = 2.0;
+  for (var index = 0; index < spec.commands.length; index++) {
+    final command = spec.commands[index];
+    if (command case PdfStrokePathCommand(:final stroke)
+        when stroke.width > 0) {
+      final joinScale = stroke.join == 0 ? stroke.miterLimit : 1.0;
+      paintPadding = math.max(
+        paintPadding,
+        stroke.width * joinScale / 2 + 2,
+      );
+    }
     final draw = switch (command) {
       PdfFillPathCommand(
         :final path,
@@ -3019,9 +3383,16 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
       PdfStrokePathCommand() => _compileStroke(geometry, command),
       _ => null,
     };
-    if (draw != null) draws.add(draw);
+    if (draw != null) draws.add((draw, spec.paintClips[index]));
   }
-  return draws.isEmpty ? null : _SequenceDraw(List.unmodifiable(draws));
+  if (draws.isEmpty) return null;
+  return spec.offscreen
+      ? _OffscreenGroupDraw(
+          List.unmodifiable(draws),
+          spec.groupAlpha,
+          math.max(0, paintPadding - 2),
+        )
+      : _SequenceDraw(List.unmodifiable([for (final draw in draws) draw.$1]));
 }
 
 Future<_GpuDraw> _compileSoftMaskFill(
@@ -4540,6 +4911,22 @@ class _SequenceDraw implements _GpuDraw {
   }
 }
 
+/// A retained isolated group whose overlapping paints must first render onto
+/// a transparent tile-sized attachment. [_CompiledScene] encodes [paints]
+/// into that attachment, then samples the completed texture once into the
+/// page pass with [alpha] and the unit's outer blend mode.
+class _OffscreenGroupDraw implements _GpuDraw {
+  const _OffscreenGroupDraw(this.paints, this.alpha, this.extraPadding);
+
+  final List<(_GpuDraw, PdfRect?)> paints;
+  final double alpha;
+  final double extraPadding;
+
+  @override
+  void encode(_GpuEncoder encoder) =>
+      throw StateError('offscreen group requires a separate render pass');
+}
+
 class _SolidDraw implements _GpuDraw {
   const _SolidDraw(this.vertices);
   final _GpuBuffer vertices;
@@ -5005,6 +5392,55 @@ class _GpuEncoder {
         ),
       );
     _drawBuffer(vertices);
+    pass.clearBindings();
+  }
+
+  /// Samples a tile-sized offscreen group back into the same raster region.
+  /// The texture was produced at this pass's exact dimensions, so nearest
+  /// sampling is a one-to-one texel copy; [alpha] and [_paintBlend] apply to
+  /// the completed group once, as required by PDF transparency semantics.
+  void tileTexture(gpu.Texture texture, Rect textureRegion, double alpha) {
+    final inverse = pageToRaster.inverted();
+    if (inverse == null) throw StateError('singular page-to-raster transform');
+    final left = textureRegion.left, right = textureRegion.right;
+    final top = textureRegion.top, bottom = textureRegion.bottom;
+    final bl = (
+      inverse.transformX(left, bottom),
+      inverse.transformY(left, bottom),
+    );
+    final br = (
+      inverse.transformX(right, bottom),
+      inverse.transformY(right, bottom),
+    );
+    final tl = (
+      inverse.transformX(left, top),
+      inverse.transformY(left, top),
+    );
+    final vertices = _imageVertices(PdfMatrix(
+      br.$1 - bl.$1,
+      br.$2 - bl.$2,
+      tl.$1 - bl.$1,
+      tl.$2 - bl.$2,
+      bl.$1,
+      bl.$2,
+    ));
+    final info = Float32List(8)..[3] = alpha.clamp(0.0, 1.0);
+    _defaultStencil();
+    pass
+      ..setColorBlendEquation(_paintBlend)
+      ..bindPipeline(pipelines.texture)
+      ..bindUniform(pipelines.textureTransform, transform)
+      ..bindUniform(
+          pipelines.textureInfo, emplaceTransient(ByteData.sublistView(info)))
+      ..bindTexture(
+        pipelines.textureSampler,
+        texture,
+        sampler: gpu.SamplerOptions(
+          minFilter: gpu.MinMagFilter.nearest,
+          magFilter: gpu.MinMagFilter.nearest,
+        ),
+      );
+    _drawView(emplaceTransient(vertices.bytes), 6);
     pass.clearBindings();
   }
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -36,6 +36,10 @@ class FlutterGpuTileBackendStats {
   int analyticTextFallbackRuns = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
+  int offscreenGroupPasses = 0;
+  int offscreenGroupAllocatedBytes = 0;
+  int peakOffscreenGroupBytes = 0;
+  int offscreenGroupBudgetFallbacks = 0;
   int geometryBudgetFallbacks = 0;
   int activeGeometryLeases = 0;
   int geometryBytes = 0;
@@ -99,6 +103,10 @@ class FlutterGpuTileBackendStats {
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
+        'offscreenGroupPasses': offscreenGroupPasses,
+        'offscreenGroupAllocatedBytes': offscreenGroupAllocatedBytes,
+        'peakOffscreenGroupBytes': peakOffscreenGroupBytes,
+        'offscreenGroupBudgetFallbacks': offscreenGroupBudgetFallbacks,
         'geometryBudgetFallbacks': geometryBudgetFallbacks,
         'activeGeometryLeases': activeGeometryLeases,
         'geometryBytes': geometryBytes,
@@ -161,6 +169,10 @@ class FlutterGpuTileBackendStats {
     analyticTextFallbackRuns = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
+    offscreenGroupPasses = 0;
+    offscreenGroupAllocatedBytes = 0;
+    peakOffscreenGroupBytes = 0;
+    offscreenGroupBudgetFallbacks = 0;
     geometryBudgetFallbacks = 0;
     peakGeometryBytes = geometryBytes;
     texturesUploaded = 0;
@@ -206,6 +218,10 @@ class FlutterGpuTileBackendStats {
       'analyticAtlasFallbacks=$analyticAtlasFallbacks '
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
+      'groupPasses=$offscreenGroupPasses '
+      'groupAllocatedBytes=$offscreenGroupAllocatedBytes '
+      'peakGroupBytes=$peakOffscreenGroupBytes '
+      'groupBudgetFallbacks=$offscreenGroupBudgetFallbacks '
       'geometryBudgetFallbacks=$geometryBudgetFallbacks '
       'activeGeometryLeases=$activeGeometryLeases '
       'geometryBytes=$geometryBytes peakGeometryBytes=$peakGeometryBytes '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
@@ -77,7 +77,11 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
     for (var index = 0; index < text.length;) {
       final length = _runeLengthAt(text, index);
       final rune = _runeAt(text, index, length);
-      final blank = _isWhitespace(rune);
+      // HarfBuzz treats C1 controls as default-ignorable characters: they
+      // advance through the PDF's own offset table but paint no fallback box.
+      // Keep them as empty placements instead of requiring a cmap glyph that
+      // Canvas never draws.
+      final blank = _isWhitespace(rune) || _isControl(rune);
       final glyphId = face.gidForUnicode(rune);
       PdfPath? outline;
       if (!blank) {
@@ -91,8 +95,9 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
       resolved.add(_ResolvedGlyph(index, length, outline));
       index += length;
     }
-    if (naturalAdvance <= 0 || pdfAdvance <= 0) return null;
-    final xScale = pdfAdvance / naturalAdvance;
+    final hasInk = resolved.any((glyph) => glyph.outline != null);
+    if (hasInk && (naturalAdvance <= 0 || pdfAdvance <= 0)) return null;
+    final xScale = hasInk ? pdfAdvance / naturalAdvance : 1.0;
     if (!xScale.isFinite || xScale <= 0) return null;
 
     final glyphs = <PdfGlyphPlacement>[
@@ -171,6 +176,8 @@ bool _isWhitespace(int rune) =>
     rune == 0x3000 ||
     rune == 0xFEFF;
 
+bool _isControl(int rune) => rune >= 0x7F && rune <= 0x9F;
+
 bool _isPlaceableText(String text) {
   for (var i = 0; i < text.length; i++) {
     final code = text.codeUnitAt(i);
@@ -180,7 +187,7 @@ bool _isPlaceableText(String text) {
 }
 
 bool _isPlaceableCodeUnit(int code) =>
-    (code >= 0x20 && code <= 0x2FF && code != 0x7F) ||
+    (code >= 0x20 && code <= 0x2FF) ||
     (code >= 0x370 && code <= 0x482) ||
     (code >= 0x48A && code <= 0x52F) ||
     (code >= 0x2000 && code <= 0x206F) ||

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -63,6 +63,10 @@ void main() {
       ..analyticAtlasBytes = 4096
       ..analyticAtlasFallbacks = 1
       ..analyticTextFallbackRuns = 2
+      ..offscreenGroupPasses = 3
+      ..offscreenGroupAllocatedBytes = 6 << 20
+      ..peakOffscreenGroupBytes = 4 << 20
+      ..offscreenGroupBudgetFallbacks = 1
       ..completedSubmissions = 8
       ..completionMicros = 32000
       ..maxCompletionMicros = 9000
@@ -93,6 +97,11 @@ void main() {
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
+    expect(stats.toJson(), containsPair('offscreenGroupPasses', 3));
+    expect(
+        stats.toJson(), containsPair('offscreenGroupAllocatedBytes', 6 << 20));
+    expect(stats.toJson(), containsPair('peakOffscreenGroupBytes', 4 << 20));
+    expect(stats.toJson(), containsPair('offscreenGroupBudgetFallbacks', 1));
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
@@ -126,6 +135,10 @@ void main() {
     expect(stats.analyticAtlasBytes, 0);
     expect(stats.analyticAtlasFallbacks, 0);
     expect(stats.analyticTextFallbackRuns, 0);
+    expect(stats.offscreenGroupPasses, 0);
+    expect(stats.offscreenGroupAllocatedBytes, 0);
+    expect(stats.peakOffscreenGroupBytes, 0);
+    expect(stats.offscreenGroupBudgetFallbacks, 0);
     expect(stats.completedSubmissions, 0);
     expect(stats.completionMicros, 0);
     expect(stats.inFlightSubmissions, 2);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
@@ -1095,12 +1096,6 @@ void main() {
         ),
         const PdfRestoreCommand(),
         const PdfEndGroupCommand(),
-        PdfFillPathCommand(
-          _rect(175, 120, 215, 220),
-          const PdfColor(0.85, 0.65, 0.2),
-          PdfFillRule.nonzero,
-          0.75,
-        ),
         const PdfSetBlendModeCommand(PdfBlendMode.normal),
       ]);
       addTearDown(scene.dispose);
@@ -1174,6 +1169,37 @@ void main() {
     });
   });
 
+  testWidgets('single-paint groups with a seeded backdrop keep Canvas',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(
+          0.8,
+          backdropColor: PdfColor(0.2, 0.3, 0.4),
+        ),
+        PdfFillPathCommand(
+          _rect(70, 120, 280, 340),
+          const PdfColor(0.85, 0.18, 0.3),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(scene), isNull);
+      expect(
+        backend.stats.lastRejection,
+        'non-identity single-paint transparency group',
+      );
+    });
+  });
+
   testWidgets('identity groups retain ordered fill and stroke paints',
       (tester) async {
     await tester.runAsync(() async {
@@ -1225,8 +1251,61 @@ void main() {
     });
   });
 
-  testWidgets('disjoint group paints retain their outer blend and clips',
+  testWidgets('disjoint fills retain a transparency group outer blend',
       (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(1),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 140, 310),
+          const PdfColor(0.95, 0.7, 0.2),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(210, 140, 270, 310),
+          const PdfColor(0.2, 0.8, 0.85),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+    });
+  });
+
+  testWidgets('disjoint group paints retain distinct clips', (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
         markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
@@ -1281,29 +1360,227 @@ void main() {
       }
       expect(difference / a.length, lessThan(2));
       expect(backend.stats.lastTileRoute, 'flutter_gpu');
+    });
+  });
 
-      final overlapping = await PdfRetainedScene.fromCommands(page, [
+  testWidgets('isolated overlapping paints composite through an offscreen tile',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.62,
+          isolated: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 230, 310),
+          const PdfColor(0.95, 0.7, 0.2),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        PdfStrokePathCommand(
+          _rect(150, 160, 270, 325),
+          const PdfColor(0.2, 0.8, 0.85),
+          const PdfStroke(width: 12, join: 1),
+          0.75,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+      expect(backend.stats.offscreenGroupAllocatedBytes, greaterThan(0));
+      expect(
+        backend.stats.peakOffscreenGroupBytes,
+        backend.stats.offscreenGroupAllocatedBytes,
+      );
+    });
+  });
+
+  testWidgets('offscreen group budget rejects before submitting group passes',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[];
+      for (var index = 0; index < 27; index++) {
+        commands.addAll([
+          const PdfBeginGroupCommand(
+            0.8,
+            isolated: true,
+            bounds: PdfRect(0, 0, 612, 792),
+          ),
+          PdfFillPathCommand(
+            _rect(0, 0, 612, 792),
+            const PdfColor(0.8, 0.2, 0.1),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          PdfFillPathCommand(
+            _rect(0, 0, 612, 792),
+            const PdfColor(0.1, 0.3, 0.8),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfEndGroupCommand(),
+        ]);
+      }
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      await expectLater(
+        session.rasterizeRegion(
+          const Rect.fromLTWH(0, 0, 512, 512),
+          pixelRatio: 1,
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(backend.stats.offscreenGroupBudgetFallbacks, 1);
+      expect(backend.stats.offscreenGroupPasses, 0);
+      expect(backend.stats.offscreenGroupAllocatedBytes, 0);
+    });
+  });
+
+  testWidgets('overlapping fills keep non-normal groups on Canvas',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
         const PdfSetBlendModeCommand(PdfBlendMode.multiply),
         const PdfBeginGroupCommand(1),
         const PdfSetBlendModeCommand(PdfBlendMode.normal),
         PdfFillPathCommand(
-          _rect(40, 100, 220, 260),
-          const PdfColor(0.9, 0.3, 0.2),
+          _rect(70, 140, 220, 310),
+          const PdfColor(0.95, 0.7, 0.2),
           PdfFillRule.nonzero,
-          0.8,
+          1,
         ),
         PdfFillPathCommand(
-          _rect(160, 120, 340, 280),
-          const PdfColor(0.25, 0.85, 0.35),
+          _rect(150, 140, 270, 310),
+          const PdfColor(0.2, 0.8, 0.85),
           PdfFillRule.nonzero,
-          0.7,
+          1,
         ),
         const PdfEndGroupCommand(),
       ]);
-      addTearDown(overlapping.dispose);
-      final conservative = FlutterGpuTileRasterBackend();
-      expect(conservative.createSession(overlapping), isNull);
-      expect(conservative.stats.lastRejection, contains('non-identity'));
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(scene), isNull);
+      expect(
+        backend.stats.lastRejection,
+        'non-identity multi-paint transparency group',
+      );
+    });
+  });
+
+  testWidgets('zero-alpha and degenerate groups are exact no-ops',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(40, 100, 300, 360),
+          const PdfColor(0.2, 0.65, 0.8),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(
+          1,
+          isolated: true,
+          bounds: PdfRect(170, 100, 170, 360),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.overlay),
+        PdfFillPathCommand(
+          _rect(70, 130, 270, 330),
+          const PdfColor(0.95, 0.15, 0.35),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(0.5, knockout: true),
+        PdfStrokePathCommand(
+          _rect(80, 140, 260, 320),
+          const PdfColor(0.2, 0.9, 0.25),
+          const PdfStroke(width: 8),
+          1,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfEndGroupCommand(),
+        const PdfBeginGroupCommand(
+          0,
+          isolated: false,
+          bounds: PdfRect(60, 120, 280, 340),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.colorBurn),
+        PdfFillPathCommand(
+          _rect(70, 130, 270, 330),
+          const PdfColor(0.9, 0.25, 0.1),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(30, 420, 290, 290);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(2));
     });
   });
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -5,6 +5,8 @@ import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
+import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 bool _gpuAvailable() {
@@ -31,6 +33,23 @@ Future<int> _timeImage(Future<ui.Image> Function() render) async {
   image.dispose();
   return clock.elapsedMicroseconds;
 }
+
+Future<int> _timeSettledImage(Future<ui.Image> Function() render) async {
+  final clock = Stopwatch()..start();
+  final image = await render();
+  await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  clock.stop();
+  image.dispose();
+  return clock.elapsedMicroseconds;
+}
+
+PdfPath _rect(double left, double bottom, double right, double top) => PdfPath([
+      PdfMoveTo(left, bottom),
+      PdfLineTo(right, bottom),
+      PdfLineTo(right, top),
+      PdfLineTo(left, top),
+      const PdfClosePath(),
+    ]);
 
 void main() {
   testWidgets('reports cold compile and warm tile replay separately',
@@ -91,6 +110,104 @@ void main() {
       // Keep an always-visible machine-readable-ish line in benchmark runs.
       // ignore: avoid_print
       print(summary);
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('reports isolated group settle against Canvas', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      final commands = <PdfRenderCommand>[
+        PdfFillPathCommand(
+          _rect(0, 0, 612, 792),
+          const PdfColor(0.32, 0.4, 0.52),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          bounds: PdfRect(40, 80, 572, 730),
+        ),
+      ];
+      for (var index = 0; index < 32; index++) {
+        final offset = index * 11.0;
+        commands.add(PdfFillPathCommand(
+          _rect(
+            45 + offset % 170,
+            90 + offset % 230,
+            355 + offset % 170,
+            430 + offset % 230,
+          ),
+          PdfColor(
+            0.2 + (index % 5) * 0.14,
+            0.18 + (index % 7) * 0.1,
+            0.25 + (index % 4) * 0.16,
+          ),
+          PdfFillRule.nonzero,
+          0.6,
+        ));
+      }
+      commands.add(const PdfEndGroupCommand());
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(50, 120, 512, 512);
+      final coldGpu = await _timeSettledImage(
+        () => session.rasterizeRegion(region, pixelRatio: 1),
+      );
+      final issueGpu = <int>[];
+      for (var index = 0; index < 7; index++) {
+        issueGpu.add(await _timeImage(
+          () => session.rasterizeRegion(region, pixelRatio: 1),
+        ));
+      }
+      // Wait for the issue-only samples before measuring visual settle.
+      await _timeSettledImage(
+        () => session.rasterizeRegion(region, pixelRatio: 1),
+      );
+
+      final settledGpu = <int>[];
+      final warmCanvas = <int>[];
+      for (var index = 0; index < 7; index++) {
+        if (index.isEven) {
+          settledGpu.add(await _timeSettledImage(
+            () => session.rasterizeRegion(region, pixelRatio: 1),
+          ));
+          warmCanvas.add(await _timeSettledImage(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          ));
+        } else {
+          warmCanvas.add(await _timeSettledImage(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          ));
+          settledGpu.add(await _timeSettledImage(
+            () => session.rasterizeRegion(region, pixelRatio: 1),
+          ));
+        }
+      }
+
+      final issueMedian = _median(issueGpu);
+      final settleMedian = _median(settledGpu);
+      final canvasMedian = _median(warmCanvas);
+      expect(backend.stats.offscreenGroupPasses, 16);
+      expect(backend.stats.offscreenGroupAllocatedBytes, greaterThan(0));
+      // ignore: avoid_print
+      print('flutter_gpu isolated group benchmark: cold=${coldGpu}us '
+          'issueMedian=${issueMedian.toStringAsFixed(0)}us '
+          'settleMedian=${settleMedian.toStringAsFixed(0)}us '
+          'canvasMedian=${canvasMedian.toStringAsFixed(0)}us '
+          'issueVsCanvas=${(issueMedian / canvasMedian).toStringAsFixed(2)}x '
+          'settleVsCanvas=${(settleMedian / canvasMedian).toStringAsFixed(2)}x '
+          '${backend.stats}');
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 }

--- a/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
@@ -66,6 +66,24 @@ void main() {
     expect(outlined.glyphs![1].text, ' ');
   });
 
+  test('keeps default-ignorable controls as empty placements', () {
+    final outlined = outliner.outline(
+      run('A\u007fB\u0081', const [0, 0.6, 0.8, 1.8, 2.0], width: 2),
+    );
+    expect(outlined, isNotNull);
+    expect(outlined!.glyphs, hasLength(4));
+    expect(outlined.glyphs![1].outline, isNull);
+    expect(outlined.glyphs![1].text, '\u007f');
+    expect(outlined.glyphs![3].outline, isNull);
+    expect(outlined.glyphs![3].text, '\u0081');
+
+    final controlsOnly =
+        outliner.outline(run('\u007f', const [0, 0.5], width: 0.5));
+    expect(controlsOnly, isNotNull);
+    expect(controlsOnly!.glyphs!.single.outline, isNull);
+    expect(controlsOnly.transform, run('', const [0]).transform);
+  });
+
   test('declines missing glyphs, malformed offsets, and complex shaping', () {
     expect(outliner.outline(run('AC', const [0, 0.6, 1.2])), isNull);
     expect(outliner.outline(run('AB', const [0, 0.6])), isNull);

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Give synthesized FreeText and form-widget fallback text exact Base-14
+  character offsets, keeping Canvas placement, selection geometry, and
+  retained outline backends on the same per-character advances.
 - Export the TrueType outline reader and add indexed TrueType Collection
   parsing so retained backends can derive exact glyph paths from a host's
   registered TTF/TTC bytes.

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -806,7 +806,9 @@ class PdfInterpreter {
       var line = '';
       for (final word in words) {
         final candidate = line.isEmpty ? word : '$line $word';
-        if (line.isNotEmpty && measureHelvetica(candidate, size) > available) {
+        if (line.isNotEmpty &&
+            _fallbackTextGeometry(candidate, style.fontName).width * size >
+                available) {
           lines.add(line);
           line = word;
         } else {
@@ -822,8 +824,8 @@ class PdfInterpreter {
       for (final line in lines) {
         if (y + size < rect.bottom) break;
         if (line.isNotEmpty) {
-          final measured = measureHelvetica(line, size);
-          final width = measured / size;
+          final geometry = _fallbackTextGeometry(line, style.fontName);
+          final measured = geometry.width * size;
           final q = cos.resolve(annotation.dict['Q']);
           final alignment = q is CosInteger ? q.value : 0;
           final x = switch (alignment) {
@@ -835,9 +837,10 @@ class PdfInterpreter {
             text: line,
             transform: PdfMatrix(size, 0, 0, size, x, y),
             color: style.color,
-            width: width,
+            width: geometry.width,
             fontName: style.fontName,
             fontSize: size,
+            charOffsets: geometry.offsets,
           ));
         }
         y -= lineHeight;
@@ -974,7 +977,7 @@ class PdfInterpreter {
     const pad = 2.0;
     var size = style.size;
     final text = value.replaceAll('\n', ' ');
-    final width = measureHelvetica(text, size) / size;
+    final geometry = _fallbackTextGeometry(text, style.fontName);
     final ascent = size * 0.718;
     final y =
         ((rect.height - ascent) / 2 < pad ? pad : (rect.height - ascent) / 2) +
@@ -991,9 +994,10 @@ class PdfInterpreter {
         text: text,
         transform: PdfMatrix(size, 0, 0, size, rect.left + pad, y),
         color: style.color,
-        width: width,
+        width: geometry.width,
         fontName: style.fontName,
         fontSize: size,
+        charOffsets: geometry.offsets,
       ));
     } finally {
       device.restore();
@@ -1108,7 +1112,8 @@ class PdfInterpreter {
     // The DA size (defaulted to 12 when the string says auto-size), capped so
     // the caption fits a short button.
     final size = math.min(style.size, rect.height);
-    final textWidth = measureHelvetica(caption, size);
+    final geometry = _fallbackTextGeometry(caption, style.fontName);
+    final textWidth = geometry.width * size;
     final x = rect.left + (rect.width - textWidth) / 2;
     final y = rect.bottom + (rect.height - size * 0.718) / 2;
     device.save();
@@ -1118,13 +1123,32 @@ class PdfInterpreter {
         text: caption,
         transform: PdfMatrix(size, 0, 0, size, x, y),
         color: style.color,
-        width: size == 0 ? 0 : textWidth / size,
+        width: geometry.width,
         fontName: style.fontName,
         fontSize: size,
+        charOffsets: geometry.offsets,
       ));
     } finally {
       device.restore();
     }
+  }
+
+  /// Base-14 advance geometry for text synthesized when an annotation has no
+  /// appearance stream. Unlike ordinary page text there is no font object to
+  /// supply per-code advances, so derive both the total and every character
+  /// boundary from the same standard-font table. Canvas and retained backends
+  /// can then place substitute glyphs at identical, authoritative positions.
+  ({double width, List<double> offsets}) _fallbackTextGeometry(
+      String text, String fontName) {
+    final font =
+        PdfStandardFont.tryFromName(fontName) ?? PdfStandardFont.helvetica;
+    final offsets = <double>[0];
+    var width = 0.0;
+    for (final code in text.codeUnits) {
+      width += font.widthOf(code) / 1000;
+      offsets.add(width);
+    }
+    return (width: width, offsets: List.unmodifiable(offsets));
   }
 
   /// A checkbox check (stroked tick) or radio dot (filled disc), inset in

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -1427,6 +1427,13 @@ void main() {
       expect(device.texts.single.fontSize, 12);
       expect(device.texts.single.transform.e, 22);
       expect(device.texts.single.transform.f, closeTo(106.692, 1e-3));
+      expect(device.texts.single.charOffsets,
+          hasLength('tx annotation'.length + 1));
+      expect(device.texts.single.charOffsets!.first, 0);
+      expect(device.texts.single.charOffsets![1],
+          closeTo(measureHelvetica('t', 1), 1e-9));
+      expect(device.texts.single.charOffsets!.last,
+          closeTo(device.texts.single.width, 1e-9));
       expect(device.clips, hasLength(1));
     });
 


### PR DESCRIPTION
System-font PDF.js GPU coverage improves from **164/15 to 165/14 accepted/fallback**, while the refreshed Ghent result remains **39/18** and default PDF.js remains **108/71**.

This gives text synthesized for missing annotation/form appearance streams the same authoritative Base-14 character boundaries already carried by ordinary substituted PDF text. The native outline seam can therefore retain exact simple-script fallback text instead of rejecting the scene. Complex shaping (including the Arabic FreeText corpus case) remains on Canvas.

Stacked on #767.

<details>
<summary>Implementation and validation</summary>

- derive total width and every character boundary from one standard-font metric table
- thread the offsets through fallback FreeText, text-widget, and push-button text runs
- use the same geometry for FreeText wrapping and quadding
- focused Metal comparison: `annotation-tx.pdf` moves from fallback to acceptance and matches Canvas
- refreshed system-font corpus: Ghent 39/18; PDF.js 165/14
- refreshed default corpus: Ghent 39/18; PDF.js 108/71
- `pdf_graphics`: 1,047 tests passed
- `dart_pdf_editor_flutter_gpu` Metal suite: 259 passed, 3 skipped
- workspace analysis: clean

</details>
