### PR TITLE
perf(gpu): retain knockout masked fills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,8 @@ jobs:
                   "$label" == "text-mask-1" ||
                   "$label" == "text-mask-2" ||
                   "$label" == "system-text" ||
+                  "$label" == "knockout-mask" ||
+                  "$label" == "knockout-overlap" ||
                   "$label" == "hairline" ]]; then
               route_change=1
             fi
@@ -320,6 +322,8 @@ jobs:
           text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
+          knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
+          knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           fi
@@ -352,6 +356,8 @@ jobs:
           text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
+          knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
+          knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           done
@@ -394,6 +400,10 @@ jobs:
             --require-scenario-runs gpu-text-mask-2-page-0-canvas-tile=6
             --require-scenario-runs gpu-system-text-page-0-first-tile=6
             --require-scenario-runs gpu-system-text-page-0-canvas-tile=6
+            --require-scenario-runs gpu-knockout-mask-page-0-first-tile=6
+            --require-scenario-runs gpu-knockout-mask-page-0-canvas-tile=6
+            --require-scenario-runs gpu-knockout-overlap-page-0-first-tile=6
+            --require-scenario-runs gpu-knockout-overlap-page-0-canvas-tile=6
             --require-scenario-runs gpu-hairline-page-0-first-tile=6
             --require-scenario-runs gpu-hairline-page-0-canvas-tile=6
           )

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+- Retain isolated knockout groups made entirely from vector fills. Later
+  sibling shapes use exact source replacement only inside their retained path,
+  while the group's alpha and outer blend remain a single offscreen composite.
+- Retain isolated knockout groups containing a base fill and one
+  vector-soft-masked fill, including clipped vector mask bounds.
 - Render overlapping Normal paints in isolated transparency groups into a
   shader-readable tile attachment, then apply group alpha and outer blend once
   when sampling it into the page pass.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -215,9 +215,10 @@ retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
 markers for each pipeline/scene/tile phase. CI uses those markers to run the
 checked-in tiling-pattern, radial-shading, hairline, vector-mask transfer,
-GWG168/169 vector soft-mask, and GWG1610/1611 text soft-mask pages plus the
-PDF.js system-font outline page and deterministic deferred-mask fixture six
-times on macOS Metal, compare the exact
+PDF.js knockout soft-mask and isolated-knockout overlap, GWG168/169 vector
+soft-mask, and GWG1610/1611 text soft-mask pages plus the PDF.js system-font
+outline page and deterministic deferred-mask fixture six times on macOS Metal,
+compare the exact
 PR base and candidate on the same runner with balanced execution order, and
 publish both a concise PR headline and a collapsed detailed trace.
 Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
@@ -231,8 +232,8 @@ reference warm on both the accepted and fallback routes without warming the
 cold first-tile measurement.
 Set `PDF_GPU_BENCHMARK_ROUTE_CHANGE=1` for the same normalization when a PDF
 path, rather than the built-in fixture, changes from Canvas fallback to direct
-GPU. CI uses it for the checked-in vector-mask transfer, hairline, and GWG
-vector/text soft-mask pages.
+GPU. CI uses it for the checked-in vector-mask transfer, knockout soft-mask,
+isolated-knockout overlap, hairline, and GWG vector/text soft-mask pages.
 Set `PDF_GPU_BENCHMARK_SYSTEM_TEXT=1` to enable the native system-font outline
 adapter. For a like-for-like macOS parity control,
 `PDF_GPU_BENCHMARK_REGISTER_SYSTEM_FONTS=1` registers those same font bytes

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -304,6 +304,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             break;
           case _GroupPaintSpec():
             break;
+          case _KnockoutSoftMaskFillSpec():
+            break;
           case _FlattenSoftMaskSpec():
             break;
           case _FlattenGroupSpec():
@@ -496,14 +498,33 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     required this.contentClip,
     this.groupAlpha = 1,
     this.offscreen = false,
+    this.knockout = false,
   });
 
   final List<PdfRenderCommand> commands;
   final List<PdfRect?> paintClips;
   final double groupAlpha;
   final bool offscreen;
+  final bool knockout;
   @override
   final PdfRect? contentClip;
