### PR TITLE
feat(gpu): retain black overprint groups

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Add a deterministic repeated-advanced-blend CI workload whose twelve ordered
   destination-sampling passes provide a higher-signal same-host comparison for
   future blend optimizations.
+- Retain solid-black overprint paints inside single- and multi-paint
+  transparency groups, matching the existing exact top-level path. Unsafe
+  process-color, gradient, and mesh overprint still fall back to Canvas and
+  now report that cause instead of a generic group rejection.
 - Retain axial/radial gradient and Gouraud mesh paints in single-paint and
   mixed offscreen transparency groups.
 - Preserve per-paint Normal, Multiply, and Screen state inside isolated

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -83,7 +83,8 @@ embedded-outline text, simple substituted text when an exact
 `FlutterGpuTextOutliner` resolves it,
 decoded images/image masks, Gouraud meshes, axial gradients, nested-circle
 radial gradients, vector and stencil-image tiling cells, normal/Multiply/Screen
-blending, and exact destination-sampling Overlay, Darken, Lighten, ColorDodge,
+blending, solid-black overprint (including inside transparency groups), and
+exact destination-sampling Overlay, Darken, Lighten, ColorDodge,
 ColorBurn, HardLight, SoftLight, Difference, Exclusion, Hue, Saturation, Color,
 and Luminosity blending,
 rectangular and arbitrary path clips, and the common isolated single-image

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -1479,14 +1479,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     if (softCount == 0 && softDepth == 0 && paints.length == 1) {
       final paint = paints.single;
-      if (paint.$5) {
-        return (
-          null,
-          paint.$2 is PdfStrokePathCommand
-              ? 'transparency-group stroke overprint'
-              : 'transparency-group fill overprint',
-        );
-      }
+      final overprintReason = _compositeOverprintReason(paint.$2, paint.$5);
+      if (overprintReason != null) return (null, overprintReason);
       if (backdropColor != null) {
         final canRenderSeededKnockout = !isolated &&
             knockout &&
@@ -1578,11 +1572,12 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
       final commonClip = paints.first.$3;
-      final normalPaints =
-          paints.every((paint) => paint.$4 == PdfBlendMode.normal && !paint.$5);
+      final normalPaints = paints.every((paint) =>
+          paint.$4 == PdfBlendMode.normal &&
+          _compositeOverprintReason(paint.$2, paint.$5) == null);
       final fixedFunctionPaints = paints.every((paint) =>
           FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(paint.$4) &&
-          !paint.$5);
+          _compositeOverprintReason(paint.$2, paint.$5) == null);
       final commonPaintClip =
           paints.every((paint) => _samePdfRect(paint.$3, commonClip));
       final disjointOuterBlend = initialBlend != PdfBlendMode.normal &&
@@ -1619,6 +1614,10 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           canRenderKnockout ||
           canRenderSeededKnockout;
       if (!canFlatten && !canRenderOffscreen) {
+        for (final paint in paints) {
+          final reason = _compositeOverprintReason(paint.$2, paint.$5);
+          if (reason != null) return (null, reason);
+        }
         return (null, 'non-identity multi-paint transparency group');
       }
       if (canFlatten &&
@@ -2740,6 +2739,22 @@ bool _pdfIntersects(PdfRect a, PdfRect b) =>
     a.right > b.left &&
     a.bottom < b.top &&
     a.top > b.bottom;
+
+String? _compositeOverprintReason(
+  PdfRenderCommand command,
+  bool overprint,
+) {
+  if (!overprint) return null;
+  return switch (command) {
+    PdfFillMeshCommand() => 'mesh overprint',
+    PdfFillPathGradientCommand() => 'gradient overprint',
+    PdfDrawTextCommand(:final run) when run.gradient != null =>
+      'gradient text overprint',
+    _ when _commandNeedsDarken(command, true, true) =>
+      'non-black overprint requires Canvas fallback',
+    _ => null,
+  };
+}
 
 String? _unsafeOverprint(_GpuUnit unit, PdfRenderCommand command) {
   switch (command) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1415,6 +1415,102 @@ void main() {
     });
   });
 
+  testWidgets('solid black overprint remains exact inside groups',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(30, 90, 310, 370),
+          const PdfColor(0.35, 0.65, 0.85),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfBeginGroupCommand(1),
+        const PdfSetOverprintCommand(fill: true, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(65, 125, 145, 325),
+          PdfColor.black,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+        const PdfBeginGroupCommand(1, isolated: true),
+        const PdfSetOverprintCommand(fill: false, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(150, 125, 275, 325),
+          const PdfColor(0.9, 0.55, 0.2),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetOverprintCommand(fill: true, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(205, 160, 290, 290),
+          PdfColor.black,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.lastSessionRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 410, 310, 310);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+    });
+  });
+
+  testWidgets('colored overprint inside a group reports the exact fallback',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(1, isolated: true),
+        const PdfSetOverprintCommand(fill: true, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(70, 140, 220, 310),
+          const PdfColor(0.95, 0.7, 0.2),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 140, 270, 310),
+          const PdfColor(0.2, 0.8, 0.85),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(scene), isNull);
+      expect(
+        backend.stats.lastRejection,
+        'non-black overprint requires Canvas fallback',
+      );
+    });
+  });
+
   testWidgets('empty clipped transparency groups remain no-ops',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Summary

- retain solid-black overprint inside single- and multi-paint transparency groups, matching the existing exact top-level GPU rule
- keep process-color, gradient, and mesh overprint on the conservative Canvas fallback
- report the true unsafe-overprint reason instead of the generic transparency-group rejection

## Validation

- fvm dart analyze
- fvm flutter test in packages/dart_pdf_editor_flutter_gpu
- full Metal flutter_gpu_tile_backend_test.dart: 60 passed, one intentional non-GPU-mode skip
- full Metal GPU corpus with system outlines: PDF.js 177 accepted / 2 conservative fallbacks; Ghent 41 accepted / 16 process-color-overprint fallbacks
