### PR TITLE
feat(gpu): retain clipped sub-cell overprint

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -56,6 +56,10 @@
 - Consume `pdf_graphics` exact region-clipped spatial overprint strokes as
   ordinary retained clip and stroke commands. Three additional Ghent pages
   stay on the GPU path; unresolved non-black overprint remains on Canvas.
+- Preserve shared and per-paint arbitrary path clips while flattening
+  alpha-one Normal transparency groups, and keep sub-cell strokes visible to
+  the colorant compositor before exact vector replay. One additional Ghent
+  transparency page stays on the GPU path.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -793,7 +793,8 @@ class _FlattenSoftMaskPaint {
 class _FlattenGroupSpec extends _GpuCompositeSpec {
   const _FlattenGroupSpec(this.paints);
 
-  final List<({int commandIndex, PdfRect? clip})> paints;
+  final List<({int commandIndex, PdfRect? clip, List<_GpuPathClip> pathClips})>
+      paints;
 
   @override
   PdfRect? get contentClip => null;
@@ -1361,7 +1362,14 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
           } else if (spec is _FlattenGroupSpec) {
             for (final paint in spec.paints) {
               final paintCommand = commands[paint.commandIndex];
-              final paintClip = _withGpuRectClip(capture.clip, paint.clip);
+              var paintClip = _withGpuRectClip(capture.clip, paint.clip);
+              for (final pathClip in paint.pathClips) {
+                paintClip = _pushGpuClip(
+                  paintClip,
+                  pathClip.path,
+                  pathClip.rule,
+                );
+              }
               final paintBounds = pdfRenderCommandBounds(paintCommand);
               final clipped = paintBounds == null || paintClip.empty
                   ? null
@@ -1745,7 +1753,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                   PdfBlendMode.normal,
                   false,
                 ));
-                paintPathClips.add(const []);
+                paintPathClips.add(nestedPaint.pathClips);
               }
             case _GroupFillSpec(:final content, :final groupAlpha):
               paints.add((
@@ -1921,9 +1929,10 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
       };
     }
     if (softCount == 0 && softDepth == 0 && paints.length > 1) {
-      if (paintPathClips.any((clips) => clips.isNotEmpty)) {
-        return (null, 'non-rectangular multi-paint transparency group clip');
-      }
+      final commonPathClips = paintPathClips.first;
+      final commonPaintPathClip = paintPathClips.every(
+        (clips) => _samePathClipStack(clips, commonPathClips),
+      );
       final commonClip = paints.first.$3;
       final normalPaints = paints.every((paint) =>
           paint.$4 == PdfBlendMode.normal &&
@@ -1966,23 +1975,37 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               fixedFunctionPaints) ||
           canRenderKnockout ||
           canRenderSeededKnockout;
+      if (canFlatten &&
+          paints.every((paint) => paint.$1 != null) &&
+          (!commonPaintClip || !commonPaintPathClip)) {
+        return (
+          _FlattenGroupSpec(List.unmodifiable([
+            for (var index = 0; index < paints.length; index++)
+              (
+                commandIndex: paints[index].$1!,
+                clip: paints[index].$3,
+                pathClips: paintPathClips[index],
+              ),
+          ])),
+          null,
+        );
+      }
+      if (!commonPaintPathClip) {
+        return (null, 'non-rectangular multi-paint transparency group clip');
+      }
+      // A shared path clip can stay active across a flattened draw sequence,
+      // which applies the same retained stencil to every paint. Do not move it
+      // to the resolved texture of an offscreen group: repeated translucent
+      // paints can accumulate different edge coverage from one final mask.
+      if (commonPathClips.isNotEmpty && (!canFlatten || !commonPaintClip)) {
+        return (null, 'non-rectangular multi-paint transparency group clip');
+      }
       if (!canFlatten && !canRenderOffscreen) {
         for (final paint in paints) {
           final reason = _compositeOverprintReason(paint.$2, paint.$5);
           if (reason != null) return (null, reason);
         }
         return (null, 'non-identity multi-paint transparency group');
-      }
-      if (canFlatten &&
-          !commonPaintClip &&
-          paints.every((paint) => paint.$1 != null)) {
-        return (
-          _FlattenGroupSpec(List.unmodifiable([
-            for (final paint in paints)
-              (commandIndex: paint.$1!, clip: paint.$3),
-          ])),
-          null,
-        );
       }
       // Synthesized paints from a nested group no longer have source command
       // indices, so they cannot use [_FlattenGroupSpec]'s per-command clips.
@@ -2003,6 +2026,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               : canFlatten && commonPaintClip
                   ? commonClip
                   : null,
+          contentPathClips: commonPathClips,
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
           knockout: canRenderKnockout || canRenderSeededKnockout,
@@ -3317,6 +3341,21 @@ bool _samePdfRect(PdfRect? a, PdfRect? b) =>
         a.bottom == b.bottom &&
         a.right == b.right &&
         a.top == b.top);
