### PR TITLE
fix(gpu): fall back for dense subpixel strokes

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -23,6 +23,11 @@
   instead of rounding every scene up to 16 MiB. Dense scenes still flush at
   the existing 16 MiB arena boundary and all active buffers remain under the
   same hard byte budget.
+- Retire a GPU session to the viewer's exact Canvas fallback when one tile
+  selects at least 128 paint units containing positive-width strokes that
+  resolve below the 0.25 px coverage quantum of 4x MSAA. This prevents dense
+  CAD linework from becoming faint or disappearing at low zoom while isolated
+  subpixel strokes retain the established GPU parity and routing.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -205,6 +205,10 @@ how many of those were content-free color-only submissions.
 Transient-buffer diagnostics report emplaced bytes, allocated buffers/bytes,
 and the peak allocation for one tile, making dense dynamic hairline workloads
 and ordinary 64 KiB submissions separately visible.
+Subpixel-stroke diagnostics report resolution-aware runtime fallbacks for
+dense CAD tiles whose positive-width linework falls below one 4x MSAA coverage
+quantum; the viewer permanently serves that session through Canvas rather than
+displaying incomplete linework.
 Advanced-blend diagnostics report destination-sampling passes, destination
 blits, cropped-source selections, allocated and peak temporary bytes, and
 budget fallbacks.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -451,6 +451,7 @@ class _GpuUnit {
     required this.strokeOverprint,
     required this.darken,
     this.hairline = false,
+    this.minimumPositiveStrokeWidth,
     this.composite,
   });
 
@@ -463,6 +464,7 @@ class _GpuUnit {
   final bool strokeOverprint;
   final bool darken;
   final bool hairline;
+  final double? minimumPositiveStrokeWidth;
   final _GpuCompositeSpec? composite;
 }
 
@@ -1087,6 +1089,27 @@ List<PdfRenderCommand> _dropInvisibleGroups(List<PdfRenderCommand> commands) {
   return rewritten == null ? commands : List.unmodifiable(rewritten);
 }
 
+double? _minimumPositiveStrokeWidth(
+  List<PdfRenderCommand> commands,
+  int start,
+  int end,
+) {
+  double? minimum;
+  for (var index = start; index <= end; index++) {
+    final width = switch (commands[index]) {
+      PdfStrokePathCommand(:final stroke) when stroke.width > 0 => stroke.width,
+      PdfDrawTextCommand(:final run)
+          when run.strokeColor != null && run.strokeWidth > 0 =>
+        run.strokeWidth,
+      _ => null,
+    };
+    if (width != null && (minimum == null || width < minimum)) {
+      minimum = width;
+    }
+  }
+  return minimum;
+}
+
 _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
   if (commands.length > 1000000) {
     return const _GpuUnitBuild(null, 'retained scene exceeds GPU index cap');
@@ -1162,6 +1185,11 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
                 fillOverprint: false,
                 strokeOverprint: false,
                 darken: false,
+                minimumPositiveStrokeWidth: _minimumPositiveStrokeWidth(
+                  commands,
+                  paint.commandIndex,
+                  paint.endCommandIndex,
+                ),
                 composite: paint.composite,
               ));
             }
@@ -1204,6 +1232,11 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
                 darken: false,
                 hairline: paintCommand is PdfStrokePathCommand &&
                     paintCommand.stroke.width <= 0,
+                minimumPositiveStrokeWidth: _minimumPositiveStrokeWidth(
+                  commands,
+                  paint.commandIndex,
+                  paint.commandIndex,
+                ),
               ));
             }
             final groupBounds = capture.bounds;
@@ -1237,6 +1270,8 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
                 fillOverprint: capture.fillOverprint,
                 strokeOverprint: capture.strokeOverprint,
                 darken: false,
+                minimumPositiveStrokeWidth:
+                    _minimumPositiveStrokeWidth(commands, capture.start, i),
                 composite: spec,
               ));
             }
