### PR TITLE
feat(gpu): blend completed groups as advanced sources

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -32,9 +32,9 @@
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
   paints share one blend pass, while overlapping paints retain painter order
   and scissor each sequential shader draw to its conservative command bounds.
-  Fixed-function offscreen groups can now coexist with those destination-
-  sampling paints in exact painter order; groups whose own outer blend is
-  advanced and oversized tiles keep the conservative Canvas fallback.
+  Offscreen groups can now coexist with those destination-sampling paints in
+  exact painter order and can use one advanced outer blend themselves;
+  oversized tiles keep the conservative Canvas fallback.
 - Retain isolated knockout groups made entirely from vector fills. Later
   sibling shapes use exact source replacement only inside their retained path,
   while the group's alpha and outer blend remain a single offscreen composite.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -117,9 +117,10 @@ Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
 pass; overlapping paints replay sequentially inside their conservative command
 bounds to preserve PDF painter order without shading unrelated tile pixels.
-Fixed-function offscreen groups can precede or follow those paints in the same
-exact route: each group is prepared once in its bounded single-sample target,
-then sampled into the ping-pong page at its original painter-order position.
+Offscreen groups can precede or follow those paints in the same exact route:
+each group is prepared once in its bounded single-sample target, then sampled
+into the ping-pong page at its original painter-order position. The completed
+group texture can itself be the source of one advanced outer blend.
 The route rejects before allocating when its temporary attachments would
 exceed 256 MiB.
 Rectangles use hardware scissors; other clip stacks compile once into retained
@@ -181,9 +182,8 @@ peak temporary bytes, and budget fallbacks.
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
-Pages with other transparency groups or soft masks, offscreen groups whose own
-outer blend is advanced, non-nested radial gradients, gradient overprint,
-unsafe overprint, complex
+Pages with other transparency groups or soft masks, non-nested radial
+gradients, gradient overprint, unsafe overprint, complex
 clips nested inside the single-image soft-mask shortcut, unresolved
 substituted text, or missing image pixels are rejected as a whole rather than
 approximated.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -274,14 +274,6 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         units.any((unit) => unit.composite is _KnockoutSoftMaskFillSpec)) {
       return 'advanced blend with knockout soft mask';
     }
-    if (hasAdvancedBlend &&
-        units.any((unit) => switch (unit.composite) {
-              _GroupPaintSpec(offscreen: true) =>
-                !_isFixedFunctionBlendMode(unit.blendMode),
-              _ => false,
-            })) {
-      return 'advanced-blended offscreen transparency group';
-    }
     for (final unit in units) {
       if (!_isGpuBlendMode(unit.blendMode)) {
         return 'blend mode ${unit.blendMode.name}';
@@ -3646,8 +3638,12 @@ class _CompiledScene {
         final draw = draws[unit.commandIndex];
         if (draw == null) continue;
         if (draw is _OffscreenGroupDraw) {
-          throw StateError(
-              'advanced source received an offscreen transparency group');
+          final group = groups.textures[unit.commandIndex]!;
+          sourceEncoder
+            ..setClip(unit.clip)
+            ..setBlendMode(PdfBlendMode.normal)
+            ..tileTexture(group.$1, group.$2, draw.alpha);
+          continue;
         }
         sourceEncoder
           ..setClip(unit.clip)

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -755,6 +755,71 @@ void main() {
     });
   });
 
+  testWidgets('offscreen groups retain an advanced outer blend',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.45, 0.55, 0.7),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.overlay),
+        const PdfBeginGroupCommand(
+          0.72,
+          isolated: true,
+          bounds: PdfRect(50, 110, 290, 350),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        PdfClipPathCommand(_rect(50, 110, 290, 350), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(70, 140, 230, 310),
+          const PdfColor(0.95, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          0.65,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 160, 270, 325),
+          const PdfColor(0.15, 0.45, 0.95),
+          PdfFillRule.nonzero,
+          0.55,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      var minimumAlpha = 255;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+        if (index % 4 == 3 && b[index] < minimumAlpha) {
+          minimumAlpha = b[index];
+        }
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(minimumAlpha, 255);
+      expect(backend.stats.offscreenGroupPasses, 1);
+      expect(backend.stats.advancedBlendPasses, 1);
+    });
+  });
+
   testWidgets('advanced blend budget rejects before allocating ping-pong tiles',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -219,20 +219,20 @@ void main() {
         return;
       }
 
-      const backdrop = PdfColor(0.24, 0.58, 0.72);
       final commands = <PdfRenderCommand>[
         PdfFillPathCommand(
           _rect(0, 0, 612, 792),
-          backdrop,
+          const PdfColor(0.24, 0.58, 0.72),
           PdfFillRule.nonzero,
           1,
         ),
+        const PdfSetBlendModeCommand(PdfBlendMode.overlay),
         const PdfBeginGroupCommand(
-          1,
-          knockout: true,
+          0.72,
+          isolated: true,
           bounds: PdfRect(40, 80, 572, 730),
-          backdropColor: backdrop,
         ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
       ];
       for (var index = 0; index < 24; index++) {
         final offset = index * 13.0;


### PR DESCRIPTION
## Headline performance

- The advanced-outer-group stress route changes from Canvas fallback to exact GPU submission.
- With one advanced group plus twelve later overlapping advanced strokes, caller-blocking work is 31.0 ms Canvas versus 2.3 ms GPU issue time (about 92.5% lower).
- That deliberately 13-pass case settles in 53.9 ms GPU versus 31.0 ms Canvas (1.74x); the benchmark records both sides of the trade-off.
- The automated six-run same-host suite remains authoritative for unaffected production scenarios.

## What changes

- Sample a completed bounded group texture into the transparent advanced source target.
- Apply group alpha exactly once while building the source, then apply the requested outer PDF blend exactly once against the retained destination.
- Remove the conservative session rejection for an offscreen group whose own outer blend is advanced.
- Keep advanced blend plus knockout soft mask on Canvas.
- Update the support docs and make the mixed benchmark exercise this route.

## Validation

- fvm dart analyze
- Native GPU backend + benchmarks: 61 passed, 1 expected no-context skip
- System-font GPU corpus: 218 passed
  - PDF.js: 177 accepted, 2 conservative fallbacks
  - Ghent: 41 accepted, 16 conservative fallbacks
- Focused parity regression: mean Canvas/GPU error below 3/channel, opaque output, one offscreen pass, one advanced pass.

<details><summary>Implementation notes</summary>

The destination-sampling route already prepares every group attachment before page replay. For an advanced group unit, the completed group texture is now drawn with Normal into the transparent source target using the group alpha. The ordinary advanced shader then composites that source against the current page. Disjoint advanced groups remain batchable because each group stays inside its own conservative bounds.

No current corpus page changes acceptance status; this closes a real exactness gap without weakening the remaining fallbacks.

</details>