+
+bool _samePathClipStack(
+  List<_GpuPathClip> a,
+  List<_GpuPathClip> b,
+) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var index = 0; index < a.length; index++) {
+    if (!identical(a[index].path, b[index].path) ||
+        a[index].rule != b[index].rule) {
+      return false;
+    }
+  }
+  return true;
+}
 
 PdfRect _pdfUnion(PdfRect? a, PdfRect b) => a == null
     ? b

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3324,7 +3324,7 @@ void main() {
     });
   });
 
-  testWidgets('single-paint groups retain arbitrary content clips',
+  testWidgets('flattened groups retain exact shared content clips',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -3340,7 +3340,10 @@ void main() {
         PdfClosePath(),
       ]);
 
-      Future<void> expectParity(PdfRetainedScene scene) async {
+      Future<void> expectParity(
+        PdfRetainedScene scene, {
+        int expectedClipPaths = 1,
+      }) async {
         addTearDown(scene.dispose);
         final backend = FlutterGpuTileRasterBackend();
         final session = backend.createSession(scene);
@@ -3357,7 +3360,7 @@ void main() {
           difference += (a[index] - b[index]).abs();
         }
         expect(difference / a.length, lessThan(8));
-        expect(backend.stats.clipPathsCompiled, 1);
+        expect(backend.stats.clipPathsCompiled, expectedClipPaths);
       }
 
       await expectParity(await PdfRetainedScene.fromCommands(page, [
@@ -3390,6 +3393,24 @@ void main() {
         retainDecodedPixels: true,
       ));
 
+      await expectParity(await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(1),
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 80, 180, 280),
+          const PdfColor(0.1, 0.65, 0.3),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        PdfFillPathCommand(
+          _rect(100, 120, 240, 240),
+          const PdfColor(0.8, 0.2, 0.3),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfEndGroupCommand(),
+      ]));
+
       final multiPaint = await PdfRetainedScene.fromCommands(page, [
         const PdfBeginGroupCommand(0.45),
         const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
@@ -3414,6 +3435,38 @@ void main() {
         backend.stats.lastRejection,
         'non-rectangular multi-paint transparency group clip',
       );
+
+      final distinctClips = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(1),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 80, 180, 280),
+          const PdfColor(0.1, 0.65, 0.3),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        const PdfRestoreCommand(),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(
+          PdfPath([
+            PdfMoveTo(100, 100),
+            PdfLineTo(240, 180),
+            PdfLineTo(100, 260),
+            PdfClosePath(),
+          ]),
+          PdfFillRule.evenOdd,
+        ),
+        PdfFillPathCommand(
+          _rect(80, 100, 240, 260),
+          const PdfColor(0.8, 0.2, 0.3),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfRestoreCommand(),
+        const PdfEndGroupCommand(),
+      ]);
+      await expectParity(distinctClips, expectedClipPaths: 2);
     });
   });
 

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -17,6 +17,9 @@
   per-backdrop regions instead of leaving those strokes to an RGB `darken`
   approximation. The region clips preserve the original vector stroke edge
   and let retained GPU scenes accept three additional Ghent pages exactly.
