### PR TITLE
perf(gpu): blit advanced blend destinations

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -32,6 +32,8 @@
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
   paints share one blend pass, while overlapping paints retain painter order
   and scissor each sequential shader draw to its conservative command bounds.
+  Preserve the untouched ping-pong destination with a byte-exact GPU texture
+  blit instead of a full-tile textured draw before every advanced blend.
   Offscreen groups can now coexist with those destination-sampling paints in
   exact painter order and can use one advanced outer blend themselves;
   oversized tiles keep the conservative Canvas fallback.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -117,6 +117,8 @@ Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
 pass; overlapping paints replay sequentially inside their conservative command
 bounds to preserve PDF painter order without shading unrelated tile pixels.
+Each pass preserves the untouched ping-pong destination with a byte-exact GPU
+texture blit rather than a full-tile fragment draw.
 Offscreen groups can precede or follow those paints in the same exact route:
 each group is prepared once in its bounded single-sample target, then sampled
 into the ping-pong page at its original painter-order position. The completed
@@ -176,8 +178,8 @@ scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
-Advanced-blend diagnostics report destination-sampling passes, allocated and
-peak temporary bytes, and budget fallbacks.
+Advanced-blend diagnostics report destination-sampling passes, destination
+blits, allocated and peak temporary bytes, and budget fallbacks.
 `backend.stats.toJson()` is suitable for benchmark artifacts. Keep the backend
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -3658,17 +3658,26 @@ class _CompiledScene {
     void blendSources(List<(_GpuUnit, PdfRect?)> units) {
       final target = alternate();
       final blendCommandBuffer = context.createCommandBuffer();
+      // Preserve the untouched destination with a native texture copy. The
+      // old full-tile textured draw spent fragment work rewriting every pixel
+      // before the bounded advanced-blend shader could touch its small dirty
+      // region. A blit is byte-exact and leaves the render pass free to load
+      // the copied target and shade only those conservative command bounds.
+      blendCommandBuffer.copyTextureToTexture(
+        gpu.TextureRegion(current!),
+        gpu.TextureDestinationRegion(target),
+      );
       final blendPass = blendCommandBuffer.createRenderPass(
         gpu.RenderTarget.singleColor(gpu.ColorAttachment(
           texture: target,
-          clearValue: vm.Vector4.zero(),
+          loadAction: gpu.LoadAction.load,
         )),
       )
         ..setCullMode(gpu.CullMode.none)
         ..setWindingOrder(gpu.WindingOrder.counterClockwise)
         ..setPrimitiveType(gpu.PrimitiveType.triangle)
         ..setColorBlendEnable(false);
-      final blendEncoder = encoderFor(blendPass)..copyTile(current!);
+      final blendEncoder = encoderFor(blendPass);
       for (final (unit, bounds) in units) {
         blendEncoder.advancedBlend(
           current!,
@@ -3680,7 +3689,9 @@ class _CompiledScene {
       commandBuffers.add(blendCommandBuffer);
       retained.add(blendPass);
       current = target;
-      stats.advancedBlendPasses++;
+      stats
+        ..advancedBlendPasses += 1
+        ..advancedBlendBlits += 1;
     }
 
     bool overlaps(PdfRect a, PdfRect b) =>

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -37,6 +37,7 @@ class FlutterGpuTileBackendStats {
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int advancedBlendPasses = 0;
+  int advancedBlendBlits = 0;
   int advancedBlendAllocatedBytes = 0;
   int peakAdvancedBlendBytes = 0;
   int advancedBlendBudgetFallbacks = 0;
@@ -108,6 +109,7 @@ class FlutterGpuTileBackendStats {
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'advancedBlendPasses': advancedBlendPasses,
+        'advancedBlendBlits': advancedBlendBlits,
         'advancedBlendAllocatedBytes': advancedBlendAllocatedBytes,
         'peakAdvancedBlendBytes': peakAdvancedBlendBytes,
         'advancedBlendBudgetFallbacks': advancedBlendBudgetFallbacks,
@@ -178,6 +180,7 @@ class FlutterGpuTileBackendStats {
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     advancedBlendPasses = 0;
+    advancedBlendBlits = 0;
     advancedBlendAllocatedBytes = 0;
     peakAdvancedBlendBytes = 0;
     advancedBlendBudgetFallbacks = 0;
@@ -231,6 +234,7 @@ class FlutterGpuTileBackendStats {
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'advancedBlendPasses=$advancedBlendPasses '
+      'advancedBlendBlits=$advancedBlendBlits '
       'advancedBlendAllocatedBytes=$advancedBlendAllocatedBytes '
       'peakAdvancedBlendBytes=$peakAdvancedBlendBytes '
       'advancedBlendBudgetFallbacks=$advancedBlendBudgetFallbacks '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -63,6 +63,7 @@ void main() {
       ..analyticAtlasBytes = 4096
       ..analyticAtlasFallbacks = 1
       ..analyticTextFallbackRuns = 2
+      ..advancedBlendBlits = 5
       ..offscreenGroupPasses = 3
       ..offscreenGroupAllocatedBytes = 6 << 20
       ..peakOffscreenGroupBytes = 4 << 20
@@ -97,6 +98,7 @@ void main() {
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
+    expect(stats.toJson(), containsPair('advancedBlendBlits', 5));
     expect(stats.toJson(), containsPair('offscreenGroupPasses', 3));
     expect(
         stats.toJson(), containsPair('offscreenGroupAllocatedBytes', 6 << 20));
@@ -135,6 +137,7 @@ void main() {
     expect(stats.analyticAtlasBytes, 0);
     expect(stats.analyticAtlasFallbacks, 0);
     expect(stats.analyticTextFallbackRuns, 0);
+    expect(stats.advancedBlendBlits, 0);
     expect(stats.offscreenGroupPasses, 0);
     expect(stats.offscreenGroupAllocatedBytes, 0);
     expect(stats.peakOffscreenGroupBytes, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -612,6 +612,7 @@ void main() {
       }
       expect(difference / a.length, lessThan(3));
       expect(backend.stats.advancedBlendPasses, 2);
+      expect(backend.stats.advancedBlendBlits, 2);
     });
   });
 
@@ -667,6 +668,7 @@ void main() {
       expect(difference / a.length, lessThan(3));
       expect(minimumAlpha, 255);
       expect(backend.stats.advancedBlendPasses, 8);
+      expect(backend.stats.advancedBlendBlits, 8);
     });
   });
 


### PR DESCRIPTION
## Performance

Same-host mixed offscreen-group plus 13 advanced-blend stress: GPU settle improved from 49.3 ms on main to 43.9–44.5 ms with this change, about 10–11% faster. Caller issue time remains roughly 2–3 ms versus 29–31 ms for Canvas.

## Change

Use Flutter GPU's byte-exact texture-to-texture copy to preserve the untouched ping-pong destination before each bounded advanced-blend pass. The render pass loads that copied attachment and shades only the conservative dirty bounds, replacing the previous full-tile textured fragment draw. Add an advancedBlendBlits diagnostic and exact-path regression assertions.

## Validation

- Full repository analyzer: clean
- GPU diagnostics, backend parity, and benchmarks: 63 passed, 1 expected no-context skip
- System-font GPU corpus: 218 passed; PDF.js 177 accepted / 2 exact fallbacks, Ghent 41 / 16, unchanged
- Overlapping and repeated advanced blends remain under mean pixel difference 3 against Canvas with opaque output