### PR TITLE
test(perf): warm route-change GPU scenes

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Run requested scene warm-up for route-change benchmarks, matching the
+  viewer's idle-prepared production path while suppressing the unmatched timing
+  marker when the Canvas base has no GPU session.
 - Render every PDF blend mode exactly with retained GPU destination sampling.
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
   paints share one blend pass, while overlapping paints retain painter order.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -242,9 +242,11 @@ reference warm on both the accepted and fallback routes without warming the
 cold first-tile measurement.
 Set `PDF_GPU_BENCHMARK_ROUTE_CHANGE=1` for the same normalization when a PDF
 path, rather than the built-in fixture, changes from Canvas fallback to direct
-GPU. CI uses it for the checked-in vector-mask transfer, knockout soft-mask,
-isolated-knockout overlap, hairline, advanced-blend, and GWG vector/text
-soft-mask pages.
+GPU. Route-change scene warm-up still runs when requested, matching the
+viewer's idle-prepared path, but its unmatched timing marker is omitted because
+the Canvas base has no GPU session to warm. CI uses it for the checked-in
+vector-mask transfer, knockout soft-mask, isolated-knockout overlap, hairline,
+advanced-blend, and GWG vector/text soft-mask pages.
 Set `PDF_GPU_BENCHMARK_SYSTEM_TEXT=1` to enable the native system-font outline
 adapter. For a like-for-like macOS parity control,
 `PDF_GPU_BENCHMARK_REGISTER_SYSTEM_FONTS=1` registers those same font bytes

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -290,13 +290,18 @@ void main() {
           }
           try {
             if (Platform.environment['PDF_GPU_BENCHMARK_SCENE_WARMUP'] == '1' &&
-                !productionRoute &&
                 session is PdfTileRasterWarmUp) {
-              final scenario = _scenarioName(
-                scenarioLabel,
-                'scene-warm',
-                page: pageIndex,
-              );
+              // Route-change cohorts compare a Canvas base with a GPU
+              // candidate, so only one side can produce a scene-warm timing.
+              // Still perform the warm-up—the viewer does—while suppressing
+              // the unmatched marker from the comparison report.
+              final scenario = productionRoute
+                  ? null
+                  : _scenarioName(
+                      scenarioLabel,
+                      'scene-warm',
+                      page: pageIndex,
+                    );
               _startScenario(scenario);
               final warmUp = Stopwatch()..start();
               await (session as PdfTileRasterWarmUp).warmUp();


### PR DESCRIPTION
Headline: route-change first-tile numbers now represent the viewer idle-prepared GPU session.

This always performs requested scene warm-up for route-change benchmarks, while suppressing only the unmatched scene-warm timing marker because the Canvas base has no GPU session. Canvas control normalization and first-tile markers are unchanged.

Validation:
- fvm dart analyze
- accepted vector-mask route benchmark with route-change normalization, scene warm-up, and perf logging
- observed sceneWarmUpUs=52143, GPU first tile 5.616 ms, Canvas tile 8.261 ms, mean pixel difference 0.499

The first report may show broad first-tile improvements versus main because main skipped this viewer-equivalent warm-up; that is the measurement bug this PR corrects.