### PR TITLE
perf(gpu): single-sample group targets

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 
+- Keep intermediate transparency-group targets single-sample while retaining
+  4x MSAA on the final page target. This removes a redundant color/stencil
+  raster and resolve, cuts live group attachment estimates from 40 to 8 bytes
+  per pixel, and preserves diagonal-edge parity with Canvas.
 - Flatten nested alpha-one, normal source-over groups into their parent
   retained group, preserving distinct per-paint clips without a nested render
   target or Canvas fallback.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -98,7 +98,9 @@ associative, so their isolation layer is an identity operation. Nested
 alpha-one identity groups flatten into the same retained parent while keeping
 their distinct per-paint clips. Isolated overlapping groups retain those same
 paint types in the bounded offscreen tile pass before applying group alpha and
-the outer blend once. Normal, Multiply, and Screen
+the outer blend once. The intermediate group target stays single-sample while
+the final page target retains 4x MSAA, avoiding a redundant color/stencil
+raster and resolve. Normal, Multiply, and Screen
 remain per-paint state inside that attachment rather than being collapsed into
 the group's outer blend. Platform-decoded JPEGs whose
 `/SMask` remains a companion GPU

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -59,7 +59,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         _imageCache = _GpuImageCache(maxTextureBytes),
         _geometryPool = _GpuGeometryPool(maxGeometryBytes);
 
-  /// Enables 4x offscreen MSAA where the Impeller context supports it.
+  /// Enables 4x MSAA on the final tile target where Impeller supports it.
+  /// Intermediate transparency-group targets stay single-sample and are
+  /// sampled through that final pass.
   final bool msaa;
 
   /// Allows non-black overprint paints to use source-over.
@@ -3686,11 +3688,13 @@ class _CompiledScene {
           (groupRegion.width * pixelRatio).ceil().clamp(1, width);
       final groupHeight =
           (groupRegion.height * pixelRatio).ceil().clamp(1, height);
-      // Resolve RGBA + stencil is about 8 B/px. A 4x attachment adds four
-      // samples of each; 40 B/px is deliberately conservative across backend
-      // stencil formats. Bound all live intermediates so a pathological page
-      // falls back instead of multiplying a deep-zoom tile into an OOM.
-      final estimatedBytes = groupWidth * groupHeight * (multisampled ? 40 : 8);
+      // The resolved RGBA + stencil pair is about 8 B/px. The intermediate
+      // stays single-sample: it is sampled through the final multisampled page
+      // pass, and a second 4x color+stencil raster plus resolve makes visual
+      // settle slower than Canvas for ordinary groups. Bound all live
+      // intermediates so a pathological page falls back instead of
+      // multiplying a deep-zoom tile into an OOM.
+      final estimatedBytes = groupWidth * groupHeight * 8;
       offscreenBytes += estimatedBytes;
       if (offscreenBytes > (256 << 20)) {
         stats.offscreenGroupBudgetFallbacks++;
@@ -3717,25 +3721,16 @@ class _CompiledScene {
         groupHeight,
         format: context.defaultColorFormat,
       );
-      final groupColor = multisampled
-          ? context.createTexture(
-              gpu.StorageMode.deviceTransient,
-              groupWidth,
-              groupHeight,
-              format: context.defaultColorFormat,
-              sampleCount: 4,
-            )
-          : groupResolve;
+      final groupColor = groupResolve;
       final groupStencil = context.createTexture(
         gpu.StorageMode.deviceTransient,
         groupWidth,
         groupHeight,
         format: context.defaultStencilFormat,
-        sampleCount: multisampled ? 4 : 1,
+        sampleCount: 1,
       );
       final groupAttachments = <gpu.Texture>[
         groupResolve,
-        if (multisampled) groupColor,
         groupStencil,
       ];
       retainedGroupTextures.addAll(groupAttachments);
@@ -3745,7 +3740,6 @@ class _CompiledScene {
           groupCommandBuffer,
           groupColor,
           groupStencil,
-          resolveTarget: multisampled ? groupResolve : null,
         ),
         targetRegion: groupRegion,
         targetWidth: groupWidth,

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2265,6 +2265,87 @@ void main() {
     });
   });
 
