### PR TITLE
feat(gpu): combine offscreen groups with advanced blends

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -30,9 +30,11 @@
   same-host scenario.
 - Render every PDF blend mode exactly with retained GPU destination sampling.
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
-  paints share one blend pass, while overlapping paints retain painter order.
-  Oversized tiles and scenes that combine advanced blends with offscreen
-  transparency groups keep the conservative Canvas fallback.
+  paints share one blend pass, while overlapping paints retain painter order
+  and scissor each sequential shader draw to its conservative command bounds.
+  Fixed-function offscreen groups can now coexist with those destination-
+  sampling paints in exact painter order; groups whose own outer blend is
+  advanced and oversized tiles keep the conservative Canvas fallback.
 - Retain isolated knockout groups made entirely from vector fills. Later
   sibling shapes use exact source replacement only inside their retained path,
   while the group's alpha and outer blend remain a single offscreen composite.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -115,7 +115,11 @@ transfer functions, are partitioned into constant-mask stencil cover cells and
 need no intermediate texture.
 Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
-pass; overlapping paints replay sequentially to preserve PDF painter order.
+pass; overlapping paints replay sequentially inside their conservative command
+bounds to preserve PDF painter order without shading unrelated tile pixels.
+Fixed-function offscreen groups can precede or follow those paints in the same
+exact route: each group is prepared once in its bounded single-sample target,
+then sampled into the ping-pong page at its original painter-order position.
 The route rejects before allocating when its temporary attachments would
 exceed 256 MiB.
 Rectangles use hardware scissors; other clip stacks compile once into retained
@@ -177,9 +181,9 @@ peak temporary bytes, and budget fallbacks.
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
-Pages with other transparency groups or soft masks, scenes that combine
-advanced blend paints with offscreen transparency groups, non-nested radial
-gradients, gradient overprint, unsafe overprint, complex
+Pages with other transparency groups or soft masks, offscreen groups whose own
+outer blend is advanced, non-nested radial gradients, gradient overprint,
+unsafe overprint, complex
 clips nested inside the single-image soft-mask shortcut, unresolved
 substituted text, or missing image pixels are rejected as a whole rather than
 approximated.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -28,17 +28,15 @@ import 'text_outliner.dart';
 /// once; zero-width hairlines alone expand their retained polyline for the
 /// current device scale.
 ///
-/// The exact subset includes a common isolated single-image soft-mask group
-/// and decoded images whose `/SMask` stayed as a companion GPU surface:
-/// content and mask stay as separate scene-lifetime textures and are combined
-/// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
-/// masks (with rectangular clips additionally using the hardware scissor).
-/// Knockout/non-isolated groups, isolated groups with non-Normal internal
-/// paints, blend modes beyond Multiply/Screen, complex clips *inside* the
-/// special soft-mask shortcuts, non-nested radial gradients, unresolved
-/// substituted text, unsafe overprint, or missing image pixels reject the
-/// whole scene. Zero-width PDF hairlines are expanded at tile submission time
-/// so they remain exactly one device pixel at every level of detail.
+/// The exact subset includes retained soft masks, bounded transparency and
+/// knockout groups, every PDF blend mode through destination-sampling passes,
+/// and decoded images whose `/SMask` stays as a companion GPU surface.
+/// Ordinary PDF clip paths remain exact stencil masks (with rectangular clips
+/// additionally using the hardware scissor). Unsupported transparency forms,
+/// complex clips *inside* special soft-mask shortcuts, non-nested radial
+/// gradients, unresolved substituted text, unsafe overprint, or missing image
+/// pixels reject the whole scene. Zero-width PDF hairlines are expanded at
+/// tile submission time so they remain exactly one device pixel at every LoD.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -66,10 +64,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
 
   /// Allows non-black overprint paints to use source-over.
   ///
-  /// False by default: stable flutter_gpu cannot sample an offscreen target
-  /// in a later darken pass reliably on every Impeller backend. Keep this for
-  /// controlled benchmarking only; ordinary clients get the exact Canvas
-  /// fallback instead.
+  /// False by default because source-over does not preserve untouched process
+  /// channels as PDF overprint requires. Keep this for controlled benchmarking
+  /// only; ordinary clients get the exact Canvas fallback instead.
   final bool allowOverprintApproximation;
 
   /// Byte budget for decoded image textures shared by every scene/session
