### PR TITLE
ci(perf): stabilize native Patrol comparisons

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -15,6 +15,7 @@ env:
   PATROL_CLI_VERSION: 4.7.0
   PATROL_ANALYTICS_ENABLED: "false"
   PATROL_PERF_REPETITIONS: 3
+  PATROL_NATIVE_PERF_REPETITIONS: 6
   EXAMPLE_DIR: packages/dart_pdf_editor/example
   PDF_PATROL_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -215,7 +216,7 @@ jobs:
             --output test-results/perf/android
             --markdown "$GITHUB_STEP_SUMMARY"
             --label Android
-            --require-scenario-runs "native-mobile-tiles=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "native-mobile-tiles=$PATROL_NATIVE_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then
@@ -275,8 +276,8 @@ jobs:
             2>&1 | tee "$RUNNER_TEMP/patrol-ios.log"
           completed=0
           attempt=0
-          max_attempts=$((PATROL_PERF_REPETITIONS + 2))
-          while ((completed < PATROL_PERF_REPETITIONS && attempt < max_attempts)); do
+          max_attempts=$((PATROL_NATIVE_PERF_REPETITIONS + 2))
+          while ((completed < PATROL_NATIVE_PERF_REPETITIONS && attempt < max_attempts)); do
             attempt=$((attempt + 1))
             attempt_log="$RUNNER_TEMP/patrol-ios-perf-$attempt.log"
             echo "::group::Patrol native performance attempt $attempt/$max_attempts"
@@ -300,8 +301,8 @@ jobs:
               echo "::warning::iOS Patrol attempt $attempt returned without a complete performance marker; retrying"
             fi
           done
-          if ((completed < PATROL_PERF_REPETITIONS)); then
-            echo "::error::iOS Patrol produced $completed/$PATROL_PERF_REPETITIONS complete performance repetitions"
+          if ((completed < PATROL_NATIVE_PERF_REPETITIONS)); then
+            echo "::error::iOS Patrol produced $completed/$PATROL_NATIVE_PERF_REPETITIONS complete performance repetitions"
             exit 1
           fi
       - name: Download latest main Patrol iOS baseline
@@ -344,7 +345,7 @@ jobs:
             --output test-results/perf/ios
             --markdown "$GITHUB_STEP_SUMMARY"
             --label "iOS Simulator"
-            --require-scenario-runs "native-mobile-tiles=$PATROL_PERF_REPETITIONS"
+            --require-scenario-runs "native-mobile-tiles=$PATROL_NATIVE_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then

--- a/tool/run_android_patrol_ci.sh
+++ b/tool/run_android_patrol_ci.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 : "${RUNNER_TEMP:?RUNNER_TEMP must be set by GitHub Actions}"
 : "${PDF_PATROL_BUILD_COMMIT:?PDF_PATROL_BUILD_COMMIT must be set}"
-: "${PATROL_PERF_REPETITIONS:=3}"
+: "${PATROL_NATIVE_PERF_REPETITIONS:=${PATROL_PERF_REPETITIONS:-3}}"
 
-if ! [[ "$PATROL_PERF_REPETITIONS" =~ ^[1-9][0-9]*$ ]]; then
-  echo "PATROL_PERF_REPETITIONS must be a positive integer" >&2
+if ! [[ "$PATROL_NATIVE_PERF_REPETITIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "PATROL_NATIVE_PERF_REPETITIONS must be a positive integer" >&2
   exit 64
 fi
 
@@ -20,8 +20,8 @@ patrol test \
   --verbose \
   2>&1 | tee "$RUNNER_TEMP/patrol-android.log"
 
-for ((iteration = 1; iteration <= PATROL_PERF_REPETITIONS; iteration++)); do
-  echo "::group::Patrol native performance repetition $iteration/$PATROL_PERF_REPETITIONS"
+for ((iteration = 1; iteration <= PATROL_NATIVE_PERF_REPETITIONS; iteration++)); do
+  echo "::group::Patrol native performance repetition $iteration/$PATROL_NATIVE_PERF_REPETITIONS"
   patrol test \
     --device emulator-5554 \
     --target patrol_test/native_perf_e2e_test.dart \


### PR DESCRIPTION
## Summary

- collect six Android and iOS native performance repetitions while leaving the broader web journey at three
- require all six native-mobile-tiles samples in the generated reports
- keep the Android helper backward-compatible for callers that only set the existing repetition variable

## Why

Three native samples cannot use the report generator's interquartile-range overlap classification, which made unrelated runner noise look like a material regression during GPU PR review. Six samples make future Android/iOS comparisons useful for automated GPU merge decisions without repeating the expensive application build.

## Validation

- bash -n tool/run_android_patrol_ci.sh
- git diff --check
- this PR's Patrol run exercises the six-sample workflow end to end