### PR TITLE
perf(gpu): retain exact CJK system text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
                   "$label" == "text-mask-1" ||
                   "$label" == "text-mask-2" ||
                   "$label" == "system-text" ||
+                  "$label" == "cjk-text" ||
                   "$label" == "advanced-blend" ||
                   "$label" == "knockout-mask" ||
                   "$label" == "knockout-overlap" ||
@@ -257,6 +258,7 @@ jobs:
             fi
             local system_text=0
             if [[ "$label" == "system-text" ||
+                  "$label" == "cjk-text" ||
                   "$label" == "advanced-blend" ]]; then
               system_text=1
             fi
@@ -324,6 +326,7 @@ jobs:
           text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
+          cjk-text pdf ../../test_corpora/pdfjs/SimFang-variant.pdf
           advanced-blend pdf ../../test_corpora/pdfjs/blendmode.pdf
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
@@ -359,6 +362,7 @@ jobs:
           text-mask-1 pdf ../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf
           text-mask-2 pdf ../../test_corpora/ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
+          cjk-text pdf ../../test_corpora/pdfjs/SimFang-variant.pdf
           advanced-blend pdf ../../test_corpora/pdfjs/blendmode.pdf
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
@@ -404,6 +408,8 @@ jobs:
             --require-scenario-runs gpu-text-mask-2-page-0-canvas-tile=6
             --require-scenario-runs gpu-system-text-page-0-first-tile=6
             --require-scenario-runs gpu-system-text-page-0-canvas-tile=6
