### PR TITLE
perf(gpu): skip sparse system-text atlases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,6 @@ jobs:
                   "$label" == "vector-stack-2" ||
                   "$label" == "text-mask-1" ||
                   "$label" == "text-mask-2" ||
-                  "$label" == "system-text" ||
-                  "$label" == "cjk-text" ||
                   "$label" == "advanced-blend" ||
                   "$label" == "advanced-blend-stress" ||
                   "$label" == "knockout-mask" ||
@@ -416,8 +414,12 @@ jobs:
             --require-scenario-runs gpu-text-mask-1-page-0-canvas-tile=6
             --require-scenario-runs gpu-text-mask-2-page-0-first-tile=6
             --require-scenario-runs gpu-text-mask-2-page-0-canvas-tile=6
+            --require-scenario-runs gpu-system-text-pipeline-warm=6
+            --require-scenario-runs gpu-system-text-page-0-scene-warm=6
             --require-scenario-runs gpu-system-text-page-0-first-tile=6
             --require-scenario-runs gpu-system-text-page-0-canvas-tile=6
+            --require-scenario-runs gpu-cjk-text-pipeline-warm=6
+            --require-scenario-runs gpu-cjk-text-page-0-scene-warm=6
             --require-scenario-runs gpu-cjk-text-page-0-first-tile=6
             --require-scenario-runs gpu-cjk-text-page-0-canvas-tile=6
             --require-scenario-runs gpu-advanced-blend-page-0-first-tile=6

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 
+- Keep sparse native system-font outlines on retained stencil geometry instead
+  of allocating a curve atlas for fewer than 32 glyph placements. Dense text
+  still uses the atlas; short Latin/CJK pages avoid its texture construction
+  and driver setup while producing the same pixels.
 - Render content-free interior tiles with a color-only pass that clears
   directly to the folded paper color. This avoids stencil, MSAA, host-buffer,
   and pipeline work when spatial selection proves that no retained command can

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -25,7 +25,8 @@ PdfReader(
     maxTextureBytes: 256 << 20,
     maxGeometryBytes: 256 << 20,
     // Ordinary filled outlines use a scale-independent curve atlas by
-    // default. Set false only for an A/B against legacy stencil fans.
+    // default. Sparse native substitution runs stay on cheaper retained
+    // stencil geometry; dense text still amortizes the atlas setup.
     analyticText: true,
     // Optional: retain simple substituted text using the native faces that
     // Canvas normally selects. Leave false if the app registers replacements

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -99,7 +99,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   ///
   /// Unsupported glyphs and gradient or soft-masked text keep the exact
   /// stencil path. The atlas is independent of tile scale, so later LoD tiles
-  /// reuse both its outline streams and the six-vertex glyph quads.
+  /// reuse both its outline streams and the six-vertex glyph quads. Native
+  /// substitution scenes with fewer than 32 outlined glyph placements keep
+  /// the cheaper retained stencil path because atlas setup cannot amortize.
   final bool analyticText;
 
   /// Optional exact vector outlines for unembedded/substituted text.
@@ -207,6 +209,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       final outlinedCommands = textOutliner == null
           ? scene.commands
           : _outlineGpuTextCommands(scene.commands, textOutliner!);
+      final usesHostOutlines = !identical(outlinedCommands, scene.commands);
       final commandBuild = _buildGpuCommands(outlinedCommands);
       final commands = commandBuild.commands;
       if (commands == null) {
@@ -254,6 +257,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         imageCache: _imageCache,
         geometryPool: _geometryPool,
         analyticText: analyticText,
+        analyticTextMinimumGlyphs:
+            systemTextOutlines && usesHostOutlines ? 32 : 1,
       );
     } catch (error) {
       _lastSessionRejection = 'initialization failed: $error';
@@ -3301,6 +3306,7 @@ class _FlutterGpuTileSession
     required this.imageCache,
     required this.geometryPool,
     required this.analyticText,
+    required this.analyticTextMinimumGlyphs,
   });
 
   @override
@@ -3327,6 +3333,7 @@ class _FlutterGpuTileSession
   final _GpuImageCache imageCache;
   final _GpuGeometryPool geometryPool;
   final bool analyticText;
