### PR TITLE
fix(gpu): bound transient tile buffers

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -9,6 +9,12 @@
   directly to the folded paper color. This avoids stencil, MSAA, host-buffer,
   and pipeline work when spatial selection proves that no retained command can
   affect the tile, while boundary tiles keep the exact antialiased paper path.
+- Replace Flutter's four-frame `HostBuffer` in tile submissions with a
+  completion-fenced single-submission arena. It starts at 64 KiB, grows from
+  256 KiB to 1 MiB only for dense dynamic geometry, validates the full aligned
+  emplacement before every write, and fixes CAD hairline pages that could
+  cross Flutter 3.47's 1,024,000-byte block boundary and throw. An ordinary
+  tile now reserves 64 KiB instead of 4,096,000 bytes.
 - Discard exactly transparent advanced-blend source texels before sampling the
   backdrop or evaluating the PDF blend equation. The destination is already a
   native copy of that backdrop, so sparse sources avoid redundant fragment

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -202,6 +202,9 @@ evictions, budget fallbacks, retained bytes, and live resource leases.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
 Paper diagnostics report how many tiles used the exact interior clear path and
 how many of those were content-free color-only submissions.
+Transient-buffer diagnostics report emplaced bytes, allocated buffers/bytes,
+and the peak allocation for one tile, making dense dynamic hairline workloads
+and ordinary 64 KiB submissions separately visible.
 Advanced-blend diagnostics report destination-sampling passes, destination
 blits, cropped-source selections, allocated and peak temporary bytes, and
 budget fallbacks.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -3552,7 +3552,7 @@ class _CompiledScene {
     required _GpuPipelines pipelines,
     required int width,
     required int height,
-    required gpu.HostBuffer transient,
+    required _GpuTransientArena transient,
     int maxBytes = 256 << 20,
   }) {
     Rect groupRegionFor(_GpuUnit unit, _OffscreenGroupDraw draw) {
@@ -3677,6 +3677,7 @@ class _CompiledScene {
         groupPass,
         transient,
       ];
+      transient.flush();
       groupCommandBuffer.submit(completionCallback: (_) {
         // The page completion owns the textures on the success path. This
         // independent capture also fences every submitted group resource if a
@@ -3805,7 +3806,7 @@ class _CompiledScene {
             sampleCount: multisampled ? 4 : 1,
           )
         : stencil;
-    final transient = context.createHostBuffer();
+    final transient = _GpuTransientArena(context, stats);
     final groups = _renderOffscreenGroups(
       selected,
       region: region,
@@ -4148,6 +4149,7 @@ class _CompiledScene {
         stats.peakInFlightSubmissions,
         stats.inFlightSubmissions,
       );
+    transient.flush();
     try {
       for (var i = 0; i < commandBuffers.length; i++) {
         final last = i == commandBuffers.length - 1;
@@ -4213,7 +4215,7 @@ class _CompiledScene {
       format: context.defaultStencilFormat,
       sampleCount: multisampled ? 4 : 1,
     );
-    final transient = context.createHostBuffer();
+    final transient = _GpuTransientArena(context, stats);
 
     gpu.RenderPass createPass(
       gpu.CommandBuffer commandBuffer,
@@ -4319,6 +4321,16 @@ class _CompiledScene {
       }
     }
     stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
+    transient.flush();
+    final retained = <Object>[
+      resolve,
+      color,
+      stencil,
+      transient,
+      ...retainedGroupTextures,
+      commandBuffer,
+      pass,
+    ];
     final submit = Stopwatch()..start();
     final completion = Stopwatch()..start();
     _inFlight++;
@@ -4333,7 +4345,7 @@ class _CompiledScene {
         completionCallback: (success) {
           // Keep every intermediate attachment alive until the command buffer
           // has finished sampling it into the page target.
-          retainedGroupTextures.length;
+          retained.length;
           _completeSubmission(
             success,
             completion,
@@ -6076,6 +6088,103 @@ class _GpuGeometryArena {
   }
 }
 
+/// Single-submission bump arena for transient uniforms and dynamic vertices.
+///
+/// Flutter 3.47's HostBuffer reserves four 1,024,000-byte frame blocks even
+/// though the tile renderer creates a fresh allocator for every submission.
+/// Its rollover check also ignores the incoming emplacement length, so a
+/// dense sequence of individually small CAD hairlines can cross the active
+/// block boundary and fail the upload. This arena owns only the buffers used
+/// by one tile, tests the complete aligned range before every write, and is
+/// retained until the command-buffer completion fence fires.
+class _GpuTransientArena {
+  _GpuTransientArena(this.context, [this.stats]);
+
+  static const _firstBlockBytes = 64 << 10;
+  static const _secondBlockBytes = 256 << 10;
+  static const _maximumBlockBytes = 1 << 20;
+
+  final gpu.GpuContext context;
+  final FlutterGpuTileBackendStats? stats;
+  final List<_GpuTransientBlock> _blocks = [];
+  _GpuTransientBlock? _active;
+  var _allocatedBytes = 0;
+  var _nextBlockBytes = _secondBlockBytes;
+
+  gpu.BufferView emplace(ByteData bytes) {
+    final length = bytes.lengthInBytes;
+    if (length <= 0) {
+      throw ArgumentError.value(length, 'bytes.lengthInBytes');
+    }
+    final alignment = math.max(1, context.minimumUniformByteAlignment);
+    var block = _active;
+    var offset = block == null ? 0 : _align(block.usedBytes, alignment);
+    if (block == null || offset + length > block.capacity) {
+      final minimum = _align(length, alignment);
+      final first = _blocks.isEmpty;
+      final base = first ? _firstBlockBytes : _nextBlockBytes;
+      final capacity = math.max(base, minimum);
+      block = _GpuTransientBlock(
+        context.createDeviceBuffer(gpu.StorageMode.hostVisible, capacity),
+        capacity,
+      );
+      _blocks.add(block);
+      _active = block;
+      _allocatedBytes += capacity;
+      if (!first) {
+        _nextBlockBytes = math.min(
+          _maximumBlockBytes,
+          math.max(_nextBlockBytes * 2, capacity),
+        );
+      }
+      stats
+        ?..transientBuffers += 1
+        ..transientAllocatedBytes += capacity
+        ..peakTransientTileBytes = math.max(
+          stats!.peakTransientTileBytes,
+          _allocatedBytes,
+        );
+      offset = 0;
+    }
+    if (!block.buffer.overwrite(bytes, destinationOffsetInBytes: offset)) {
+      throw StateError(
+        'GPU transient upload failed: offset=$offset length=$length '
+        'capacity=${block.capacity}',
+      );
+    }
+    block.usedBytes = offset + length;
+    stats?.transientEmplacedBytes += length;
+    return gpu.BufferView(
+      block.buffer,
+      offsetInBytes: offset,
+      lengthInBytes: length,
+    );
+  }
+
+  void flush() {
+    for (final block in _blocks) {
+      if (block.flushedBytes == block.usedBytes) continue;
+      block.buffer.flush(
+        offsetInBytes: block.flushedBytes,
+        lengthInBytes: block.usedBytes - block.flushedBytes,
+      );
+      block.flushedBytes = block.usedBytes;
+    }
+  }
+
+  static int _align(int value, int alignment) =>
+      ((value + alignment - 1) ~/ alignment) * alignment;
+}
+
+class _GpuTransientBlock {
+  _GpuTransientBlock(this.buffer, this.capacity);
+
+  final gpu.DeviceBuffer buffer;
+  final int capacity;
+  var usedBytes = 0;
+  var flushedBytes = 0;
+}
+
 class _GpuGeometryPool {
   _GpuGeometryPool(this.maxBytes);
 
@@ -7112,7 +7221,7 @@ class _GpuPipelines {
       const [255, 255, 255, 255],
     )));
 
-    final transient = context.createHostBuffer();
+    final transient = _GpuTransientArena(context);
     final transform =
         transient.emplace(ByteData.sublistView(Float32List.fromList(
       const [
@@ -7399,6 +7508,7 @@ class _GpuPipelines {
       pass,
       blendPass,
     ];
+    transient.flush();
     try {
       var completed = 0;
       var succeeded = true;

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -52,6 +52,10 @@ class FlutterGpuTileBackendStats {
   int activeGeometryLeases = 0;
   int geometryBytes = 0;
   int peakGeometryBytes = 0;
+  int transientBuffers = 0;
+  int transientEmplacedBytes = 0;
+  int transientAllocatedBytes = 0;
+  int peakTransientTileBytes = 0;
   int texturesUploaded = 0;
   int textureDirectUploads = 0;
   int textureReadbacks = 0;
@@ -127,6 +131,10 @@ class FlutterGpuTileBackendStats {
         'activeGeometryLeases': activeGeometryLeases,
         'geometryBytes': geometryBytes,
         'peakGeometryBytes': peakGeometryBytes,
+        'transientBuffers': transientBuffers,
+        'transientEmplacedBytes': transientEmplacedBytes,
+        'transientAllocatedBytes': transientAllocatedBytes,
+        'peakTransientTileBytes': peakTransientTileBytes,
         'texturesUploaded': texturesUploaded,
         'textureDirectUploads': textureDirectUploads,
         'textureReadbacks': textureReadbacks,
@@ -199,6 +207,10 @@ class FlutterGpuTileBackendStats {
     offscreenGroupBudgetFallbacks = 0;
     geometryBudgetFallbacks = 0;
     peakGeometryBytes = geometryBytes;
+    transientBuffers = 0;
+    transientEmplacedBytes = 0;
+    transientAllocatedBytes = 0;
+    peakTransientTileBytes = 0;
     texturesUploaded = 0;
     textureDirectUploads = 0;
     textureReadbacks = 0;
@@ -257,6 +269,10 @@ class FlutterGpuTileBackendStats {
       'geometryBudgetFallbacks=$geometryBudgetFallbacks '
       'activeGeometryLeases=$activeGeometryLeases '
       'geometryBytes=$geometryBytes peakGeometryBytes=$peakGeometryBytes '
+      'transientBuffers=$transientBuffers '
+      'transientEmplacedBytes=$transientEmplacedBytes '
+      'transientAllocatedBytes=$transientAllocatedBytes '
+      'peakTransientTileBytes=$peakTransientTileBytes '
       'uploads=$texturesUploaded directUploads=$textureDirectUploads '
       'readbacks=$textureReadbacks textureHits=$textureCacheHits '
       'textureMisses=$textureCacheMisses evictions=$textureEvictions '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -57,6 +57,10 @@ void main() {
       ..geometryBuffers = 3
       ..geometryBytes = 32 << 20
       ..peakGeometryBytes = 48 << 20
+      ..transientBuffers = 5
+      ..transientEmplacedBytes = 768 << 10
+      ..transientAllocatedBytes = 1 << 20
+      ..peakTransientTileBytes = 896 << 10
       ..analyticTextRuns = 7
       ..analyticGlyphQuads = 18
       ..analyticGlyphSlots = 4
@@ -96,6 +100,10 @@ void main() {
     expect(stats.toJson(), containsPair('sceneWarmUpCancellations', 1));
     expect(stats.toJson(), containsPair('sceneWarmUpMicros', 18000));
     expect(stats.toJson(), containsPair('analyticTextRuns', 7));
+    expect(stats.toJson(), containsPair('transientBuffers', 5));
+    expect(stats.toJson(), containsPair('transientEmplacedBytes', 768 << 10));
+    expect(stats.toJson(), containsPair('transientAllocatedBytes', 1 << 20));
+    expect(stats.toJson(), containsPair('peakTransientTileBytes', 896 << 10));
     expect(stats.toJson(), containsPair('analyticGlyphQuads', 18));
     expect(stats.toJson(), containsPair('analyticGlyphSlots', 4));
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
@@ -137,6 +145,10 @@ void main() {
     expect(stats.geometryBuffers, 3);
     expect(stats.geometryBytes, 32 << 20);
     expect(stats.peakGeometryBytes, 32 << 20);
+    expect(stats.transientBuffers, 0);
+    expect(stats.transientEmplacedBytes, 0);
+    expect(stats.transientAllocatedBytes, 0);
+    expect(stats.peakTransientTileBytes, 0);
     expect(stats.analyticTextRuns, 0);
     expect(stats.analyticGlyphQuads, 0);
     expect(stats.analyticGlyphSlots, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -451,6 +451,57 @@ void main() {
     });
   });
 
+  testWidgets('dense hairlines roll transient buffers without crossing blocks',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      PdfPath densePath(int points, double baseline) => PdfPath([
+            PdfMoveTo(35, baseline),
+            for (var index = 1; index < points; index++)
+              PdfLineTo(
+                35 + (index % 520),
+                baseline + (index.isEven ? 2 : -2),
+              ),
+          ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        for (final (points, baseline) in const [(6200, 240.0), (4200, 300.0)])
+          PdfStrokePathCommand(
+            densePath(points, baseline),
+            const PdfColor(0.05, 0.12, 0.3),
+            const PdfStroke(width: 0, cap: 1, join: 1),
+            1,
+          ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend(msaa: false);
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final image = await session.rasterizeRegion(
+        const Rect.fromLTWH(0, 400, 612, 220),
+        pixelRatio: 0.5,
+      );
+      addTearDown(image.dispose);
+      final pixels = await _pixels(image);
+      expect(
+        pixels.indexed.any((item) => item.$1 % 4 != 3 && item.$2 < 240),
+        isTrue,
+      );
+      expect(
+        backend.stats.transientEmplacedBytes,
+        greaterThan(1024000),
+        reason: 'the regression must cross Flutter HostBuffer\'s old block',
+      );
+      expect(backend.stats.transientBuffers, greaterThan(1));
+      expect(backend.stats.peakTransientTileBytes, lessThan(4 << 20));
+    });
+  });
+
   testWidgets('filled, stroked, and hairline text retain exact GPU outlines',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Headline

- Ordinary tiles reserve **65,536 bytes instead of 4,096,000 bytes** for transient GPU uploads: **-98.4% / 62.5x smaller**.
- Both formerly crashing dense-CAD fixtures now render all **4/4 audited pages** with Canvas parity instead of hitting the Flutter `HostBuffer` range bug.
- Six paired same-host runs were neutral: cold **+0.02%**, warm **+1.44% (~20 us)**, both within run spread.

This replaces the Flutter `HostBuffer` used for per-submission geometry with a small, growing transient arena. The arena validates the full aligned write range, flushes only the blocks used by each submission, and retains those blocks until Impeller completes the command buffer.

The change also fixes the simple-tile lifetime path: transient storage and texture leases are now retained by the completion callback rather than becoming collectible immediately after submit.

<details>
<summary>Correctness and performance evidence</summary>

### Dense CAD

- A real page safely emplaced **13.9 MB** across **21** growing blocks without a crash.
- The dedicated regression crosses the old 1,024,000-byte block boundary and asserts that the tile paints while the arena remains bounded.
- The two private CAD fixtures were used locally only; no fixture names, paths, or data are included in this change.

### Rendering

- Full native Metal package suite: **297 passed**, 3 expected skips.
- Ghent system-font GPU corpus: **41 accepted / 16 expected Canvas fallbacks**.
- PDF.js system-font GPU corpus: **177 accepted / 2 expected Canvas fallbacks**.
- Designated non-optional GPU smoke: passed.
- Focused analyzer: clean.

### Same-host timings

Six balanced pairs on the tiling benchmark:

- cold median: 210,764.5 us -> 210,811.5 us (**+0.02%**)
- warm median: 1,386.5 us -> 1,406.5 us (**+1.44%**, about 20 us)

Both shifts are smaller than ordinary run-to-run spread. A representative ordinary tile now emplaces 64 bytes into one 64 KiB block instead of eagerly allocating four roughly 1 MB blocks.

</details>

## Implementation

- add a single-submission `_GpuTransientArena` with 64 KiB initial storage and bounded growth up to 1 MiB blocks
- validate `offset + alignment + payload length` before every write
- flush used blocks immediately before submission
- retain arena storage and resource leases through completion callbacks
- expose transient buffer/emplaced/allocated/peak counters in GPU diagnostics
- cover counter snapshot/reset behavior and dense block rollover