+  testWidgets('single-sample group targets preserve diagonal edge coverage',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      PdfPath triangle(
+        double ax,
+        double ay,
+        double bx,
+        double by,
+        double cx,
+        double cy,
+      ) =>
+          PdfPath([
+            PdfMoveTo(ax, ay),
+            PdfLineTo(bx, by),
+            PdfLineTo(cx, cy),
+            const PdfClosePath(),
+          ]);
+
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(35, 95, 365, 365),
+          const PdfColor(0.28, 0.44, 0.66),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          bounds: PdfRect(55, 115, 345, 345),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfFillPathCommand(
+          triangle(63.3, 126.7, 332.4, 159.6, 118.8, 337.2),
+          const PdfColor(0.94, 0.24, 0.34),
+          PdfFillRule.nonzero,
+          0.82,
+        ),
+        PdfFillPathCommand(
+          triangle(79.6, 311.4, 301.7, 121.8, 339.2, 329.5),
+          const PdfColor(0.2, 0.82, 0.42),
+          PdfFillRule.nonzero,
+          0.68,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(30, 390, 340, 340);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      var changedPixels = 0;
+      for (var pixel = 0; pixel < a.length; pixel += 4) {
+        var pixelDifference = 0;
+        for (var channel = 0; channel < 4; channel++) {
+          final delta = (a[pixel + channel] - b[pixel + channel]).abs();
+          difference += delta;
+          if (delta > pixelDifference) pixelDifference = delta;
+        }
+        if (pixelDifference > 16) changedPixels++;
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(changedPixels / (a.length / 4), lessThan(0.02));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('offscreen group budget rejects before submitting group passes',
       (tester) async {
     await tester.runAsync(() async {
@@ -2274,7 +2355,7 @@ void main() {
       }
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final commands = <PdfRenderCommand>[];
-      for (var index = 0; index < 27; index++) {
+      for (var index = 0; index < 129; index++) {
         commands.addAll([
           const PdfBeginGroupCommand(
             0.8,


### PR DESCRIPTION
## Headline

Compared with current main on the same macOS Metal host, intermediate transparency-group visual settle moves from **1.34–1.39× Canvas (34–39% slower)** to **0.77–0.87× Canvas (13–23% faster)**. Blocking issue time remains **0.03–0.05× Canvas**, and estimated intermediate attachment memory falls **80%**, from **40 to 8 B/pixel** (148.6 MB to 29.7 MB across the 16-pass probe).

<details>
<summary>Implementation, benchmark, and validation</summary>

- Keep the final page target at 4x MSAA while making only intermediate transparency-group color/stencil targets single-sample.
- Remove the redundant intermediate multisample color/stencil attachments and resolve; group compositing still resolves into the final antialiased page.
- Update group-budget accounting from 40 to 8 B/pixel, allowing 128 bounded full-page groups instead of 26 before rejecting safely.
- Add diagonal overlapping-edge parity coverage against Canvas: mean channel delta below 4 and pixels differing by more than 16/channel below 2%.
- Matched local samples, old target: settle 21.37–21.84 ms vs Canvas 15.34–16.34 ms; new target: settle 10.57–14.11 ms vs Canvas 13.36–16.14 ms.
- `fvm dart analyze`: clean after rebasing onto #785.
- Native Metal backend: 54 passed, 1 intentional non-GPU-mode skip.
- Exact GPU corpus: 218 tests passed; PDF.js 177 accepted / 2 rejected, Ghent 41 accepted / 16 rejected, unchanged from main.

The remaining exact fallbacks require seeded-backdrop knockout, colorant-aware overprint, or complex text shaping; this memory/performance change does not approximate them.
</details>