### PR TITLE
perf(gpu): retain transparency group images

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Retain ordinary images in single-paint and mixed vector/text transparency
+  groups, reusing the scene texture cache and the exact offscreen group pass.
 - Retain outlined text in single-paint and mixed vector transparency groups,
   including clipped isolated groups that require the exact offscreen tile
   pass for group alpha and outer blending.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -88,15 +88,16 @@ ColorBurn, HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color,
 and Luminosity blending,
 rectangular and arbitrary path clips, and the common isolated single-image
 soft-mask group. Isolated transparency groups containing a single vector fill,
-stroke, or outlined text run also stay on the GPU: their group alpha and page
-blend mode are folded into retained stencil geometry. One-element knockout
-groups are included
+stroke, outlined text run, or ordinary image also stay on the GPU: their group
+alpha and page blend mode are retained exactly. One-element knockout groups are
+included
 because there are no sibling elements for knockout to change. Alpha-one,
 normal-blend non-knockout groups may contain multiple ordered fills, strokes,
-and outlined text runs because source-over is associative, so their isolation
-layer is an identity operation. Isolated overlapping groups retain those same
-paint types in the bounded offscreen tile pass before applying group alpha and
-the outer blend once. Platform-decoded JPEGs whose `/SMask` remains a companion GPU
+outlined text runs, and ordinary images because source-over is associative, so
+their isolation layer is an identity operation. Isolated overlapping groups
+retain those same paint types in the bounded offscreen tile pass before
+applying group alpha and the outer blend once. Platform-decoded JPEGs whose
+`/SMask` remains a companion GPU
 surface also keep their base and mask as separate cached textures and combine
 them in the same shader path. A single vector fill can use one opaque grayscale
 image soft mask directly through retained stencil geometry. Rectangular vector

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -317,9 +317,17 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             if (reason != null) return reason;
           case _GroupPaintSpec():
             for (final command in composite.commands) {
-              if (command case PdfDrawTextCommand(:final run)) {
-                final reason = _unsupportedTextReason(run);
-                if (reason != null) return reason;
+              switch (command) {
+                case PdfDrawTextCommand(:final run):
+                  final reason = _unsupportedTextReason(run);
+                  if (reason != null) return reason;
+                case PdfDrawImageCommand(:final request):
+                  if (scene.imageFor(request) == null &&
+                      !scene.imageDecodingAttempted) {
+                    return 'missing transparency-group image pixels';
+                  }
+                default:
+                  break;
               }
             }
             break;
@@ -1306,7 +1314,12 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           if (emptyClipOnly) {
             return (null, 'empty transparency group contains paint');
           }
-          if (softDepth != 1 || content != null) {
+          if (softDepth == 0 && content == null) {
+            paints.add((i, command, clip, blend, false));
+            contentClip = clip;
+            break;
+          }
+          if (softDepth != 1 || content != null || paints.isNotEmpty) {
             return (null, 'soft-mask group is not a single image');
           }
           content = command;
@@ -1468,6 +1481,16 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               content: content,
               groupAlpha: alpha,
               contentClip: paint.$3,
+            ),
+            null,
+          ),
+        PdfDrawImageCommand content => (
+            _GroupPaintSpec(
+              commands: [content],
+              paintClips: [paint.$3],
+              contentClip: paint.$3,
+              groupAlpha: alpha,
+              offscreen: alpha != 1,
             ),
             null,
           ),
@@ -2966,7 +2989,18 @@ class _CompiledScene {
             _GroupFillSpec spec => _compileGroupFill(geometry, spec),
             _GroupStrokeSpec spec => _compileGroupStroke(geometry, spec),
             _GroupTextSpec spec => _compileGroupText(geometry, spec),
-            _GroupPaintSpec spec => _compileGroupPaint(geometry, spec),
+            _GroupPaintSpec spec => await _compileGroupPaint(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                glyphAtlas,
+                pageToRaster,
+                mipmapImages: mipmapImages,
+              ),
             _KnockoutSoftMaskFillSpec spec =>
               _compileKnockoutSoftMaskFill(geometry, spec),
             _FlattenSoftMaskSpec() => null,
@@ -3952,7 +3986,18 @@ _GpuDraw? _compileGroupTextRun(
   };
 }
 
