### PR TITLE
feat(gpu): skip empty-clipped group paints

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -35,6 +35,10 @@
   group by resolving the mask in one bounded offscreen target before applying
   the enclosing group alpha. Explicit backdrops, non-Normal internal blends,
   enabled overprint, and additional paints remain exact Canvas fallbacks.
+- Treat paints behind a provably empty rectangular clip as no-ops while
+  parsing transparency groups, carrying that clip state through save/restore
+  and balanced soft-mask structures. Empty group content no longer forces an
+  otherwise supported page onto Canvas.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -124,6 +124,10 @@ group: the backend resolves that source in a bounded offscreen target and then
 applies the enclosing group alpha once. This exact route requires no explicit
 group backdrop, a Normal internal blend, and no enabled overprint; the other
 forms remain on Canvas.
+Paints behind a degenerate or disjoint rectangular clip are discarded while
+capturing a transparency group, including balanced soft-mask content that can
+no longer affect a pixel. Save/restore still reinstates the prior clip for any
+later visible paint.
 Tiles that sit at least one device pixel inside the transformed crop box use
 the folded opaque paper color as their render-pass clear, avoiding a separate
 transparent clear and full-tile paper draw. Boundary tiles retain the paper

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -1509,11 +1509,13 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     PdfRect? clip = initialClip;
     PdfRect? contentClip;
     var emptyClipOnly = false;
+    PdfRect? emptyClipBounds;
+    var skippedEmptyPaint = false;
     var fillOverprint = initialFillOverprint;
     var strokeOverprint = initialStrokeOverprint;
     var blend = initialBlend;
     var invisibleGroupDepth = 0;
