### PR TITLE
perf(gpu): retain transparency group text

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Retain outlined text in single-paint and mixed vector transparency groups,
+  including clipped isolated groups that require the exact offscreen tile
+  pass for group alpha and outer blending.
 - Retain exact macOS CJK substitutions for Songti, Heiti, Hiragino Sans, and
   Hiragino Mincho, including CFF outlines inside OpenType collections. Six
   additional PDF.js corpus pages now stay on the GPU, with a dedicated CJK

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -87,13 +87,16 @@ blending, and exact destination-sampling Overlay, Darken, Lighten, ColorDodge,
 ColorBurn, HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color,
 and Luminosity blending,
 rectangular and arbitrary path clips, and the common isolated single-image
-soft-mask group. Isolated transparency groups containing a single vector fill
-or stroke also stay on the GPU: their group alpha and page blend mode are folded
-into retained stencil geometry. One-element knockout groups are included
+soft-mask group. Isolated transparency groups containing a single vector fill,
+stroke, or outlined text run also stay on the GPU: their group alpha and page
+blend mode are folded into retained stencil geometry. One-element knockout
+groups are included
 because there are no sibling elements for knockout to change. Alpha-one,
-normal-blend non-knockout groups may contain multiple ordered fills and strokes
-because source-over is associative, so their isolation layer is an identity
-operation. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
+normal-blend non-knockout groups may contain multiple ordered fills, strokes,
+and outlined text runs because source-over is associative, so their isolation
+layer is an identity operation. Isolated overlapping groups retain those same
+paint types in the bounded offscreen tile pass before applying group alpha and
+the outer blend once. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
 surface also keep their base and mask as separate cached textures and combine
 them in the same shader path. A single vector fill can use one opaque grayscale
 image soft mask directly through retained stencil geometry. Rectangular vector

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -312,7 +312,16 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             break;
           case _GroupStrokeSpec():
             break;
+          case _GroupTextSpec():
+            final reason = _unsupportedTextReason(composite.content.run);
+            if (reason != null) return reason;
           case _GroupPaintSpec():
+            for (final command in composite.commands) {
+              if (command case PdfDrawTextCommand(:final run)) {
+                final reason = _unsupportedTextReason(run);
+                if (reason != null) return reason;
+              }
+            }
             break;
           case _KnockoutSoftMaskFillSpec():
             break;
@@ -516,6 +525,19 @@ class _GroupStrokeSpec extends _GpuCompositeSpec {
   });
 
   final PdfStrokePathCommand content;
+  final double groupAlpha;
+  @override
+  final PdfRect? contentClip;
+}
+
+class _GroupTextSpec extends _GpuCompositeSpec {
+  const _GroupTextSpec({
+    required this.content,
+    required this.groupAlpha,
+    required this.contentClip,
+  });
+
+  final PdfDrawTextCommand content;
   final double groupAlpha;
   @override
   final PdfRect? contentClip;
@@ -1307,6 +1329,22 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           }
           paints.add((i, command, clip, blend, strokeOverprint));
           contentClip = clip;
+        case PdfDrawTextCommand(:final run):
+          if (emptyClipOnly) {
+            return (null, 'empty transparency group contains paint');
+          }
+          if (softDepth != 0 || content != null) {
+            return (null, 'soft-mask group contains PdfDrawTextCommand');
+          }
+          paints.add((
+            i,
+            command,
+            clip,
+            blend,
+            (run.fill && fillOverprint) ||
+                (run.strokeColor != null && strokeOverprint),
+          ));
+          contentClip = clip;
         case PdfSetBlendModeCommand(:final mode):
           // A one-element group may use any internal blend: with a transparent
           // group backdrop every PDF blend function reduces to the source.
