### PR TITLE
test(gpu): benchmark repeated advanced blends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,12 @@ jobs:
           set -euo pipefail
           log="$RUNNER_TEMP/flutter-gpu-performance.log"
           baseline_log="$RUNNER_TEMP/flutter-gpu-main-performance.log"
+          stress_pdf="$RUNNER_TEMP/flutter-gpu-advanced-blend-stress.pdf"
           : > "$log"
           : > "$baseline_log"
+          # Generate once in the PR worktree, then give this absolute path to
+          # both test binaries so the first introducing PR has a valid base.
+          dart tool/advanced_blend_stress_fixture.dart "$stress_pdf"
 
           run_case() {
             local workspace="$1"
@@ -251,6 +255,7 @@ jobs:
                   "$label" == "system-text" ||
                   "$label" == "cjk-text" ||
                   "$label" == "advanced-blend" ||
+                  "$label" == "advanced-blend-stress" ||
                   "$label" == "knockout-mask" ||
                   "$label" == "knockout-overlap" ||
                   "$label" == "hairline" ]]; then
@@ -268,6 +273,9 @@ jobs:
                 ;;
               fixture)
                 source_env="PDF_GPU_BENCHMARK_FIXTURE=$source"
+                ;;
+              generated)
+                source_env="PDF_GPU_BENCHMARK_PDF=$stress_pdf"
                 ;;
               *)
                 echo "Unknown Flutter GPU benchmark source kind: $source_kind" >&2
@@ -328,6 +336,7 @@ jobs:
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
           cjk-text pdf ../../test_corpora/pdfjs/SimFang-variant.pdf
           advanced-blend pdf ../../test_corpora/pdfjs/blendmode.pdf
+          advanced-blend-stress generated advanced-blend-stress
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
@@ -364,6 +373,7 @@ jobs:
           system-text pdf ../../test_corpora/pdfjs/hello_world_rotated.pdf
           cjk-text pdf ../../test_corpora/pdfjs/SimFang-variant.pdf
           advanced-blend pdf ../../test_corpora/pdfjs/blendmode.pdf
+          advanced-blend-stress generated advanced-blend-stress
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
@@ -412,6 +422,8 @@ jobs:
             --require-scenario-runs gpu-cjk-text-page-0-canvas-tile=6
             --require-scenario-runs gpu-advanced-blend-page-0-first-tile=6
             --require-scenario-runs gpu-advanced-blend-page-0-canvas-tile=6
+            --require-scenario-runs gpu-advanced-blend-stress-page-0-first-tile=6
+            --require-scenario-runs gpu-advanced-blend-stress-page-0-canvas-tile=6
             --require-scenario-runs gpu-knockout-mask-page-0-first-tile=6
             --require-scenario-runs gpu-knockout-mask-page-0-canvas-tile=6
             --require-scenario-runs gpu-knockout-overlap-page-0-first-tile=6

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
+- Add a deterministic repeated-advanced-blend CI workload whose twelve ordered
+  destination-sampling passes provide a higher-signal same-host comparison for
+  future blend optimizations.
 - Retain axial/radial gradient and Gouraud mesh paints in single-paint and
   mixed offscreen transparency groups.
 - Preserve per-paint Normal, Multiply, and Screen state inside isolated

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -250,10 +250,12 @@ vector-mask transfer, PDF.js knockout soft-mask and isolated-knockout overlap,
 GWG168/169 vector
 soft-mask, and GWG1610/1611 text soft-mask pages plus the PDF.js Latin and CJK
 system-font outline pages and deterministic deferred-mask fixture six times on
-macOS Metal,
-compare the exact
-PR base and candidate on the same runner with balanced execution order, and
-publish both a concise PR headline and a collapsed detailed trace.
+macOS Metal. A generated repeated-advanced-blend page adds twelve ordered
+destination-sampling passes, giving blend optimizations a higher-signal
+measurement than the small PDF.js conformance page alone.
+CI compares the exact PR base and candidate on the same runner with balanced
+execution order, and publishes both a concise PR headline and a collapsed
+detailed trace.
 Set `PDF_GPU_BENCHMARK_FIXTURE=deferred-mask` instead of a PDF path to exercise
 a deterministic 1024x768 JPEG under a Flate grayscale soft mask. This fixture
 emits the same first-tile and Canvas scenarios whether the backend accepts the

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -13,8 +13,11 @@ import 'package:image/image.dart' as img;
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
+import '../tool/advanced_blend_stress_fixture.dart';
+
 const _defaultPages = [27, 30, 29, 32, 31, 34, 37, 39, 28];
 const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
