### PR TITLE
feat(gpu): retain nested soft-mask layers

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -31,6 +31,10 @@
 - Retain positive-width vector strokes under image and axial-gradient soft
   masks, including dashed caps and joins. Zero-width masked hairlines remain
   on the exact Canvas fallback because their geometry depends on tile scale.
+- Retain a single ordinary soft-masked source nested inside a transparency
+  group by resolving the mask in one bounded offscreen target before applying
+  the enclosing group alpha. Explicit backdrops, non-Normal internal blends,
+  enabled overprint, and additional paints remain exact Canvas fallbacks.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -119,6 +119,11 @@ their dashed caps and joins become the same exact stencil geometry used by
 ordinary retained strokes before the mask is applied. Masked zero-width
 hairlines stay on Canvas because their one-device-pixel geometry is tile-scale
 dependent.
+A single ordinary soft-masked source may itself sit inside a transparency
+group: the backend resolves that source in a bounded offscreen target and then
+applies the enclosing group alpha once. This exact route requires no explicit
+group backdrop, a Normal internal blend, and no enabled overprint; the other
+forms remain on Canvas.
 Tiles that sit at least one device pixel inside the transformed crop box use
 the folded opaque paper color as their render-pass clear, avoiding a separate
 transparent clear and full-tile paper draw. Boundary tiles retain the paper

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -310,6 +310,12 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
           case _SoftMaskGradientTextSpec():
             final reason = _unsupportedTextReason(composite.content.run);
             if (reason != null) return reason;
+          case _SoftMaskGroupSpec():
+            final reason = _unsupportedNestedSoftMaskReason(
+              scene,
+              composite.content,
+            );
+            if (reason != null) return reason;
           case _GroupFillSpec():
             break;
           case _GroupStrokeSpec():
@@ -400,6 +406,41 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         default:
           break;
       }
+    }
+    return null;
+  }
+
+  static String? _unsupportedNestedSoftMaskReason(
+    PdfRetainedScene scene,
+    _GpuCompositeSpec composite,
+  ) {
+    switch (composite) {
+      case _SoftMaskImageSpec():
+        if (scene.imageFor(composite.content) == null ||
+            scene.imageFor(composite.mask) == null) {
+          return 'missing soft-mask image pixels';
+        }
+      case _SoftMaskFillSpec():
+        if (scene.imageFor(composite.mask) == null) {
+          return 'missing soft-mask image pixels';
+        }
+      case _SoftMaskStrokeSpec():
+        if (scene.imageFor(composite.mask) == null) {
+          return 'missing soft-mask image pixels';
+        }
+      case _SoftMaskVectorFillSpec() ||
+            _SoftMaskGradientFillSpec() ||
+            _SoftMaskGradientStrokeSpec():
+        break;
+      case _SoftMaskTextSpec():
+        if (scene.imageFor(composite.mask) == null) {
+          return 'missing soft-mask image pixels';
+        }
+        return _unsupportedTextReason(composite.content.run);
+      case _SoftMaskGradientTextSpec():
+        return _unsupportedTextReason(composite.content.run);
+      default:
+        return 'unsupported nested soft-mask group';
     }
     return null;
   }
@@ -901,6 +942,18 @@ class _SoftMaskGradientTextSpec extends _GpuCompositeSpec {
   @override
   final PdfRect? contentClip;
   final bool luminosity;
+}
+
+/// One already-masked source that must be composited through its enclosing
+/// transparency-group alpha after the mask has resolved.
+class _SoftMaskGroupSpec extends _GpuCompositeSpec {
+  const _SoftMaskGroupSpec(this.content, this.groupAlpha);
+
+  final _GpuCompositeSpec content;
+  final double groupAlpha;
+
+  @override
+  PdfRect? get contentClip => content.contentClip;
 }
 
 class _VectorMaskFill {
@@ -1432,6 +1485,18 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       );
       if (knockoutFill != null) return (knockoutFill, null);
     }
