### PR TITLE
feat(gpu): retain exact clipped group masks

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -50,6 +50,9 @@
 - Retain arbitrary path clips inside a single-image soft-mask transcript when
   the alpha/luminosity backdrop and transfer function prove that the mask is
   zero outside the clip. Non-zero outside-mask values remain on Canvas.
+- Retain arbitrary path clips around one fill, stroke, text run, image,
+  gradient, or mesh inside a single-paint transparency group. Multi-paint
+  groups with path clips remain conservative Canvas fallbacks.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -47,6 +47,9 @@
   including the single-image transparency-group route. The resolved source is
   constrained by the existing exact stencil clip instead of requiring an
   axis-aligned shortcut.
+- Retain arbitrary path clips inside a single-image soft-mask transcript when
+  the alpha/luminosity backdrop and transfer function prove that the mask is
+  zero outside the clip. Non-zero outside-mask values remain on Canvas.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -121,9 +121,11 @@ ordinary retained strokes before the mask is applied. Masked zero-width
 hairlines stay on Canvas because their one-device-pixel geometry is tile-scale
 dependent.
 An arbitrary content-side path clip around one soft-masked source is retained
-as the ordinary GPU stencil clip on the resolved composite. Rectangular clips
-inside the mask-image transcript remain the bounded shader scissor; arbitrary
-mask-side clips still use Canvas.
+as the ordinary GPU stencil clip on the resolved composite. Arbitrary clips
+inside a single-image mask transcript use that same exact stencil when the
+mask's backdrop and transfer function make its outside value zero. Rectangular
+mask clips remain the bounded shader scissor; arbitrary mask clips with a
+non-zero outside value still use Canvas.
 A single ordinary soft-masked source may itself sit inside a transparency
 group: the backend resolves that source in a bounded offscreen target and then
 applies the enclosing group alpha once. This exact route requires no explicit
@@ -237,7 +239,7 @@ describe the real workload rather than one page at a time.
 
 Pages with other transparency groups or soft masks, non-nested radial
 gradients, gradient overprint, unsafe overprint, complex
-clips inside a soft-mask image transcript, unresolved
+clips around a non-zero soft-mask backdrop, unresolved
 substituted text, or missing image pixels are rejected as a whole rather than
 approximated.
 `allowOverprintApproximation` exists only for controlled experiments and

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -126,6 +126,10 @@ inside a single-image mask transcript use that same exact stencil when the
 mask's backdrop and transfer function make its outside value zero. Rectangular
 mask clips remain the bounded shader scissor; arbitrary mask clips with a
 non-zero outside value still use Canvas.
+The same composite stencil retains an arbitrary path clip around one fill,
+stroke, text run, image, gradient, or mesh inside a single-paint transparency
+group. Groups whose separately ordered paints carry path clips remain on
+Canvas until the offscreen pass can preserve a distinct stencil per paint.
 A single ordinary soft-masked source may itself sit inside a transparency
 group: the backend resolves that source in a bounded offscreen target and then
 applies the enclosing group alpha once. This exact route requires no explicit

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -2001,15 +2001,29 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       return (null, 'unsupported soft-mask image group');
     }
     final maskState = _singleMaskImage(softEnd.maskCommands);
