### PR TITLE
feat(gpu): retain uniformly seeded knockout groups

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -36,6 +36,10 @@
 - Retain isolated knockout groups made entirely from vector fills. Later
   sibling shapes use exact source replacement only inside their retained path,
   while the group's alpha and outer blend remain a single offscreen composite.
+- Retain opaque non-isolated knockout groups whose declared backdrop is one
+  uniform color. The bounded single-sample group target is seeded with that
+  color and clipped to the form BBox, preserving exact Canvas output for
+  ordered vector fills and strokes without admitting unsafe overprint.
 - Retain isolated knockout groups containing a base fill and one
   vector-soft-masked fill, including clipped vector mask bounds.
 - Render overlapping Normal paints in isolated transparency groups into a

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -98,7 +98,10 @@ associative, so their isolation layer is an identity operation. Nested
 alpha-one identity groups flatten into the same retained parent while keeping
 their distinct per-paint clips. Isolated overlapping groups retain those same
 paint types in the bounded offscreen tile pass before applying group alpha and
-the outer blend once. The intermediate group target stays single-sample while
+the outer blend once. Opaque non-isolated knockout groups with a declared
+uniform backdrop also retain ordered vector fills and strokes: their bounded
+attachment is seeded with that color and clipped to the form BBox. The
+intermediate group target stays single-sample while
 the final page target retains 4x MSAA, avoiding a redundant color/stencil
 raster and resolve. Normal, Multiply, and Screen
 remain per-paint state inside that attachment rather than being collapsed into

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -565,6 +565,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     this.groupAlpha = 1,
     this.offscreen = false,
     this.knockout = false,
+    this.backdropColor,
   });
 
   final List<PdfRenderCommand> commands;
@@ -573,6 +574,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final double groupAlpha;
   final bool offscreen;
   final bool knockout;
+  final PdfColor? backdropColor;
   @override
   final PdfRect? contentClip;
 }
@@ -1238,6 +1240,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         :final alpha,
         :final knockout,
         :final isolated,
+        bounds: final groupBounds,
         :final backdropColor,
       )) {
     if (commands[end] is! PdfEndGroupCommand) {
@@ -1492,6 +1495,31 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         );
       }
       if (backdropColor != null) {
+        final canRenderSeededKnockout = !isolated &&
+            knockout &&
+            alpha == 1 &&
+            initialBlend == PdfBlendMode.normal &&
+            groupBounds != null &&
+            paint.$4 == PdfBlendMode.normal &&
+            switch (paint.$2) {
+              PdfFillPathCommand(:final alpha) => alpha == 1,
+              PdfStrokePathCommand(:final alpha) => alpha == 1,
+              _ => false,
+            };
+        if (canRenderSeededKnockout) {
+          return (
+            _GroupPaintSpec(
+              commands: [paint.$2],
+              paintClips: [paint.$3],
+              paintBlends: [paint.$4],
+              contentClip: groupBounds,
+              offscreen: true,
+              knockout: true,
+              backdropColor: backdropColor,
+            ),
+            null,
+          );
+        }
         return (null, 'non-identity single-paint transparency group');
       }
       return switch (paint.$2) {
@@ -1579,11 +1607,24 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           backdropColor == null &&
           normalPaints &&
           paints.every((paint) => paint.$2 is PdfFillPathCommand);
+      final canRenderSeededKnockout = !isolated &&
+          knockout &&
+          alpha == 1 &&
+          initialBlend == PdfBlendMode.normal &&
+          groupBounds != null &&
+          backdropColor != null &&
+          normalPaints &&
+          paints.every((paint) => switch (paint.$2) {
+                PdfFillPathCommand(:final alpha) => alpha == 1,
+                PdfStrokePathCommand(:final alpha) => alpha == 1,
+                _ => false,
+              });
       final canRenderOffscreen = (isolated &&
               !knockout &&
               backdropColor == null &&
               fixedFunctionPaints) ||
-          canRenderKnockout;
+          canRenderKnockout ||
+          canRenderSeededKnockout;
       if (!canFlatten && !canRenderOffscreen) {
         return (null, 'non-identity multi-paint transparency group');
       }
@@ -1612,10 +1653,15 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           paintClips: List.unmodifiable([for (final paint in paints) paint.$3]),
           paintBlends:
               List.unmodifiable([for (final paint in paints) paint.$4]),
-          contentClip: canFlatten && commonPaintClip ? commonClip : null,
+          contentClip: canRenderSeededKnockout
+              ? groupBounds
+              : canFlatten && commonPaintClip
+                  ? commonClip
+                  : null,
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
-          knockout: canRenderKnockout,
+          knockout: canRenderKnockout || canRenderSeededKnockout,
+          backdropColor: canRenderSeededKnockout ? backdropColor : null,
         ),
         null,
       );
