### PR TITLE
perf(gpu): right-size pooled geometry buffers

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -13,6 +13,10 @@
   backdrop or evaluating the PDF blend equation. The destination is already a
   native copy of that backdrop, so sparse sources avoid redundant fragment
   reads, arithmetic, and writes without changing the resolved pixels.
+- Pool retained geometry in power-of-two size classes starting at 64 KiB
+  instead of rounding every scene up to 16 MiB. Dense scenes still flush at
+  the existing 16 MiB arena boundary and all active buffers remain under the
+  same hard byte budget.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -157,10 +157,12 @@ across scenes, pages, workers, zoom levels, and LoDs.
 Pinned scene textures count toward the same ceiling; if no unpinned entry can
 make room, that scene falls back to Canvas instead of overshooting the budget.
 Compiled vertices share a second strict byte budget. They are packed into
-reusable 16 MiB device-buffer blocks and returned to the backend-wide pool only
-after their scene is disposed and every submitted command buffer completes.
-This keeps command-heavy CAD navigation bounded without relying on delayed
-native finalizers; a scene that cannot lease enough geometry also falls back.
+reusable power-of-two device-buffer size classes from 64 KiB through the 16 MiB
+arena chunk size, and returned to the backend-wide pool only after their scene
+is disposed and every submitted command buffer completes. This keeps sparse
+pages small and command-heavy CAD navigation bounded without relying on
+delayed native finalizers; a scene that cannot lease enough geometry also
+falls back.
 
 Ordinary filled outline text uses retained Slug-style quadratic curve streams:
 one small nearest-sampled atlas stores each distinct page glyph and each draw

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -80,9 +80,10 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   ///
   /// Stable flutter_gpu does not expose explicit DeviceBuffer disposal, so
   /// relying on native finalizers lets fast CAD navigation outrun collection.
-  /// Buffers are therefore pooled in 16 MiB blocks, leased by compiled scenes,
-  /// and reused only after the scene is disposed and every submitted command
-  /// buffer has completed. A scene that cannot fit falls back to Canvas.
+  /// Buffers are therefore pooled in power-of-two size classes from 64 KiB to
+  /// the arena's 16 MiB chunk size, leased by compiled scenes, and reused only
+  /// after the scene is disposed and every submitted command buffer has
+  /// completed. A scene that cannot fit falls back to Canvas.
   final int maxGeometryBytes;
 
   /// Whether the viewer should prepare GPU pipelines and live scenes at idle.
@@ -6078,6 +6079,7 @@ class _GpuGeometryArena {
 class _GpuGeometryPool {
   _GpuGeometryPool(this.maxBytes);
 
+  static const minimumBytes = 64 << 10;
   static const chunkBytes = 16 << 20;
 
   final int maxBytes;
@@ -6089,8 +6091,7 @@ class _GpuGeometryPool {
     ByteData data,
     FlutterGpuTileBackendStats stats,
   ) {
-    final capacity =
-        ((data.lengthInBytes + chunkBytes - 1) ~/ chunkBytes) * chunkBytes;
+    final capacity = _capacityFor(data.lengthInBytes);
     _GpuGeometryResource? resource;
     for (final candidate in _resources) {
       if (!identical(candidate.context, context) ||
@@ -6129,6 +6130,15 @@ class _GpuGeometryPool {
       ..geometryBytes = _bytes
       ..peakGeometryBytes = math.max(stats.peakGeometryBytes, _bytes);
     return resource;
+  }
+
+  static int _capacityFor(int bytes) {
+    var capacity = minimumBytes;
+    while (capacity < bytes && capacity < chunkBytes) {
+      capacity <<= 1;
+    }
+    if (capacity >= bytes) return capacity;
+    return ((bytes + chunkBytes - 1) ~/ chunkBytes) * chunkBytes;
   }
 
   void releaseAll(

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1559,7 +1559,7 @@ void main() {
     });
   });
 
-  testWidgets('geometry buffers stay bounded and reuse retired scene blocks',
+  testWidgets('geometry buffers stay bounded and reuse retired size classes',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -1577,7 +1577,7 @@ void main() {
       ]);
       addTearDown(scene.dispose);
       final backend = FlutterGpuTileRasterBackend(
-        maxGeometryBytes: 16 << 20,
+        maxGeometryBytes: 64 << 10,
       );
       const region = Rect.fromLTWH(0, 0, 320, 320);
 
@@ -1586,7 +1586,7 @@ void main() {
       await _pixels(firstImage);
       firstImage.dispose();
       expect(backend.stats.geometryBuffers, 1);
-      expect(backend.stats.geometryBytes, 16 << 20);
+      expect(backend.stats.geometryBytes, 64 << 10);
       expect(backend.stats.activeGeometryLeases, 1);
 
       final blocked = backend.createSession(scene)!;
@@ -1614,9 +1614,9 @@ void main() {
       secondImage.dispose();
       admitted.dispose();
       expect(backend.stats.geometryBuffers, 1,
-          reason: 'the retired 16 MiB block should be reused');
-      expect(backend.stats.geometryBytes, 16 << 20);
-      expect(backend.stats.peakGeometryBytes, 16 << 20);
+          reason: 'the retired 64 KiB size class should be reused');
+      expect(backend.stats.geometryBytes, 64 << 10);
+      expect(backend.stats.peakGeometryBytes, 64 << 10);
     });
   });
 


### PR DESCRIPTION
## Performance versus main

- Sparse vector scene: pooled geometry allocation **16 MiB → 64 KiB** (**-99.61%, 256× smaller**).
- Tiling-pattern scene: **16 MiB → 256 KiB** (**-98.44%, 64× smaller**).
- Six balanced tiling A/B pairs: session median **-9.87%**, scene compilation **-1.31%**; cold/warm tile timings remained within run noise.
- Pixel comparison remained unchanged.

This replaces the fixed 16 MiB geometry allocation with power-of-two size classes from 64 KiB through 16 MiB, retaining the existing hard budget, lease lifetime, and retired-block reuse behavior.

<details>
<summary>Validation details</summary>

- Focused analyzer: clean after rebasing onto current main.
- Focused native Metal size-class/reuse regression: passed.
- Complete native Metal backend suite: 296 passed with expected platform skips.
- Non-optional GPU smoke: passed.
- System-font GPU corpora: Ghent 41 accepted / 16 conservatively rejected; PDF.js 177 accepted / 2 conservatively rejected.
- Exact GPU and Canvas image hashes stayed unchanged in the benchmark fixture.

</details>