### PR TITLE
perf(gpu): retain isolated knockout fills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
                   "$label" == "text-mask-2" ||
                   "$label" == "system-text" ||
                   "$label" == "knockout-mask" ||
+                  "$label" == "knockout-overlap" ||
                   "$label" == "hairline" ]]; then
               route_change=1
             fi
@@ -322,6 +323,7 @@ jobs:
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
+          knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           fi
@@ -355,6 +357,7 @@ jobs:
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
+          knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           done
@@ -399,6 +402,8 @@ jobs:
             --require-scenario-runs gpu-system-text-page-0-canvas-tile=6
             --require-scenario-runs gpu-knockout-mask-page-0-first-tile=6
             --require-scenario-runs gpu-knockout-mask-page-0-canvas-tile=6
+            --require-scenario-runs gpu-knockout-overlap-page-0-first-tile=6
+            --require-scenario-runs gpu-knockout-overlap-page-0-canvas-tile=6
             --require-scenario-runs gpu-hairline-page-0-first-tile=6
             --require-scenario-runs gpu-hairline-page-0-canvas-tile=6
           )

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Retain isolated knockout groups made entirely from vector fills. Later
+  sibling shapes use exact source replacement only inside their retained path,
+  while the group's alpha and outer blend remain a single offscreen composite.
 - Retain isolated knockout groups containing a base fill and one
   vector-soft-masked fill, including clipped vector mask bounds.
 - Render overlapping Normal paints in isolated transparency groups into a

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -215,9 +215,10 @@ retained scene before measuring that tile.
 Set `PDF_GPU_BENCHMARK_SCENARIO` to emit normalized `PdfPerfLog` scenario
 markers for each pipeline/scene/tile phase. CI uses those markers to run the
 checked-in tiling-pattern, radial-shading, hairline, vector-mask transfer,
-PDF.js knockout soft-mask, GWG168/169 vector soft-mask, and GWG1610/1611 text
-soft-mask pages plus the PDF.js system-font outline page and deterministic
-deferred-mask fixture six times on macOS Metal, compare the exact
+PDF.js knockout soft-mask and isolated-knockout overlap, GWG168/169 vector
+soft-mask, and GWG1610/1611 text soft-mask pages plus the PDF.js system-font
+outline page and deterministic deferred-mask fixture six times on macOS Metal,
+compare the exact
 PR base and candidate on the same runner with balanced execution order, and
 publish both a concise PR headline and a collapsed detailed trace.
 Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
@@ -232,7 +233,7 @@ cold first-tile measurement.
 Set `PDF_GPU_BENCHMARK_ROUTE_CHANGE=1` for the same normalization when a PDF
 path, rather than the built-in fixture, changes from Canvas fallback to direct
 GPU. CI uses it for the checked-in vector-mask transfer, knockout soft-mask,
-hairline, and GWG vector/text soft-mask pages.
+isolated-knockout overlap, hairline, and GWG vector/text soft-mask pages.
 Set `PDF_GPU_BENCHMARK_SYSTEM_TEXT=1` to enable the native system-font outline
 adapter. For a like-for-like macOS parity control,
 `PDF_GPU_BENCHMARK_REGISTER_SYSTEM_FONTS=1` registers those same font bytes

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -498,12 +498,14 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     required this.contentClip,
     this.groupAlpha = 1,
     this.offscreen = false,
+    this.knockout = false,
   });
 
   final List<PdfRenderCommand> commands;
   final List<PdfRect?> paintClips;
   final double groupAlpha;
   final bool offscreen;
+  final bool knockout;
   @override
   final PdfRect? contentClip;
 }
@@ -1412,8 +1414,16 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           backdropColor == null &&
           compatiblePaints &&
           (initialBlend == PdfBlendMode.normal || disjointOuterBlend);
-      final canRenderOffscreen =
-          isolated && !knockout && backdropColor == null && compatiblePaints;
+      final canRenderKnockout = isolated &&
+          knockout &&
+          backdropColor == null &&
+          compatiblePaints &&
+          paints.every((paint) => paint.$2 is PdfFillPathCommand);
+      final canRenderOffscreen = (isolated &&
+              !knockout &&
+              backdropColor == null &&
+              compatiblePaints) ||
+          canRenderKnockout;
       if (!canFlatten && !canRenderOffscreen) {
         return (null, 'non-identity multi-paint transparency group');
       }
@@ -1443,6 +1453,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip: canFlatten && commonPaintClip ? commonClip : null,
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
+          knockout: canRenderKnockout,
         ),
         null,
       );
@@ -3250,9 +3261,13 @@ class _CompiledScene {
         targetWidth: groupWidth,
         targetHeight: groupHeight,
       );
-      groupEncoder.setBlendMode(PdfBlendMode.normal);
       for (final paint in draw.paints) {
         groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
+        if (paint.$3) {
+          groupEncoder.setSourceBlend();
+        } else {
+          groupEncoder.setBlendMode(PdfBlendMode.normal);
+        }
         paint.$1.encode(groupEncoder);
       }
       stats.clipMaskRebuilds += groupEncoder.clipMaskRebuilds;