+    final singleSoftMask = _parseSingleSoftMaskGroup(
+      commands,
+      start,
+      end,
+      groupAlpha: alpha,
+      backdropColor: backdropColor,
+      initialClip: initialClip,
+      initialFillOverprint: initialFillOverprint,
+      initialStrokeOverprint: initialStrokeOverprint,
+      initialBlend: initialBlend,
+    );
+    if (singleSoftMask != null) return (singleSoftMask, null);
     // Knockout only changes how multiple sibling elements interact inside a
     // group. A one-element group is therefore identical either way. The
     // multi-paint path below is deliberately narrower: alpha-one, normal
@@ -2073,6 +2138,117 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     };
   }
   return (null, 'unsupported composite ${commands[start].runtimeType}');
+}
+
+/// Retains a one-element soft-masked transparency group as one bounded layer.
+///
+/// The soft mask first resolves the source shape inside a transparent group;
+/// only then does the enclosing group alpha apply to that completed source.
+/// Keeping those stages separate mirrors Canvas' saveLayer ordering and avoids
+/// edge-coverage differences from folding the alpha into the masked paint.
+/// State-only commands may surround the element; additional paints, explicit
+/// backdrops, and non-Normal internal blends stay on Canvas.
+_GpuCompositeSpec? _parseSingleSoftMaskGroup(
+  List<PdfRenderCommand> commands,
+  int start,
+  int end, {
+  required double groupAlpha,
+  required PdfColor? backdropColor,
+  required PdfRect? initialClip,
+  required bool initialFillOverprint,
+  required bool initialStrokeOverprint,
+  required PdfBlendMode initialBlend,
+}) {
+  if (backdropColor != null || !groupAlpha.isFinite) return null;
+  var clip = initialClip;
+  var blend = initialBlend;
+  var fillOverprint = initialFillOverprint;
+  var strokeOverprint = initialStrokeOverprint;
+  final saved = <(PdfRect?, PdfBlendMode, bool, bool)>[];
+  _GpuCompositeSpec? nested;
+
+  int? nestedEnd(int nestedStart) {
+    var depth = 1;
+    for (var index = nestedStart + 1; index < end; index++) {
+      switch (commands[index]) {
+        case PdfBeginSoftMaskedCommand():
+          depth++;
+        case PdfEndSoftMaskedCommand():
+          depth--;
+          if (depth == 0) return index;
+        case PdfBeginGroupCommand() || PdfEndGroupCommand():
+          return null;
+        default:
+          break;
+      }
+    }
+    return null;
+  }
+
+  for (var index = start + 1; index < end; index++) {
+    final command = commands[index];
+    switch (command) {
+      case PdfSaveCommand():
+        saved.add((clip, blend, fillOverprint, strokeOverprint));
+      case PdfRestoreCommand():
+        if (saved.isEmpty) return null;
+        final restored = saved.removeLast();
+        clip = restored.$1;
+        blend = restored.$2;
+        fillOverprint = restored.$3;
+        strokeOverprint = restored.$4;
+      case PdfClipPathCommand(:final path):
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) return null;
+        clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (clip == null) return null;
+      case PdfSetBlendModeCommand(:final mode):
+        blend = mode;
+      case PdfSetOverprintCommand(:final fill, :final stroke):
+        fillOverprint = fill;
+        strokeOverprint = stroke;
+      case PdfBeginSoftMaskedCommand():
+        if (nested != null ||
+            blend != PdfBlendMode.normal ||
+            fillOverprint ||
+            strokeOverprint) {
+          return null;
+        }
+        final stop = nestedEnd(index);
+        if (stop == null) return null;
+        for (var scan = index + 1; scan < stop; scan++) {
+          if (commands[scan]
+              case PdfSetOverprintCommand(:final fill, :final stroke)
+              when fill || stroke) {
+            // Canvas' RGB overprint fallback is destination-dependent inside
+            // the transparent soft-mask capture. Do not treat it as a plain
+            // one-source layer; keep the exact Canvas route.
+            return null;
+          }
+        }
+        final parsed = _parseComposite(
+          commands,
+          index,
+          stop,
+          initialClip: clip,
+          initialFillOverprint: fillOverprint,
+          initialStrokeOverprint: strokeOverprint,
+          initialBlend: blend,
+        ).$1;
+        if (parsed == null) return null;
+        nested = _SoftMaskGroupSpec(
+          parsed,
+          groupAlpha.clamp(0.0, 1.0).toDouble(),
+        );
+        index = stop;
+      case PdfBeginGroupCommand() ||
+            PdfEndGroupCommand() ||
+            PdfEndSoftMaskedCommand():
+        return null;
+      default:
+        if (pdfRenderCommandBounds(command) != null) return null;
+    }
+  }
+  return saved.isEmpty ? nested : null;
 }
 
 /// Recognizes the exact isolated-knockout shape emitted by PDF.js's