@@ -1270,6 +1305,8 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
                 _commandNeedsDarken(command, fillOverprint, strokeOverprint),
             hairline:
                 command is PdfStrokePathCommand && command.stroke.width <= 0,
+            minimumPositiveStrokeWidth:
+                _minimumPositiveStrokeWidth(commands, i, i),
           ));
         }
     }
@@ -3129,6 +3166,34 @@ class _FlutterGpuTileSession
       final issue = Stopwatch()..start();
       final selected =
           _selectGpuUnits(units, compiled.pageToRaster, region, pixelRatio);
+      final coverageQuantum =
+          msaa && context.doesSupportOffscreenMSAA ? 0.25 : 1.0;
+      final deviceScale = _pageDeviceScale(compiled.pageToRaster, pixelRatio);
+      var undersampledUnits = 0;
+      double? narrowest;
+      for (final unit in selected) {
+        final width = unit.minimumPositiveStrokeWidth;
+        if (width != null && width * deviceScale < coverageQuantum) {
+          undersampledUnits++;
+          if (narrowest == null || width < narrowest) narrowest = width;
+        }
+      }
+      // Four-sample MSAA can represent coverage only in quarter-pixel
+      // increments. Isolated thinner strokes stay within the established
+      // Canvas parity tolerance, but dense CAD drawings accumulate hundreds
+      // of missed strokes into material blank regions. Retire the accelerated
+      // session before issuing a knowingly incomplete tile; the viewer serves
+      // this request and all later LoDs from its exact Canvas fallback session.
+      if (undersampledUnits >= 128) {
+        final resolvedWidth = narrowest! * deviceScale;
+        stats.subpixelStrokeFallbacks++;
+        throw StateError(
+          '$undersampledUnits paint units contain positive-width strokes that '
+          'resolve as narrowly as ${resolvedWidth.toStringAsFixed(3)} device '
+          'pixels, below the ${coverageQuantum.toStringAsFixed(2)} '
+          'flutter_gpu coverage quantum',
+        );
+      }
       stats.selectedCommands += selected.length;
       final image = compiled.render(
         selected,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -38,6 +38,7 @@ class FlutterGpuTileBackendStats {
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
   int paperOnlyTiles = 0;
+  int subpixelStrokeFallbacks = 0;
   int advancedBlendPasses = 0;
   int advancedBlendBlits = 0;
   int advancedBlendCroppedSources = 0;
@@ -117,6 +118,7 @@ class FlutterGpuTileBackendStats {
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
         'paperOnlyTiles': paperOnlyTiles,
+        'subpixelStrokeFallbacks': subpixelStrokeFallbacks,
         'advancedBlendPasses': advancedBlendPasses,
         'advancedBlendBlits': advancedBlendBlits,
         'advancedBlendCroppedSources': advancedBlendCroppedSources,
@@ -195,6 +197,7 @@ class FlutterGpuTileBackendStats {
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
     paperOnlyTiles = 0;
+    subpixelStrokeFallbacks = 0;
     advancedBlendPasses = 0;
     advancedBlendBlits = 0;
     advancedBlendCroppedSources = 0;
@@ -256,6 +259,7 @@ class FlutterGpuTileBackendStats {
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '
+      'subpixelStrokeFallbacks=$subpixelStrokeFallbacks '
       'advancedBlendPasses=$advancedBlendPasses '
       'advancedBlendBlits=$advancedBlendBlits '
       'advancedBlendCroppedSources=$advancedBlendCroppedSources '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -69,6 +69,7 @@ void main() {
       ..analyticTextFallbackRuns = 2
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
+      ..subpixelStrokeFallbacks = 2
       ..advancedBlendBlits = 5
       ..advancedBlendCroppedSources = 4
       ..offscreenGroupPasses = 3
@@ -111,6 +112,7 @@ void main() {
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
+    expect(stats.toJson(), containsPair('subpixelStrokeFallbacks', 2));
     expect(stats.toJson(), containsPair('advancedBlendBlits', 5));
     expect(stats.toJson(), containsPair('advancedBlendCroppedSources', 4));
     expect(stats.toJson(), containsPair('offscreenGroupPasses', 3));
@@ -157,6 +159,7 @@ void main() {
     expect(stats.analyticTextFallbackRuns, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);
+    expect(stats.subpixelStrokeFallbacks, 0);
     expect(stats.advancedBlendBlits, 0);
     expect(stats.advancedBlendCroppedSources, 0);
     expect(stats.offscreenGroupPasses, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -451,6 +451,72 @@ void main() {
     });
   });
 
+  testWidgets('sub-MSAA positive strokes request exact Canvas fallback',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        for (var index = 0; index < 128; index++)
+          PdfStrokePathCommand(
+            PdfPath([
+              PdfMoveTo(60, index == 127 ? 400 : 240 + index * 0.01),
+              PdfLineTo(550, index == 127 ? 400 : 240 + index * 0.01),
+            ]),
+            const PdfColor(0.05, 0.1, 0.2),
+            const PdfStroke(width: 0.24),
+            1,
+          ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(40, 500, 520, 100);
+
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 2);
+      final accelerated = await session.rasterizeRegion(region, pixelRatio: 2);
+      try {
+        final a = await _pixels(expected), b = await _pixels(accelerated);
+        var difference = 0;
+        for (var index = 0; index < a.length; index++) {
+          difference += (a[index] - b[index]).abs();
+        }
+        expect(difference / a.length, lessThan(3));
+      } finally {
+        expected.dispose();
+        accelerated.dispose();
+      }
+
+      final belowThreshold =
+          await session.rasterizeRegion(region, pixelRatio: 0.5);
+      belowThreshold.dispose();
+      expect(backend.stats.subpixelStrokeFallbacks, 0);
+
+      await expectLater(
+        session.rasterizeRegion(
+          Offset.zero & scene.pageSize,
+          pixelRatio: 0.5,
+        ),
+        throwsA(isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          allOf(
+            contains('128 paint units contain positive-width strokes'),
+            contains('below the 0.25 flutter_gpu coverage quantum'),
+          ),
+        )),
+      );
+      expect(backend.stats.subpixelStrokeFallbacks, 1);
+      expect(backend.stats.rasterFallbacks, 1);
+      expect(backend.stats.lastTileRoute, 'canvas-fallback');
+    });
+  });
+
   testWidgets('dense hairlines roll transient buffers without crossing blocks',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Outcome

Dense subpixel CAD linework now switches the retained session to the viewer's exact Canvas path before GPU submission instead of allowing materially faint or missing strokes. Official GPU corpus routing is unchanged: Ghent remains 41 accepted / 16 conservative fallbacks and PDF.js remains 177 / 2 with the native system-font adapter.

## What changed

- Record the minimum positive stroke width for each retained paint unit, including composite ranges.
- At tile replay, compare selected strokes with the active MSAA coverage quantum (0.25 px at 4x MSAA, 1 px without MSAA).
- Retire the session only when a tile selects at least 128 affected paint units. Isolated thin strokes and PDF zero-width hairlines retain the established GPU route.
- Report `subpixelStrokeFallbacks` in backend diagnostics.
- Add a threshold regression proving 127 units stay on GPU and the 128th requests the exact Canvas fallback before submission.

<details>
<summary>Validation</summary>

- `fvm dart analyze`: clean
- Full native Metal package suite: 298 passed, 3 expected opt-in skips
- Native system-font corpus: Ghent 41 accepted / 16 fallback; PDF.js 177 / 2
- Audited affected CAD page: 265 positive-width paint units at 0.240 px now request Canvas instead of displaying the previously measured material GPU/Canvas difference
- Existing viewer fallback integration permanently serves the retired session through Canvas

</details>