+            --require-scenario-runs gpu-cjk-text-page-0-first-tile=6
+            --require-scenario-runs gpu-cjk-text-page-0-canvas-tile=6
             --require-scenario-runs gpu-advanced-blend-page-0-first-tile=6
             --require-scenario-runs gpu-advanced-blend-page-0-canvas-tile=6
             --require-scenario-runs gpu-knockout-mask-page-0-first-tile=6

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Retain exact macOS CJK substitutions for Songti, Heiti, Hiragino Sans, and
+  Hiragino Mincho, including CFF outlines inside OpenType collections. Six
+  additional PDF.js corpus pages now stay on the GPU, with a dedicated CJK
+  same-host scenario.
 - Render every PDF blend mode exactly with retained GPU destination sampling.
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
   paints share one blend pass, while overlapping paints retain painter order.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -38,13 +38,16 @@ PdfReader(
 Unembedded text remains on the conservative Canvas fallback by default because
 Flutter does not expose the glyph paths selected by `TextPainter`. A host that
 owns its font registrations can pass a `FlutterGpuTrueTypeTextOutliner` whose
-resolver returns `FlutterGpuTrueTypeFontFace` instances built from those exact
-bytes. `systemTextOutlines: true` is the native convenience adapter: it probes
+resolver returns `FlutterGpuFontFace` instances built from those exact bytes,
+including `FlutterGpuTrueTypeFontFace` and `FlutterGpuOpenTypeCffFontFace`.
+`systemTextOutlines: true` is the native convenience adapter: it probes
 known Helvetica/Arial, Times, Courier, Symbol, and platform-equivalent font
-files and declines a run when the requested face, glyph, or simple horizontal
-placement cannot be proved. It is deliberately opt-in because an app may have
-registered different bytes under the same Flutter family name. Web keeps the
-Canvas path.
+files. On macOS it also resolves the exact Songti, Heiti, Hiragino Sans, and
+Hiragino Mincho faces selected by the Canvas CJK substitution stack, including
+OpenType CFF faces inside font collections. It declines a run when the
+requested face, glyph, or simple horizontal placement cannot be proved. It is
+deliberately opt-in because an app may have registered different bytes under
+the same Flutter family name. Web keeps the Canvas path.
 
 Flutter GPU must also be enabled by the host. Add
 `<key>FLTEnableFlutterGPU</key><true/>` to the iOS/macOS Info.plist (and
@@ -226,8 +229,9 @@ markers for each pipeline/scene/tile phase. CI uses those markers to run the
 checked-in tiling-pattern, radial-shading, hairline, advanced-blend,
 vector-mask transfer, PDF.js knockout soft-mask and isolated-knockout overlap,
 GWG168/169 vector
-soft-mask, and GWG1610/1611 text soft-mask pages plus the PDF.js system-font
-outline page and deterministic deferred-mask fixture six times on macOS Metal,
+soft-mask, and GWG1610/1611 text soft-mask pages plus the PDF.js Latin and CJK
+system-font outline pages and deterministic deferred-mask fixture six times on
+macOS Metal,
 compare the exact
 PR base and candidate on the same runner with balanced execution order, and
 publish both a concise PR headline and a collapsed detailed trace.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/system_text_outliner_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/system_text_outliner_native.dart
@@ -35,7 +35,17 @@ class FlutterGpuSystemTextOutliner implements FlutterGpuTextOutliner {
   PdfTextRun? outline(PdfTextRun run) => _delegate.outline(run);
 }
 
-enum _Family { sans, serif, mono, symbol, dingbats }
+enum _Family {
+  sans,
+  serif,
+  mono,
+  symbol,
+  dingbats,
+  cjkSong,
+  cjkHeiti,
+  cjkJapaneseSans,
+  cjkJapaneseSerif,
+}
 
 enum _Style { regular, bold, italic, boldItalic }
 
@@ -44,7 +54,7 @@ class _SystemFontCatalogue {
 
   final Map<(_Family, _Style), _FontSpec> specs;
   final Map<String, Uint8List> _byteCache = {};
-  final Map<(_Family, _Style), FlutterGpuTrueTypeFontFace> _faces = {};
+  final Map<(_Family, _Style), FlutterGpuFontFace> _faces = {};
   final Set<(_Family, _Style)> _attempted = {};
 
   static _SystemFontCatalogue? load() {
@@ -62,12 +72,15 @@ class _SystemFontCatalogue {
     return specs.isEmpty ? null : _SystemFontCatalogue(specs);
   }
 
-  FlutterGpuTrueTypeFontFace? resolve(PdfTextRun run) {
+  FlutterGpuFontFace? resolve(PdfTextRun run) {
     final name = run.fontName ?? '';
     final lower = name.toLowerCase();
     // Canvas uses a separately registered TeX Gyre Adventor asset for these.
     // System paths cannot prove they match it.
-    if (_usesAdventor(lower) || _isCjkName(name)) return null;
+    if (_usesAdventor(lower)) return null;
+    final cjkFamily = _cjkFamily(name);
+    if (cjkFamily != null) return _face((cjkFamily, _Style.regular));
+    if (_isCjkName(name)) return null;
     final family = name.contains('ZapfDingbats')
         ? _Family.dingbats
         : name.contains('Symbol')
@@ -94,7 +107,7 @@ class _SystemFontCatalogue {
             : null);
   }
 
-  FlutterGpuTrueTypeFontFace? _face((_Family, _Style) key) {
+  FlutterGpuFontFace? _face((_Family, _Style) key) {
     if (!_attempted.add(key)) return _faces[key];
     final spec = specs[key];
     if (spec == null) return null;
@@ -103,10 +116,17 @@ class _SystemFontCatalogue {
       if (!file.existsSync()) continue;
       try {
         final bytes = _byteCache.putIfAbsent(path, file.readAsBytesSync);
-        return _faces[key] = FlutterGpuTrueTypeFontFace(
-          bytes,
-          collectionIndex: spec.collectionIndex,
-        );
+        try {
+          return _faces[key] = FlutterGpuTrueTypeFontFace(
+            bytes,
+            collectionIndex: spec.collectionIndex,
+          );
+        } on FormatException {
+          return _faces[key] = FlutterGpuOpenTypeCffFontFace(
+            bytes,
+            collectionIndex: spec.collectionIndex,
+          );
+        }
       } on Object {
         // Try the next known location. Failure keeps this face unavailable.
       }
@@ -131,6 +151,29 @@ bool _usesAdventor(String name) =>
     name.contains('tex gyre adventor') ||
     name.contains('urwgothic') ||
     name.contains('urw gothic');
+
+_Family? _cjkFamily(String name) {
+  if (name.contains('ºÚÌå')) return _Family.cjkHeiti; // 黑体
+  if (name.contains('ËÎÌå') ||
+      name.contains('·ÂËÎ') ||
+      name.contains('Ð¡±êËÎ')) {
+    return _Family.cjkSong; // 宋体 / 仿宋 / 小标宋
+  }
+  if (name.contains('Mincho') ||
+      name.contains('HeiseiMin') ||
+      name.contains('Ryumin') ||
+      name.contains('KozMin')) {
+    return _Family.cjkJapaneseSerif;
+  }
+  if (name.contains('HeiseiKakuGo') ||
+      name.contains('GothicBBB') ||
+      name.contains('KozGo') ||
+      name.contains('Kaku') ||
+      name.contains('MS-Gothic')) {
+    return _Family.cjkJapaneseSans;
+  }
+  return null;
+}
 
 bool _isCjkName(String name) =>
     name.contains('ºÚÌå') ||
@@ -192,6 +235,23 @@ const _macFonts = <(_Family, _Style), _FontSpec>{
   ),
   (_Family.dingbats, _Style.regular): _FontSpec(
     ['/System/Library/Fonts/ZapfDingbats.ttf'],
+  ),
+  // These are the exact faces selected by CanvasPdfDevice's CJK family
+  // mapping. Keeping the TTC indices explicit avoids silently outlining with
+  // a neighbouring weight or Traditional-Chinese face.
+  (_Family.cjkSong, _Style.regular): _FontSpec(
+    ['/System/Library/Fonts/Supplemental/Songti.ttc'],
+    collectionIndex: 4,
+  ),
+  (_Family.cjkHeiti, _Style.regular): _FontSpec(
+    ['/System/Library/Fonts/STHeiti Medium.ttc'],
+    collectionIndex: 1,
+  ),
+  (_Family.cjkJapaneseSans, _Style.regular): _FontSpec(
+    ['/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc'],
+  ),
+  (_Family.cjkJapaneseSerif, _Style.regular): _FontSpec(
+    ['/System/Library/Fonts/ヒラギノ明朝 ProN.ttc'],
   ),
 };
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
@@ -13,7 +13,16 @@ abstract interface class FlutterGpuTextOutliner {
 }
 
 /// A parsed TrueType face used by [FlutterGpuTrueTypeTextOutliner].
-class FlutterGpuTrueTypeFontFace {
+abstract interface class FlutterGpuFontFace {
+  int gidForUnicode(int codePoint);
+
+  PdfPath? outlineForGlyph(int glyphId);
+
+  double? advanceForGlyph(int glyphId);
+}
+
+/// A parsed TrueType `glyf` face used by [FlutterGpuTrueTypeTextOutliner].
+class FlutterGpuTrueTypeFontFace implements FlutterGpuFontFace {
   FlutterGpuTrueTypeFontFace._(this.font);
 
   /// Parses [bytes], throwing when the selected face cannot provide TrueType
@@ -35,6 +44,47 @@ class FlutterGpuTrueTypeFontFace {
   }
 
   final TrueTypeFont font;
+
+  @override
+  int gidForUnicode(int codePoint) => font.gidForUnicode(codePoint);
+
+  @override
+  PdfPath? outlineForGlyph(int glyphId) => font.outlineForGlyph(glyphId);
+
+  @override
+  double? advanceForGlyph(int glyphId) => font.advanceForGlyph(glyphId);
+}
+
+/// A parsed CFF-flavoured OpenType face, including one TTC collection entry.
+class FlutterGpuOpenTypeCffFontFace implements FlutterGpuFontFace {
+  FlutterGpuOpenTypeCffFontFace._(this.font);
+
+  factory FlutterGpuOpenTypeCffFontFace(
+    Uint8List bytes, {
+    int collectionIndex = 0,
+  }) {
+    final font = OpenTypeCffFont.parse(
+      bytes,
+      collectionIndex: collectionIndex,
+    );
+    if (font == null) {
+      throw FormatException(
+        'font face $collectionIndex has no usable OpenType CFF outlines',
+      );
+    }
+    return FlutterGpuOpenTypeCffFontFace._(font);
+  }
+
+  final OpenTypeCffFont font;
+
+  @override
+  int gidForUnicode(int codePoint) => font.gidForUnicode(codePoint);
+
+  @override
+  PdfPath? outlineForGlyph(int glyphId) => font.outlineForGlyph(glyphId);
+
+  @override
+  double? advanceForGlyph(int glyphId) => font.advanceForGlyph(glyphId);
 }
 
 /// Resolves the exact substitute face for one recorded text run.
@@ -42,7 +92,7 @@ class FlutterGpuTrueTypeFontFace {
 /// The resolver should return null when it cannot prove that its bytes match
 /// the face Flutter Canvas selects. In particular, bold/italic synthesis and
 /// complex-script fallback should not be guessed.
-typedef FlutterGpuFontFaceResolver = FlutterGpuTrueTypeFontFace? Function(
+typedef FlutterGpuFontFaceResolver = FlutterGpuFontFace? Function(
   PdfTextRun run,
 );
 
@@ -68,7 +118,7 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
         !_isPlaceableText(text)) {
       return null;
     }
-    final face = resolveFace(run)?.font;
+    final face = resolveFace(run);
     if (face == null) return null;
 
     final resolved = <_ResolvedGlyph>[];

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
@@ -12,7 +12,7 @@ abstract interface class FlutterGpuTextOutliner {
   PdfTextRun? outline(PdfTextRun run);
 }
 
-/// A parsed TrueType face used by [FlutterGpuTrueTypeTextOutliner].
+/// A parsed outline font face used by [FlutterGpuTrueTypeTextOutliner].
 abstract interface class FlutterGpuFontFace {
   int gidForUnicode(int codePoint);
 
@@ -96,7 +96,7 @@ typedef FlutterGpuFontFaceResolver = FlutterGpuFontFace? Function(
   PdfTextRun run,
 );
 
-/// Converts simple horizontal substituted text to retained TrueType outlines.
+/// Converts simple horizontal substituted text to retained font outlines.
 ///
 /// PDF character offsets remain authoritative. Glyph shapes receive one
 /// uniform horizontal scale—the same copy-fitting rule used by

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -247,6 +247,22 @@ Future<void> _registerMacSystemFonts() async {
   ]);
   await load('Symbol', ['/System/Library/Fonts/Symbol.ttf']);
   await load('Zapf Dingbats', ['/System/Library/Fonts/ZapfDingbats.ttf']);
+  await load(
+    'STSong',
+    ['/System/Library/Fonts/Supplemental/Songti.ttc'],
+  );
+  await load(
+    'Heiti SC',
+    ['/System/Library/Fonts/STHeiti Medium.ttc'],
+  );
+  await load(
+    'Hiragino Sans',
+    ['/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc'],
+  );
+  await load(
+    'Hiragino Mincho ProN',
+    ['/System/Library/Fonts/ヒラギノ明朝 ProN.ttc'],
+  );
 }
 
 Future<void> _writeFailure(String suite, String name, int page, ui.Image canvas,

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -130,6 +130,19 @@ Future<void> _registerMacSystemFonts() async {
 
   await load('Helvetica', '/System/Library/Fonts/Helvetica.ttc');
   await load('Symbol', '/System/Library/Fonts/Symbol.ttf');
+  await load(
+    'STSong',
+    '/System/Library/Fonts/Supplemental/Songti.ttc',
+  );
+  await load('Heiti SC', '/System/Library/Fonts/STHeiti Medium.ttc');
+  await load(
+    'Hiragino Sans',
+    '/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc',
+  );
+  await load(
+    'Hiragino Mincho ProN',
+    '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc',
+  );
 }
 
 void main() {

--- a/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
@@ -92,7 +92,7 @@ void main() {
   });
 
   test(
-    'macOS system adapter resolves every Helvetica collection face',
+    'macOS system adapter resolves exact Latin and CJK faces',
     () {
       final system = FlutterGpuSystemTextOutliner.tryCreate();
       expect(system, isNotNull);
@@ -120,6 +120,20 @@ void main() {
         ),
         isNull,
       );
+      for (final (name, text) in const [
+        ('ºÚÌå', '中文'),
+        ('·ÂËÎ_GB2312', '中文'),
+        ('HeiseiMin-W3', '日本'),
+        ('MS-Gothic', '日本'),
+      ]) {
+        expect(
+          system.outline(
+            run(text, const [0, 0.8, 1.6], fontName: name),
+          ),
+          isNotNull,
+          reason: name,
+        );
+      }
     },
     skip: !Platform.isMacOS,
   );

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+- Export an OpenType CFF face reader that retains Unicode cmap mappings and
+  selects collection entries, allowing native substitution adapters to obtain
+  exact glyph outlines and advances from CFF-flavoured system fonts.
 - Give synthesized FreeText and form-widget fallback text exact Base-14
   character offsets, keeping Canvas placement, selection geometry, and
   retained outline backends on the same per-character advances.

--- a/packages/pdf_graphics/lib/pdf_graphics.dart
+++ b/packages/pdf_graphics/lib/pdf_graphics.dart
@@ -15,6 +15,7 @@ export 'package:pdf_cos/pdf_cos.dart'
 export 'src/device.dart';
 export 'src/font_info.dart';
 export 'src/fonts/truetype.dart' show TrueTypeFont;
+export 'src/fonts/cff.dart' show OpenTypeCffFont;
 export 'src/function.dart';
 export 'src/icc.dart';
 export 'src/image_colorants.dart';

--- a/packages/pdf_graphics/lib/src/fonts/cff.dart
+++ b/packages/pdf_graphics/lib/src/fonts/cff.dart
@@ -491,6 +491,203 @@ class CffFont {
   }
 }
 
+/// One CFF-flavoured OpenType face with its Unicode cmap preserved.
+///
+/// [CffFont] also parses a standalone OpenType `CFF ` table, but PDF-embedded
+/// fonts already supply character-to-glyph mappings separately. Native font
+/// substitution needs the sfnt container's cmap instead. This wrapper keeps
+/// that mapping and selects a face from a TrueType collection (`ttcf`) while
+/// delegating Type 2 charstrings and advances to [CffFont].
+class OpenTypeCffFont {
+  OpenTypeCffFont._(this._font, this._cmaps);
+
+  /// Parses one CFF OpenType face. Returns null for TrueType `glyf` faces,
+  /// malformed inputs, missing Unicode cmaps, or an invalid collection index.
+  static OpenTypeCffFont? parse(
+    Uint8List bytes, {
+    int collectionIndex = 0,
+  }) {
+    try {
+      final reader = _Reader(bytes);
+      var faceOffset = 0;
+      var scaler = reader.u32();
+      if (scaler == 0x74746366 /* ttcf */) {
+        reader.u32(); // version
+        final count = reader.u32();
+        if (count == 0 || collectionIndex < 0 || collectionIndex >= count) {
+          return null;
+        }
+        reader.seek(12 + collectionIndex * 4);
+        faceOffset = reader.u32();
+        reader.seek(faceOffset);
+        scaler = reader.u32();
+      } else if (collectionIndex != 0) {
+        return null;
+      }
+      if (scaler != 0x4F54544F /* OTTO */) return null;
+
+      final tableCount = reader.u16();
+      reader.skip(6);
+      (int, int)? cffTable;
+      (int, int)? cmapTable;
+      for (var index = 0; index < tableCount; index++) {
+        final tag = String.fromCharCodes([
+          reader.u8(),
+          reader.u8(),
+          reader.u8(),
+          reader.u8(),
+        ]);
+        reader.u32(); // checksum
+        final offset = reader.u32();
+        final length = reader.u32();
+        if (tag == 'CFF ') cffTable = (offset, length);
+        if (tag == 'cmap') cmapTable = (offset, length);
+      }
+      if (cffTable == null || cmapTable == null) return null;
+      final cffEnd = cffTable.$1 + cffTable.$2;
+      final cmapEnd = cmapTable.$1 + cmapTable.$2;
+      if (cffTable.$1 < 0 ||
+          cffEnd > bytes.length ||
+          cmapTable.$1 < 0 ||
+          cmapEnd > bytes.length) {
+        return null;
+      }
+      final font = CffFont.parse(
+        Uint8List.sublistView(bytes, cffTable.$1, cffEnd),
+      );
+      if (font == null) return null;
+
+      reader.seek(cmapTable.$1 + 2);
+      final cmapCount = reader.u16();
+      final cmaps = <_OpenTypeCmap>[];
+      for (var index = 0; index < cmapCount; index++) {
+        final platform = reader.u16();
+        final encoding = reader.u16();
+        final offset = reader.u32();
+        final absolute = cmapTable.$1 + offset;
+        if (absolute >= cmapTable.$1 && absolute < cmapEnd) {
+          cmaps.add(_OpenTypeCmap(bytes, absolute, platform, encoding));
+        }
+      }
+      if (cmaps.isEmpty) return null;
+      return OpenTypeCffFont._(font, List.unmodifiable(cmaps));
+    } on Object {
+      return null;
+    }
+  }
+
+  final CffFont _font;
+  final List<_OpenTypeCmap> _cmaps;
+
+  int get numGlyphs => _font.numGlyphs;
+
+  /// Maps one Unicode scalar through the face's Unicode cmap.
+  int gidForUnicode(int codePoint) {
+    for (final cmap in _cmaps) {
+      final unicode =
+          (cmap.platform == 3 && (cmap.encoding == 1 || cmap.encoding == 10)) ||
+              cmap.platform == 0;
+      if (!unicode) continue;
+      final glyph = cmap.lookup(codePoint);
+      if (glyph != 0) return glyph;
+    }
+    return 0;
+  }
+
+  PdfPath? outlineForGlyph(int glyphId) => _font.outlineForGlyph(glyphId);
+
+  double? advanceForGlyph(int glyphId) => _font.advanceForGlyph(glyphId);
+}
+
+class _OpenTypeCmap {
+  const _OpenTypeCmap(
+    this._bytes,
+    this._offset,
+    this.platform,
+    this.encoding,
+  );
+
+  final Uint8List _bytes;
+  final int _offset;
+  final int platform;
+  final int encoding;
+
+  int lookup(int codePoint) {
+    try {
+      final reader = _Reader(_bytes)..seek(_offset);
+      return switch (reader.u16()) {
+        0 => _format0(reader, codePoint),
+        4 => _format4(reader, codePoint),
+        6 => _format6(reader, codePoint),
+        12 => _format12(reader, codePoint),
+        _ => 0,
+      };
+    } on Object {
+      return 0;
+    }
+  }
+
+  int _format0(_Reader reader, int codePoint) {
+    if (codePoint < 0 || codePoint > 0xFF) return 0;
+    reader.skip(4);
+    reader.skip(codePoint);
+    return reader.u8();
+  }
+
+  int _format4(_Reader reader, int codePoint) {
+    if (codePoint < 0 || codePoint > 0xFFFF) return 0;
+    reader.skip(4); // length, language
+    final segmentCount = reader.u16() ~/ 2;
+    reader.skip(6);
+    final endCodesAt = reader.position;
+    var segment = -1;
+    for (var index = 0; index < segmentCount; index++) {
+      if (reader.u16() >= codePoint) {
+        segment = index;
+        break;
+      }
+    }
+    if (segment < 0) return 0;
+    final startCodesAt = endCodesAt + segmentCount * 2 + 2;
+    reader.seek(startCodesAt + segment * 2);
+    final startCode = reader.u16();
+    if (codePoint < startCode) return 0;
+    final idDeltaAt = startCodesAt + segmentCount * 2;
+    reader.seek(idDeltaAt + segment * 2);
+    final idDelta = reader.s16();
+    final rangeOffsetAt = idDeltaAt + segmentCount * 2 + segment * 2;
+    reader.seek(rangeOffsetAt);
+    final rangeOffset = reader.u16();
+    if (rangeOffset == 0) return (codePoint + idDelta) & 0xFFFF;
+    reader.seek(rangeOffsetAt + rangeOffset + (codePoint - startCode) * 2);
+    final glyph = reader.u16();
+    return glyph == 0 ? 0 : (glyph + idDelta) & 0xFFFF;
+  }
+
+  int _format6(_Reader reader, int codePoint) {
+    reader.skip(4);
+    final first = reader.u16();
+    final count = reader.u16();
+    if (codePoint < first || codePoint >= first + count) return 0;
+    reader.skip((codePoint - first) * 2);
+    return reader.u16();
+  }
+
+  int _format12(_Reader reader, int codePoint) {
+    reader.skip(10);
+    final count = reader.u32();
+    for (var index = 0; index < count; index++) {
+      final start = reader.u32();
+      final end = reader.u32();
+      final firstGlyph = reader.u32();
+      if (codePoint >= start && codePoint <= end) {
+        return firstGlyph + codePoint - start;
+      }
+    }
+    return 0;
+  }
+}
+
 class _PrivateDict {
   const _PrivateDict(this.subrs, this.defaultWidthX, this.nominalWidthX);
 
@@ -871,12 +1068,28 @@ class _Reader {
 
   void seek(int p) => position = p;
 
+  void skip(int n) => position += n;
+
   int u8() => bytes[position++];
 
   int u16() {
     final v = (bytes[position] << 8) | bytes[position + 1];
     position += 2;
     return v;
+  }
+
+  int s16() {
+    final value = u16();
+    return value > 0x7FFF ? value - 0x10000 : value;
+  }
+
+  int u32() {
+    final value = (bytes[position] << 24) |
+        (bytes[position + 1] << 16) |
+        (bytes[position + 2] << 8) |
+        bytes[position + 3];
+    position += 4;
+    return value;
   }
 }
 

--- a/packages/pdf_graphics/test/cff_test.dart
+++ b/packages/pdf_graphics/test/cff_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -91,7 +92,158 @@ void main() {
     },
     skip: !Platform.isMacOS,
   );
+
+  test('OpenType CFF reads Unicode cmap formats and collections', () {
+    final bytes = _testOpenTypeCff();
+    final face = OpenTypeCffFont.parse(bytes);
+    expect(face, isNotNull);
+    expect(face!.numGlyphs, 2);
+    expect(face.gidForUnicode(0x41), 1, reason: 'format 0');
+    expect(face.gidForUnicode(0x42), 1, reason: 'format 4');
+    expect(face.gidForUnicode(0x400), 1, reason: 'format 6');
+    expect(face.gidForUnicode(0x1F600), 1, reason: 'format 12');
+    expect(face.gidForUnicode(0x43), 0);
+    expect(face.outlineForGlyph(1), isNotNull);
+    expect(face.advanceForGlyph(1), closeTo(0.66, 1e-9));
+
+    final collection = _testOpenTypeCffCollection();
+    expect(OpenTypeCffFont.parse(collection, collectionIndex: 1), isNotNull);
+    expect(OpenTypeCffFont.parse(collection, collectionIndex: -1), isNull);
+    expect(OpenTypeCffFont.parse(collection, collectionIndex: 2), isNull);
+  });
+
+  test('OpenType CFF rejects malformed or incomplete containers', () {
+    final plain = _testOpenTypeCff();
+    expect(OpenTypeCffFont.parse(plain, collectionIndex: 1), isNull);
+    expect(OpenTypeCffFont.parse(ascii('not an sfnt')), isNull);
+
+    final trueType = Uint8List.fromList(plain)
+      ..setRange(0, 4, const [0, 1, 0, 0]);
+    expect(OpenTypeCffFont.parse(trueType), isNull);
+    expect(OpenTypeCffFont.parse(_testOpenTypeCff(cmaps: const [])), isNull);
+  });
 }
+
+Uint8List _testOpenTypeCff({
+  int faceOffset = 0,
+  List<List<int>>? cmaps,
+}) {
+  final cff = buildTestCffFont();
+  final cmap = _cmapTable(cmaps ?? _testCmaps());
+  const directoryLength = 12 + 2 * 16;
+  final cffOffset = faceOffset + directoryLength;
+  final cmapOffset = cffOffset + cff.length;
+  return Uint8List.fromList([
+    ..._u32(0x4F54544F), // OTTO
+    ..._u16(2),
+    ..._u16(0),
+    ..._u16(0),
+    ..._u16(0),
+    ...'CFF '.codeUnits,
+    ..._u32(0),
+    ..._u32(cffOffset),
+    ..._u32(cff.length),
+    ...'cmap'.codeUnits,
+    ..._u32(0),
+    ..._u32(cmapOffset),
+    ..._u32(cmap.length),
+    ...cff,
+    ...cmap,
+  ]);
+}
+
+Uint8List _testOpenTypeCffCollection() {
+  const firstOffset = 20;
+  final first = _testOpenTypeCff(faceOffset: firstOffset);
+  final secondOffset = firstOffset + first.length;
+  final second = _testOpenTypeCff(faceOffset: secondOffset);
+  return Uint8List.fromList([
+    ...'ttcf'.codeUnits,
+    ..._u32(0x00010000),
+    ..._u32(2),
+    ..._u32(firstOffset),
+    ..._u32(secondOffset),
+    ...first,
+    ...second,
+  ]);
+}
+
+List<List<int>> _testCmaps() {
+  final format0Glyphs = List<int>.filled(256, 0)..[0x41] = 1;
+  return [
+    [
+      ..._u16(0),
+      ..._u16(262),
+      ..._u16(0),
+      ...format0Glyphs,
+    ],
+    [
+      ..._u16(4),
+      ..._u16(34),
+      ..._u16(0),
+      ..._u16(4), // two segments
+      ..._u16(4),
+      ..._u16(1),
+      ..._u16(0),
+      ..._u16(0x42),
+      ..._u16(0xFFFF),
+      ..._u16(0),
+      ..._u16(0x42),
+      ..._u16(0xFFFF),
+      ..._u16(0xFFFF), // glyph 2 plus -1 => glyph 1
+      ..._u16(1),
+      ..._u16(4),
+      ..._u16(0),
+      ..._u16(2),
+    ],
+    [
+      ..._u16(6),
+      ..._u16(12),
+      ..._u16(0),
+      ..._u16(0x400),
+      ..._u16(1),
+      ..._u16(1),
+    ],
+    [
+      ..._u16(12),
+      ..._u16(0),
+      ..._u32(28),
+      ..._u32(0),
+      ..._u32(1),
+      ..._u32(0x1F600),
+      ..._u32(0x1F600),
+      ..._u32(1),
+    ],
+  ];
+}
+
+Uint8List _cmapTable(List<List<int>> subtables) {
+  final recordsLength = 4 + subtables.length * 8;
+  var offset = recordsLength;
+  final records = <int>[];
+  for (var index = 0; index < subtables.length; index++) {
+    records
+      ..addAll(_u16(0))
+      ..addAll(_u16(index))
+      ..addAll(_u32(offset));
+    offset += subtables[index].length;
+  }
+  return Uint8List.fromList([
+    ..._u16(0),
+    ..._u16(subtables.length),
+    ...records,
+    for (final subtable in subtables) ...subtable,
+  ]);
+}
+
+List<int> _u16(int value) => [(value >> 8) & 0xFF, value & 0xFF];
+
+List<int> _u32(int value) => [
+      (value >> 24) & 0xFF,
+      (value >> 16) & 0xFF,
+      (value >> 8) & 0xFF,
+      value & 0xFF,
+    ];
 
 CffFont _cffFromPageFont(String path, {required String fontName}) {
   final doc = PdfDocument.open(File(path).readAsBytesSync());

--- a/packages/pdf_graphics/test/cff_test.dart
+++ b/packages/pdf_graphics/test/cff_test.dart
@@ -75,6 +75,22 @@ void main() {
   test('garbage input parses to null', () {
     expect(CffFont.parse(ascii('not a font')), isNull);
   });
+
+  test(
+    'OpenType CFF faces retain their Unicode cmap',
+    () {
+      final bytes = File(
+        '/System/Library/Fonts/ヒラギノ明朝 ProN.ttc',
+      ).readAsBytesSync();
+      final face = OpenTypeCffFont.parse(bytes);
+      expect(face, isNotNull);
+      final glyph = face!.gidForUnicode('日'.codeUnitAt(0));
+      expect(glyph, greaterThan(0));
+      expect(face.outlineForGlyph(glyph), isNotNull);
+      expect(face.advanceForGlyph(glyph), greaterThan(0));
+    },
+    skip: !Platform.isMacOS,
+  );
 }
 
 CffFont _cffFromPageFont(String path, {required String fontName}) {


### PR DESCRIPTION
Headline: PDF.js GPU corpus acceptance improves from 171/179 to 177/179 exact pages. On the representative non-empty SimFang tile, the viewer-equivalent first tile drops from about 225 ms on the Canvas fallback to 6.4–7.2 ms on GPU, about 97% faster, with mean pixel difference 0.145.

This retains the exact macOS CJK faces selected by the Canvas substitution stack: Songti, Heiti, Hiragino Sans, and Hiragino Mincho. It adds a generic retained font-face seam plus OpenType CFF and TTC/OTC collection support, preserving Unicode cmap selection, glyph outlines, and advances. Unsupported shaping or faces still decline to Canvas.

Six newly exact PDF.js pages:
- 90ms_rksj_h_sample.pdf
- SimFang-variant.pdf
- XiaoBiaoSong.pdf
- issue3521.pdf
- noembed-eucjp.pdf
- noembed-sjis.pdf

Validation:
- fvm dart analyze
- full pdf_graphics suite: 1048 passed
- full native Flutter GPU suite: 275 passed, 3 expected skips before the follow-up group-text tests
- PDF.js GPU corpus: 177 accepted, 2 conservative fallbacks
- Ghent GPU corpus unchanged: 41 accepted, 16 conservative fallbacks
- dedicated same-host CJK PR trace uses SimFang-variant and six balanced runs

Warm GPU replay is about 5.0–5.9 ms versus Canvas at 3.8–3.9 ms; the material win is removing the roughly 225 ms first-use Canvas font/shaping stall after the viewer has performed its existing idle scene preparation.

Depends on #778 for corrected route-change scene preparation. Until #778 merges, this PR includes that one benchmark-method commit in its comparison; afterward the rendering diff is only the CJK work.