### PR TITLE
feat(gpu): retain soft-masked strokes

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -28,6 +28,9 @@
   resolve below the 0.25 px coverage quantum of 4x MSAA. This prevents dense
   CAD linework from becoming faint or disappearing at low zoom while isolated
   subpixel strokes retain the established GPU parity and routing.
+- Retain positive-width vector strokes under image and axial-gradient soft
+  masks, including dashed caps and joins. Zero-width masked hairlines remain
+  on the exact Canvas fallback because their geometry depends on tile scale.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -114,6 +114,11 @@ image soft mask directly through retained stencil geometry. Rectangular vector
 soft-mask fills, including alpha or luminosity backdrops and linearized
 transfer functions, are partitioned into constant-mask stencil cover cells and
 need no intermediate texture.
+Positive-width vector strokes also retain image and axial-gradient soft masks;
+their dashed caps and joins become the same exact stencil geometry used by
+ordinary retained strokes before the mask is applied. Masked zero-width
+hairlines stay on Canvas because their one-device-pixel geometry is tile-scale
+dependent.
 Tiles that sit at least one device pixel inside the transformed crop box use
 the folded opaque paper color as their render-pass clear, avoiding a separate
 transparent clear and full-tile paper draw. Boundary tiles retain the paper

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -291,9 +291,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             if (scene.imageFor(composite.mask) == null) {
               return 'missing soft-mask image pixels';
             }
+          case _SoftMaskStrokeSpec():
+            if (scene.imageFor(composite.mask) == null) {
+              return 'missing soft-mask image pixels';
+            }
           case _SoftMaskVectorFillSpec():
             break;
           case _SoftMaskGradientFillSpec():
+            break;
+          case _SoftMaskGradientStrokeSpec():
             break;
           case _SoftMaskTextSpec():
             if (scene.imageFor(composite.mask) == null) {
@@ -785,6 +791,29 @@ class _SoftMaskFillSpec extends _GpuCompositeSpec {
   final double transferOffset;
 }
 
+class _SoftMaskStrokeSpec extends _GpuCompositeSpec {
+  const _SoftMaskStrokeSpec({
+    required this.content,
+    required this.mask,
+    required this.contentClip,
+    required this.maskClip,
+    required this.luminosity,
+    required this.backdropLuminance,
+    required this.transferScale,
+    required this.transferOffset,
+  });
+
+  final PdfStrokePathCommand content;
+  final PdfImageRequest mask;
+  @override
+  final PdfRect? contentClip;
+  final PdfRect? maskClip;
+  final bool luminosity;
+  final double backdropLuminance;
+  final double transferScale;
+  final double transferOffset;
+}
+
 class _SoftMaskVectorFillSpec extends _GpuCompositeSpec {
   const _SoftMaskVectorFillSpec({
     required this.content,
@@ -815,6 +844,21 @@ class _SoftMaskGradientFillSpec extends _GpuCompositeSpec {
   });
 
   final PdfFillPathCommand content;
+  final PdfFillPathGradientCommand mask;
+  @override
+  final PdfRect? contentClip;
+  final bool luminosity;
+}
+
+class _SoftMaskGradientStrokeSpec extends _GpuCompositeSpec {
+  const _SoftMaskGradientStrokeSpec({
+    required this.content,
+    required this.mask,
+    required this.contentClip,
+    required this.luminosity,
+  });
+
+  final PdfStrokePathCommand content;
   final PdfFillPathGradientCommand mask;
   @override
   final PdfRect? contentClip;
@@ -1865,7 +1909,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             return (null, 'non-rectangular soft-mask fill clip');
           }
           clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
-        case PdfFillPathCommand() || PdfDrawTextCommand():
+        case PdfFillPathCommand() ||
+              PdfStrokePathCommand() ||
+              PdfDrawTextCommand():
           if (content != null) {
             return (null, 'soft-mask group has multiple paints');
           }
@@ -1923,6 +1969,19 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 ),
                 null,
               ),
