### PR TITLE
fix(graphics): resolve sub-cell glyph overprint

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -60,6 +60,9 @@
   alpha-one Normal transparency groups, and keep sub-cell strokes visible to
   the colorant compositor before exact vector replay. One additional Ghent
   transparency page stays on the GPU path.
+- Keep sub-cell embedded glyphs represented in the colorant compositor so one
+  additional Ghent overprint page stays on the GPU path. Sub-cell multi-glyph
+  and unresolved process-color cases remain conservative Canvas fallbacks.
 - Initialize tiles wholly inside the transformed crop box with the folded
   opaque paper color in the render-pass clear, skipping the transparent clear
   and full-tile paper draw. A one-device-pixel guard keeps rotated and

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -22,6 +22,10 @@
   compound sub-cell paths conservative rather than inflating their joins and
   caps into unrelated backdrops. Substitute regions remain clipped through
   the original vector stroke at replay.
+- Retain an intersected colorant-grid cell for a single embedded glyph whose
+  real outline is smaller than the grid sampling interval. The original glyph
+  remains the visible geometry while its overprint resolves against the
+  correct backdrop.
 
 - Export an OpenType CFF face reader that retains Unicode cmap mappings and
   selects collection entries, allowing native substitution adapters to obtain

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -2873,6 +2873,8 @@ class PdfInterpreter {
               runFill,
               ink,
               blendInk: blendInk,
+              subCellBounds:
+                  glyphs?.length == 1 ? _pathBounds(glyphPath) : null,
               overprint: isOverprint,
               mode: _state.overprintMode,
               opaque: _opaquePaint(alpha),

--- a/packages/pdf_graphics/lib/src/overprint_compositor.dart
+++ b/packages/pdf_graphics/lib/src/overprint_compositor.dart
@@ -34,6 +34,8 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
+
 import 'color.dart';
 import 'color_context.dart';
 import 'colorants.dart';
@@ -272,23 +274,30 @@ class PdfOverprintCompositor {
   /// Resolves a fill. Returns the colour to paint when the overprint composite
   /// is a single colour across the draw, or null to leave the device's own
   /// handling (its RGB approximation, or plain painting when not overprinting)
-  /// in charge.
+  /// in charge. [subCellBounds] may conservatively retain one or more
+  /// intersected grid cells when a real vector shape covered no cell centre;
+  /// the caller must clip visible replay through the original path.
   PdfColor? fill(
       PdfPath path, PdfFillRule rule, PdfColor color, PdfInkColorants? ink,
       {PdfInkColorants? blendInk,
+      PdfRect? subCellBounds,
       required bool overprint,
       required int mode,
       required bool opaque}) {
     _skipPaint = false;
     _spatialPaint = null;
-    return _resolve(
-        () => _raster.fillSpans(path, evenOdd: rule == PdfFillRule.evenOdd),
-        color,
-        ink,
-        blendInk: blendInk,
-        overprint: overprint,
-        mode: mode,
-        opaque: opaque);
+    return _resolve(() {
+      final spans =
+          _raster.fillSpans(path, evenOdd: rule == PdfFillRule.evenOdd);
+      if (!spans.isEmpty || subCellBounds == null) return spans;
+      return _raster.coveringBoxSpans(
+        subCellBounds.left,
+        subCellBounds.bottom,
+        subCellBounds.right,
+        subCellBounds.top,
+      );
+    }, color, ink,
+        blendInk: blendInk, overprint: overprint, mode: mode, opaque: opaque);
   }
 
   bool _skipPaint = false;

--- a/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
+++ b/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
@@ -576,6 +576,42 @@ class PdfColorantRaster {
     return ColorantSpans._(out, n ~/ 3);
   }
 
+  /// Spans for every cell whose interior intersects an axis-aligned
+  /// page-space box.
+  ///
+  /// Ordinary coverage is sampled at cell centres. This conservative variant
+  /// is only for a real vector shape that covered no centre at all: it keeps a
+  /// sub-cell mark represented in the colorant grid while the caller retains
+  /// the original vector path for exact visible replay.
+  ColorantSpans coveringBoxSpans(
+      double left, double bottom, double right, double top) {
+    final m = mapping.matrix;
+    var minX = double.infinity, minY = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    for (var corner = 0; corner < 4; corner++) {
+      final px = corner.isEven ? left : right;
+      final py = corner < 2 ? bottom : top;
+      final x = m.transformX(px, py), y = m.transformY(px, py);
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    final y0 = minY.floor().clamp(0, height);
+    final y1 = maxY.ceil().clamp(0, height);
+    final x0 = minX.floor().clamp(0, width);
+    final x1 = maxX.ceil().clamp(0, width);
+    if (x1 <= x0 || y1 <= y0) return ColorantSpans.empty;
+    final out = Int32List((y1 - y0) * 3);
+    var n = 0;
+    for (var y = y0; y < y1; y++) {
+      out[n++] = y;
+      out[n++] = x0;
+      out[n++] = x1;
+    }
+    return ColorantSpans._(out, n ~/ 3);
+  }
+
   /// First cell whose centre (`x + 0.5`) is at or past [edge].
   static int _cellFrom(double edge) => (edge - 0.5).ceil();
 

--- a/packages/pdf_graphics/test/colorant_buffer_test.dart
+++ b/packages/pdf_graphics/test/colorant_buffer_test.dart
@@ -17,6 +17,7 @@
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
@@ -517,7 +518,6 @@ void main() {
       fill(c, rect(0, 0, 50, 100), green, spot.inkColorants(const [0.5, 1]));
       fill(c, rect(50, 0, 100, 100), green,
           PdfInkColorants.deviceCmyk(0.5, 0, 1, 0.5));
-
       // At this buffer scale 0.1pt covers less than half a cell and its
       // centreline lies exactly between two sample rows. The colorant grid
       // must retain one cell of coverage; the renderer later clips the
@@ -577,6 +577,44 @@ void main() {
         isNull,
       );
       expect(c.takeSpatialPaint(), isNull);
+    });
+
+    test('explicit bounds preserve a sub-cell fill for spatial replay', () {
+      const green = PdfColor(0.31, 0.45, 0.13);
+      const inkColor = PdfColor(0.5, 0.5, 0.5);
+      final spot = PdfColorSpace.parse(
+          cos,
+          CosArray([
+            const CosName('DeviceN'),
+            CosArray([const CosName('Black'), const CosName('GWG Green')]),
+            const CosName('DeviceCMYK'),
+            exponential(const [0, 0, 0, 1]),
+          ]));
+      final c = buffer();
+      fill(c, rect(0, 0, 50, 100), green, spot.inkColorants(const [0.5, 1]));
+      fill(c, rect(50, 0, 100, 100), green,
+          PdfInkColorants.deviceCmyk(0.5, 0, 1, 0.5));
+      final skinny = rect(49.95, 10, 50.05, 90);
+
+      expect(
+        c.fill(
+          skinny,
+          PdfFillRule.nonzero,
+          inkColor,
+          PdfInkColorants.deviceGray(0.5),
+          subCellBounds: const PdfRect(49.95, 10, 50.05, 90),
+          overprint: true,
+          mode: 0,
+          opaque: true,
+        ),
+        isNull,
+      );
+      final regions = c.takeSpatialPaint();
+      expect(regions, isNotNull);
+      expect(
+        {for (final region in regions!) region.color},
+        containsAll([green, inkColor]),
+      );
     });
   });
 }