-    if (maskState.$1 == null) return (null, maskState.$3);
+    final mask = maskState.image;
+    if (mask == null) return (null, maskState.rejection);
+    final maskPathClips = maskState.pathClips;
+    if (maskPathClips.isNotEmpty &&
+        !_softMaskOutsideIsZero(
+          luminosity: softEnd.luminosity,
+          backdropLuminance: softEnd.backdropLuminance,
+          transferScale: softEnd.transferScale,
+          transferOffset: softEnd.transferOffset,
+        )) {
+      return (null, 'non-zero soft-mask backdrop outside path clip');
+    }
     return (
       _SoftMaskImageSpec(
         content: content.request,
-        mask: maskState.$1!.request,
+        mask: mask.request,
         groupAlpha: alpha,
         contentClip: contentClip,
-        contentPathClips: contentPathClips,
-        maskClip: maskState.$2,
+        contentPathClips: List.unmodifiable([
+          ...contentPathClips,
+          ...maskPathClips,
+        ]),
+        maskClip: maskState.clip,
         luminosity: softEnd.luminosity,
         backdropLuminance: softEnd.backdropLuminance,
         transferScale: softEnd.transferScale,
@@ -2104,7 +2118,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       return (null, 'unsupported soft-mask fill group');
     }
     final maskState = _singleMaskImage(maskCommands);
-    final mask = maskState.$1;
+    final mask = maskState.image;
     if (mask == null) {
       final gradientState = _singleMaskGradient(maskCommands);
       final gradient = gradientState.$1;
@@ -2164,7 +2178,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       }
       final vectorMask = _vectorMaskFills(maskCommands);
       final maskFills = vectorMask.$1;
-      if (maskFills == null) return (null, vectorMask.$2 ?? maskState.$3);
+      if (maskFills == null) {
+        return (null, vectorMask.$2 ?? maskState.rejection);
+      }
       if (![backdropLuminance, transferScale, transferOffset]
           .every((value) => value.isFinite)) {
         return (null, 'invalid vector soft-mask transfer');
@@ -2193,14 +2209,28 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     if (maskDictionary['SMask'] != null || maskDictionary['Mask'] != null) {
       return (null, 'transparent soft-mask fill image');
     }
+    final maskPathClips = maskState.pathClips;
+    if (maskPathClips.isNotEmpty &&
+        !_softMaskOutsideIsZero(
+          luminosity: luminosity,
+          backdropLuminance: backdropLuminance,
+          transferScale: transferScale,
+          transferOffset: transferOffset,
+        )) {
+      return (null, 'non-zero soft-mask backdrop outside path clip');
+    }
+    final compositePathClips = List<_GpuPathClip>.unmodifiable([
+      ...contentPathClips,
+      ...maskPathClips,
+    ]);
     return switch (content) {
       PdfFillPathCommand fill => (
           _SoftMaskFillSpec(
             content: fill,
             mask: mask.request,
             contentClip: contentClip,
-            contentPathClips: contentPathClips,
-            maskClip: maskState.$2,
+            contentPathClips: compositePathClips,
+            maskClip: maskState.clip,
             luminosity: luminosity,
             backdropLuminance: backdropLuminance,
             transferScale: transferScale,
@@ -2213,8 +2243,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             content: stroke,
             mask: mask.request,
             contentClip: contentClip,
-            contentPathClips: contentPathClips,
-            maskClip: maskState.$2,
+            contentPathClips: compositePathClips,
+            maskClip: maskState.clip,
             luminosity: luminosity,
             backdropLuminance: backdropLuminance,
             transferScale: transferScale,
@@ -2231,8 +2261,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             content: text,
             mask: mask.request,
             contentClip: contentClip,
-            contentPathClips: contentPathClips,
-            maskClip: maskState.$2,
+            contentPathClips: compositePathClips,
+            maskClip: maskState.clip,
             luminosity: luminosity,
             backdropLuminance: backdropLuminance,
             transferScale: transferScale,
@@ -2900,47 +2930,96 @@ bool _pdfContains(PdfRect outer, PdfRect inner) =>
     outer.right + 0.001 >= inner.right &&
     outer.top + 0.001 >= inner.top;
 
-(PdfDrawImageCommand?, PdfRect?, String?) _singleMaskImage(
-    List<PdfRenderCommand> commands) {
+typedef _SingleMaskImageState = ({
+  PdfDrawImageCommand? image,
+  PdfRect? clip,
+  List<_GpuPathClip> pathClips,
+  String? rejection,
+});
+
+_SingleMaskImageState _rejectedMaskImage(String rejection) => (
+      image: null,
+      clip: null,
+      pathClips: const [],
+      rejection: rejection,
+    );
+
+_SingleMaskImageState _singleMaskImage(List<PdfRenderCommand> commands) {
   PdfDrawImageCommand? image;
   PdfRect? imageClip;
+  var pathClips = const <_GpuPathClip>[];
+  var imagePathClips = const <_GpuPathClip>[];
   PdfRect? clip;
   var blend = PdfBlendMode.normal;
-  final saved = <(PdfRect?, PdfBlendMode)>[];
+  final saved = <(PdfRect?, List<_GpuPathClip>, PdfBlendMode)>[];
   for (final command in commands) {
     switch (command) {
       case PdfSaveCommand():
-        saved.add((clip, blend));
+        saved.add((clip, pathClips, blend));
       case PdfRestoreCommand():
-        if (saved.isEmpty) return (null, null, 'unbalanced mask image state');
+        if (saved.isEmpty) {
+          return _rejectedMaskImage('unbalanced mask image state');
+        }
         final restored = saved.removeLast();
         clip = restored.$1;
-        blend = restored.$2;
-      case PdfClipPathCommand(:final path):
-        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
-          return (null, null, 'non-rectangular mask image clip');
-        }
+        pathClips = restored.$2;
+        blend = restored.$3;
+      case PdfClipPathCommand(:final path, :final rule):
         clip = _pdfIntersection(clip, pdfRenderPathBounds(path));
+        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+          pathClips = List.unmodifiable([
+            ...pathClips,
+            (path: path, rule: rule),
+          ]);
+        }
       case PdfDrawImageCommand():
-        if (image != null) return (null, null, 'mask contains multiple images');
+        if (image != null) {
+          return _rejectedMaskImage('mask contains multiple images');
+        }
         if (blend != PdfBlendMode.normal) {
-          return (null, null, 'mask image blend mode ${blend.name}');
+          return _rejectedMaskImage('mask image blend mode ${blend.name}');
         }
         image = command;
         imageClip = clip;
+        imagePathClips = pathClips;
       case PdfSetBlendModeCommand(:final mode):
         blend = mode;
       case PdfSetOverprintCommand():
         break;
       default:
         if (pdfRenderCommandBounds(command) != null) {
-          return (null, null, 'mask contains ${command.runtimeType}');
+          return _rejectedMaskImage(
+            'mask contains ${command.runtimeType}',
+          );
         }
     }
   }
-  if (saved.isNotEmpty) return (null, null, 'unbalanced mask image state');
-  if (image == null) return (null, null, 'mask has no image');
-  return (image, imageClip, null);
+  if (saved.isNotEmpty) {
+    return _rejectedMaskImage('unbalanced mask image state');
+  }
+  if (image == null) {
+    return _rejectedMaskImage('mask has no image');
+  }
+  return (
+    image: image,
+    clip: imageClip,
+    pathClips: imagePathClips,
+    rejection: null,
+  );
+}
+
+bool _softMaskOutsideIsZero({
+  required bool luminosity,
+  required double backdropLuminance,
+  required double transferScale,
+  required double transferOffset,
+}) {
+  if (![backdropLuminance, transferScale, transferOffset]
+      .every((value) => value.isFinite)) {
+    return false;
+  }
+  final outside = luminosity ? backdropLuminance : 0.0;
+  return outside * transferScale + transferOffset <= 0;
 }
 
 (PdfFillPathGradientCommand?, PdfRect?, String?) _singleMaskGradient(

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -675,12 +675,15 @@ class _GroupFillSpec extends _GpuCompositeSpec {
     required this.content,
     required this.groupAlpha,
     required this.contentClip,
+    this.contentPathClips = const [],
   });
 
   final PdfFillPathCommand content;
   final double groupAlpha;
   @override
   final PdfRect? contentClip;
+  @override
+  final List<_GpuPathClip> contentPathClips;
 }
 
 class _GroupStrokeSpec extends _GpuCompositeSpec {
@@ -688,12 +691,15 @@ class _GroupStrokeSpec extends _GpuCompositeSpec {
     required this.content,
     required this.groupAlpha,
     required this.contentClip,
+    this.contentPathClips = const [],
   });
 
   final PdfStrokePathCommand content;
   final double groupAlpha;
   @override
   final PdfRect? contentClip;
+  @override
+  final List<_GpuPathClip> contentPathClips;
 }
 
 class _GroupTextSpec extends _GpuCompositeSpec {
@@ -701,12 +707,15 @@ class _GroupTextSpec extends _GpuCompositeSpec {
     required this.content,
     required this.groupAlpha,
     required this.contentClip,
+    this.contentPathClips = const [],
   });
 
   final PdfDrawTextCommand content;
   final double groupAlpha;
   @override
   final PdfRect? contentClip;
+  @override
+  final List<_GpuPathClip> contentPathClips;
 }
 
 class _GroupPaintSpec extends _GpuCompositeSpec {
@@ -715,6 +724,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     required this.paintClips,
     required this.paintBlends,
     required this.contentClip,
+    this.contentPathClips = const [],
     this.groupAlpha = 1,
     this.offscreen = false,
     this.knockout = false,
@@ -730,6 +740,8 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final PdfColor? backdropColor;
   @override
   final PdfRect? contentClip;
+  @override
+  final List<_GpuPathClip> contentPathClips;
 }
 
 class _KnockoutSoftMaskFillSpec extends _GpuCompositeSpec {
@@ -1551,6 +1563,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     // source-over, non-knockout groups whose isolation layer is an identity.
     PdfDrawImageCommand? content;
     final paints = <(int?, PdfRenderCommand, PdfRect?, PdfBlendMode, bool)>[];
+    final paintPathClips = <List<_GpuPathClip>>[];
     PdfEndSoftMaskedCommand? softEnd;
     var softDepth = 0;
     var softCount = 0;
@@ -1630,10 +1643,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             break;
           }
           if (softDepth == 0 && content == null) {
-            if (pathClips.isNotEmpty) {
-              return (null, 'non-rectangular soft-mask image clip');
-            }
             paints.add((i, command, clip, blend, false));
+            paintPathClips.add(pathClips);
             contentClip = clip;
             break;
           }
@@ -1651,10 +1662,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfFillPathCommand');
           }
