### PR TITLE
perf(gpu): fast-path content-free paper tiles

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 
+- Render content-free interior tiles with a color-only pass that clears
+  directly to the folded paper color. This avoids stencil, MSAA, host-buffer,
+  and pipeline work when spatial selection proves that no retained command can
+  affect the tile, while boundary tiles keep the exact antialiased paper path.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -118,6 +118,10 @@ Tiles that sit at least one device pixel inside the transformed crop box use
 the folded opaque paper color as their render-pass clear, avoiding a separate
 transparent clear and full-tile paper draw. Boundary tiles retain the paper
 quad so rotated and translucent page colors keep their exact antialiased edge.
+When spatial selection finds no retained command for one of those interior
+tiles, the backend submits a color-only clear pass. It does not allocate a
+stencil or multisample attachment, create a transient host buffer, or bind a
+draw pipeline; tiles near the crop edge continue through the ordinary path.
 Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
 pass; overlapping paints replay sequentially inside their conservative command
@@ -191,7 +195,8 @@ scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
-Paper diagnostics report how many tiles used the exact interior clear path.
+Paper diagnostics report how many tiles used the exact interior clear path and
+how many of those were content-free color-only submissions.
 Advanced-blend diagnostics report destination-sampling passes, destination
 blits, cropped-source selections, allocated and peak temporary bytes, and
 budget fallbacks.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -3420,6 +3420,13 @@ class _CompiledScene {
   }) {
     final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
     final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    if (selected.isEmpty && _canClearPaper(region, pixelRatio)) {
+      return _renderPaperOnly(
+        width: width,
+        height: height,
+        tracePage: tracePage,
+      );
+    }
     if (selected.any((unit) =>
         !FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(
             unit.blendMode))) {
@@ -3444,6 +3451,63 @@ class _CompiledScene {
       height: height,
       tracePage: tracePage,
     );
+  }
+
+  ui.Image _renderPaperOnly({
+    required int width,
+    required int height,
+    int? tracePage,
+  }) {
+    final issue = Stopwatch()..start();
+    final texture = context.createTexture(
+      gpu.StorageMode.devicePrivate,
+      width,
+      height,
+      format: context.defaultColorFormat,
+    );
+    final commandBuffer = context.createCommandBuffer();
+    final pass = commandBuffer.createRenderPass(
+      gpu.RenderTarget.singleColor(gpu.ColorAttachment(
+        texture: texture,
+        clearValue: paper.clearColor,
+      )),
+    );
+    final retained = <Object>[texture, commandBuffer, pass];
+    final submit = Stopwatch()..start();
+    final completion = Stopwatch()..start();
+    _inFlight++;
+    stats
+      ..paperClearTiles += 1
+      ..paperOnlyTiles += 1
+      ..inFlightSubmissions += 1
+      ..peakInFlightSubmissions = math.max(
+        stats.peakInFlightSubmissions,
+        stats.inFlightSubmissions,
+      );
+    try {
+      commandBuffer.submit(completionCallback: (success) {
+        retained.length;
+        _completeSubmission(
+          success,
+          completion,
+          tracePage,
+          width,
+          height,
+          0,
+        );
+      });
+    } catch (_) {
+      _inFlight--;
+      stats
+        ..inFlightSubmissions = math.max(0, stats.inFlightSubmissions - 1)
+        ..failedSubmissions += 1;
+      _releaseResourcesIfReady();
+      rethrow;
+    }
+    stats
+      ..submitMicros += submit.elapsedMicroseconds
+      ..issueMicros += issue.elapsedMicroseconds;
+    return texture.asImage();
   }
 
   PdfRect _rasterFootprintBounds(

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -37,6 +37,7 @@ class FlutterGpuTileBackendStats {
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
+  int paperOnlyTiles = 0;
   int advancedBlendPasses = 0;
   int advancedBlendBlits = 0;
   int advancedBlendCroppedSources = 0;
@@ -111,6 +112,7 @@ class FlutterGpuTileBackendStats {
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
+        'paperOnlyTiles': paperOnlyTiles,
         'advancedBlendPasses': advancedBlendPasses,
         'advancedBlendBlits': advancedBlendBlits,
         'advancedBlendCroppedSources': advancedBlendCroppedSources,
@@ -184,6 +186,7 @@ class FlutterGpuTileBackendStats {
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
+    paperOnlyTiles = 0;
     advancedBlendPasses = 0;
     advancedBlendBlits = 0;
     advancedBlendCroppedSources = 0;
@@ -240,6 +243,7 @@ class FlutterGpuTileBackendStats {
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
+      'paperOnlyTiles=$paperOnlyTiles '
       'advancedBlendPasses=$advancedBlendPasses '
       'advancedBlendBlits=$advancedBlendBlits '
       'advancedBlendCroppedSources=$advancedBlendCroppedSources '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -64,6 +64,7 @@ void main() {
       ..analyticAtlasFallbacks = 1
       ..analyticTextFallbackRuns = 2
       ..paperClearTiles = 6
+      ..paperOnlyTiles = 3
       ..advancedBlendBlits = 5
       ..advancedBlendCroppedSources = 4
       ..offscreenGroupPasses = 3
@@ -101,6 +102,7 @@ void main() {
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
+    expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
     expect(stats.toJson(), containsPair('advancedBlendBlits', 5));
     expect(stats.toJson(), containsPair('advancedBlendCroppedSources', 4));
     expect(stats.toJson(), containsPair('offscreenGroupPasses', 3));
@@ -142,6 +144,7 @@ void main() {
     expect(stats.analyticAtlasFallbacks, 0);
     expect(stats.analyticTextFallbackRuns, 0);
     expect(stats.paperClearTiles, 0);
+    expect(stats.paperOnlyTiles, 0);
     expect(stats.advancedBlendBlits, 0);
     expect(stats.advancedBlendCroppedSources, 0);
     expect(stats.offscreenGroupPasses, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -347,6 +347,46 @@ void main() {
     });
   });
 
+  testWidgets('content-free interior tiles skip raster attachments and draws',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        const [],
+        plan: const PdfPageRenderPlan(
+          pageColor: Color(0x8066AA22),
+          rotation: 270,
+        ),
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      for (final (region, paperOnly) in const [
+        (Rect.fromLTWH(60, 60, 240, 200), 1),
+        (Rect.fromLTWH(0, 0, 240, 200), 1),
+      ]) {
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+        try {
+          final a = await _pixels(expected), b = await _pixels(actual);
+          expect(b, a);
+          expect(backend.stats.paperOnlyTiles, paperOnly);
+        } finally {
+          expected.dispose();
+          actual.dispose();
+        }
+      }
+    });
+  });
+
   testWidgets('zero-width strokes remain one device pixel at every LoD',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -1,4 +1,5 @@
 import 'dart:ui' as ui;
+import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
@@ -41,6 +42,16 @@ Future<int> _timeSettledImage(Future<ui.Image> Function() render) async {
   clock.stop();
   image.dispose();
   return clock.elapsedMicroseconds;
+}
+
+Future<(int, Uint8List)> _timePixels(Future<ui.Image> Function() render) async {
+  final clock = Stopwatch()..start();
+  final image = await render();
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  clock.stop();
+  image.dispose();
+  if (data == null) throw StateError('tile readback failed');
+  return (clock.elapsedMicroseconds, Uint8List.sublistView(data));
 }
 
 PdfPath _rect(double left, double bottom, double right, double top) => PdfPath([
@@ -110,6 +121,74 @@ void main() {
       // Keep an always-visible machine-readable-ish line in benchmark runs.
       // ignore: avoid_print
       print(summary);
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('reports content-free interior tile settle', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        const [],
+        plan: const PdfPageRenderPlan(
+          pageColor: Color(0x8066AA22),
+          rotation: 90,
+        ),
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      await backend.warmUp();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      final liveSession = session!;
+      addTearDown(liveSession.dispose);
+      if (liveSession is PdfTileRasterWarmUp) {
+        await (liveSession as PdfTileRasterWarmUp).warmUp();
+      }
+
+      const region = Rect.fromLTWH(50, 50, 512, 512);
+      final firstGpu = await _timePixels(
+        () => liveSession.rasterizeRegion(region, pixelRatio: 1),
+      );
+      final firstCanvas = await _timePixels(
+        () => scene.rasterizeRegion(region, pixelRatio: 1),
+      );
+      expect(firstGpu.$2, firstCanvas.$2);
+
+      final warmGpu = <int>[], warmCanvas = <int>[];
+      for (var index = 0; index < 7; index++) {
+        late (int, Uint8List) gpuResult, canvasResult;
+        if (index.isEven) {
+          gpuResult = await _timePixels(
+            () => liveSession.rasterizeRegion(region, pixelRatio: 1),
+          );
+          canvasResult = await _timePixels(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          );
+        } else {
+          canvasResult = await _timePixels(
+            () => scene.rasterizeRegion(region, pixelRatio: 1),
+          );
+          gpuResult = await _timePixels(
+            () => liveSession.rasterizeRegion(region, pixelRatio: 1),
+          );
+        }
+        expect(gpuResult.$2, canvasResult.$2);
+        warmGpu.add(gpuResult.$1);
+        warmCanvas.add(canvasResult.$1);
+      }
+
+      // ignore: avoid_print
+      print('flutter_gpu paper-only benchmark: first=${firstGpu.$1}us '
+          'firstCanvas=${firstCanvas.$1}us '
+          'warmMedian=${_median(warmGpu).toStringAsFixed(0)}us '
+          'canvasMedian=${_median(warmCanvas).toStringAsFixed(0)}us '
+          '${backend.stats}');
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 


### PR DESCRIPTION
## Performance versus `main`

**Content-free interior tile settle on macOS Metal:** first **3.022 ms → 1.917 ms (-36.6%)**; warm **1.637 ms → 0.713 ms (-56.4%)**.

Six same-host pairs alternated main and this branch. Every timed GPU result was byte-for-byte equal to Canvas; the Canvas medians stayed stable at 2.592 ms versus 2.549 ms.

## Change

When spatial selection finds no retained command and the tile is at least one device pixel inside the transformed crop box, submit a color-only render pass cleared directly to the folded paper color. This avoids stencil, MSAA, transient host-buffer, geometry, and pipeline work. Boundary tiles keep the ordinary paper-quad route for exact crop-edge antialiasing.

Diagnostics now distinguish `paperOnlyTiles` from the broader `paperClearTiles` count. The permanent benchmark exercises the route and checks every GPU result against Canvas pixels.

<details>
<summary>Validation details</summary>

- `fvm dart analyze`
- focused native Metal parity test, including rotation 270 and translucent paper
- complete native Flutter GPU package suite: 296 passing plus expected platform skips
- non-optional `gpu_ci_smoke_test.dart`
- system-font GPU corpus: Ghent 41 accepted / 16 known non-black-overprint fallbacks; PDF.js 177 accepted / 2 known fallbacks
- default-font GPU corpus from the full suite remained at its pinned acceptance/fallback counts

</details>