+const _advancedBlendStressScenario = 'advanced-blend-stress';
 const _deferredMaskFixture = 'deferred-mask';
 
 bool _gpuAvailable() {
@@ -147,6 +150,26 @@ Future<void> _registerMacSystemFonts() async {
 
 void main() {
   if (_buildCommit.isNotEmpty) PdfPerfLog.buildTag = 'commit=$_buildCommit';
+
+  testWidgets('advanced-blend stress fixture records twelve ordered strokes',
+      (tester) async {
+    await tester.runAsync(() async {
+      final document = PdfDocument.open(buildAdvancedBlendStressPdf());
+      final scene = await PdfRetainedScene.record(document.page(0));
+      try {
+        expect(
+          scene.commands.whereType<PdfStrokePathCommand>(),
+          hasLength(12),
+        );
+        expect(
+          scene.commands.whereType<PdfSetBlendModeCommand>().map((c) => c.mode),
+          contains(PdfBlendMode.darken),
+        );
+      } finally {
+        scene.dispose();
+      }
+    });
+  });
 
   testWidgets('deferred-mask fixture keeps its companion image surface',
       (tester) async {
@@ -407,6 +430,13 @@ void main() {
       print('REAL_GPU_BENCHMARK rssStart=$rssStart peakRss=$peakRss '
           'delta=${peakRss - rssStart} stats=${backend.stats}');
       expect(rows, isNotEmpty);
+      if (scenarioLabel == _advancedBlendStressScenario) {
+        expect(backend.stats.advancedBlendPasses, greaterThanOrEqualTo(24));
+        expect(
+          backend.stats.advancedBlendBlits,
+          backend.stats.advancedBlendPasses,
+        );
+      }
     });
   }, timeout: const Timeout(Duration(minutes: 20)));
 }

--- a/packages/dart_pdf_editor_flutter_gpu/tool/advanced_blend_stress_fixture.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/tool/advanced_blend_stress_fixture.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Builds a deterministic page with overlapping advanced-blend strokes.
+///
+/// The strokes are geometrically separate but have overlapping conservative
+/// bounds. That forces twelve ordered destination-sampling passes and makes
+/// advanced-blend performance large enough to distinguish from runner noise.
+Uint8List buildAdvancedBlendStressPdf() {
+  final content = StringBuffer()
+    ..writeln('q')
+    ..writeln('0.160 0.350 0.620 rg')
+    ..writeln('0 0 612 792 re f')
+    ..writeln('/Darken gs')
+    ..writeln('2.5 w');
+  for (var index = 0; index < 12; index++) {
+    final red = 0.12 + index * 0.035;
+    final y1 = 105 + index * 9;
+    final y2 = 465 + index * 9;
+    content
+      ..writeln('${red.toStringAsFixed(3)} 0.240 0.720 RG')
+      ..writeln('55 $y1 m 557 $y2 l S');
+  }
+  content.writeln('Q');
+
+  final stream = content.toString();
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /ExtGState << '
+        '/Darken << /Type /ExtGState /BM /Darken >> >> >> >>',
+    '<< /Length ${stream.length} >>\nstream\n$stream' 'endstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var index = 0; index < objects.length; index++) {
+    offsets.add(buffer.length);
+    buffer.write('${index + 1} 0 obj\n${objects[index]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
+void main(List<String> arguments) {
+  if (arguments.length != 1) {
+    stderr.writeln('usage: dart advanced_blend_stress_fixture.dart OUTPUT');
+    exitCode = 64;
+    return;
+  }
+  File(arguments.single).writeAsBytesSync(buildAdvancedBlendStressPdf());
+}


### PR DESCRIPTION
## Summary
- generate a deterministic PDF with twelve ordered advanced-blend destination-sampling passes
- compare the same generated PDF on the base and candidate worktrees in Metal CI
- require all six GPU and Canvas samples so future blend changes cannot silently lose the high-signal cohort

## Local validation
- fvm dart analyze
- focused fixture test
- Metal real-document benchmark: 36 advanced passes, 36 blits, zero fallback, Canvas mean difference 0.058

This is measurement infrastructure only; it does not change the runtime rendering route.