@@ -3492,7 +3507,7 @@ _GpuDraw? _compileGroupStroke(
     );
 
 _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
-  final draws = <(_GpuDraw, PdfRect?)>[];
+  final draws = <(_GpuDraw, PdfRect?, bool)>[];
   var paintPadding = 2.0;
   for (var index = 0; index < spec.commands.length; index++) {
     final command = spec.commands[index];
@@ -3522,7 +3537,9 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
       PdfStrokePathCommand() => _compileStroke(geometry, command),
       _ => null,
     };
-    if (draw != null) draws.add((draw, spec.paintClips[index]));
+    if (draw != null) {
+      draws.add((draw, spec.paintClips[index], spec.knockout && index > 0));
+    }
   }
   if (draws.isEmpty) return null;
   return spec.offscreen
@@ -3548,9 +3565,9 @@ _GpuDraw? _compileKnockoutSoftMaskFill(
     false,
   );
   final maskedDraw = _compileSoftMaskVectorFill(geometry, spec.masked);
-  final paints = <(_GpuDraw, PdfRect?)>[
-    if (baseDraw != null) (baseDraw, spec.baseClip),
-    if (maskedDraw != null) (maskedDraw, spec.masked.contentClip),
+  final paints = <(_GpuDraw, PdfRect?, bool)>[
+    if (baseDraw != null) (baseDraw, spec.baseClip, false),
+    if (maskedDraw != null) (maskedDraw, spec.masked.contentClip, false),
   ];
   if (paints.isEmpty) return null;
   return _OffscreenGroupDraw(
@@ -5083,7 +5100,11 @@ class _SequenceDraw implements _GpuDraw {
 class _OffscreenGroupDraw implements _GpuDraw {
   const _OffscreenGroupDraw(this.paints, this.alpha, this.extraPadding);
 
-  final List<(_GpuDraw, PdfRect?)> paints;
+  /// The third field selects shape-limited source replacement for knockout
+  /// siblings. Retained path stencils emit fragments only inside the painted
+  /// shape; masked texture quads keep source-over so transparent pixels beyond
+  /// their source shape cannot erase earlier siblings.
+  final List<(_GpuDraw, PdfRect?, bool)> paints;
   final double alpha;
   final double extraPadding;
 
@@ -5242,6 +5263,12 @@ class _GpuEncoder {
     sourceAlphaBlendFactor: gpu.BlendFactor.one,
     destinationAlphaBlendFactor: gpu.BlendFactor.oneMinusSourceAlpha,
   );
+  static final _source = gpu.ColorBlendEquation(
+    sourceColorBlendFactor: gpu.BlendFactor.one,
+    destinationColorBlendFactor: gpu.BlendFactor.zero,
+    sourceAlphaBlendFactor: gpu.BlendFactor.one,
+    destinationAlphaBlendFactor: gpu.BlendFactor.zero,
+  );
   // The page paper makes the destination beneath every supported primitive
   // opaque. Under that invariant PDF Multiply and Screen each reduce to one
   // exact fixed-function equation, with no destination-texture readback.
@@ -5271,6 +5298,8 @@ class _GpuEncoder {
       _ => _srcOver,
     };
   }
+
+  void setSourceBlend() => _paintBlend = _source;
 
   void setClip(_GpuClipState clip) {
     if (identical(_clipState, clip)) return;

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1427,6 +1427,66 @@ void main() {
     });
   });
 
+  testWidgets('isolated knockout fills replace earlier overlapping shapes',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          knockout: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 230, 310),
+          const PdfColor(0.95, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          0.65,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 160, 270, 325),
+          const PdfColor(0.15, 0.45, 0.95),
+          PdfFillRule.nonzero,
+          0.55,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('isolated knockout groups retain a vector-soft-masked fill',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
Headline

- PDF.js retained coverage: 111 accepted / 68 fallback, improving the parent by one exact GPU page.
- Real knockout_isolated_overlap.pdf parity: mean channel difference 0.000 versus Canvas.
- Representative isolated-group issue path: 1.00 ms GPU submission versus 18.00 ms synchronous Canvas (0.06x); forced visual settle is 23.28 ms versus 18.00 ms (1.29x). The new same-host CI scenario keeps this tradeoff visible.

Summary

- Retain isolated knockout transparency groups made entirely from vector fills.
- Use source replacement only for later path-limited siblings inside the offscreen group.
- Keep masked texture paints on source-over so transparent pixels cannot erase earlier siblings.
- Preserve per-paint clips, group alpha, and the outer page blend.
- Add the knockout-overlap route to the six-run Metal comparison against the exact PR base.

Validation

- fvm dart analyze
- focused Metal backend suite: 42 passed, 1 expected non-GPU skip
- full Metal package: 271 passed, 3 expected opt-in skips
- PDF.js corpus: 111 accepted / 68 fallback
- Ghent corpus: 39 accepted / 18 fallback
- CI-equivalent real fixture benchmark: exact meanDiff 0.000