--- a/packages/pdf_graphics/test/overprint_test.dart
+++ b/packages/pdf_graphics/test/overprint_test.dart
@@ -212,6 +212,59 @@ void main() {
     expect(nonBlackOverprintStrokes(true), 0,
         reason: 'exact region-clipped replay clears stroked overprint');
   });
+
+  test('sub-cell glyph overprint resolves and stays selectable', () {
+    final file =
+        File('../../test_corpora/ghent/2-SPOT/GWG030_Gray_K_black_OP_X1.pdf');
+    if (!file.existsSync()) {
+      markTestSkipped('test_corpora/ghent not found');
+      return;
+    }
+    final doc = PdfDocument.open(file.readAsBytesSync());
+
+    ({Set<String> fallbacks, Set<String> texts}) run(bool resolve) {
+      final recorder = RecordingPdfDevice();
+      final previous = PdfInterpreter.debugResolveOverprint;
+      PdfInterpreter.debugResolveOverprint = resolve;
+      try {
+        PdfInterpreter(cos: doc.cos, device: recorder).drawPage(doc.page(0));
+      } finally {
+        PdfInterpreter.debugResolveOverprint = previous;
+      }
+      var fillOverprint = false;
+      final fallbacks = <String>{};
+      final texts = <String>{};
+      final saved = <bool>[];
+      for (final command in recorder.commands) {
+        switch (command) {
+          case PdfSaveCommand():
+            saved.add(fillOverprint);
+          case PdfRestoreCommand() when saved.isNotEmpty:
+            fillOverprint = saved.removeLast();
+          case PdfSetOverprintCommand(:final fill):
+            fillOverprint = fill;
+          case PdfDrawTextCommand(:final run):
+            texts.add(run.text);
+            if (fillOverprint &&
+                !run.invisible &&
+                run.color != PdfColor.black) {
+              fallbacks.add(run.text);
+            }
+          default:
+        }
+      }
+      return (fallbacks: fallbacks, texts: texts);
+    }
+
+    final control = run(false);
+    expect(control.fallbacks, isNotEmpty,
+        reason: 'the fixture must exercise the RGB text fallback control');
+    final exact = run(true);
+    expect(exact.fallbacks, isEmpty,
+        reason: 'the colorant sample resolves non-black glyph overprint');
+    expect(exact.texts, containsAll(control.fallbacks),
+        reason: 'resolved glyphs remain available to extraction and selection');
+  });
 }
 
 /// Smallest valid PDF the interpreter can resolve names against - the content


### PR DESCRIPTION
## Main comparison

- Ghent native Flutter GPU: 46 accepted / 11 fallback on corrected main -> 48 accepted / 9 fallback on this PR.
- PDF.js native Flutter GPU: unchanged at 177 accepted / 2 fallback.
- Canvas Ghent output: all 54 checked-in baselines pass on corrected main and this PR; no raster delta or baseline refresh.

## What changed

- Retain conservative colorant-grid coverage for a single embedded glyph whose exact outline is smaller than one grid cell.
- Use the measured page-space glyph bounds only when the exact rasterized outline produces no colorant-cell spans.
- Keep multi-glyph, system-text, and unresolved colorant cases on the existing conservative Canvas fallback.
- Keep the original embedded glyph as visible vector geometry, so exact edges and selectable text are preserved.

## Validation

- Focused colorant-buffer and overprint tests pass after rebasing onto #812.
- Graphics and experimental GPU analyzers are clean.
- GWG030 target: accepted=1, rejected=0.
- Complete native GPU corpus: Ghent 48/9; PDF.js 177/2.
- Complete Ghent Canvas baseline run: 54/54 pass with no updates.