### PR TITLE
perf(gpu): flatten nested identity groups

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 
+- Flatten nested alpha-one, normal source-over groups into their parent
+  retained group, preserving distinct per-paint clips without a nested render
+  target or Canvas fallback.
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -94,10 +94,11 @@ One-element knockout groups are included
 because there are no sibling elements for knockout to change. Alpha-one,
 normal-blend non-knockout groups may contain multiple ordered fills, strokes,
 outlined text runs, images, gradients, and meshes because source-over is
-associative, so their isolation layer is an identity operation. Isolated
-overlapping groups retain those same paint types in the bounded offscreen tile
-pass before applying group alpha and the outer blend once. Normal, Multiply,
-and Screen
+associative, so their isolation layer is an identity operation. Nested
+alpha-one identity groups flatten into the same retained parent while keeping
+their distinct per-paint clips. Isolated overlapping groups retain those same
+paint types in the bounded offscreen tile pass before applying group alpha and
+the outer blend once. Normal, Multiply, and Screen
 remain per-paint state inside that attachment rather than being collapsed into
 the group's outer blend. Platform-decoded JPEGs whose
 `/SMask` remains a companion GPU

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -1403,6 +1403,16 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           );
           final nestedSpec = nested.$1;
           switch (nestedSpec) {
+            case _FlattenGroupSpec(paints: final nestedPaints):
+              for (final nestedPaint in nestedPaints) {
+                paints.add((
+                  nestedPaint.commandIndex,
+                  commands[nestedPaint.commandIndex],
+                  nestedPaint.clip,
+                  PdfBlendMode.normal,
+                  false,
+                ));
+              }
             case _GroupFillSpec(:final content, :final groupAlpha):
               paints.add((
                 null,
@@ -1434,7 +1444,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                   :final paintClips,
                   :final paintBlends,
                 )
-                when !nestedSpec.offscreen:
+                when nestedSpec.groupAlpha == 1 &&
+                    !nestedSpec.knockout &&
+                    paintBlends.every((mode) => mode == PdfBlendMode.normal):
               for (var nestedIndex = 0;
                   nestedIndex < commands.length;
                   nestedIndex++) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1678,6 +1678,104 @@ void main() {
     });
   });
 
+  testWidgets('nested identity groups retain distinct paint clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(20, 80, 380, 300),
+          const PdfColor(0.35, 0.65, 0.85),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.68,
+          isolated: true,
+          bounds: PdfRect(35, 95, 365, 285),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfFillPathCommand(
+          _rect(45, 105, 355, 275),
+          const PdfColor(0.86, 0.72, 0.22),
+          PdfFillRule.nonzero,
+          0.75,
+        ),
+        const PdfBeginGroupCommand(1),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(55, 115, 190, 260), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 100, 205, 275),
+          const PdfColor(0.92, 0.2, 0.3),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        const PdfRestoreCommand(),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(210, 115, 345, 260), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(195, 100, 360, 275),
+          const PdfColor(0.15, 0.82, 0.38),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfRestoreCommand(),
+        const PdfEndGroupCommand(),
+        const PdfBeginGroupCommand(1, isolated: true),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(105, 125, 235, 245), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(90, 110, 250, 260),
+          const PdfColor(0.72, 0.18, 0.82),
+          PdfFillRule.nonzero,
+          0.55,
+        ),
+        const PdfRestoreCommand(),
+        const PdfBeginGroupCommand(1),
+        PdfClipPathCommand(_rect(165, 145, 300, 255), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(150, 130, 315, 270),
+          const PdfColor(0.15, 0.78, 0.88),
+          PdfFillRule.nonzero,
+          0.6,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfEndGroupCommand(),
+        PdfStrokePathCommand(
+          _rect(80, 130, 320, 250),
+          const PdfColor(0.18, 0.3, 0.92),
+          const PdfStroke(width: 9, join: 1),
+          0.85,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(10, 390, 380, 330);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('isolated overlapping paints composite through an offscreen tile',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

Compared with main, nested alpha-one, Normal, non-knockout identity transparency groups now flatten into their retained GPU parent instead of allocating another offscreen group or falling back to Canvas. Per-paint clips and painter order remain exact; exact corpus coverage is unchanged at PDF.js 177/179 and Ghent 41/57.

<details>
<summary>Implementation and validation</summary>

- Flatten only nested groups whose alpha, blend, knockout, isolation, and backdrop semantics make the extra group boundary an identity operation.
- Preserve each child paint clip while appending retained commands to the parent group.
- Cover nested fills with distinct clips against Canvas pixel output.
- `fvm dart analyze`: clean after rebasing onto #784.
- Native Metal backend: 53 passed, 1 intentional non-GPU-mode skip.
- Exact GPU corpus: 218 tests passed; PDF.js 177 accepted / 2 rejected, Ghent 41 accepted / 16 rejected.

Remaining group fallbacks require non-identity compositing semantics such as seeded-backdrop knockout, non-Normal outer blends, or colorant-aware overprint; this change does not approximate them.
</details>