-          if (pathClips.isNotEmpty) {
-            return (null, 'non-rectangular soft-mask image clip');
-          }
           paints.add((i, command, clip, blend, fillOverprint));
+          paintPathClips.add(pathClips);
           contentClip = clip;
         case PdfFillPathGradientCommand() || PdfFillMeshCommand():
           if (emptyClipOnly) {
@@ -1667,10 +1676,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               'soft-mask group contains ${command.runtimeType}',
             );
           }
-          if (pathClips.isNotEmpty) {
-            return (null, 'non-rectangular soft-mask image clip');
-          }
           paints.add((i, command, clip, blend, fillOverprint));
+          paintPathClips.add(pathClips);
           contentClip = clip;
         case PdfStrokePathCommand():
           if (emptyClipOnly) {
@@ -1680,10 +1687,8 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfStrokePathCommand');
           }
-          if (pathClips.isNotEmpty) {
-            return (null, 'non-rectangular soft-mask image clip');
-          }
           paints.add((i, command, clip, blend, strokeOverprint));
+          paintPathClips.add(pathClips);
           contentClip = clip;
         case PdfDrawTextCommand(:final run):
           if (emptyClipOnly) {
@@ -1693,9 +1698,6 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           if (softDepth != 0 || content != null) {
             return (null, 'soft-mask group contains PdfDrawTextCommand');
           }
-          if (pathClips.isNotEmpty) {
-            return (null, 'non-rectangular soft-mask image clip');
-          }
           paints.add((
             i,
             command,
@@ -1704,6 +1706,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             (run.fill && fillOverprint) ||
                 (run.strokeColor != null && strokeOverprint),
           ));
+          paintPathClips.add(pathClips);
           contentClip = clip;
         case PdfSetBlendModeCommand(:final mode):
           // A one-element group may use any internal blend: with a transparent
@@ -1742,6 +1745,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                   PdfBlendMode.normal,
                   false,
                 ));