-_GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
+Future<_GpuDraw?> _compileGroupPaint(
+  gpu.GpuContext context,
+  _GpuGeometryArena geometry,
+  PdfRetainedScene scene,
+  _GroupPaintSpec spec,
+  FlutterGpuTileBackendStats stats,
+  _GpuImageCache imageCache,
+  List<_GpuImageTexture> textureLeases,
+  _GpuGlyphAtlas? glyphAtlas,
+  PdfMatrix pageToRaster, {
+  required bool mipmapImages,
+}) async {
   final draws = <(_GpuDraw, PdfRect?, bool)>[];
   var paintPadding = 2.0;
   for (var index = 0; index < spec.commands.length; index++) {
@@ -3965,25 +4010,18 @@ _GpuDraw? _compileGroupPaint(_GpuGeometryArena geometry, _GroupPaintSpec spec) {
         stroke.width * joinScale / 2 + 2,
       );
     }
-    final draw = switch (command) {
-      PdfFillPathCommand(
-        :final path,
-        :final color,
-        :final rule,
-        :final alpha,
-      ) =>
-        _stencilDraw(
-          geometry,
-          flattenPath(path, PdfMatrix.identity, tolerance: 0.01),
-          color,
-          alpha,
-          rule,
-          false,
-        ),
-      PdfStrokePathCommand() => _compileStroke(geometry, command),
-      PdfDrawTextCommand(:final run) => _compileGroupTextRun(geometry, run),
-      _ => null,
-    };
+    final draw = await _compileCommand(
+      context,
+      geometry,
+      scene,
+      command,
+      stats,
+      imageCache,
+      textureLeases,
+      glyphAtlas,
+      pageToRaster,
+      mipmapImages: mipmapImages,
+    );
     if (draw != null) {
       draws.add((draw, spec.paintClips[index], spec.knockout && index > 0));
     }

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1416,6 +1416,74 @@ void main() {
     });
   });
 
+  testWidgets('isolated single-image groups preserve clip blend and alpha',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfFillPathCommand(
+            _rect(40, 100, 300, 360),
+            const PdfColor(0.72, 0.68, 0.2),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          const PdfBeginGroupCommand(0.58),
+          PdfClipPathCommand(_rect(75, 130, 275, 330), PdfFillRule.nonzero),
+          _decodedImage(
+            Uint8List.fromList(const [
+              220,
+              35,
+              40,
+              255,
+              25,
+              180,
+              215,
+              255,
+              45,
+              90,
+              225,
+              255,
+              235,
+              195,
+              30,
+              255,
+            ]),
+            const PdfMatrix(190, 0, 0, 190, 80, 135),
+            'single-group-image',
+          ),
+          const PdfEndGroupCommand(),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(30, 420, 300, 300);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('single-paint groups with a seeded backdrop keep Canvas',
       (tester) async {
     await tester.runAsync(() async {
@@ -1711,6 +1779,85 @@ void main() {
         const PdfEndGroupCommand(),
         const PdfSetBlendModeCommand(PdfBlendMode.normal),
       ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
+  testWidgets('isolated image and path composite through an offscreen tile',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfFillPathCommand(
+            _rect(30, 90, 310, 370),
+            const PdfColor(0.45, 0.55, 0.7),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          const PdfBeginGroupCommand(
+            0.62,
+            isolated: true,
+            bounds: PdfRect(50, 110, 290, 350),
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+          PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+          PdfFillPathCommand(
+            _rect(70, 140, 230, 310),
+            const PdfColor(0.95, 0.7, 0.2),
+            PdfFillRule.nonzero,
+            0.8,
+          ),
+          _decodedImage(
+            Uint8List.fromList(const [
+              220,
+              35,
+              40,
+              255,
+              25,
+              180,
+              215,
+              255,
+              45,
+              90,
+              225,
+              255,
+              235,
+              195,
+              30,
+              255,
+            ]),
+            const PdfMatrix(155, 0, 0, 155, 125, 150),
+            'mixed-group-image',
+          ),
+          const PdfEndGroupCommand(),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        ],
+        retainDecodedPixels: true,
+      );
       addTearDown(scene.dispose);
       final backend = FlutterGpuTileRasterBackend();
       final session = backend.createSession(scene);


### PR DESCRIPTION
## Result

- Removes the Canvas fallback for ordinary images inside single-paint and mixed isolated transparency groups.
- Reuses the retained scene image cache and the exact offscreen group pass, preserving group alpha, outer blend, per-paint clipping, and painter order.
- Keeps conservative fallback for deferred or unsupported mask semantics.
- Corpus acceptance remains PDF.js 177 GPU / 2 conservative fallbacks and Ghent 41 GPU / 16 conservative fallbacks; this expands exact general-document coverage without weakening the audit.

## Validation

- `fvm dart analyze`
- `fvm flutter test --enable-impeller --enable-flutter-gpu test/flutter_gpu_tile_backend_test.dart` — 50 passed, 1 expected non-GPU-mode skip
- PDF.js and Ghent GPU corpus suites validated on the full local transparency stack

## Scope

This is the second focused transparency-group increment. Per-paint fixed blends, gradient/mesh paints, and nested identity groups remain separate follow-up PRs.