### PR TITLE
fix(graphics): keep compound sub-cell strokes conservative

### DIFF
--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -17,9 +17,11 @@
   per-backdrop regions instead of leaving those strokes to an RGB `darken`
   approximation. The region clips preserve the original vector stroke edge
   and let retained GPU scenes accept three additional Ghent pages exactly.
-- Preserve one colorant-grid sample for strokes narrower than a grid cell so
-  spatial overprint can discover every crossed backdrop; the substitute
-  regions remain clipped through the original vector stroke at replay.
+- Preserve one colorant-grid sample for a single straight stroke narrower than
+  a grid cell so spatial overprint can discover every crossed backdrop; keep
+  compound sub-cell paths conservative rather than inflating their joins and
+  caps into unrelated backdrops. Substitute regions remain clipped through
+  the original vector stroke at replay.
 
 - Export an OpenType CFF face reader that retains Unicode cmap mappings and
   selects collection entries, allowing native substitution adapters to obtain

--- a/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
+++ b/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
@@ -519,11 +519,17 @@ class PdfColorantRaster {
     }
     final contours = StrokeContours();
     final mappedWidth = width * scale;
+    final isSingleOpenSegment = subpaths.length == 1 &&
+        !subpaths.single.closed &&
+        subpaths.single.pointCount == 2;
     strokeToContours(subpaths,
-        // The colorant grid cannot represent a stroke narrower than one cell.
-        // Preserve one sample cell here; spatial replay still clips the result
-        // through the original vector stroke, so its visible width is exact.
-        width: mappedWidth < 1 ? 1 : mappedWidth,
+        // A single straight stroke narrower than one cell can miss every cell
+        // centre. Preserve one probe cell for that bounded case; spatial
+        // replay still clips the result through the original vector stroke,
+        // so its visible width is exact. Inflating multi-segment paths changes
+        // joins/caps and can sample unrelated backdrops outside their exact
+        // geometry (the Ghent transparency X patches expose that error).
+        width: mappedWidth < 1 && isSingleOpenSegment ? 1 : mappedWidth,
         cap: cap,
         join: join,
         miterLimit: miterLimit,

--- a/packages/pdf_graphics/test/colorant_buffer_test.dart
+++ b/packages/pdf_graphics/test/colorant_buffer_test.dart
@@ -545,5 +545,38 @@ void main() {
         containsAll([green, inkColor]),
       );
     });
+
+    test('a multi-segment sub-cell stroke stays conservative', () {
+      const green = PdfColor(0.31, 0.45, 0.13);
+      const inkColor = PdfColor(0.5, 0.5, 0.5);
+      final c = buffer();
+      fill(c, rect(0, 0, 100, 100), green,
+          PdfInkColorants.deviceCmyk(0.5, 0, 1, 0.5));
+
+      // Both exact 0.1pt segments lie between sample rows and cover no
+      // colorant cell centre. Inflating the whole compound path resolves it
+      // as [inkColor], even though joins/caps and neighbouring backdrops are
+      // unknowable at this grid resolution. Declining keeps the device's
+      // conservative overprint path; the Ghent composite pages expose the
+      // forced resolution as a visible X.
+      expect(
+        c.strokeShape(
+          PdfPath([
+            const PdfMoveTo(10, 50),
+            const PdfLineTo(40, 50),
+            const PdfMoveTo(60, 50),
+            const PdfLineTo(90, 50),
+          ]),
+          const PdfStroke(width: 0.1),
+          inkColor,
+          PdfInkColorants.deviceGray(0.5),
+          overprint: true,
+          mode: 0,
+          opaque: true,
+        ),
+        isNull,
+      );
+      expect(c.takeSpatialPaint(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Main comparison

- Ghent Canvas baselines: main fails 6 pages, including a conspicuous incorrect magenta X; this PR passes all 54 documents.
- Ghent native Flutter GPU: main 45 accepted / 12 fallback -> PR 46 accepted / 11 fallback.
- PDF.js native Flutter GPU: unchanged at 177 accepted / 2 fallback.

## Cause and fix

PR #810 inflated every stroke narrower than one colorant-grid cell to a full probe cell. Exact vector clipping preserved the visible stroke width, but compound paths acquired inflated joins and caps in the colorant lookup. Those probes could sample unrelated backdrops and force the wrong ink-space composite.

Keep the one-cell probe only for its bounded, validated case: one straight open segment. Compound and dashed sub-cell paths now remain on the conservative overprint fallback when their exact geometry covers no colorant cell centre.

## Validation

- New focused regression fails under #810 with an incorrect forced gray composite and passes here.
- Complete colorant and overprint unit suites pass.
- Graphics and experimental GPU analyzers are clean.
- Complete Ghent Canvas baseline suite: 54/54 pass with no baseline updates.
- Complete native GPU corpus: Ghent 46/11; PDF.js 177/2.