+                paintPathClips.add(const []);
               }
             case _GroupFillSpec(:final content, :final groupAlpha):
               paints.add((
@@ -1756,6 +1760,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 PdfBlendMode.normal,
                 false,
               ));
+              paintPathClips.add(nestedSpec.contentPathClips);
             case _GroupStrokeSpec(:final content, :final groupAlpha):
               paints.add((
                 null,
@@ -1769,6 +1774,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 PdfBlendMode.normal,
                 false,
               ));
+              paintPathClips.add(nestedSpec.contentPathClips);
             case _GroupPaintSpec(
                   :final commands,
                   :final paintClips,
@@ -1787,6 +1793,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                   paintBlends[nestedIndex],
                   false,
                 ));
+                paintPathClips.add(nestedSpec.contentPathClips);
               }
             default:
               return (null, nested.$2 ?? 'nested image group');
@@ -1814,6 +1821,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     }
     if (softCount == 0 && softDepth == 0 && paints.length == 1) {
       final paint = paints.single;
+      final paintPaths = paintPathClips.single;
       final overprintReason = _compositeOverprintReason(paint.$2, paint.$5);
       if (overprintReason != null) return (null, overprintReason);
       if (backdropColor != null) {
@@ -1835,6 +1843,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               paintClips: [paint.$3],
               paintBlends: [paint.$4],
               contentClip: groupBounds,
+              contentPathClips: paintPaths,
               offscreen: true,
               knockout: true,
               backdropColor: backdropColor,
@@ -1850,6 +1859,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               content: content,
               groupAlpha: alpha,
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
             ),
             null,
           ),