@@ -274,12 +271,16 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     final hasAdvancedBlend =
         units.any((unit) => !_isFixedFunctionBlendMode(unit.blendMode));
     if (hasAdvancedBlend &&
+        units.any((unit) => unit.composite is _KnockoutSoftMaskFillSpec)) {
+      return 'advanced blend with knockout soft mask';
+    }
+    if (hasAdvancedBlend &&
         units.any((unit) => switch (unit.composite) {
-              _GroupPaintSpec(:final offscreen) => offscreen,
-              _KnockoutSoftMaskFillSpec() => true,
+              _GroupPaintSpec(offscreen: true) =>
+                !_isFixedFunctionBlendMode(unit.blendMode),
               _ => false,
             })) {
-      return 'advanced blend with offscreen transparency group';
+      return 'advanced-blended offscreen transparency group';
     }
     for (final unit in units) {
       if (!_isGpuBlendMode(unit.blendMode)) {
@@ -3284,6 +3285,191 @@ class _CompiledScene {
     );
   }
 
+  ({
+    Map<int, (gpu.Texture, Rect)> textures,
+    List<gpu.Texture> retained,
+  }) _renderOffscreenGroups(
+    List<_GpuUnit> selected, {
+    required Rect region,
+    required double pixelRatio,
+    required _GpuPipelines pipelines,
+    required int width,
+    required int height,
+    required gpu.HostBuffer transient,
+    int maxBytes = 256 << 20,
+  }) {
+    Rect groupRegionFor(_GpuUnit unit, _OffscreenGroupDraw draw) {
+      final hairlinePadding = math.max(
+        0.0,
+        0.5 / _pageDeviceScale(pageToRaster, pixelRatio) - 2,
+      );
+      final extraPadding = math.max(draw.extraPadding, hairlinePadding);
+      final bounds = extraPadding == 0
+          ? unit.bounds
+          : _inflatePdf(unit.bounds, extraPadding);
+      final points = <(double, double)>[
+        (bounds.left, bounds.bottom),
+        (bounds.right, bounds.bottom),
+        (bounds.right, bounds.top),
+        (bounds.left, bounds.top),
+      ];
+      var left = double.infinity, top = double.infinity;
+      var right = double.negativeInfinity, bottom = double.negativeInfinity;
+      for (final (x, y) in points) {
+        final rx = pageToRaster.transformX(x, y);
+        final ry = pageToRaster.transformY(x, y);
+        if (rx < left) left = rx;
+        if (rx > right) right = rx;
+        if (ry < top) top = ry;
+        if (ry > bottom) bottom = ry;
+      }
+      left = math.max(
+          region.left,
+          region.left +
+              (((left - region.left) * pixelRatio).floor() / pixelRatio));
+      top = math.max(
+          region.top,
+          region.top +
+              (((top - region.top) * pixelRatio).floor() / pixelRatio));
+      right = math.min(
+          region.right,
+          region.left +
+              (((right - region.left) * pixelRatio).ceil() / pixelRatio));
+      bottom = math.min(
+          region.bottom,
+          region.top +
+              (((bottom - region.top) * pixelRatio).ceil() / pixelRatio));
+      return Rect.fromLTRB(left, top, right, bottom);
+    }
+
+    final groupPlans = <(_GpuUnit, _OffscreenGroupDraw, Rect, int, int, int)>[];
+    var offscreenBytes = 0;
+    for (final unit in selected) {
+      final draw = draws[unit.commandIndex];
+      if (draw is! _OffscreenGroupDraw) continue;
+      final groupRegion = groupRegionFor(unit, draw);
+      final groupWidth =
+          (groupRegion.width * pixelRatio).ceil().clamp(1, width);
+      final groupHeight =
+          (groupRegion.height * pixelRatio).ceil().clamp(1, height);
+      // The resolved RGBA + stencil pair is about 8 B/px. The intermediate
+      // stays single-sample: it is sampled through the final page pass, and a
+      // second 4x color+stencil raster plus resolve makes visual settle slower
+      // than Canvas for ordinary groups. Bound all live intermediates so a
+      // pathological page falls back instead of multiplying a deep-zoom tile
+      // into an OOM.
+      final estimatedBytes = groupWidth * groupHeight * 8;
+      offscreenBytes += estimatedBytes;
+      if (offscreenBytes > maxBytes) {
+        stats.offscreenGroupBudgetFallbacks++;
+        throw StateError('offscreen group tiles exceed the route budget');
+      }
+      groupPlans.add((
+        unit,
+        draw,
+        groupRegion,
+        groupWidth,
+        groupHeight,
+        estimatedBytes,
+      ));
+    }
+
+    final groupTextures = <int, (gpu.Texture, Rect)>{};
+    final retainedGroupTextures = <gpu.Texture>[];
+    for (final plan in groupPlans) {
+      final (unit, draw, groupRegion, groupWidth, groupHeight, estimatedBytes) =
+          plan;
+      final groupResolve = context.createTexture(
+        gpu.StorageMode.devicePrivate,
+        groupWidth,
+        groupHeight,
+        format: context.defaultColorFormat,
+      );
+      final groupStencil = context.createTexture(
+        gpu.StorageMode.deviceTransient,
+        groupWidth,
+        groupHeight,
+        format: context.defaultStencilFormat,
+        sampleCount: 1,
+      );
+      final groupAttachments = <gpu.Texture>[groupResolve, groupStencil];
+      retainedGroupTextures.addAll(groupAttachments);
+      final groupCommandBuffer = context.createCommandBuffer();
+      final backdropColor = draw.backdropColor;
+      final groupPass = groupCommandBuffer.createRenderPass(gpu.RenderTarget(
+        colorAttachments: [
+          gpu.ColorAttachment(
+            texture: groupResolve,
+            clearValue: backdropColor == null
+                ? vm.Vector4.zero()
+                : vm.Vector4(
+                    backdropColor.red,
+                    backdropColor.green,
+                    backdropColor.blue,
+                    1,
+                  ),
+          ),
+        ],
+        depthStencilAttachment: gpu.DepthStencilAttachment(
+          texture: groupStencil,
+          stencilClearValue: 0,
+        ),
+      ))
+        ..setCullMode(gpu.CullMode.none)
+        ..setWindingOrder(gpu.WindingOrder.counterClockwise)
+        ..setPrimitiveType(gpu.PrimitiveType.triangle)
+        ..setStencilReference(0)
+        ..setColorBlendEnable(true);
+      final groupEncoder = _GpuEncoder(
+        pass: groupPass,
+        pipelines: pipelines,
+        transform: transient.emplace(_tileTransform(
+          pageToRaster,
+          groupRegion,
+          pixelRatio,
+          groupWidth,
+          groupHeight,
+        )),
+        pageToRaster: pageToRaster,
+        region: groupRegion,
+        pixelRatio: pixelRatio,
+        width: groupWidth,
+        height: groupHeight,
+        clipDraws: clipDraws,
+        stencilClear: paper.vertices,
+        emplaceTransient: transient.emplace,
+      );
+      for (final paint in draw.paints) {
+        groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
+        if (paint.$4) {
+          groupEncoder.setSourceBlend();
+        } else {
+          groupEncoder.setBlendMode(paint.$3);
+        }
+        paint.$1.encode(groupEncoder);
+      }
+      stats.clipMaskRebuilds += groupEncoder.clipMaskRebuilds;
+      final groupResources = <Object>[
+        ...groupAttachments,
+        groupPass,
+        transient,
+      ];
+      groupCommandBuffer.submit(completionCallback: (_) {
+        // The page completion owns the textures on the success path. This
+        // independent capture also fences every submitted group resource if a
+        // later allocation or the final page submission throws.
+        groupResources.length;
+      });
+      stats
+        ..offscreenGroupPasses += 1
+        ..offscreenGroupAllocatedBytes += estimatedBytes;
+      groupTextures[unit.commandIndex] = (groupResolve, groupRegion);
+    }
+    stats.peakOffscreenGroupBytes =
+        math.max(stats.peakOffscreenGroupBytes, offscreenBytes);
+    return (textures: groupTextures, retained: retainedGroupTextures);
+  }
+
   ui.Image _renderAdvanced(
     List<_GpuUnit> selected, {
     required Rect region,
@@ -3337,6 +3523,19 @@ class _CompiledScene {
       sampleCount: multisampled ? 4 : 1,
     );
     final transient = context.createHostBuffer();
+    final groups = _renderOffscreenGroups(
+      selected,
+      region: region,
+      pixelRatio: pixelRatio,
+      pipelines: pipelines,
+      width: width,
+      height: height,
+      transient: transient,
+      // Keep page ping-pong and every simultaneously live group attachment
+      // inside one route-wide budget rather than allowing two independent
+      // 256 MiB pools.
+      maxBytes: (256 << 20) - estimatedBytes,
+    );
     final transform = transient.emplace(_tileTransform(
       pageToRaster,
       region,
@@ -3352,6 +3551,7 @@ class _CompiledScene {
       if (color != null) color,
       stencil,
       transient,
+      ...groups.retained,
       commandBuffers,
     ];
 
@@ -3420,8 +3620,12 @@ class _CompiledScene {
         final draw = draws[unit.commandIndex];
         if (draw == null) continue;
         if (draw is _OffscreenGroupDraw) {
-          throw StateError(
-              'advanced blend route received an offscreen group draw');
+          final group = groups.textures[unit.commandIndex]!;
+          encoder
+            ..setClip(unit.clip)
+            ..setBlendMode(unit.blendMode)
+            ..tileTexture(group.$1, group.$2, draw.alpha);
+          continue;
         }
         encoder
           ..setClip(unit.clip)
@@ -3443,7 +3647,7 @@ class _CompiledScene {
         if (draw == null) continue;
         if (draw is _OffscreenGroupDraw) {
           throw StateError(
-              'advanced blend route received an offscreen group draw');
+              'advanced source received an offscreen transparency group');
         }
         sourceEncoder
           ..setClip(unit.clip)
@@ -3542,7 +3746,7 @@ class _CompiledScene {
         }
         if (index < selected.length) {
           paintSources([selected[index]]);
-          blendSources([(selected[index], null)]);
+          blendSources([(selected[index], selected[index].bounds)]);
           index++;
         }
       }
@@ -3681,149 +3885,17 @@ class _CompiledScene {
           emplaceTransient: transient.emplace,
         );
 
-    Rect groupRegionFor(_GpuUnit unit, _OffscreenGroupDraw draw) {
-      final hairlinePadding = math.max(
-        0.0,
-        0.5 / _pageDeviceScale(pageToRaster, pixelRatio) - 2,
-      );
-      final extraPadding = math.max(draw.extraPadding, hairlinePadding);
-      final bounds = extraPadding == 0
-          ? unit.bounds
-          : _inflatePdf(unit.bounds, extraPadding);
-      final points = <(double, double)>[
-        (bounds.left, bounds.bottom),
-        (bounds.right, bounds.bottom),
-        (bounds.right, bounds.top),
-        (bounds.left, bounds.top),
-      ];
-      var left = double.infinity, top = double.infinity;
-      var right = double.negativeInfinity, bottom = double.negativeInfinity;
-      for (final (x, y) in points) {
-        final rx = pageToRaster.transformX(x, y);
-        final ry = pageToRaster.transformY(x, y);
-        if (rx < left) left = rx;
-        if (rx > right) right = rx;
-        if (ry < top) top = ry;
-        if (ry > bottom) bottom = ry;
-      }
-      left = math.max(
-          region.left,
-          region.left +
-              (((left - region.left) * pixelRatio).floor() / pixelRatio));
-      top = math.max(
-          region.top,
-          region.top +
-              (((top - region.top) * pixelRatio).floor() / pixelRatio));
-      right = math.min(
-          region.right,
-          region.left +
-              (((right - region.left) * pixelRatio).ceil() / pixelRatio));
-      bottom = math.min(
-          region.bottom,
-          region.top +
-              (((bottom - region.top) * pixelRatio).ceil() / pixelRatio));
-      return Rect.fromLTRB(left, top, right, bottom);
-    }
-
-    final groupPlans = <(_GpuUnit, _OffscreenGroupDraw, Rect, int, int, int)>[];
-    var offscreenBytes = 0;
-    for (final unit in selected) {
-      final draw = draws[unit.commandIndex];
-      if (draw is! _OffscreenGroupDraw) continue;
-      final groupRegion = groupRegionFor(unit, draw);
-      final groupWidth =
-          (groupRegion.width * pixelRatio).ceil().clamp(1, width);
-      final groupHeight =
-          (groupRegion.height * pixelRatio).ceil().clamp(1, height);
-      // The resolved RGBA + stencil pair is about 8 B/px. The intermediate
-      // stays single-sample: it is sampled through the final multisampled page
-      // pass, and a second 4x color+stencil raster plus resolve makes visual
-      // settle slower than Canvas for ordinary groups. Bound all live
-      // intermediates so a pathological page falls back instead of
-      // multiplying a deep-zoom tile into an OOM.
-      final estimatedBytes = groupWidth * groupHeight * 8;
-      offscreenBytes += estimatedBytes;
-      if (offscreenBytes > (256 << 20)) {
-        stats.offscreenGroupBudgetFallbacks++;
-        throw StateError('offscreen group tiles exceed 256 MiB');
-      }
-      groupPlans.add((
-        unit,
-        draw,
-        groupRegion,
-        groupWidth,
-        groupHeight,
-        estimatedBytes,
-      ));
-    }
-
-    final groupTextures = <int, (gpu.Texture, Rect)>{};
-    final retainedGroupTextures = <gpu.Texture>[];
-    for (final plan in groupPlans) {
-      final (unit, draw, groupRegion, groupWidth, groupHeight, estimatedBytes) =
-          plan;
-      final groupResolve = context.createTexture(
-        gpu.StorageMode.devicePrivate,
-        groupWidth,
-        groupHeight,
-        format: context.defaultColorFormat,
-      );
-      final groupColor = groupResolve;
-      final groupStencil = context.createTexture(
-        gpu.StorageMode.deviceTransient,
-        groupWidth,
-        groupHeight,
-        format: context.defaultStencilFormat,
-        sampleCount: 1,
-      );
-      final groupAttachments = <gpu.Texture>[
-        groupResolve,
-        groupStencil,
-      ];
-      retainedGroupTextures.addAll(groupAttachments);
-      final groupCommandBuffer = context.createCommandBuffer();
-      final backdropColor = draw.backdropColor;
-      final groupEncoder = encoderFor(
-        createPass(
-          groupCommandBuffer,
-          groupColor,
-          groupStencil,
-          clearValue: backdropColor == null
-              ? null
-              : vm.Vector4(
-                  backdropColor.red,
-                  backdropColor.green,
-                  backdropColor.blue,
-                  1,
-                ),
-        ),
-        targetRegion: groupRegion,
-        targetWidth: groupWidth,
-        targetHeight: groupHeight,
-      );
-      for (final paint in draw.paints) {
-        groupEncoder.setClip(_withGpuRectClip(unit.clip, paint.$2));
-        if (paint.$4) {
-          groupEncoder.setSourceBlend();
-        } else {
-          groupEncoder.setBlendMode(paint.$3);
-        }
-        paint.$1.encode(groupEncoder);
-      }
-      stats.clipMaskRebuilds += groupEncoder.clipMaskRebuilds;
-      groupCommandBuffer.submit(completionCallback: (_) {
-        // The page completion owns the same textures on the success path.
-        // This independent capture also fences them if a later allocation or
-        // the final page submission throws after this pass was queued.
-        groupAttachments.length;
-      });
-      stats
-        ..offscreenGroupPasses += 1
-        ..offscreenGroupAllocatedBytes += estimatedBytes;
-      groupTextures[unit.commandIndex] = (groupResolve, groupRegion);
-    }
-    stats.peakOffscreenGroupBytes =
-        math.max(stats.peakOffscreenGroupBytes, offscreenBytes);
+    final groups = _renderOffscreenGroups(
+      selected,
+      region: region,
+      pixelRatio: pixelRatio,
+      pipelines: pipelines,
+      width: width,
+      height: height,
+      transient: transient,
+    );
+    final groupTextures = groups.textures;
+    final retainedGroupTextures = groups.retained;
 
     final commandBuffer = context.createCommandBuffer();
     final pass = createPass(

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -615,6 +615,146 @@ void main() {
     });
   });
 
+  testWidgets('repeated thin advanced-blend strokes preserve opaque backdrop',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[
+        PdfFillPathCommand(
+          _rect(0, 0, 300, 160),
+          const PdfColor(0.82, 0.68, 0.34),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.darken),
+        for (var index = 0; index < 8; index++)
+          PdfStrokePathCommand(
+            PdfPath([
+              PdfMoveTo(15, 20 + index * 3),
+              PdfLineTo(285, 110 + index * 3),
+            ]),
+            PdfColor(0.12 + index * 0.03, 0.24, 0.72),
+            const PdfStroke(width: 0.4),
+            1,
+          ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ];
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.75);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.75);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      var minimumAlpha = 255;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+        if (index % 4 == 3 && b[index] < minimumAlpha) {
+          minimumAlpha = b[index];
+        }
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(minimumAlpha, 255);
+      expect(backend.stats.advancedBlendPasses, 8);
+    });
+  });
+
+  testWidgets('advanced blends surrounding offscreen groups stay exact',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const backdrop = PdfColor(0.24, 0.58, 0.72);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[
+        PdfFillPathCommand(
+          _rect(0, 0, 300, 160),
+          backdrop,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.overlay),
+        PdfFillPathCommand(
+          _rect(25, 65, 205, 155),
+          const PdfColor(0.86, 0.64, 0.18),
+          PdfFillRule.nonzero,
+          0.58,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        const PdfBeginGroupCommand(
+          1,
+          knockout: true,
+          bounds: PdfRect(55, 75, 175, 150),
+          backdropColor: backdrop,
+        ),
+        PdfClipPathCommand(_rect(55, 75, 175, 150), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(65, 85, 145, 140),
+          const PdfColor(0.92, 0.24, 0.16),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(105, 95, 165, 145),
+          const PdfColor(0.14, 0.38, 0.94),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.darken),
+        for (var index = 0; index < 8; index++)
+          PdfStrokePathCommand(
+            PdfPath([
+              PdfMoveTo(15, 20 + index * 3),
+              PdfLineTo(285, 110 + index * 3),
+            ]),
+            PdfColor(0.12 + index * 0.03, 0.24, 0.72),
+            const PdfStroke(width: 0.4),
+            1,
+          ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ];
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.75);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.75);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      var minimumAlpha = 255;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+        if (index % 4 == 3 && b[index] < minimumAlpha) {
+          minimumAlpha = b[index];
+        }
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(minimumAlpha, 255);
+      expect(backend.stats.offscreenGroupPasses, 1);
+      expect(backend.stats.advancedBlendPasses, 9);
+    });
+  });
+
   testWidgets('advanced blend budget rejects before allocating ping-pong tiles',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -210,4 +210,119 @@ void main() {
           '${backend.stats}');
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('reports mixed offscreen group and advanced-blend settle',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      const backdrop = PdfColor(0.24, 0.58, 0.72);
+      final commands = <PdfRenderCommand>[
+        PdfFillPathCommand(
+          _rect(0, 0, 612, 792),
+          backdrop,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(
+          1,
+          knockout: true,
+          bounds: PdfRect(40, 80, 572, 730),
+          backdropColor: backdrop,
+        ),
+      ];
+      for (var index = 0; index < 24; index++) {
+        final offset = index * 13.0;
+        commands.add(PdfFillPathCommand(
+          _rect(
+            45 + offset % 190,
+            90 + offset % 250,
+            355 + offset % 190,
+            430 + offset % 250,
+          ),
+          PdfColor(
+            0.18 + (index % 5) * 0.15,
+            0.2 + (index % 7) * 0.1,
+            0.24 + (index % 4) * 0.17,
+          ),
+          PdfFillRule.nonzero,
+          1,
+        ));
+      }
+      commands
+        ..add(const PdfEndGroupCommand())
+        ..add(const PdfSetBlendModeCommand(PdfBlendMode.darken));
+      for (var index = 0; index < 12; index++) {
+        commands.add(PdfStrokePathCommand(
+          PdfPath([
+            PdfMoveTo(55, 105 + index * 9),
+            PdfLineTo(557, 465 + index * 9),
+          ]),
+          PdfColor(0.12 + index * 0.035, 0.24, 0.72),
+          const PdfStroke(width: 2.5),
+          1,
+        ));
+      }
+      commands.add(const PdfSetBlendModeCommand(PdfBlendMode.normal));
+
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(50, 120, 512, 512);
+      final coldGpu = await _timeSettledImage(
+        () => session.rasterizeRegion(region, pixelRatio: 1),
+      );
+      final issueGpu = <int>[];
+      for (var index = 0; index < 7; index++) {
+        issueGpu.add(await _timeImage(
+          () => session.rasterizeRegion(region, pixelRatio: 1),
+        ));
+      }
+      // Drain the issue-only samples before measuring visual settle.
+      await _timeSettledImage(
+        () => session.rasterizeRegion(region, pixelRatio: 1),
+      );
+      final settledGpu = <int>[];
+      final warmCanvas = <int>[];
+      for (var index = 0; index < 7; index++) {
+        if (index.isEven) {
+          settledGpu.add(await _timeSettledImage(
+            () => session.rasterizeRegion(region, pixelRatio: 1),
+          ));
+          warmCanvas.add(await _timeSettledImage(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          ));
+        } else {
+          warmCanvas.add(await _timeSettledImage(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          ));
+          settledGpu.add(await _timeSettledImage(
+            () => session.rasterizeRegion(region, pixelRatio: 1),
+          ));
+        }
+      }
+
+      final issueMedian = _median(issueGpu);
+      final settleMedian = _median(settledGpu);
+      final canvasMedian = _median(warmCanvas);
+      expect(backend.stats.offscreenGroupPasses, 16);
+      expect(backend.stats.advancedBlendPasses, greaterThan(0));
+      // ignore: avoid_print
+      print('flutter_gpu mixed group+blend benchmark: cold=${coldGpu}us '
+          'issueMedian=${issueMedian.toStringAsFixed(0)}us '
+          'settleMedian=${settleMedian.toStringAsFixed(0)}us '
+          'canvasMedian=${canvasMedian.toStringAsFixed(0)}us '
+          'issueVsCanvas=${(issueMedian / canvasMedian).toStringAsFixed(2)}x '
+          'settleVsCanvas=${(settleMedian / canvasMedian).toStringAsFixed(2)}x '
+          '${backend.stats}');
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
 }


### PR DESCRIPTION
## Headline performance

- Mixed group + 12 overlapping advanced paints: caller-blocking work falls from 34.1 ms Canvas to 2.5 ms GPU issue time (0.07x, about 93% lower).
- The same deliberately pass-heavy stress case settles in 50.4 ms GPU versus 34.1 ms Canvas (1.48x); this trade-off is now pinned by a durable benchmark rather than hidden.
- Existing PDF.js advanced-blend first tile was 7.883 ms on main versus 7.566 ms here (about 4% faster) in a one-run same-host check. The six-run CI comparison remains authoritative.

## What changes

- Prepare bounded offscreen groups through one shared implementation used by both simple and destination-sampling routes.
- Composite fixed-function groups at their exact painter-order position before or after advanced blends.
- Scissor sequential advanced-blend shader draws to conservative command bounds.
- Keep advanced-blended groups and knockout soft masks on the conservative Canvas fallback.
- Share one 256 MiB route budget across ping-pong and group attachments.
- Update the package support docs and changelog.

## Validation

- fvm dart analyze
- Native GPU backend + benchmarks: 60 passed, 1 expected no-context skip
- System-font GPU corpus: 218 passed
  - PDF.js: 177 accepted, 2 conservative fallbacks
  - Ghent: 41 accepted, 16 conservative fallbacks
- New parity regression checks Canvas/GPU mean error below 3/channel, fully opaque output, 1 group pass, and 9 ordered advanced passes.

<details><summary>Implementation notes</summary>

The previous route rejected any scene containing both an offscreen group and any advanced blend. Group attachments are now prepared once, queue-ordered before the page ping-pong buffers, retained through completion, and sampled only when painter order reaches that unit. The group itself must still use Normal, Multiply, or Screen as its outer blend; broader combinations remain intentionally rejected.

The stress benchmark uses a uniformly seeded knockout group followed by twelve overlapping Darken strokes, matching the interaction that exposed the earlier fallback/corruption investigation.

</details>