+  final int analyticTextMinimumGlyphs;
 
   Future<_CompiledScene>? _compiled;
   _CompiledScene? _ready;
@@ -3343,6 +3350,7 @@ class _FlutterGpuTileSession
         imageCache,
         geometryPool,
         analyticText: analyticText,
+        analyticTextMinimumGlyphs: analyticTextMinimumGlyphs,
         mipmapImages: mipmapImages,
       ).then((compiled) {
         if (_disposed) {
@@ -3516,6 +3524,7 @@ class _CompiledScene {
       _GpuImageCache imageCache,
       _GpuGeometryPool geometryPool,
       {required bool analyticText,
+      required int analyticTextMinimumGlyphs,
       required bool mipmapImages}) async {
     final clock = Stopwatch()..start();
     final draws = <int, _GpuDraw>{};
@@ -3534,7 +3543,13 @@ class _CompiledScene {
       _GpuGlyphAtlas? glyphAtlas;
       if (analyticText) {
         try {
-          glyphAtlas = _GpuGlyphAtlas.build(context, commands, units, stats);
+          glyphAtlas = _GpuGlyphAtlas.build(
+            context,
+            commands,
+            units,
+            stats,
+            minimumGlyphs: analyticTextMinimumGlyphs,
+          );
         } catch (_) {
           // This is a retained-geometry optimization, never a new reason for
           // an otherwise supported page to abandon the exact GPU route.
@@ -5512,8 +5527,24 @@ class _GpuGlyphAtlas {
     gpu.GpuContext context,
     List<PdfRenderCommand> commands,
     List<_GpuUnit> units,
-    FlutterGpuTileBackendStats stats,
-  ) {
+    FlutterGpuTileBackendStats stats, {
+    required int minimumGlyphs,
+  }) {
+    var candidateGlyphs = 0;
+    for (final unit in units) {
+      if (unit.composite != null) continue;
+      final command = commands[unit.commandIndex];
+      if (command case PdfDrawTextCommand(:final run)
+          when !run.invisible && run.fill && run.gradient == null) {
+        candidateGlyphs += (run.glyphs ?? const <PdfGlyphPlacement>[])
+            .where((glyph) => glyph.outline != null)
+            .length;
+      }
+    }
+    if (candidateGlyphs < minimumGlyphs) {
+      if (candidateGlyphs > 0) stats.analyticSparseAtlasSkips++;
+      return null;
+    }
     final slots = Map<PdfPath, int>.identity();
     final data = <SlugGlyphData>[];
     for (final unit in units) {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -33,6 +33,7 @@ class FlutterGpuTileBackendStats {
   int analyticGlyphSlots = 0;
   int analyticAtlasBytes = 0;
   int analyticAtlasFallbacks = 0;
+  int analyticSparseAtlasSkips = 0;
   int analyticTextFallbackRuns = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
@@ -113,6 +114,7 @@ class FlutterGpuTileBackendStats {
         'analyticGlyphSlots': analyticGlyphSlots,
         'analyticAtlasBytes': analyticAtlasBytes,
         'analyticAtlasFallbacks': analyticAtlasFallbacks,
+        'analyticSparseAtlasSkips': analyticSparseAtlasSkips,
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
@@ -192,6 +194,7 @@ class FlutterGpuTileBackendStats {
     analyticGlyphSlots = 0;
     analyticAtlasBytes = 0;
     analyticAtlasFallbacks = 0;
+    analyticSparseAtlasSkips = 0;
     analyticTextFallbackRuns = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
@@ -255,6 +258,7 @@ class FlutterGpuTileBackendStats {
       'analyticRuns=$analyticTextRuns analyticQuads=$analyticGlyphQuads '
       'analyticSlots=$analyticGlyphSlots atlasBytes=$analyticAtlasBytes '
       'analyticAtlasFallbacks=$analyticAtlasFallbacks '
+      'analyticSparseSkips=$analyticSparseAtlasSkips '
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -66,6 +66,7 @@ void main() {
       ..analyticGlyphSlots = 4
       ..analyticAtlasBytes = 4096
       ..analyticAtlasFallbacks = 1
+      ..analyticSparseAtlasSkips = 3
       ..analyticTextFallbackRuns = 2
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
@@ -109,6 +110,7 @@ void main() {
     expect(stats.toJson(), containsPair('analyticGlyphSlots', 4));
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
+    expect(stats.toJson(), containsPair('analyticSparseAtlasSkips', 3));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
@@ -156,6 +158,7 @@ void main() {
     expect(stats.analyticGlyphSlots, 0);
     expect(stats.analyticAtlasBytes, 0);
     expect(stats.analyticAtlasFallbacks, 0);
+    expect(stats.analyticSparseAtlasSkips, 0);
     expect(stats.analyticTextFallbackRuns, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -4452,6 +4452,53 @@ void main() {
         reason: 'retained glyph quads must replace outline stencil fans',
       );
 
+      final sparseSystemBackend = FlutterGpuTileRasterBackend(
+        textOutliner: outliner,
+        systemTextOutlines: true,
+      );
+      final sparseSystemSession =
+          sparseSystemBackend.createSession(substituteScene);
+      expect(sparseSystemSession, isNotNull,
+          reason: sparseSystemBackend.lastSessionRejection);
+      addTearDown(sparseSystemSession!.dispose);
+      final sparseSystem = await sparseSystemSession.rasterizeRegion(
+        textRegion,
+        pixelRatio: 1,
+      );
+      addTearDown(sparseSystem.dispose);
+      expect(sparseSystemBackend.stats.analyticSparseAtlasSkips, 1);
+      expect(sparseSystemBackend.stats.analyticGlyphSlots, 0);
+      expect(sparseSystemBackend.stats.analyticTextRuns, 0);
+      expect(
+        sparseSystemBackend.stats.geometryVertices,
+        flattenedBackend.stats.geometryVertices,
+        reason: 'sparse native outlines should use the cheaper stencil path',
+      );
+      final sparsePixels = await _pixels(sparseSystem);
+      var sparseDifference = 0;
+      for (var i = 0; i < expectedPixels.length; i++) {
+        sparseDifference += (expectedPixels[i] - sparsePixels[i]).abs();
+      }
+      expect(sparseDifference / expectedPixels.length, lessThan(8));
+
+      final embeddedProbeBackend = FlutterGpuTileRasterBackend(
+        textOutliner: outliner,
+        systemTextOutlines: true,
+      );
+      final embeddedProbeSession =
+          embeddedProbeBackend.createSession(outlineControl);
+      expect(embeddedProbeSession, isNotNull,
+          reason: embeddedProbeBackend.lastSessionRejection);
+      addTearDown(embeddedProbeSession!.dispose);
+      final embeddedProbe = await embeddedProbeSession.rasterizeRegion(
+        textRegion,
+        pixelRatio: 1,
+      );
+      addTearDown(embeddedProbe.dispose);
+      expect(embeddedProbeBackend.stats.analyticSparseAtlasSkips, 0);
+      expect(embeddedProbeBackend.stats.analyticTextRuns, 1,
+          reason: 'a system-font probe must not penalize embedded outlines');
+
       final radial = await PdfRetainedScene.fromCommands(page, [
         PdfFillPathGradientCommand(
           _rect(40, 40, 300, 300),


### PR DESCRIPTION
## Summary\n\n- preflight outlined glyph placements before constructing the analytic curve atlas\n- keep sparse native substitution text on the exact retained-stencil path when atlas setup cannot amortize\n- leave embedded/custom outlined text and dense native text on the analytic atlas path\n- expose sparse-atlas skips in backend stats and add system/CJK pipeline plus scene warm-up comparisons to GPU CI\n\n## Validation\n\n- repository analyzer\n- full native GPU package suite\n- checked-in Ghent and PDF.js GPU corpora with system-font outlines enabled\n- focused pixel-parity coverage for sparse native text\n- regression coverage that a system-font probe does not demote embedded outlines\n\nThe GPU performance workflow will publish the six-run comparison against main.\n