@@ -1858,6 +1868,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               content: content,
               groupAlpha: alpha,
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
             ),
             null,
           ),
@@ -1866,6 +1877,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               content: content,
               groupAlpha: alpha,
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
             ),
             null,
           ),
@@ -1875,6 +1887,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               paintClips: [paint.$3],
               paintBlends: const [PdfBlendMode.normal],
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
               groupAlpha: alpha,
               offscreen: alpha != 1,
             ),
@@ -1886,6 +1899,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               paintClips: [paint.$3],
               paintBlends: const [PdfBlendMode.normal],
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
               groupAlpha: alpha,
               offscreen: alpha != 1,
             ),
@@ -1897,6 +1911,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               paintClips: [paint.$3],
               paintBlends: const [PdfBlendMode.normal],
               contentClip: paint.$3,
+              contentPathClips: paintPaths,
               groupAlpha: alpha,
               offscreen: alpha != 1,
             ),
@@ -1906,6 +1921,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       };
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
+      if (paintPathClips.any((clips) => clips.isNotEmpty)) {
+        return (null, 'non-rectangular multi-paint transparency group clip');
+      }
       final commonClip = paints.first.$3;
       final normalPaints = paints.every((paint) =>
           paint.$4 == PdfBlendMode.normal &&

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3324,6 +3324,99 @@ void main() {
     });
   });
 
+  testWidgets('single-paint groups retain arbitrary content clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const diamond = PdfPath([
+        PdfMoveTo(140, 90),
+        PdfLineTo(230, 180),
+        PdfLineTo(140, 270),
+        PdfLineTo(50, 180),
+        PdfClosePath(),
+      ]);
+
+      Future<void> expectParity(PdfRetainedScene scene) async {
+        addTearDown(scene.dispose);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        addTearDown(session!.dispose);
+        const region = Rect.fromLTWH(30, 70, 220, 220);
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+        addTearDown(expected.dispose);
+        addTearDown(actual.dispose);
+        final a = await _pixels(expected), b = await _pixels(actual);
+        var difference = 0;
+        for (var index = 0; index < a.length; index++) {
+          difference += (a[index] - b[index]).abs();
+        }
+        expect(difference / a.length, lessThan(8));
+        expect(backend.stats.clipPathsCompiled, 1);
+      }
+
+      await expectParity(await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(0.45),
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 80, 240, 280),
+          const PdfColor(0.1, 0.65, 0.3),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        const PdfEndGroupCommand(),
+      ]));
+
+      final image = _decodedImage(
+        Uint8List.fromList([
+          for (var i = 0; i < 4; i++) ...const [220, 55, 25, 255],
+        ]),
+        const PdfMatrix(200, 0, 0, 200, 40, 80),
+        'path-clipped-group-image',
+      );
+      await expectParity(await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(0.65),
+          const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+          image,
+          const PdfEndGroupCommand(),
+        ],
+        retainDecodedPixels: true,
+      ));
+
+      final multiPaint = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(0.45),
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 80, 240, 280),
+          const PdfColor(0.1, 0.65, 0.3),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        PdfFillPathCommand(
+          _rect(80, 120, 200, 240),
+          const PdfColor(0.8, 0.2, 0.3),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(multiPaint.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(multiPaint), isNull);
+      expect(
+        backend.stats.lastRejection,
+        'non-rectangular multi-paint transparency group clip',
+      );
+    });
+  });
+
   testWidgets(
       'single-image knockout luminosity masks stay as two retained textures',
       (tester) async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3515,6 +3515,139 @@ void main() {
     });
   });
 