+}
+
+class _KnockoutSoftMaskFillSpec extends _GpuCompositeSpec {
+  const _KnockoutSoftMaskFillSpec({
+    required this.base,
+    required this.baseClip,
+    required this.masked,
+    required this.groupAlpha,
+  });
+
+  final PdfFillPathCommand base;
+  final PdfRect? baseClip;
+  final _SoftMaskVectorFillSpec masked;
+  final double groupAlpha;
+
+  @override
+  PdfRect? get contentClip => null;
 }
 
 class _FlattenSoftMaskSpec extends _GpuCompositeSpec {
@@ -1155,6 +1176,19 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     if (commands[end] is! PdfEndGroupCommand) {
       return (null, 'unsupported composite nesting');
     }
+    if (isolated && knockout && backdropColor == null) {
+      final knockoutFill = _parseKnockoutSoftMaskFill(
+        commands,
+        start,
+        end,
+        groupAlpha: alpha,
+        initialClip: initialClip,
+        initialFillOverprint: initialFillOverprint,
+        initialStrokeOverprint: initialStrokeOverprint,
+        initialBlend: initialBlend,
+      );
+      if (knockoutFill != null) return (knockoutFill, null);
+    }
     // Knockout only changes how multiple sibling elements interact inside a
     // group. A one-element group is therefore identical either way. The
     // multi-paint path below is deliberately narrower: alpha-one, normal
@@ -1380,8 +1414,16 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           backdropColor == null &&
           compatiblePaints &&
           (initialBlend == PdfBlendMode.normal || disjointOuterBlend);
-      final canRenderOffscreen =
-          isolated && !knockout && backdropColor == null && compatiblePaints;
+      final canRenderKnockout = isolated &&
+          knockout &&
+          backdropColor == null &&
+          compatiblePaints &&
+          paints.every((paint) => paint.$2 is PdfFillPathCommand);
+      final canRenderOffscreen = (isolated &&
+              !knockout &&
+              backdropColor == null &&
+              compatiblePaints) ||
+          canRenderKnockout;
       if (!canFlatten && !canRenderOffscreen) {
         return (null, 'non-identity multi-paint transparency group');
       }
@@ -1411,6 +1453,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip: canFlatten && commonPaintClip ? commonClip : null,
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
+          knockout: canRenderKnockout,
         ),
         null,
       );
@@ -1618,6 +1661,111 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     };
   }
   return (null, 'unsupported composite ${commands[start].runtimeType}');
+}
+
+/// Recognizes the exact isolated-knockout shape emitted by PDF.js's
+/// `knockout_smask.pdf`: one ordinary base fill followed by one
+/// vector-soft-masked fill. The masked source remains one captured object (its
+/// mask is not applied to sibling paints), then the completed transparent
+/// group applies its alpha and outer blend once.
+_KnockoutSoftMaskFillSpec? _parseKnockoutSoftMaskFill(
+  List<PdfRenderCommand> commands,
+  int start,
+  int end, {
+  required double groupAlpha,
+  required PdfRect? initialClip,
+  required bool initialFillOverprint,
+  required bool initialStrokeOverprint,
+  required PdfBlendMode initialBlend,
+}) {
+  var clip = initialClip;
+  var blend = initialBlend;
+  var fillOverprint = initialFillOverprint;
+  var strokeOverprint = initialStrokeOverprint;
+  final saved = <(PdfRect?, PdfBlendMode, bool, bool)>[];
+  PdfFillPathCommand? base;
+  PdfRect? baseClip;
+  _SoftMaskVectorFillSpec? masked;
+
+  int? nestedEnd(int nestedStart) {
+    var depth = 1;
+    for (var index = nestedStart + 1; index < end; index++) {
+      switch (commands[index]) {
+        case PdfBeginSoftMaskedCommand():
+          depth++;
+        case PdfEndSoftMaskedCommand():
+          depth--;
+          if (depth == 0) return index;
+        case PdfBeginGroupCommand() || PdfEndGroupCommand():
+          return null;
+        default:
+          break;
+      }
+    }
+    return null;
+  }
+
+  for (var index = start + 1; index < end; index++) {
+    final command = commands[index];
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, blend, fillOverprint, strokeOverprint));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return null;
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        blend = restored.$2;
+        fillOverprint = restored.$3;
+        strokeOverprint = restored.$4;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) return null;
+        clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (clip == null) return null;
+      case PdfSetBlendModeCommand(:final mode):
+        blend = mode;
+      case PdfSetOverprintCommand(:final fill, :final stroke):
+        fillOverprint = fill;
+        strokeOverprint = stroke;
+      case PdfFillPathCommand():
+        if (base != null ||
+            masked != null ||
+            blend != PdfBlendMode.normal ||
+            fillOverprint) {
+          return null;
+        }
+        base = command;
+        baseClip = clip;
+      case PdfBeginSoftMaskedCommand():
+        if (base == null || masked != null) return null;
+        final nestedStop = nestedEnd(index);
+        if (nestedStop == null) return null;
+        final parsed = _parseComposite(
+          commands,
+          index,
+          nestedStop,
+          initialClip: clip,
+          initialFillOverprint: fillOverprint,
+          initialStrokeOverprint: strokeOverprint,
+          initialBlend: blend,
+        ).$1;
+        if (parsed is! _SoftMaskVectorFillSpec) return null;
+        masked = parsed;
+        index = nestedStop;
+      case PdfBeginGroupCommand() ||
+            PdfEndGroupCommand() ||
+            PdfEndSoftMaskedCommand():
+        return null;
+      default:
+        if (pdfRenderCommandBounds(command) != null) return null;
+    }
+  }
+  if (saved.isNotEmpty || base == null || masked == null) return null;
+  return _KnockoutSoftMaskFillSpec(
+    base: base,
+    baseClip: baseClip,
+    masked: masked,
+    groupAlpha: groupAlpha,
+  );
 }
 
 /// Whether a multi-paint group can apply its outer blend per paint without