@@ -3583,13 +3629,14 @@ class _CompiledScene {
       gpu.Texture target,
       gpu.Texture stencilTarget, {
       gpu.Texture? resolveTarget,
+      vm.Vector4? clearValue,
     }) {
       final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
         colorAttachments: [
           gpu.ColorAttachment(
             texture: target,
             resolveTexture: resolveTarget,
-            clearValue: vm.Vector4(0, 0, 0, 0),
+            clearValue: clearValue ?? vm.Vector4.zero(),
             storeAction: resolveTarget == null
                 ? gpu.StoreAction.store
                 : gpu.StoreAction.multisampleResolve,
@@ -3735,11 +3782,20 @@ class _CompiledScene {
       ];
       retainedGroupTextures.addAll(groupAttachments);
       final groupCommandBuffer = context.createCommandBuffer();
+      final backdropColor = draw.backdropColor;
       final groupEncoder = encoderFor(
         createPass(
           groupCommandBuffer,
           groupColor,
           groupStencil,
+          clearValue: backdropColor == null
+              ? null
+              : vm.Vector4(
+                  backdropColor.red,
+                  backdropColor.green,
+                  backdropColor.blue,
+                  1,
+                ),
         ),
         targetRegion: groupRegion,
         targetWidth: groupWidth,
@@ -4092,6 +4148,7 @@ Future<_GpuDraw?> _compileGroupPaint(
           List.unmodifiable(draws),
           spec.groupAlpha,
           math.max(0, paintPadding - 2),
+          backdropColor: spec.backdropColor,
         )
       : _SequenceDraw(List.unmodifiable([for (final draw in draws) draw.$1]));
 }
@@ -5639,12 +5696,17 @@ class _SequenceDraw implements _GpuDraw {
   }
 }
 
-/// A retained isolated group whose overlapping paints must first render onto
-/// a transparent tile-sized attachment. [_CompiledScene] encodes [paints]
+/// A retained group whose overlapping paints must first render onto a bounded
+/// tile-sized attachment. [_CompiledScene] encodes [paints]
 /// into that attachment, then samples the completed texture once into the
 /// page pass with [alpha] and the unit's outer blend mode.
 class _OffscreenGroupDraw implements _GpuDraw {
-  const _OffscreenGroupDraw(this.paints, this.alpha, this.extraPadding);
+  const _OffscreenGroupDraw(
+    this.paints,
+    this.alpha,
+    this.extraPadding, {
+    this.backdropColor,
+  });
 
   /// The third field preserves the paint's internal blend. The fourth selects
   /// shape-limited source replacement for knockout
@@ -5654,6 +5716,7 @@ class _OffscreenGroupDraw implements _GpuDraw {
   final List<(_GpuDraw, PdfRect?, PdfBlendMode, bool)> paints;
   final double alpha;
   final double extraPadding;
+  final PdfColor? backdropColor;
 
   @override
   void encode(_GpuEncoder encoder) =>

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2197,6 +2197,70 @@ void main() {
     });
   });
 
+  testWidgets('opaque knockout groups retain a uniform seeded backdrop',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const backdrop = PdfColor(0.24, 0.58, 0.72);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(40, 100, 340, 370),
+          backdrop,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(
+          1,
+          knockout: true,
+          bounds: PdfRect(60, 120, 320, 350),
+          backdropColor: backdrop,
+        ),
+        PdfClipPathCommand(_rect(60, 120, 320, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(75, 140, 235, 320),
+          const PdfColor(0.95, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 160, 300, 335),
+          const PdfColor(0.15, 0.42, 0.95),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfStrokePathCommand(
+          _rect(115, 180, 275, 305),
+          const PdfColor(0.2, 0.85, 0.38),
+          const PdfStroke(width: 10),
+          1,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(30, 390, 330, 330);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
   testWidgets('isolated knockout groups retain a vector-soft-masked fill',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

- Removes the Canvas fallback for opaque non-isolated knockout groups with a uniform recorded backdrop.
- Exact synthetic Canvas/GPU parity: mean byte difference `< 4`.
- Checked corpora remain green: PDF.js 177 accepted / 2 conservative fallbacks; Ghent 41 accepted / 16 conservative fallbacks.
- The focused Ghent knockout page advances beyond both seeded-group rejection points, then still falls back on its independent non-black-overprint content. No corpus acceptance count is claimed by this PR.

<details>
<summary>Implementation and validation</summary>

The retained group parser now admits only the bounded exact subset: group alpha 1, Normal outer/internal blend, declared group BBox, uniform non-isolated backdrop, knockout enabled, opaque vector fills/strokes, and no overprint. Its existing single-sample offscreen attachment is cleared to the recorded backdrop and sampled only inside the declared BBox.

Unsafe overprint and advanced-blend/offscreen combinations keep their existing Canvas fallback. A broader overprint experiment was deliberately excluded after repeated narrow strokes exposed destination-alpha corruption in the advanced-blend route.

Validation:

- `fvm dart analyze`
- `fvm flutter test --enable-impeller --enable-flutter-gpu test/flutter_gpu_tile_backend_test.dart` (55 passed, 1 expected skip)
- `GPU_CORPUS_REGISTER_SYSTEM_FONTS=1 GPU_CORPUS_SYSTEM_TEXT=1 fvm flutter test --enable-impeller --enable-flutter-gpu test/gpu_corpus_test.dart` (218 passed)

</details>