+  testWidgets('zero-outside soft masks retain arbitrary mask clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const diamond = PdfPath([
+        PdfMoveTo(140, 90),
+        PdfLineTo(230, 180),
+        PdfLineTo(140, 270),
+        PdfLineTo(50, 180),
+        PdfClosePath(),
+      ]);
+      final mask = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+        ]),
+        const PdfMatrix(180, 0, 0, 180, 50, 90),
+        'mask-path-clip',
+      );
+      final maskCommands = <PdfRenderCommand>[
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        mask,
+      ];
+
+      Future<void> expectParity(PdfRetainedScene scene) async {
+        addTearDown(scene.dispose);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        addTearDown(session!.dispose);
+        const region = Rect.fromLTWH(30, 70, 220, 220);
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
+        addTearDown(expected.dispose);
+        addTearDown(actual.dispose);
+        final a = await _pixels(expected), b = await _pixels(actual);
+        var difference = 0;
+        for (var index = 0; index < a.length; index++) {
+          difference += (a[index] - b[index]).abs();
+        }
+        expect(difference / a.length, lessThan(8));
+        expect(backend.stats.clipPathsCompiled, 1);
+      }
+
+      await expectParity(await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(40, 80, 240, 280),
+            const PdfColor(0.1, 0.65, 0.3),
+            PdfFillRule.nonzero,
+            0.85,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: page.cropBox,
+            maskCommands: maskCommands,
+          ),
+        ],
+        retainDecodedPixels: true,
+      ));
+
+      final content = _decodedImage(
+        Uint8List.fromList([
+          for (var i = 0; i < 4; i++) ...const [220, 55, 25, 255],
+        ]),
+        const PdfMatrix(200, 0, 0, 200, 40, 80),
+        'mask-path-content',
+      );
+      await expectParity(await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(0.75),
+          const PdfBeginSoftMaskedCommand(),
+          content,
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: page.cropBox,
+            maskCommands: maskCommands,
+          ),
+          const PdfEndGroupCommand(),
+        ],
+        retainDecodedPixels: true,
+      ));
+
+      final rejected = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(40, 80, 240, 280),
+            const PdfColor(0.1, 0.65, 0.3),
+            PdfFillRule.nonzero,
+            0.85,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: maskCommands,
+            backdropLuminance: 0.5,
+          ),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(rejected.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(rejected), isNull);
+      expect(
+        backend.stats.lastRejection,
+        'non-zero soft-mask backdrop outside path clip',
+      );
+    });
+  });
+
   testWidgets('single vector fills use an image soft mask directly',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Summary

- retain arbitrary mask-side path clips when the transformed outside-mask value is provably zero
- retain arbitrary content path clips for ordinary single-paint transparency groups
- preserve exact Canvas fallback for nonzero outside masks and multi-paint clip stacks

## Validation

- `fvm dart analyze packages/dart_pdf_editor_flutter_gpu`
- `fvm flutter test --enable-impeller --enable-flutter-gpu test/flutter_gpu_tile_backend_test.dart` (72 passed, 1 expected availability skip)
- full native GPU package suite passed before the clean rebase (304 passed, 3 expected skips)
- system-font Ghent and PDF.js route surveys retained their existing acceptance counts

The implementation advances a real soft-mask page through both clip blockers, while the later unrelated non-black-overprint guard remains conservative under exact defaults.