@@ -1419,6 +1457,14 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           ),
         PdfStrokePathCommand content => (
             _GroupStrokeSpec(
+              content: content,
+              groupAlpha: alpha,
+              contentClip: paint.$3,
+            ),
+            null,
+          ),
+        PdfDrawTextCommand content => (
+            _GroupTextSpec(
               content: content,
               groupAlpha: alpha,
               contentClip: paint.$3,
@@ -2919,6 +2965,7 @@ class _CompiledScene {
           draw = switch (unit.composite!) {
             _GroupFillSpec spec => _compileGroupFill(geometry, spec),
             _GroupStrokeSpec spec => _compileGroupStroke(geometry, spec),
+            _GroupTextSpec spec => _compileGroupText(geometry, spec),
             _GroupPaintSpec spec => _compileGroupPaint(geometry, spec),
             _KnockoutSoftMaskFillSpec spec =>
               _compileKnockoutSoftMaskFill(geometry, spec),
@@ -3854,6 +3901,57 @@ _GpuDraw? _compileGroupStroke(
       alphaScale: spec.groupAlpha,
     );
 
+_GpuDraw? _compileGroupText(_GpuGeometryArena geometry, _GroupTextSpec spec) =>
+    _compileGroupTextRun(
+      geometry,
+      spec.content.run,
+      alphaScale: spec.groupAlpha,
+    );
+
+_GpuDraw? _compileGroupTextRun(
+  _GpuGeometryArena geometry,
+  PdfTextRun run, {
+  double alphaScale = 1,
+}) {
+  if (run.invisible) return null;
+  final subpaths = _textSubpaths(run)!;
+  final gradient = run.gradient;
+  final fill = !run.fill
+      ? null
+      : gradient != null
+          ? _compileGradientSubpaths(
+              geometry,
+              subpaths,
+              PdfFillRule.nonzero,
+              gradient,
+              (run.fillAlpha * alphaScale).clamp(0.0, 1.0),
+            )
+          : _stencilDraw(
+              geometry,
+              subpaths,
+              run.color,
+              (run.fillAlpha * alphaScale).clamp(0.0, 1.0),
+              PdfFillRule.nonzero,
+              false,
+            );
+  final strokeColor = run.strokeColor;
+  final stroke = strokeColor == null
+      ? null
+      : _compileStrokeSubpaths(
+          geometry,
+          subpaths,
+          strokeColor,
+          PdfStroke(width: run.strokeWidth, miterLimit: 4),
+          (run.strokeAlpha * alphaScale).clamp(0.0, 1.0),
+        );
+  return switch ((fill, stroke)) {
+    (null, null) => null,
+    (final _GpuDraw draw, null) || (null, final _GpuDraw draw) => draw,
+    (final _GpuDraw fill, final _GpuDraw stroke) =>
+      _SequenceDraw([fill, stroke]),
+  };
+}
+
 _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
   final draws = <(_GpuDraw, PdfRect?, bool)>[];
   var paintPadding = 2.0;
@@ -3883,6 +3981,7 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
           false,
         ),
       PdfStrokePathCommand() => _compileStroke(geometry, command),
+      PdfDrawTextCommand(:final run) => _compileGroupTextRun(geometry, run),
       _ => null,
     };
     if (draw != null) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1370,6 +1370,52 @@ void main() {
     });
   });
 
+  testWidgets('isolated single-text groups preserve clip blend and alpha',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(40, 100, 300, 360),
+          const PdfColor(0.72, 0.68, 0.2),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(0.58),
+        PdfClipPathCommand(_rect(75, 130, 275, 330), PdfFillRule.nonzero),
+        _outlinedText(
+          transform: const PdfMatrix(170, 0, 0, 170, 95, 145),
+          color: const PdfColor(0.2, 0.28, 0.9),
+          alpha: 0.75,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(30, 420, 300, 300);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+    });
+  });
+
   testWidgets('single-paint groups with a seeded backdrop keep Canvas',
       (tester) async {
     await tester.runAsync(() async {
@@ -1625,6 +1671,64 @@ void main() {
         backend.stats.peakOffscreenGroupBytes,
         backend.stats.offscreenGroupAllocatedBytes,
       );
+    });
+  });
+
+  testWidgets('isolated text and path composite through an offscreen tile',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.62,
+          isolated: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 230, 310),
+          const PdfColor(0.95, 0.7, 0.2),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        _outlinedText(
+          transform: const PdfMatrix(155, 0, 0, 155, 125, 150),
+          color: const PdfColor(0.2, 0.8, 0.85),
+          alpha: 0.75,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
     });
   });
 


### PR DESCRIPTION
## Result

- Removes the Canvas fallback for exact text paints inside isolated transparency groups.
- Preserves group alpha, outer blend, clipping, and mixed text/path painter order through one retained offscreen pass.
- Keeps conservative fallback for unsupported group semantics.
- Corpus acceptance remains PDF.js 177 GPU / 2 conservative fallbacks and Ghent 41 GPU / 16 conservative fallbacks; the large Ghent composites now advance to their real overprint or non-identity group blockers.

## Validation

- `fvm dart analyze`
- `fvm flutter test --enable-impeller --enable-flutter-gpu test/flutter_gpu_tile_backend_test.dart` — 48 passed, 1 expected non-GPU-mode skip
- PDF.js and Ghent GPU corpus suites validated on the full local transparency stack

## Scope

This is the first focused increment in the transparency-group sequence. Image paints, per-paint fixed blends, and gradient/mesh paints follow as separate PRs after this lands.