-    final saved = <(PdfRect?, bool, bool, PdfBlendMode)>[];
+    final saved = <(PdfRect?, bool, bool, bool, PdfBlendMode)>[];
     for (var i = start + 1; i < end; i++) {
       final command = commands[i];
       if (invisibleGroupDepth != 0) {
@@ -1528,14 +1530,21 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       }
       switch (command) {
         case PdfSaveCommand():
-          saved.add((clip, fillOverprint, strokeOverprint, blend));
+          saved.add((
+            clip,
+            emptyClipOnly,
+            fillOverprint,
+            strokeOverprint,
+            blend,
+          ));
         case PdfRestoreCommand():
           if (saved.isEmpty) return (null, 'unbalanced soft-mask image state');
           final restored = saved.removeLast();
           clip = restored.$1;
-          fillOverprint = restored.$2;
-          strokeOverprint = restored.$3;
-          blend = restored.$4;
+          emptyClipOnly = restored.$2;
+          fillOverprint = restored.$3;
+          strokeOverprint = restored.$4;
+          blend = restored.$5;
         case PdfClipPathCommand(:final path):
           if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
             return (null, 'non-rectangular soft-mask image clip');
@@ -1549,6 +1558,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               (clip != null && pathBounds != null && narrowed == null)) {
             emptyClipOnly = true;
             clip = pathBounds;
+            emptyClipBounds ??= pathBounds;
             break;
           }
           clip = narrowed;
@@ -1560,7 +1570,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           softEnd = command;
         case PdfDrawImageCommand():
           if (emptyClipOnly) {
-            return (null, 'empty transparency group contains paint');
+            skippedEmptyPaint = true;
+            break;
           }
           if (softDepth == 0 && content == null) {
             paints.add((i, command, clip, blend, false));
@@ -1574,7 +1585,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip = clip;
         case PdfFillPathCommand():
           if (emptyClipOnly) {
-            return (null, 'empty transparency group contains paint');
+            skippedEmptyPaint = true;
+            break;
           }
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfFillPathCommand');
@@ -1583,7 +1595,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip = clip;
         case PdfFillPathGradientCommand() || PdfFillMeshCommand():
           if (emptyClipOnly) {
-            return (null, 'empty transparency group contains paint');
+            skippedEmptyPaint = true;
+            break;
           }
           if (softDepth != 0 || content != null) {
             return (
@@ -1595,7 +1608,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip = clip;
         case PdfStrokePathCommand():
           if (emptyClipOnly) {
-            return (null, 'empty transparency group contains paint');
+            skippedEmptyPaint = true;
+            break;
           }
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfStrokePathCommand');
@@ -1604,7 +1618,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           contentClip = clip;
         case PdfDrawTextCommand(:final run):
           if (emptyClipOnly) {
-            return (null, 'empty transparency group contains paint');
+            skippedEmptyPaint = true;
+            break;
           }
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfDrawTextCommand');
@@ -1719,8 +1734,11 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     if (invisibleGroupDepth != 0) {
       return (null, 'unbalanced invisible transparency group');
     }
-    if (emptyClipOnly && softCount == 0 && paints.isEmpty && content == null) {
-      return (_EmptyGroupSpec(clip!), null);
+    if ((emptyClipOnly || skippedEmptyPaint) &&
+        softDepth == 0 &&
+        paints.isEmpty &&
+        content == null) {
+      return (_EmptyGroupSpec(emptyClipBounds ?? clip!), null);
     }
     if (softCount == 0 && softDepth == 0 && paints.length == 1) {
       final paint = paints.single;

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1916,9 +1916,113 @@ void main() {
         const PdfEndGroupCommand(),
       ]);
       addTearDown(painted.dispose);
-      final conservative = FlutterGpuTileRasterBackend();
-      expect(conservative.createSession(painted), isNull);
-      expect(conservative.stats.lastRejection, contains('contains paint'));
+      final paintedBackend = FlutterGpuTileRasterBackend();
+      final paintedSession = paintedBackend.createSession(painted);
+      expect(paintedSession, isNotNull,
+          reason: paintedBackend.stats.lastRejection);
+      addTearDown(paintedSession!.dispose);
+      const paintedRegion = Rect.fromLTWH(40, 70, 80, 180);
+      final paintedExpected =
+          await painted.rasterizeRegion(paintedRegion, pixelRatio: 1);
+      final paintedActual =
+          await paintedSession.rasterizeRegion(paintedRegion, pixelRatio: 1);
+      addTearDown(paintedExpected.dispose);
+      addTearDown(paintedActual.dispose);
+      expect(await _pixels(paintedActual), await _pixels(paintedExpected));
+
+      final restored = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(1),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(80, 100, 80, 220), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(60, 90, 100, 230),
+          const PdfColor(0.8, 0.2, 0.1),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfRestoreCommand(),
+        PdfFillPathCommand(
+          _rect(140, 90, 260, 230),
+          const PdfColor(0.15, 0.45, 0.85),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(restored.dispose);
+      final restoredBackend = FlutterGpuTileRasterBackend();
+      final restoredSession = restoredBackend.createSession(restored);
+      expect(restoredSession, isNotNull,
+          reason: restoredBackend.stats.lastRejection);
+      addTearDown(restoredSession!.dispose);
+      const restoredRegion = Rect.fromLTWH(40, 70, 240, 180);
+      final restoredExpected =
+          await restored.rasterizeRegion(restoredRegion, pixelRatio: 1);
+      final restoredActual =
+          await restoredSession.rasterizeRegion(restoredRegion, pixelRatio: 1);
+      addTearDown(restoredExpected.dispose);
+      addTearDown(restoredActual.dispose);
+      final restoredA = await _pixels(restoredExpected);
+      final restoredB = await _pixels(restoredActual);
+      var restoredDifference = 0;
+      for (var index = 0; index < restoredA.length; index++) {
+        restoredDifference += (restoredA[index] - restoredB[index]).abs();
+      }
+      expect(restoredDifference / restoredA.length, lessThan(1));
+
+      final transform = const PdfMatrix(80, 0, 0, 80, 60, 90);
+      final maskedEmpty = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(1),
+          const PdfSaveCommand(),
+          PdfClipPathCommand(_rect(80, 100, 80, 220), PdfFillRule.nonzero),
+          const PdfBeginSoftMaskedCommand(),
+          _decodedImage(
+            Uint8List.fromList([
+              for (var i = 0; i < 4; i++) ...const [200, 40, 20, 255],
+            ]),
+            transform,
+            'empty-clipped-content',
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: page.cropBox,
+            maskCommands: [
+              _decodedImage(
+                Uint8List.fromList([
+                  for (var i = 0; i < 4; i++) ...const [255, 255, 255, 255],
+                ]),
+                transform,
+                'empty-clipped-mask',
+              ),
+            ],
+          ),
+          const PdfRestoreCommand(),
+          const PdfEndGroupCommand(),
+          PdfFillPathCommand(
+            _rect(180, 90, 300, 230),
+            const PdfColor(0.2, 0.55, 0.85),
+            PdfFillRule.nonzero,
+            0.9,
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(maskedEmpty.dispose);
+      final maskedBackend = FlutterGpuTileRasterBackend();
+      final maskedSession = maskedBackend.createSession(maskedEmpty);
+      expect(maskedSession, isNotNull,
+          reason: maskedBackend.stats.lastRejection);
+      addTearDown(maskedSession!.dispose);
+      const maskedRegion = Rect.fromLTWH(40, 70, 280, 180);
+      final maskedExpected =
+          await maskedEmpty.rasterizeRegion(maskedRegion, pixelRatio: 1);
+      final maskedActual =
+          await maskedSession.rasterizeRegion(maskedRegion, pixelRatio: 1);
+      addTearDown(maskedExpected.dispose);
+      addTearDown(maskedActual.dispose);
+      expect(await _pixels(maskedActual), await _pixels(maskedExpected));
     });
   });
 


### PR DESCRIPTION
## What changed

- carry an empty rectangular clip through save and restore while parsing transparency groups
- discard paints that cannot contribute behind a degenerate or disjoint clip
- represent a balanced group with no visible content as an exact no-op
- preserve later visible paints after restoring the graphics state

## Validation

- dart_pdf_editor_flutter_gpu analyzer clean
- focused native Flutter GPU parity test passes after rebasing onto main
- full native GPU suite: 301 passed, 3 expected skips
- Ghent GPU corpus routing unchanged
- PDF.js GPU corpus routing unchanged