### PR TITLE
perf(gpu): retain default-ignorable controls

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Treat C1 controls as non-rendering glyph placements in the exact native
+  outline seam, matching Flutter shaping while preserving their PDF advances.
 - Retain stroke-only and fill-plus-stroke outline text, including page-space
   alpha and zero-width hairlines, by reusing the exact path stroke pipeline.
   Filled glyphs keep the analytic atlas while their stroke overlays in painter

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
@@ -77,7 +77,11 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
     for (var index = 0; index < text.length;) {
       final length = _runeLengthAt(text, index);
       final rune = _runeAt(text, index, length);
-      final blank = _isWhitespace(rune);
+      // HarfBuzz treats C1 controls as default-ignorable characters: they
+      // advance through the PDF's own offset table but paint no fallback box.
+      // Keep them as empty placements instead of requiring a cmap glyph that
+      // Canvas never draws.
+      final blank = _isWhitespace(rune) || _isControl(rune);
       final glyphId = face.gidForUnicode(rune);
       PdfPath? outline;
       if (!blank) {
@@ -91,8 +95,9 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
       resolved.add(_ResolvedGlyph(index, length, outline));
       index += length;
     }
-    if (naturalAdvance <= 0 || pdfAdvance <= 0) return null;
-    final xScale = pdfAdvance / naturalAdvance;
+    final hasInk = resolved.any((glyph) => glyph.outline != null);
+    if (hasInk && (naturalAdvance <= 0 || pdfAdvance <= 0)) return null;
+    final xScale = hasInk ? pdfAdvance / naturalAdvance : 1.0;
     if (!xScale.isFinite || xScale <= 0) return null;
 
     final glyphs = <PdfGlyphPlacement>[
@@ -171,6 +176,8 @@ bool _isWhitespace(int rune) =>
     rune == 0x3000 ||
     rune == 0xFEFF;
 
+bool _isControl(int rune) => rune >= 0x7F && rune <= 0x9F;
+
 bool _isPlaceableText(String text) {
   for (var i = 0; i < text.length; i++) {
     final code = text.codeUnitAt(i);
@@ -180,7 +187,7 @@ bool _isPlaceableText(String text) {
 }
 
 bool _isPlaceableCodeUnit(int code) =>
-    (code >= 0x20 && code <= 0x2FF && code != 0x7F) ||
+    (code >= 0x20 && code <= 0x2FF) ||
     (code >= 0x370 && code <= 0x482) ||
     (code >= 0x48A && code <= 0x52F) ||
     (code >= 0x2000 && code <= 0x206F) ||

--- a/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
@@ -66,6 +66,24 @@ void main() {
     expect(outlined.glyphs![1].text, ' ');
   });
 
+  test('keeps default-ignorable controls as empty placements', () {
+    final outlined = outliner.outline(
+      run('A\u007fB\u0081', const [0, 0.6, 0.8, 1.8, 2.0], width: 2),
+    );
+    expect(outlined, isNotNull);
+    expect(outlined!.glyphs, hasLength(4));
+    expect(outlined.glyphs![1].outline, isNull);
+    expect(outlined.glyphs![1].text, '\u007f');
+    expect(outlined.glyphs![3].outline, isNull);
+    expect(outlined.glyphs![3].text, '\u0081');
+
+    final controlsOnly =
+        outliner.outline(run('\u007f', const [0, 0.5], width: 0.5));
+    expect(controlsOnly, isNotNull);
+    expect(controlsOnly!.glyphs!.single.outline, isNull);
+    expect(controlsOnly.transform, run('', const [0]).transform);
+  });
+
   test('declines missing glyphs, malformed offsets, and complex shaping', () {
     expect(outliner.outline(run('AC', const [0, 0.6, 1.2])), isNull);
     expect(outliner.outline(run('AB', const [0, 0.6])), isNull);


### PR DESCRIPTION
System-font PDF.js improves from **165 GPU / 14 Canvas** to **167 / 12**. The refreshed Ghent matrix remains **39 / 18**, and the default no-host-font matrix remains **108 / 71**.

<details>
<summary>What changed</summary>

- Treat C1 control characters U+007F through U+009F as default-ignorable empty placements in the native TrueType outline seam.
- Preserve their PDF character offsets without requiring a cmap outline or painting a missing-glyph box.
- Keep ordinary scaling for mixed ink/control runs and accept control-only runs without inventing geometry.

This is stacked on #768.

</details>

<details>
<summary>Validation</summary>

- fvm dart analyze
- Full Metal Flutter GPU package suite: 260 passed, 3 intentionally skipped
- Refreshed system-font corpus: Ghent 39/18; PDF.js 167/12
- Refreshed default corpus: Ghent 39/18; PDF.js 108/71
- Focused standard_fonts.pdf comparison passes pixel validation

</details>