@@ -2742,6 +2890,8 @@ class _CompiledScene {
             _GroupFillSpec spec => _compileGroupFill(geometry, spec),
             _GroupStrokeSpec spec => _compileGroupStroke(geometry, spec),
             _GroupPaintSpec spec => _compileGroupPaint(geometry, spec),
+            _KnockoutSoftMaskFillSpec spec =>
+              _compileKnockoutSoftMaskFill(geometry, spec),
             _FlattenSoftMaskSpec() => null,
             _FlattenGroupSpec() => null,
             _EmptyGroupSpec() => null,
@@ -3111,9 +3261,13 @@ class _CompiledScene {
         targetWidth: groupWidth,
         targetHeight: groupHeight,
       );
-      groupEncoder.setBlendMode(PdfBlendMode.normal);
       for (final paint in draw.paints) {
         groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
+        if (paint.$3) {
+          groupEncoder.setSourceBlend();
+        } else {
+          groupEncoder.setBlendMode(PdfBlendMode.normal);
+        }
         paint.$1.encode(groupEncoder);
       }
       stats.clipMaskRebuilds += groupEncoder.clipMaskRebuilds;
@@ -3353,7 +3507,7 @@ _GpuDraw? _compileGroupStroke(
     );
 
 _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
-  final draws = <(_GpuDraw, PdfRect?)>[];
+  final draws = <(_GpuDraw, PdfRect?, bool)>[];
   var paintPadding = 2.0;
   for (var index = 0; index < spec.commands.length; index++) {
     final command = spec.commands[index];
@@ -3383,7 +3537,9 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
       PdfStrokePathCommand() => _compileStroke(geometry, command),
       _ => null,
     };
-    if (draw != null) draws.add((draw, spec.paintClips[index]));
+    if (draw != null) {
+      draws.add((draw, spec.paintClips[index], spec.knockout && index > 0));
+    }
   }
   if (draws.isEmpty) return null;
   return spec.offscreen
@@ -3393,6 +3549,32 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
           math.max(0, paintPadding - 2),
         )
       : _SequenceDraw(List.unmodifiable([for (final draw in draws) draw.$1]));