@@ -3465,6 +3641,16 @@ class _CompiledScene {
               ),
             _SoftMaskGradientTextSpec spec =>
               _compileSoftMaskGradientText(geometry, spec),
+            _SoftMaskGroupSpec spec => await _compileSoftMaskGroup(
+                context,
+                geometry,
+                scene,
+                spec,
+                stats,
+                imageCache,
+                textureLeases,
+                mipmapImages: mipmapImages,
+              ),
           };
         }
         if (draw != null) draws[unit.commandIndex] = draw;
@@ -4828,6 +5014,82 @@ _GpuDraw? _compileKnockoutSoftMaskFill(
   if (paints.isEmpty) return null;
   return _OffscreenGroupDraw(
     paints,
+    spec.groupAlpha,
+    0,
+  );
+}
+
+Future<_GpuDraw?> _compileSoftMaskGroup(
+  gpu.GpuContext context,
+  _GpuGeometryArena geometry,
+  PdfRetainedScene scene,
+  _SoftMaskGroupSpec spec,
+  FlutterGpuTileBackendStats stats,
+  _GpuImageCache imageCache,
+  List<_GpuImageTexture> textureLeases, {
+  required bool mipmapImages,
+}) async {
+  final content = spec.content;
+  final _GpuDraw? draw;
+  switch (content) {
+    case _SoftMaskImageSpec():
+      draw = await _compileSoftMaskImage(
+        context,
+        geometry,
+        scene,
+        content,
+        stats,
+        imageCache,
+        textureLeases,
+        mipmapImages: mipmapImages,
+      );
+    case _SoftMaskFillSpec():
+      draw = await _compileSoftMaskFill(
+        context,
+        geometry,
+        scene,
+        content,
+        stats,
+        imageCache,
+        textureLeases,
+        mipmapImages: mipmapImages,
+      );
+    case _SoftMaskStrokeSpec():
+      draw = await _compileSoftMaskStroke(
+        context,
+        geometry,
+        scene,
+        content,
+        stats,
+        imageCache,
+        textureLeases,
+        mipmapImages: mipmapImages,
+      );
+    case _SoftMaskVectorFillSpec():
+      draw = _compileSoftMaskVectorFill(geometry, content);
+    case _SoftMaskGradientFillSpec():
+      draw = _compileSoftMaskGradientFill(geometry, content);
+    case _SoftMaskGradientStrokeSpec():
+      draw = _compileSoftMaskGradientStroke(geometry, content);
+    case _SoftMaskTextSpec():
+      draw = await _compileSoftMaskText(
+        context,
+        geometry,
+        scene,
+        content,
+        stats,
+        imageCache,
+        textureLeases,
+        mipmapImages: mipmapImages,
+      );
+    case _SoftMaskGradientTextSpec():
+      draw = _compileSoftMaskGradientText(geometry, content);
+    default:
+      return null;
+  }
+  if (draw == null) return null;
+  return _OffscreenGroupDraw(
+    [(draw, null, PdfBlendMode.normal, false)],
     spec.groupAlpha,
     0,
   );

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3793,6 +3793,153 @@ void main() {
     });
   });
 
