### PR TITLE
perf(gpu): retain transparency group blends

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Preserve per-paint Normal, Multiply, and Screen state inside isolated
+  offscreen transparency groups.
 - Retain ordinary images in single-paint and mixed vector/text transparency
   groups, reusing the scene texture cache and the exact offscreen group pass.
 - Retain outlined text in single-paint and mixed vector transparency groups,

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -96,7 +96,9 @@ normal-blend non-knockout groups may contain multiple ordered fills, strokes,
 outlined text runs, and ordinary images because source-over is associative, so
 their isolation layer is an identity operation. Isolated overlapping groups
 retain those same paint types in the bounded offscreen tile pass before
-applying group alpha and the outer blend once. Platform-decoded JPEGs whose
+applying group alpha and the outer blend once. Normal, Multiply, and Screen
+remain per-paint state inside that attachment rather than being collapsed into
+the group's outer blend. Platform-decoded JPEGs whose
 `/SMask` remains a companion GPU
 surface also keep their base and mask as separate cached textures and combine
 them in the same shader path. A single vector fill can use one opaque grayscale

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -555,6 +555,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   const _GroupPaintSpec({
     required this.commands,
     required this.paintClips,
+    required this.paintBlends,
     required this.contentClip,
     this.groupAlpha = 1,
     this.offscreen = false,
@@ -563,6 +564,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
 
   final List<PdfRenderCommand> commands;
   final List<PdfRect?> paintClips;
+  final List<PdfBlendMode> paintBlends;
   final double groupAlpha;
   final bool offscreen;
   final bool knockout;
@@ -1412,7 +1414,11 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 PdfBlendMode.normal,
                 false,
               ));
-            case _GroupPaintSpec(:final commands, :final paintClips)
+            case _GroupPaintSpec(
+                  :final commands,
+                  :final paintClips,
+                  :final paintBlends,
+                )
                 when !nestedSpec.offscreen:
               for (var nestedIndex = 0;
                   nestedIndex < commands.length;
@@ -1421,7 +1427,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                   null,
                   commands[nestedIndex],
                   paintClips[nestedIndex],
-                  PdfBlendMode.normal,
+                  paintBlends[nestedIndex],
                   false,
                 ));
               }