+            PdfStrokePathCommand stroke when stroke.stroke.width > 0 => (
+                _SoftMaskGradientStrokeSpec(
+                  content: stroke,
+                  mask: gradient,
+                  contentClip: contentClip,
+                  luminosity: luminosity,
+                ),
+                null,
+              ),
+            PdfStrokePathCommand() => (
+                null,
+                'gradient soft-mask hairline requires Canvas fallback',
+              ),
             PdfDrawTextCommand text => (
                 _SoftMaskGradientTextSpec(
                   content: text,
@@ -1979,6 +2038,23 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             transferOffset: transferOffset,
           ),
           null,
+        ),
+      PdfStrokePathCommand stroke when stroke.stroke.width > 0 => (
+          _SoftMaskStrokeSpec(
+            content: stroke,
+            mask: mask.request,
+            contentClip: contentClip,
+            maskClip: maskState.$2,
+            luminosity: luminosity,
+            backdropLuminance: backdropLuminance,
+            transferScale: transferScale,
+            transferOffset: transferOffset,
+          ),
+          null,
+        ),
+      PdfStrokePathCommand() => (
+          null,
+          'image soft-mask hairline requires Canvas fallback'
         ),
       PdfDrawTextCommand text => (
           _SoftMaskTextSpec(
@@ -3361,10 +3437,22 @@ class _CompiledScene {
                 textureLeases,
                 mipmapImages: mipmapImages,
               ),
+            _SoftMaskStrokeSpec spec => await _compileSoftMaskStroke(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                mipmapImages: mipmapImages,
+              ),
             _SoftMaskVectorFillSpec spec =>
               _compileSoftMaskVectorFill(geometry, spec),
             _SoftMaskGradientFillSpec spec =>
               _compileSoftMaskGradientFill(geometry, spec),
+            _SoftMaskGradientStrokeSpec spec =>
+              _compileSoftMaskGradientStroke(geometry, spec),
             _SoftMaskTextSpec spec => await _compileSoftMaskText(
                 context,
                 geometry,
@@ -4800,6 +4888,65 @@ Future<_GpuDraw> _compileSoftMaskFill(
   );
 }
 
+Future<_GpuDraw> _compileSoftMaskStroke(
+    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
+    PdfRetainedScene scene,
+    _SoftMaskStrokeSpec spec,
+    FlutterGpuTileBackendStats stats,
+    _GpuImageCache imageCache,
+    List<_GpuImageTexture> textureLeases,
+    {required bool mipmapImages}) async {
+  final maskImage = scene.imageFor(spec.mask)!;
+  final maskResource = await imageCache.acquire(
+    context,
+    spec.mask,
+    maskImage,
+    stats,
+    mipmapped: mipmapImages,
+  );
+  textureLeases.add(maskResource);
+  final source = flattenPath(
+    spec.content.path,
+    PdfMatrix.identity,
+    tolerance: 0.01,
+  );
+  final subpaths = _prepareStrokeSubpaths(source, spec.content.stroke);
+  final stencil = _stencilGeometry(
+    geometry,
+    _strokeRings(subpaths, spec.content.stroke),
+  );
+  if (stencil == null) throw StateError('empty soft-mask stroke path');
+  final bounds = stencil.$2;
+  final cover = _imageVertices(PdfMatrix(
+    bounds.right - bounds.left,
+    0,
+    0,
+    bounds.top - bounds.bottom,
+    bounds.left,
+    bounds.bottom,
+  ));
+  return _SoftMaskFillDraw(
+    stencil.$1,
+    geometry.add(cover.bytes, cover.length ~/ 4),
+    PdfFillRule.nonzero,
+    maskResource.texture,
+    _softMaskInfo(
+      context,
+      maskTransform: spec.mask.transform,
+      contentTint: _premul(spec.content.color, spec.content.alpha),
+      maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
+      contentStencil: true,
+      maskStencil: false,
+      luminosity: spec.luminosity,
+      backdropLuminance: spec.backdropLuminance,
+      transferScale: spec.transferScale,
+      transferOffset: spec.transferOffset,
+      maskClip: spec.maskClip,
+    ),
+  );
+}
+
 Future<_GpuDraw> _compileSoftMaskText(
     gpu.GpuContext context,
     _GpuGeometryArena geometry,
@@ -4865,6 +5012,38 @@ _GpuDraw? _compileSoftMaskGradientFill(
     geometry,
     subpaths,
     spec.content.rule,
+    spec.mask.gradient,
+    1,
+    vertexColor: (maskColor) {
+      final mask = spec.luminosity
+          ? (0.2126 * maskColor.red +
+                  0.7152 * maskColor.green +
+                  0.0722 * maskColor.blue) *
+              maskAlpha
+          : maskAlpha;
+      return _premul(
+        spec.content.color,
+        (spec.content.alpha * mask).clamp(0.0, 1.0),
+      );
+    },
+  );
+}
+
+_GpuDraw? _compileSoftMaskGradientStroke(
+  _GpuGeometryArena geometry,
+  _SoftMaskGradientStrokeSpec spec,
+) {
+  final source = flattenPath(
+    spec.content.path,
+    PdfMatrix.identity,
+    tolerance: 0.01,
+  );
+  final subpaths = _prepareStrokeSubpaths(source, spec.content.stroke);
+  final maskAlpha = spec.mask.alpha.clamp(0.0, 1.0);
+  return _compileGradientSubpaths(
+    geometry,
+    _strokeRings(subpaths, spec.content.stroke),
+    PdfFillRule.nonzero,
     spec.mask.gradient,
     1,
     vertexColor: (maskColor) {
@@ -5428,10 +5607,7 @@ _GpuDraw? _compileStrokeSubpaths(
   PdfStroke stroke,
   double alpha,
 ) {
-  var subpaths = source;
-  if (stroke.dashArray.any((value) => value > 0)) {
-    subpaths = dashSubpaths(subpaths, stroke.dashArray, stroke.dashPhase);
-  }
+  final subpaths = _prepareStrokeSubpaths(source, stroke);
   if (stroke.width <= 0) {
     return alpha <= 0
         ? null
@@ -5442,6 +5618,23 @@ _GpuDraw? _compileStrokeSubpaths(
             alpha,
           );
   }
+  return _stencilDraw(
+    geometry,
+    _strokeRings(subpaths, stroke),
+    color,
+    alpha,
+    PdfFillRule.nonzero,
+    true,
+  );
+}
+
+List<FlatSubpath> _prepareStrokeSubpaths(
+        List<FlatSubpath> source, PdfStroke stroke) =>
+    stroke.dashArray.any((value) => value > 0)
+        ? dashSubpaths(source, stroke.dashArray, stroke.dashPhase)
+        : source;
+
+List<FlatSubpath> _strokeRings(List<FlatSubpath> subpaths, PdfStroke stroke) {
   final contours = StrokeContours();
   strokeToContours(
     subpaths,
@@ -5459,7 +5652,7 @@ _GpuDraw? _compileStrokeSubpaths(
       closed: true,
     ));
   }
-  return _stencilDraw(geometry, rings, color, alpha, PdfFillRule.nonzero, true);
+  return rings;
 }
 
 List<FlatSubpath>? _textSubpaths(PdfTextRun run) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3379,6 +3379,128 @@ void main() {
     });
   });
 
+  testWidgets('positive-width strokes use an image soft mask directly',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      PdfDrawImageCommand mask(String id) => _decodedImage(
+            Uint8List.fromList([
+              0,
+              0,
+              0,
+              255,
+              255,
+              255,
+              255,
+              255,
+              0,
+              0,
+              0,
+              255,
+              255,
+              255,
+              255,
+              255,
+            ]),
+            const PdfMatrix(220, 0, 0, 220, 40, 90),
+            id,
+          );
+      const path = PdfPath([
+        PdfMoveTo(60, 120),
+        PdfLineTo(225, 170),
+        PdfLineTo(75, 285),
+      ]);
+      final maskedStroke = mask('stroke-mask');
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginSoftMaskedCommand(),
+          const PdfClipPathCommand(
+            PdfPath([
+              PdfMoveTo(50, 100),
+              PdfLineTo(250, 100),
+              PdfLineTo(250, 300),
+              PdfLineTo(50, 300),
+              PdfClosePath(),
+            ]),
+            PdfFillRule.nonzero,
+          ),
+          const PdfStrokePathCommand(
+            path,
+            PdfColor(0.12, 0.38, 0.84),
+            PdfStroke(
+              width: 18,
+              cap: 1,
+              join: 1,
+              dashArray: [32, 13],
+              dashPhase: 5,
+            ),
+            0.8,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: [maskedStroke],
+            backdropLuminance: 0.15,
+            transferScale: 0.8,
+            transferOffset: 0.05,
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(30, 80, 240, 240);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(8));
+      expect(backend.stats.texturesUploaded, 1);
+      expect(backend.stats.textureDirectUploads, 1);
+      expect(maskedStroke.request.decoded, isNull);
+
+      final hairlineMask = mask('hairline-mask');
+      final hairlineScene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginSoftMaskedCommand(),
+          const PdfStrokePathCommand(
+            path,
+            PdfColor(0, 0, 0),
+            PdfStroke(width: 0),
+            1,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: page.cropBox,
+            maskCommands: [hairlineMask],
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(hairlineScene.dispose);
+      final hairlineBackend = FlutterGpuTileRasterBackend();
+      expect(hairlineBackend.createSession(hairlineScene), isNull);
+      expect(
+        hairlineBackend.lastSessionRejection,
+        'image soft-mask hairline requires Canvas fallback',
+      );
+    });
+  });
+
   testWidgets('rectangular vector masks retain backdrop and transfer values',
       (tester) async {
     await tester.runAsync(() async {
@@ -3664,6 +3786,73 @@ void main() {
       var difference = 0;
       for (var i = 0; i < a.length; i++) {
         difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(6));
+      expect(backend.stats.lastTileRoute, 'flutter_gpu');
+      expect(backend.stats.texturesUploaded, 0);
+    });
+  });
+
+  testWidgets('axial gradient soft masks tint retained vector strokes',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const maskGradient = PdfGradient(
+        isRadial: false,
+        coords: [0, 0, 1, 0],
+        colors: [PdfColor(0, 0, 0), PdfColor(1, 1, 1)],
+        stops: [0, 1],
+        transform: PdfMatrix(220, 0, 0, 220, 40, 80),
+      );
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginSoftMaskedCommand(),
+        const PdfStrokePathCommand(
+          PdfPath([
+            PdfMoveTo(60, 110),
+            PdfLineTo(235, 175),
+            PdfLineTo(70, 280),
+          ]),
+          PdfColor(0.18, 0.62, 0.85),
+          PdfStroke(
+            width: 16,
+            cap: 1,
+            join: 1,
+            dashArray: [27, 11],
+            dashPhase: 4,
+          ),
+          0.75,
+        ),
+        PdfEndSoftMaskedCommand(
+          luminosity: true,
+          backdrop: page.cropBox,
+          maskCommands: [
+            PdfFillPathGradientCommand(
+              _rect(35, 75, 265, 305),
+              PdfFillRule.nonzero,
+              maskGradient,
+              0.9,
+            ),
+          ],
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(25, 470, 250, 250);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
       }
       expect(difference / a.length, lessThan(6));
       expect(backend.stats.lastTileRoute, 'flutter_gpu');


### PR DESCRIPTION
## Outcome

Three real Trax pages that previously fell back to Canvas now stay on Flutter GPU. Warm same-host tile rendering is about **5–9× faster**, with mean channel differences of **0.56–1.81** versus the Canvas reference.

Official system-font corpus routing is unchanged: **Ghent 41 GPU / 16 exact fallbacks** and **PDF.js 177 GPU / 2 exact fallbacks**.

<details>
<summary>Implementation and validation</summary>

- Retains positive-width stroked paths inside image and axial-gradient soft masks.
- Reuses the exact stroke contour builder, preserving dash, cap, and join geometry.
- Clips the existing image-mask or axial-gradient shader through the generated stroke stencil.
- Keeps zero-width masked hairlines on the exact Canvas fallback because their geometry depends on tile level of detail.
- Adds native GPU parity regressions for image-mask strokes and axial-gradient-mask strokes.

Real document benchmark, `TRAX ARTC BRIEF 010622.pdf`:

| Page | Before | After | Mean diff | Warm GPU | Canvas | Speedup |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| 2 | Canvas fallback | Flutter GPU | 0.558 | 4.03 ms | 36.39 ms | 9.0× |
| 3 | Canvas fallback | Flutter GPU | 1.809 | 9.80 ms | 48.91 ms | 5.0× |
| 4 | Canvas fallback | Flutter GPU | 1.321 | 7.56 ms | 67.60 ms | 8.9× |

Validation:

- `fvm dart analyze packages/dart_pdf_editor_flutter_gpu`
- Two focused native Flutter GPU parity tests
- Full native GPU package suite: 300 passed, 3 expected skips
- Ghent system-font corpus: 41 accepted / 16 exact fallbacks
- PDF.js system-font corpus: 177 accepted / 2 exact fallbacks

</details>