+  testWidgets('single soft-masked groups retain their layer alpha exactly',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const maskGradient = PdfGradient(
+        isRadial: false,
+        coords: [0, 0, 1, 0],
+        colors: [PdfColor(0.05, 0.05, 0.05), PdfColor(1, 1, 1)],
+        stops: [0, 1],
+        transform: PdfMatrix(210, 0, 0, 210, 45, 85),
+      );
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfBeginGroupCommand(
+          0.42,
+          knockout: false,
+          isolated: false,
+          bounds: const PdfRect(40, 80, 260, 310),
+        ),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(
+          _rect(50, 90, 250, 300),
+          PdfFillRule.nonzero,
+        ),
+        const PdfBeginSoftMaskedCommand(),
+        const PdfSetOverprintCommand(fill: false, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(35, 75, 265, 315),
+          const PdfColor(0.82, 0.24, 0.48),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        PdfEndSoftMaskedCommand(
+          luminosity: true,
+          backdrop: page.cropBox,
+          maskCommands: [
+            PdfFillPathGradientCommand(
+              _rect(30, 70, 270, 320),
+              PdfFillRule.nonzero,
+              maskGradient,
+              1,
+            ),
+          ],
+        ),
+        const PdfSetOverprintCommand(fill: false, stroke: false, mode: 1),
+        const PdfRestoreCommand(),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      const region = Rect.fromLTWH(30, 460, 250, 270);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(6));
+      expect(backend.stats.lastTileRoute, 'flutter_gpu');
+      expect(backend.stats.offscreenGroupPasses, 1,
+          reason: 'the group alpha applies after the masked source resolves');
+
+      final unsafe = await PdfRetainedScene.fromCommands(page, [
+        PdfBeginGroupCommand(
+          0.42,
+          knockout: false,
+          isolated: false,
+          bounds: const PdfRect(40, 80, 260, 310),
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginSoftMaskedCommand(),
+        PdfFillPathCommand(
+          _rect(50, 90, 250, 300),
+          const PdfColor(0.82, 0.24, 0.48),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        PdfEndSoftMaskedCommand(
+          luminosity: true,
+          backdrop: page.cropBox,
+          maskCommands: [
+            PdfFillPathGradientCommand(
+              _rect(30, 70, 270, 320),
+              PdfFillRule.nonzero,
+              maskGradient,
+              1,
+            ),
+          ],
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(unsafe.dispose);
+      final conservative = FlutterGpuTileRasterBackend();
+      expect(conservative.createSession(unsafe), isNull);
+      expect(
+        conservative.lastSessionRejection,
+        contains('soft-mask group contains'),
+      );
+
+      final overprint = await PdfRetainedScene.fromCommands(page, [
+        PdfBeginGroupCommand(
+          0.42,
+          knockout: false,
+          isolated: false,
+          bounds: const PdfRect(40, 80, 260, 310),
+        ),
+        const PdfBeginSoftMaskedCommand(),
+        const PdfSetOverprintCommand(fill: true, stroke: true, mode: 1),
+        PdfFillPathCommand(
+          _rect(50, 90, 250, 300),
+          const PdfColor(0.82, 0.24, 0.48),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        PdfEndSoftMaskedCommand(
+          luminosity: true,
+          backdrop: page.cropBox,
+          maskCommands: [
+            PdfFillPathGradientCommand(
+              _rect(30, 70, 270, 320),
+              PdfFillRule.nonzero,
+              maskGradient,
+              1,
+            ),
+          ],
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(overprint.dispose);
+      final overprintBackend = FlutterGpuTileRasterBackend();
+      expect(overprintBackend.createSession(overprint), isNull);
+      expect(
+        overprintBackend.lastSessionRejection,
+        contains('soft-mask group contains'),
+      );
+    });
+  });
+
   testWidgets('axial gradient soft masks tint retained vector strokes',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Summary

- retain one ordinary soft-masked source nested inside a transparency group
- resolve the inner mask in one bounded offscreen target, then apply the enclosing group alpha after mask resolution
- keep explicit backdrops, non-Normal internal blends, enabled overprint, and additional paints on the exact Canvas fallback

## Why

Applying group alpha directly to the source is not generally equivalent to applying it after the soft mask. This keeps the two composition stages separate, matching Canvas save-layer ordering while expanding the safe retained GPU subset.

## Validation

- `fvm dart analyze packages/dart_pdf_editor_flutter_gpu`
- focused native exact-pixel test for image-masked and vector-masked nested sources
- full native Flutter GPU suite: 301 passed, 3 expected skips
- system-font corpus parity unchanged: Ghent 41 GPU / 16 exact fallbacks; PDF.js 177 GPU / 2 exact fallbacks
- explicit negative coverage for non-Normal internal blends and enabled overprint

The known private-corpus nested instance enables process-color overprint, so it deliberately remains on Canvas; this PR does not claim that unsafe route.