@@ -1488,6 +1494,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             _GroupPaintSpec(
               commands: [content],
               paintClips: [paint.$3],
+              paintBlends: const [PdfBlendMode.normal],
               contentClip: paint.$3,
               groupAlpha: alpha,
               offscreen: alpha != 1,
@@ -1499,8 +1506,11 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
       final commonClip = paints.first.$3;
-      final compatiblePaints =
+      final normalPaints =
           paints.every((paint) => paint.$4 == PdfBlendMode.normal && !paint.$5);
+      final fixedFunctionPaints = paints.every((paint) =>
+          FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(paint.$4) &&
+          !paint.$5);
       final commonPaintClip =
           paints.every((paint) => _samePdfRect(paint.$3, commonClip));
       final disjointOuterBlend = initialBlend != PdfBlendMode.normal &&
@@ -1511,17 +1521,17 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       final canFlatten = alpha == 1 &&
           !knockout &&
           backdropColor == null &&
-          compatiblePaints &&
+          normalPaints &&
           (initialBlend == PdfBlendMode.normal || disjointOuterBlend);
       final canRenderKnockout = isolated &&
           knockout &&
           backdropColor == null &&
-          compatiblePaints &&
+          normalPaints &&
           paints.every((paint) => paint.$2 is PdfFillPathCommand);
       final canRenderOffscreen = (isolated &&
               !knockout &&
               backdropColor == null &&
-              compatiblePaints) ||
+              fixedFunctionPaints) ||
           canRenderKnockout;
       if (!canFlatten && !canRenderOffscreen) {
         return (null, 'non-identity multi-paint transparency group');
@@ -1549,6 +1559,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         _GroupPaintSpec(
           commands: List.unmodifiable([for (final paint in paints) paint.$2]),
           paintClips: List.unmodifiable([for (final paint in paints) paint.$3]),
+          paintBlends:
+              List.unmodifiable([for (final paint in paints) paint.$4]),
           contentClip: canFlatten && commonPaintClip ? commonClip : null,
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
@@ -3692,10 +3704,10 @@ class _CompiledScene {
       );
       for (final paint in draw.paints) {
         groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
-        if (paint.$3) {
+        if (paint.$4) {
           groupEncoder.setSourceBlend();
         } else {
-          groupEncoder.setBlendMode(PdfBlendMode.normal);
+          groupEncoder.setBlendMode(paint.$3);
         }
         paint.$1.encode(groupEncoder);
       }
@@ -3998,7 +4010,7 @@ Future<_GpuDraw?> _compileGroupPaint(
   PdfMatrix pageToRaster, {
   required bool mipmapImages,
 }) async {
-  final draws = <(_GpuDraw, PdfRect?, bool)>[];
+  final draws = <(_GpuDraw, PdfRect?, PdfBlendMode, bool)>[];
   var paintPadding = 2.0;
   for (var index = 0; index < spec.commands.length; index++) {
     final command = spec.commands[index];
@@ -4023,7 +4035,12 @@ Future<_GpuDraw?> _compileGroupPaint(
       mipmapImages: mipmapImages,
     );
     if (draw != null) {
-      draws.add((draw, spec.paintClips[index], spec.knockout && index > 0));
+      draws.add((
+        draw,
+        spec.paintClips[index],
+        spec.paintBlends[index],
+        spec.knockout && index > 0,
+      ));
     }
   }
   if (draws.isEmpty) return null;
@@ -4050,9 +4067,10 @@ _GpuDraw? _compileKnockoutSoftMaskFill(
     false,
   );
   final maskedDraw = _compileSoftMaskVectorFill(geometry, spec.masked);
-  final paints = <(_GpuDraw, PdfRect?, bool)>[
-    if (baseDraw != null) (baseDraw, spec.baseClip, false),
-    if (maskedDraw != null) (maskedDraw, spec.masked.contentClip, false),
+  final paints = <(_GpuDraw, PdfRect?, PdfBlendMode, bool)>[
+    if (baseDraw != null) (baseDraw, spec.baseClip, PdfBlendMode.normal, false),
+    if (maskedDraw != null)
+      (maskedDraw, spec.masked.contentClip, PdfBlendMode.normal, false),
   ];
   if (paints.isEmpty) return null;
   return _OffscreenGroupDraw(
@@ -5585,11 +5603,12 @@ class _SequenceDraw implements _GpuDraw {
 class _OffscreenGroupDraw implements _GpuDraw {
   const _OffscreenGroupDraw(this.paints, this.alpha, this.extraPadding);
 
-  /// The third field selects shape-limited source replacement for knockout
+  /// The third field preserves the paint's internal blend. The fourth selects
+  /// shape-limited source replacement for knockout
   /// siblings. Retained path stencils emit fragments only inside the painted
   /// shape; masked texture quads keep source-over so transparent pixels beyond
   /// their source shape cannot erase earlier siblings.
-  final List<(_GpuDraw, PdfRect?, bool)> paints;
+  final List<(_GpuDraw, PdfRect?, PdfBlendMode, bool)> paints;
   final double alpha;
   final double extraPadding;
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1879,6 +1879,92 @@ void main() {
     });
   });
 
+  testWidgets('offscreen groups preserve fixed-function blends per paint',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfFillPathCommand(
+            _rect(30, 90, 310, 370),
+            const PdfColor(0.45, 0.55, 0.7),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          const PdfBeginGroupCommand(
+            0.72,
+            isolated: true,
+            bounds: PdfRect(50, 110, 290, 350),
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+          PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+          PdfFillPathCommand(
+            _rect(70, 140, 230, 310),
+            const PdfColor(0.95, 0.7, 0.2),
+            PdfFillRule.nonzero,
+            0.8,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          _outlinedText(
+            transform: const PdfMatrix(155, 0, 0, 155, 125, 150),
+            color: const PdfColor(0.2, 0.8, 0.85),
+            alpha: 0.75,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.screen),
+          _decodedImage(
+            Uint8List.fromList(const [
+              220,
+              35,
+              40,
+              255,
+              25,
+              180,
+              215,
+              255,
+              45,
+              90,
+              225,
+              255,
+              235,
+              195,
+              30,
+              255,
+            ]),
+            const PdfMatrix(90, 0, 0, 90, 175, 185),
+            'blended-group-image',
+          ),
+          const PdfEndGroupCommand(),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('isolated knockout fills replace earlier overlapping shapes',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

Compared with main, isolated transparency groups containing per-paint Normal, Multiply, and Screen blending now stay on the retained GPU path instead of falling back to Canvas. Exact corpus coverage is unchanged: PDF.js accepts 177/179 and Ghent accepts 41/57, with the same documented rejection reasons.

<details>
<summary>Implementation and validation</summary>

- Preserve each paint blend mode while compiling the bounded offscreen group attachment.
- Keep knockout source-replacement behavior separate from ordinary per-paint blending.
- Cover mixed fill, outlined-text, and image paints under group alpha and an outer blend.
- fvm dart analyze: clean.
- Native Metal backend: 51 passed, 1 intentional non-GPU-mode skip.
- Exact GPU corpus: 218 tests passed; PDF.js 177 accepted / 2 rejected, Ghent 41 accepted / 16 rejected.

Remaining corpus fallbacks are unchanged: non-black overprint, one missing Helvetica outline case, and three non-identity multi-paint transparency groups outside this fixed-function subset.
</details>