### PR TITLE
perf(gpu): retain transparency group shadings

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Retain axial/radial gradient and Gouraud mesh paints in single-paint and
+  mixed offscreen transparency groups.
 - Preserve per-paint Normal, Multiply, and Screen state inside isolated
   offscreen transparency groups.
 - Retain ordinary images in single-paint and mixed vector/text transparency

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -88,15 +88,16 @@ ColorBurn, HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color,
 and Luminosity blending,
 rectangular and arbitrary path clips, and the common isolated single-image
 soft-mask group. Isolated transparency groups containing a single vector fill,
-stroke, outlined text run, or ordinary image also stay on the GPU: their group
-alpha and page blend mode are retained exactly. One-element knockout groups are
-included
+stroke, outlined text run, ordinary image, gradient, or Gouraud mesh also stay
+on the GPU: their group alpha and page blend mode are retained exactly.
+One-element knockout groups are included
 because there are no sibling elements for knockout to change. Alpha-one,
 normal-blend non-knockout groups may contain multiple ordered fills, strokes,
-outlined text runs, and ordinary images because source-over is associative, so
-their isolation layer is an identity operation. Isolated overlapping groups
-retain those same paint types in the bounded offscreen tile pass before
-applying group alpha and the outer blend once. Normal, Multiply, and Screen
+outlined text runs, images, gradients, and meshes because source-over is
+associative, so their isolation layer is an identity operation. Isolated
+overlapping groups retain those same paint types in the bounded offscreen tile
+pass before applying group alpha and the outer blend once. Normal, Multiply,
+and Screen
 remain per-paint state inside that attachment rather than being collapsed into
 the group's outer blend. Platform-decoded JPEGs whose
 `/SMask` remains a companion GPU

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -326,6 +326,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
                       !scene.imageDecodingAttempted) {
                     return 'missing transparency-group image pixels';
                   }
+                case PdfFillPathGradientCommand(:final gradient, :final alpha):
+                  final reason = _gradientUnsupportedReason(gradient, alpha);
+                  if (reason != null) return reason;
                 default:
                   break;
               }
@@ -1335,6 +1338,18 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           }
           paints.add((i, command, clip, blend, fillOverprint));
           contentClip = clip;
+        case PdfFillPathGradientCommand() || PdfFillMeshCommand():
+          if (emptyClipOnly) {
+            return (null, 'empty transparency group contains paint');
+          }
+          if (softDepth != 0 || content != null) {
+            return (
+              null,
+              'soft-mask group contains ${command.runtimeType}',
+            );
+          }
+          paints.add((i, command, clip, blend, fillOverprint));
+          contentClip = clip;
         case PdfStrokePathCommand():
           if (emptyClipOnly) {
             return (null, 'empty transparency group contains paint');
@@ -1491,6 +1506,28 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             null,
           ),
         PdfDrawImageCommand content => (
+            _GroupPaintSpec(
+              commands: [content],
+              paintClips: [paint.$3],
+              paintBlends: const [PdfBlendMode.normal],
+              contentClip: paint.$3,
+              groupAlpha: alpha,
+              offscreen: alpha != 1,
+            ),
+            null,
+          ),
+        PdfFillPathGradientCommand content => (
+            _GroupPaintSpec(
+              commands: [content],
+              paintClips: [paint.$3],
+              paintBlends: const [PdfBlendMode.normal],
+              contentClip: paint.$3,
+              groupAlpha: alpha,
+              offscreen: alpha != 1,
+            ),
+            null,
+          ),
+        PdfFillMeshCommand content => (
             _GroupPaintSpec(
               commands: [content],
               paintClips: [paint.$3],

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1965,6 +1965,80 @@ void main() {
     });
   });
 
+  testWidgets('offscreen groups retain gradient and mesh paints',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathGradientCommand(
+          _rect(70, 140, 240, 310),
+          PdfFillRule.nonzero,
+          const PdfGradient(
+            isRadial: false,
+            coords: [70, 140, 240, 310],
+            colors: [
+              PdfColor(0.95, 0.2, 0.1),
+              PdfColor(0.1, 0.8, 0.9),
+            ],
+            stops: [0, 1],
+            transform: PdfMatrix.identity,
+          ),
+          0.8,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.screen),
+        const PdfFillMeshCommand(
+          PdfMesh(
+            [
+              PdfMeshVertex(125, 150, PdfColor(0.9, 0.1, 0.2)),
+              PdfMeshVertex(275, 170, PdfColor(0.1, 0.9, 0.25)),
+              PdfMeshVertex(205, 325, PdfColor(0.15, 0.25, 0.95)),
+            ],
+            [0, 1, 2],
+          ),
+          0.75,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('isolated knockout fills replace earlier overlapping shapes',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

Compared with main, axial-gradient and mesh paints inside isolated offscreen transparency groups now stay on the retained GPU path instead of falling back to Canvas. Exact corpus coverage is unchanged: PDF.js accepts 177/179 and Ghent accepts 41/57, with the same documented rejection reasons.

<details>
<summary>Implementation and validation</summary>

- Admit retained PdfFillPathGradientCommand and PdfFillMeshCommand paints into the bounded offscreen group attachment.
- Reuse the existing exact gradient and Gouraud mesh encoders while preserving each group clip, alpha, and outer blend.
- Cover a mixed gradient, mesh, and vector group against Canvas pixel output.
- fvm dart analyze: clean after rebasing onto #783.
- Native Metal backend: 52 passed, 1 intentional non-GPU-mode skip.
- Exact GPU corpus: 218 tests passed; PDF.js 177 accepted / 2 rejected, Ghent 41 accepted / 16 rejected.

Remaining corpus fallbacks are unchanged and require overprint colorants, seeded-backdrop knockout semantics, or complex text shaping rather than this shading route.
</details>