### PR TITLE
perf(gpu): clear interior tiles to paper

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 
+- Initialize tiles wholly inside the transformed crop box with the folded
+  opaque paper color in the render-pass clear, skipping the transparent clear
+  and full-tile paper draw. A one-device-pixel guard keeps rotated and
+  translucent page boundaries on the exact antialiased-quad path.
 - Keep intermediate transparency-group targets single-sample while retaining
   4x MSAA on the final page target. This removes a redundant color/stencil
   raster and resolve, cuts live group attachment estimates from 40 to 8 bytes

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -114,6 +114,10 @@ image soft mask directly through retained stencil geometry. Rectangular vector
 soft-mask fills, including alpha or luminosity backdrops and linearized
 transfer functions, are partitioned into constant-mask stencil cover cells and
 need no intermediate texture.
+Tiles that sit at least one device pixel inside the transformed crop box use
+the folded opaque paper color as their render-pass clear, avoiding a separate
+transparent clear and full-tile paper draw. Boundary tiles retain the paper
+quad so rotated and translucent page colors keep their exact antialiased edge.
 Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
 pass; overlapping paints replay sequentially inside their conservative command
@@ -187,6 +191,7 @@ scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
+Paper diagnostics report how many tiles used the exact interior clear path.
 Advanced-blend diagnostics report destination-sampling passes, destination
 blits, cropped-source selections, allocated and peak temporary bytes, and
 budget fallbacks.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -3466,6 +3466,9 @@ class _CompiledScene {
   }
 
   bool _canClearPaper(Rect region, double pixelRatio) {
+    // A render-pass clear cannot reproduce the paper quad's antialiased crop
+    // edge. Keep one device pixel between the tile and every transformed page
+    // edge so the clear is used only where the quad has constant full coverage.
     final margin = 1 / pixelRatio;
     final bounds = paper.rasterBounds;
     return region.left >= bounds.left + margin &&
@@ -3766,11 +3769,12 @@ class _CompiledScene {
     ];
 
     gpu.RenderPass createPaintPass(
-        gpu.CommandBuffer commandBuffer,
-        gpu.Texture resolve,
-        gpu.Texture? targetColor,
-        gpu.Texture targetStencil,
-        {vm.Vector4? clearValue}) {
+      gpu.CommandBuffer commandBuffer,
+      gpu.Texture resolve,
+      gpu.Texture? targetColor,
+      gpu.Texture targetStencil, {
+      vm.Vector4? clearValue,
+    }) {
       final target = targetColor ?? resolve;
       final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
         colorAttachments: [

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -3315,7 +3315,7 @@ class _CompiledScene {
         }
         if (draw != null) draws[unit.commandIndex] = draw;
       }
-      final paper = _paperDraw(geometry, scene);
+      final paper = _paperDraw(geometry, scene, pageToRaster);
       geometry.finalize();
       final result = _CompiledScene(
         context: context,
@@ -3344,7 +3344,7 @@ class _CompiledScene {
 
   final gpu.GpuContext context;
   final PdfMatrix pageToRaster;
-  final _SolidDraw paper;
+  final _PaperDraw paper;
   final Map<int, _GpuDraw> draws;
   final Map<int, _StraightStrokeFootprint> straightStrokes;
   final Map<_GpuClipNode, _GpuClipDraw> clipDraws;
@@ -3463,6 +3463,15 @@ class _CompiledScene {
     return extraPadding == 0
         ? unit.bounds
         : _inflatePdf(unit.bounds, extraPadding);
+  }
+
+  bool _canClearPaper(Rect region, double pixelRatio) {
+    final margin = 1 / pixelRatio;
+    final bounds = paper.rasterBounds;
+    return region.left >= bounds.left + margin &&
+        region.top >= bounds.top + margin &&
+        region.right <= bounds.right - margin &&
+        region.bottom <= bounds.bottom - margin;
   }
 
   ({
@@ -3757,18 +3766,18 @@ class _CompiledScene {
     ];
 
     gpu.RenderPass createPaintPass(
-      gpu.CommandBuffer commandBuffer,
-      gpu.Texture resolve,
-      gpu.Texture? targetColor,
-      gpu.Texture targetStencil,
-    ) {
+        gpu.CommandBuffer commandBuffer,
+        gpu.Texture resolve,
+        gpu.Texture? targetColor,
+        gpu.Texture targetStencil,
+        {vm.Vector4? clearValue}) {
       final target = targetColor ?? resolve;
       final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
         colorAttachments: [
           gpu.ColorAttachment(
             texture: target,
             resolveTexture: multisampled ? resolve : null,
-            clearValue: vm.Vector4.zero(),
+            clearValue: clearValue ?? vm.Vector4.zero(),
             storeAction: multisampled
                 ? gpu.StoreAction.multisampleResolve
                 : gpu.StoreAction.store,
@@ -3819,17 +3828,27 @@ class _CompiledScene {
     void paintSegment(List<_GpuUnit> segment) {
       final target = alternate();
       final commandBuffer = context.createCommandBuffer();
+      final clearPaper = current == null && _canClearPaper(region, pixelRatio);
+      if (clearPaper) stats.paperClearTiles++;
       final encoder = encoderFor(
-        createPaintPass(commandBuffer, target, color, stencil),
+        createPaintPass(
+          commandBuffer,
+          target,
+          color,
+          stencil,
+          clearValue: clearPaper ? paper.clearColor : null,
+        ),
         targetRegion: region,
         targetWidth: width,
         targetHeight: height,
       );
       if (current == null) {
-        encoder
-          ..setClip(_rootGpuClip)
-          ..setSourceBlend()
-          ..solid(paper.vertices);
+        if (!clearPaper) {
+          encoder
+            ..setClip(_rootGpuClip)
+            ..setSourceBlend()
+            ..solid(paper.vertices);
+        }
       } else {
         encoder
           ..setClip(_rootGpuClip)
@@ -4197,11 +4216,14 @@ class _CompiledScene {
     final retainedGroupTextures = groups.retained;
 
     final commandBuffer = context.createCommandBuffer();
+    final clearPaper = _canClearPaper(region, pixelRatio);
+    if (clearPaper) stats.paperClearTiles++;
     final pass = createPass(
       commandBuffer,
       color,
       stencil,
       resolveTarget: multisampled ? resolve : null,
+      clearValue: clearPaper ? paper.clearColor : null,
     );
     final encoder = encoderFor(
       pass,
@@ -4209,9 +4231,11 @@ class _CompiledScene {
       targetWidth: width,
       targetHeight: height,
     );
-    encoder
-      ..setClip(_rootGpuClip)
-      ..solid(paper.vertices);
+    if (!clearPaper) {
+      encoder
+        ..setClip(_rootGpuClip)
+        ..solid(paper.vertices);
+    }
     for (final unit in selected) {
       final draw = draws[unit.commandIndex];
       if (draw == null) continue;
@@ -4309,7 +4333,11 @@ _GpuClipDraw _compileClip(_GpuGeometryArena geometry, _GpuClipNode node) {
   );
 }
 
-_SolidDraw _paperDraw(_GpuGeometryArena geometry, PdfRetainedScene scene) {
+_PaperDraw _paperDraw(
+  _GpuGeometryArena geometry,
+  PdfRetainedScene scene,
+  PdfMatrix pageToRaster,
+) {
   final box = scene.page.cropBox;
   final color = scene.plan.pageColor;
   final alpha = color.a;
@@ -4333,7 +4361,27 @@ _SolidDraw _paperDraw(_GpuGeometryArena geometry, PdfRetainedScene scene) {
   ]) {
     vertices.add6(x, y, rgba[0], rgba[1], rgba[2], rgba[3]);
   }
-  return _SolidDraw(geometry.add(vertices.bytes, 6));
+  final corners = <(double, double)>[
+    (box.left, box.bottom),
+    (box.right, box.bottom),
+    (box.right, box.top),
+    (box.left, box.top),
+  ];
+  var left = double.infinity, top = double.infinity;
+  var right = double.negativeInfinity, bottom = double.negativeInfinity;
+  for (final (x, y) in corners) {
+    final rx = pageToRaster.transformX(x, y);
+    final ry = pageToRaster.transformY(x, y);
+    if (rx < left) left = rx;
+    if (rx > right) right = rx;
+    if (ry < top) top = ry;
+    if (ry > bottom) bottom = ry;
+  }
+  return _PaperDraw(
+    geometry.add(vertices.bytes, 6),
+    vm.Vector4(rgba[0], rgba[1], rgba[2], rgba[3]),
+    Rect.fromLTRB(left, top, right, bottom),
+  );
 }
 
 Future<_GpuDraw> _compileSoftMaskImage(
@@ -6100,6 +6148,13 @@ class _SolidDraw implements _GpuDraw {
 
   @override
   void encode(_GpuEncoder encoder) => encoder.solid(vertices);
+}
+
+class _PaperDraw extends _SolidDraw {
+  const _PaperDraw(super.vertices, this.clearColor, this.rasterBounds);
+
+  final vm.Vector4 clearColor;
+  final Rect rasterBounds;
 }
 
 class _StencilDraw implements _GpuDraw {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -36,6 +36,7 @@ class FlutterGpuTileBackendStats {
   int analyticTextFallbackRuns = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
+  int paperClearTiles = 0;
   int advancedBlendPasses = 0;
   int advancedBlendBlits = 0;
   int advancedBlendCroppedSources = 0;
@@ -109,6 +110,7 @@ class FlutterGpuTileBackendStats {
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
+        'paperClearTiles': paperClearTiles,
         'advancedBlendPasses': advancedBlendPasses,
         'advancedBlendBlits': advancedBlendBlits,
         'advancedBlendCroppedSources': advancedBlendCroppedSources,
@@ -181,6 +183,7 @@ class FlutterGpuTileBackendStats {
     analyticTextFallbackRuns = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
+    paperClearTiles = 0;
     advancedBlendPasses = 0;
     advancedBlendBlits = 0;
     advancedBlendCroppedSources = 0;
@@ -236,6 +239,7 @@ class FlutterGpuTileBackendStats {
       'analyticAtlasFallbacks=$analyticAtlasFallbacks '
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
+      'paperClearTiles=$paperClearTiles '
       'advancedBlendPasses=$advancedBlendPasses '
       'advancedBlendBlits=$advancedBlendBlits '
       'advancedBlendCroppedSources=$advancedBlendCroppedSources '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -63,6 +63,7 @@ void main() {
       ..analyticAtlasBytes = 4096
       ..analyticAtlasFallbacks = 1
       ..analyticTextFallbackRuns = 2
+      ..paperClearTiles = 6
       ..advancedBlendBlits = 5
       ..advancedBlendCroppedSources = 4
       ..offscreenGroupPasses = 3
@@ -99,6 +100,7 @@ void main() {
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
+    expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('advancedBlendBlits', 5));
     expect(stats.toJson(), containsPair('advancedBlendCroppedSources', 4));
     expect(stats.toJson(), containsPair('offscreenGroupPasses', 3));
@@ -139,6 +141,7 @@ void main() {
     expect(stats.analyticAtlasBytes, 0);
     expect(stats.analyticAtlasFallbacks, 0);
     expect(stats.analyticTextFallbackRuns, 0);
+    expect(stats.paperClearTiles, 0);
     expect(stats.advancedBlendBlits, 0);
     expect(stats.advancedBlendCroppedSources, 0);
     expect(stats.offscreenGroupPasses, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -279,6 +279,62 @@ void main() {
     });
   });
 
+  testWidgets('interior paper clears preserve page color and edge coverage',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfFillPathCommand(
+            _rect(240, 300, 320, 380),
+            const PdfColor(0.85, 0.12, 0.28),
+            PdfFillRule.nonzero,
+            0.7,
+          ),
+        ],
+        plan: const PdfPageRenderPlan(
+          pageColor: Color(0x8066AA22),
+          rotation: 90,
+        ),
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      for (final (region, clears) in const [
+        (Rect.fromLTWH(60, 60, 240, 200), 1),
+        (Rect.fromLTWH(0, 0, 240, 200), 1),
+      ]) {
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+        try {
+          final a = await _pixels(expected), b = await _pixels(actual);
+          var difference = 0;
+          var minimumAlpha = 255;
+          for (var index = 0; index < a.length; index++) {
+            difference += (a[index] - b[index]).abs();
+            if (index % 4 == 3 && b[index] < minimumAlpha) {
+              minimumAlpha = b[index];
+            }
+          }
+          expect(difference / a.length, lessThan(3));
+          expect(minimumAlpha, 255);
+          expect(backend.stats.paperClearTiles, clears);
+        } finally {
+          expected.dispose();
+          actual.dispose();
+        }
+      }
+    });
+  });
+
   testWidgets('zero-width strokes remain one device pixel at every LoD',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -279,7 +279,8 @@ void main() {
     });
   });
 
-  testWidgets('interior paper clears preserve page color and edge coverage',
+  testWidgets(
+      'simple and advanced interior clears preserve paper and edge coverage',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -287,49 +288,60 @@ void main() {
         return;
       }
       final page = PdfDocument.open(buildClassicPdf()).page(0);
-      final scene = await PdfRetainedScene.fromCommands(
-        page,
-        [
-          PdfFillPathCommand(
-            _rect(240, 300, 320, 380),
-            const PdfColor(0.85, 0.12, 0.28),
-            PdfFillRule.nonzero,
-            0.7,
+      for (final advanced in [false, true]) {
+        final scene = await PdfRetainedScene.fromCommands(
+          page,
+          [
+            if (advanced) const PdfSetBlendModeCommand(PdfBlendMode.overlay),
+            PdfFillPathCommand(
+              _rect(40, 40, 572, 752),
+              const PdfColor(0.85, 0.12, 0.28),
+              PdfFillRule.nonzero,
+              0.7,
+            ),
+            if (advanced) const PdfSetBlendModeCommand(PdfBlendMode.normal),
+          ],
+          plan: const PdfPageRenderPlan(
+            pageColor: Color(0x8066AA22),
+            rotation: 90,
           ),
-        ],
-        plan: const PdfPageRenderPlan(
-          pageColor: Color(0x8066AA22),
-          rotation: 90,
-        ),
-      );
-      addTearDown(scene.dispose);
-      final backend = FlutterGpuTileRasterBackend();
-      final session = backend.createSession(scene);
-      expect(session, isNotNull, reason: backend.stats.lastRejection);
-      addTearDown(session!.dispose);
-
-      for (final (region, clears) in const [
-        (Rect.fromLTWH(60, 60, 240, 200), 1),
-        (Rect.fromLTWH(0, 0, 240, 200), 1),
-      ]) {
-        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
-        final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+        );
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull,
+            reason: '$advanced: ${backend.stats.lastRejection}');
+        final liveSession = session!;
         try {
-          final a = await _pixels(expected), b = await _pixels(actual);
-          var difference = 0;
-          var minimumAlpha = 255;
-          for (var index = 0; index < a.length; index++) {
-            difference += (a[index] - b[index]).abs();
-            if (index % 4 == 3 && b[index] < minimumAlpha) {
-              minimumAlpha = b[index];
+          for (final (region, clears) in const [
+            (Rect.fromLTWH(60, 60, 240, 200), 1),
+            (Rect.fromLTWH(0, 0, 240, 200), 1),
+          ]) {
+            final expected =
+                await scene.rasterizeRegion(region, pixelRatio: 1.5);
+            final actual =
+                await liveSession.rasterizeRegion(region, pixelRatio: 1.5);
+            try {
+              final a = await _pixels(expected), b = await _pixels(actual);
+              var difference = 0;
+              var minimumAlpha = 255;
+              for (var index = 0; index < a.length; index++) {
+                difference += (a[index] - b[index]).abs();
+                if (index % 4 == 3 && b[index] < minimumAlpha) {
+                  minimumAlpha = b[index];
+                }
+              }
+              expect(difference / a.length, lessThan(3),
+                  reason: advanced ? 'advanced route' : 'simple route');
+              expect(minimumAlpha, 255);
+              expect(backend.stats.paperClearTiles, clears);
+            } finally {
+              expected.dispose();
+              actual.dispose();
             }
           }
-          expect(difference / a.length, lessThan(3));
-          expect(minimumAlpha, 255);
-          expect(backend.stats.paperClearTiles, clears);
         } finally {
-          expected.dispose();
-          actual.dispose();
+          liveSession.dispose();
+          scene.dispose();
         }
       }
     });


### PR DESCRIPTION
## Performance vs main

Six alternating same-host Metal pairs, with execution order balanced on every repetition:

| Route | Main | PR | Change |
| --- | ---: | ---: | ---: |
| Simple first tile | 3.966 ms | 3.512 ms | **-11.5%** |
| Simple warm tile | 3.056 ms | 2.470 ms | **-19.2%** |
| Advanced-blend first tile | 6.818 ms | 6.317 ms | **-7.4%** |
| Advanced-blend warm tile | 5.151 ms | 4.776 ms | **-7.3%** |

Main and PR GPU PNGs are byte-identical for both benchmark pages. The hairline control remains at mean diff 0.000 from Canvas; the advanced-blend control remains at 0.372 in both cohorts.

## What changed

Tiles at least one device pixel inside the transformed crop box now initialize the attachment directly with the folded opaque paper color. This removes the transparent clear plus full-tile paper draw. Boundary tiles retain the paper quad, preserving exact crop-edge antialiasing for rotations and translucent custom page colors.

The optimization applies to both the simple and advanced-blend page passes. A new paperClearTiles diagnostic exposes how often it is selected.

<details>
<summary>Validation details</summary>

- Repository analyzer: clean.
- Complete native Flutter GPU package suite: green.
- Non-optional Metal CI smoke: green.
- System-font corpus: Ghent 41 accepted / 16 conservative fallbacks; PDF.js 177 / 2.
- Regression test covers simple and advanced routes, a 90-degree rotation, translucent page color, interior clear selection, and boundary-quad fallback against Canvas.
- All six alternating samples in both cohorts retained their expected Canvas mean diff.

</details>