+}
+
+_GpuDraw? _compileKnockoutSoftMaskFill(
+  _GpuGeometryArena geometry,
+  _KnockoutSoftMaskFillSpec spec,
+) {
+  final base = spec.base;
+  final baseDraw = _stencilDraw(
+    geometry,
+    flattenPath(base.path, PdfMatrix.identity, tolerance: 0.01),
+    base.color,
+    base.alpha,
+    base.rule,
+    false,
+  );
+  final maskedDraw = _compileSoftMaskVectorFill(geometry, spec.masked);
+  final paints = <(_GpuDraw, PdfRect?, bool)>[
+    if (baseDraw != null) (baseDraw, spec.baseClip, false),
+    if (maskedDraw != null) (maskedDraw, spec.masked.contentClip, false),
+  ];
+  if (paints.isEmpty) return null;
+  return _OffscreenGroupDraw(
+    paints,
+    spec.groupAlpha,
+    0,
+  );
 }
 
 Future<_GpuDraw> _compileSoftMaskFill(
@@ -3571,9 +3753,9 @@ _GpuDraw? _compileSoftMaskVectorFill(
   final bounds = _pdfIntersection(
     PdfRect(
       pathBounds.left,
-      pathBounds.bottom,
-      pathBounds.right,
       pathBounds.top,
+      pathBounds.right,
+      pathBounds.bottom,
     ),
     spec.contentClip,
   );
@@ -4918,7 +5100,11 @@ class _SequenceDraw implements _GpuDraw {
 class _OffscreenGroupDraw implements _GpuDraw {
   const _OffscreenGroupDraw(this.paints, this.alpha, this.extraPadding);
 
-  final List<(_GpuDraw, PdfRect?)> paints;
+  /// The third field selects shape-limited source replacement for knockout
+  /// siblings. Retained path stencils emit fragments only inside the painted
+  /// shape; masked texture quads keep source-over so transparent pixels beyond
+  /// their source shape cannot erase earlier siblings.
+  final List<(_GpuDraw, PdfRect?, bool)> paints;
   final double alpha;
   final double extraPadding;
 
@@ -5077,6 +5263,12 @@ class _GpuEncoder {
     sourceAlphaBlendFactor: gpu.BlendFactor.one,
     destinationAlphaBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
   );
+  static final _source = gpu.ColorBlendEquation(
+    sourceColorBlendFactor: gpu.BlendFactor.one,
+    destinationColorBlendFactor: gpu.BlendFactor.zero,
+    sourceAlphaBlendFactor: gpu.BlendFactor.one,
+    destinationAlphaBlendFactor: gpu.BlendFactor.zero,
+  );
   // The page paper makes the destination beneath every supported primitive
   // opaque. Under that invariant PDF Multiply and Screen each reduce to one
   // exact fixed-function equation, with no destination-texture readback.
@@ -5106,6 +5298,8 @@ class _GpuEncoder {
       _ => _srcOver,
     };
   }
+
+  void setSourceBlend() => _paintBlend = _source;
 
   void setClip(_GpuClipState clip) {
     if (identical(_clipState, clip)) return;

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1427,6 +1427,134 @@ void main() {
     });
   });
 
+  testWidgets('isolated knockout fills replace earlier overlapping shapes',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          knockout: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 230, 310),
+          const PdfColor(0.95, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          0.65,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 160, 270, 325),
+          const PdfColor(0.15, 0.45, 0.95),
+          PdfFillRule.nonzero,
+          0.55,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
+  testWidgets('isolated knockout groups retain a vector-soft-masked fill',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(
+          0.78,
+          isolated: true,
+          knockout: true,
+          bounds: PdfRect(40, 90, 300, 360),
+        ),
+        PdfClipPathCommand(_rect(40, 90, 300, 360), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(60, 120, 220, 310),
+          const PdfColor(0.9, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginSoftMaskedCommand(),
+        PdfFillPathCommand(
+          _rect(140, 140, 280, 330),
+          const PdfColor(0.15, 0.45, 0.9),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        PdfEndSoftMaskedCommand(
+          luminosity: true,
+          backdrop: page.cropBox,
+          maskCommands: [
+            PdfClipPathCommand(
+              _rect(40, 90, 300, 360),
+              PdfFillRule.nonzero,
+            ),
+            PdfFillPathCommand(
+              _rect(170, 170, 260, 300),
+              const PdfColor(1, 1, 1),
+              PdfFillRule.nonzero,
+              1,
+            ),
+          ],
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.75);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.75);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('offscreen group budget rejects before submitting group passes',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

- Refreshed corpus comparison improves PDF.js from 109 GPU / 70 Canvas to 110 / 69 by default and from 168 / 11 to 169 / 10 with macOS system-font outlines; the updated Ghent matrix remains 39 / 18.
- The real PDF.js knockout_smask page matches Canvas at a mean channel difference of 0.031 and now stays on the retained Metal route.
- Local warm forced settle is 2.66 ms on GPU versus 2.06 ms on Canvas for this tiny fixture, about 29% slower. The new six-run same-host CI scenario will measure the production route change without disguising that trade-off.

## What changed

- Recognize the exact isolated knockout shape containing one base fill and one vector-soft-masked fill.
- Retain the masked source as one object, composite the bounded group offscreen, and apply group alpha once.
- Preserve rectangular clips and correct the clipped vector-mask Y-bound ordering exposed by the real fixture.
- Keep all broader knockout and mixed-content forms on the conservative Canvas fallback.
- Add programmatic pixel parity coverage and a persistent knockout-mask route-change benchmark scenario.

Depends on #771.

<details>
<summary>Validation details</summary>

- fvm dart analyze
- Focused Metal backend suite: 39 passed, 1 unavailable-context test skipped intentionally
- Full Metal package: 268 passed, 3 opt-in tests skipped
- Refreshed default corpus: PDF.js 110/69, Ghent 39/18
- Refreshed system-font corpus: PDF.js 169/10, Ghent 39/18
- Real knockout_smask parity: mean channel difference 0.031
- Remaining refreshed Ghent fallbacks: non-black overprint 12, text soft-mask groups 3, ColorBurn 1, HardLight 1, nonidentity group 1

</details>