+- Preserve one colorant-grid sample for strokes narrower than a grid cell so
+  spatial overprint can discover every crossed backdrop; the substitute
+  regions remain clipped through the original vector stroke at replay.
 
 - Export an OpenType CFF face reader that retains Unicode cmap mappings and
   selects collection entries, allowing native substitution adapters to obtain

--- a/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
+++ b/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
@@ -518,8 +518,12 @@ class PdfColorantRaster {
           subpaths, [for (final d in dashArray) d * scale], dashPhase * scale);
     }
     final contours = StrokeContours();
+    final mappedWidth = width * scale;
     strokeToContours(subpaths,
-        width: width * scale,
+        // The colorant grid cannot represent a stroke narrower than one cell.
+        // Preserve one sample cell here; spatial replay still clips the result
+        // through the original vector stroke, so its visible width is exact.
+        width: mappedWidth < 1 ? 1 : mappedWidth,
         cap: cap,
         join: join,
         miterLimit: miterLimit,

--- a/packages/pdf_graphics/test/colorant_buffer_test.dart
+++ b/packages/pdf_graphics/test/colorant_buffer_test.dart
@@ -501,5 +501,49 @@ void main() {
       );
       expect(c.takeSpatialPaint(), isNull);
     });
+
+    test('a sub-cell stroke still discovers every backdrop it crosses', () {
+      const green = PdfColor(0.31, 0.45, 0.13);
+      const inkColor = PdfColor(0.5, 0.5, 0.5);
+      final spot = PdfColorSpace.parse(
+          cos,
+          CosArray([
+            const CosName('DeviceN'),
+            CosArray([const CosName('Black'), const CosName('GWG Green')]),
+            const CosName('DeviceCMYK'),
+            exponential(const [0, 0, 0, 1]),
+          ]));
+      final c = buffer();
+      fill(c, rect(0, 0, 50, 100), green, spot.inkColorants(const [0.5, 1]));
+      fill(c, rect(50, 0, 100, 100), green,
+          PdfInkColorants.deviceCmyk(0.5, 0, 1, 0.5));
+
+      // At this buffer scale 0.1pt covers less than half a cell and its
+      // centreline lies exactly between two sample rows. The colorant grid
+      // must retain one cell of coverage; the renderer later clips the
+      // substitute regions through this original vector stroke.
+      const stroke = PdfStroke(width: 0.1);
+      expect(
+        c.strokeShape(
+          PdfPath([
+            const PdfMoveTo(10, 50),
+            const PdfLineTo(90, 50),
+          ]),
+          stroke,
+          inkColor,
+          PdfInkColorants.deviceGray(0.5),
+          overprint: true,
+          mode: 0,
+          opaque: true,
+        ),
+        isNull,
+      );
+      final regions = c.takeSpatialPaint();
+      expect(regions, isNotNull);
+      expect(
+        {for (final region in regions!) region.color},
+        containsAll([green, inkColor]),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Outcome

Moves one additional Ghent transparency page from Canvas fallback to the native Flutter GPU path: 45 accepted / 12 fallback versus 44 / 13 on main. PDF.js remains 177 / 2.

## What changed

- Preserve shared and distinct per-paint arbitrary path clips when an alpha-one Normal transparency group can be flattened exactly.
- Give strokes narrower than one colorant-grid cell one sample cell for backdrop discovery. The retained replay remains clipped through the original vector stroke, so visible width and edges are unchanged.
- Keep non-flattenable groups, unresolved process-color overprint, and other unsafe cases on the exact Canvas fallback.

## Validation

- Full pdf_graphics suite: 1,053 passed.
- Full native GPU corpus with system fonts: Ghent 45 / 12; PDF.js 177 / 2.
- Focused native GPU parity: shared and distinct arbitrary path clips match Canvas.
- Focused colorant regression: a sub-cell stroke crossing distinct backdrops yields exact spatial regions.
- Analyzer clean for pdf_graphics and dart_pdf_editor_flutter_gpu.
- git diff --check clean.

The remaining Ghent clip rejection is a non-flattenable multi-paint transparency group, so it stays conservative.