### PR TITLE
ci(gpu): compare corpus fallback routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: dart analyze --fatal-infos
       - name: Test Patrol performance summarizer
         run: dart tool/patrol_perf_summary_test.dart
+      - name: Test Flutter GPU corpus summarizer
+        run: dart tool/gpu_corpus_summary_test.dart
       # Enforce the lockstep versioning invariant: every workspace package
       # must depend on its siblings at the current release version (`^x.y.z`).
       # A stale lower bound makes pub.dev's downgrade analysis fail (0/20 on
@@ -190,6 +192,7 @@ jobs:
       - name: Validate native system-font GPU corpus parity
         working-directory: packages/dart_pdf_editor_flutter_gpu
         env:
+          GPU_CORPUS_REPORT: ${{ runner.temp }}/flutter-gpu-corpus-pr.json
           GPU_CORPUS_SYSTEM_TEXT: 1
           GPU_CORPUS_REGISTER_SYSTEM_FONTS: 1
         run: >-
@@ -214,8 +217,37 @@ jobs:
             cd "$destination"
             flutter pub get
           )
+          # Run the PR's report-capable corpus harness against main's package
+          # sources so route changes are compared page by page.
+          cp packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart \
+            "$destination/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_compare_test.dart"
           echo "dir=$destination" >> "$GITHUB_OUTPUT"
           echo "commit=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Measure main Flutter GPU corpus routes
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_WORKSPACE: ${{ steps.gpu-baseline.outputs.dir }}
+          GPU_CORPUS_REPORT: ${{ runner.temp }}/flutter-gpu-corpus-main.json
+          GPU_CORPUS_SYSTEM_TEXT: 1
+          GPU_CORPUS_REGISTER_SYSTEM_FONTS: 1
+        run: |
+          set -euo pipefail
+          cd "$BASE_WORKSPACE/packages/dart_pdf_editor_flutter_gpu"
+          flutter test --enable-impeller --enable-flutter-gpu \
+            test/gpu_corpus_compare_test.dart --reporter expanded
+
+      - name: Compare Flutter GPU corpus routes with main
+        if: github.event_name == 'pull_request'
+        working-directory: packages/dart_pdf_editor_flutter_gpu
+        shell: bash
+        run: >-
+          dart ../../tool/gpu_corpus_summary.dart
+          "$RUNNER_TEMP/flutter-gpu-corpus-main.json"
+          "$RUNNER_TEMP/flutter-gpu-corpus-pr.json"
+          --output test-results/gpu
+          --markdown "$GITHUB_STEP_SUMMARY"
 
       - name: Measure Flutter GPU warm-up and first-tile performance
         id: gpu-performance
@@ -509,26 +541,38 @@ jobs:
             };
             const headlinePath = find('flutter-gpu-performance', 'patrol-perf-headline.md');
             const reportPath = find('flutter-gpu-performance', 'patrol-perf.md');
+            const corpusHeadlinePath = find('flutter-gpu-performance', 'gpu-corpus-headline.md');
+            const corpusReportPath = find('flutter-gpu-performance', 'gpu-corpus.md');
             const headline = headlinePath
               ? fs.readFileSync(headlinePath, 'utf8').trim()
               : 'No headline Flutter GPU performance summary was produced.';
             const report = reportPath
               ? fs.readFileSync(reportPath, 'utf8').trim()
               : 'No Flutter GPU performance artifact was produced. Open the workflow run for the failing step and raw logs.';
+            const corpusHeadline = corpusHeadlinePath
+              ? fs.readFileSync(corpusHeadlinePath, 'utf8').trim()
+              : 'No Flutter GPU corpus comparison was produced.';
+            const corpusReport = corpusReportPath
+              ? fs.readFileSync(corpusReportPath, 'utf8').trim()
+              : 'No Flutter GPU corpus report was produced.';
             const sha = context.payload.pull_request.head.sha.slice(0, 7);
             const baseSha = context.payload.pull_request.base.sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               marker,
-              '## Flutter GPU performance',
+              '## Flutter GPU validation',
               '',
               `Automated on macOS Metal for commit \`${sha}\` · [workflow run and downloadable traces](${runUrl})`,
               `Same-host A/B: base \`${baseSha}\` and PR were alternated on one GitHub runner.`,
               '',
+              corpusHeadline,
+              '',
               headline,
               '',
               '<details>',
-              '<summary>View Flutter GPU performance details</summary>',
+              '<summary>View Flutter GPU validation details</summary>',
+              '',
+              corpusReport,
               '',
               report,
               '',

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:typed_data';
@@ -28,6 +29,8 @@ const _skippedPdfJs = {
   'poppler-937-0-fuzzed.pdf',
   'print_protection.pdf',
 };
+
+final _corpusReports = <String, Object?>{};
 
 bool _gpuAvailable() {
   try {
@@ -115,8 +118,16 @@ void _corpus(
   var rejected = 0;
   final rejectionReasons = <String, int>{};
   final missingOutlineFonts = <String, int>{};
+  final pages = <Map<String, Object?>>[];
   for (final file in files) {
     final name = file.uri.pathSegments.last;
+    final prefix = root.path.endsWith(Platform.pathSeparator)
+        ? root.path
+        : '${root.path}${Platform.pathSeparator}';
+    final relativeName = (file.path.startsWith(prefix)
+            ? file.path.substring(prefix.length)
+            : name)
+        .replaceAll('\\', '/');
     testWidgets('$suite/$name', (tester) async {
       await tester.runAsync(() async {
         final document = PdfDocument.open(
@@ -137,6 +148,11 @@ void _corpus(
             if (session == null) {
               rejected++;
               final reason = backend.lastSessionRejection ?? 'unspecified';
+              pages.add({
+                'id': '$suite/$relativeName page $pageIndex',
+                'route': 'canvas-fallback',
+                'reason': reason,
+              });
               rejectionReasons.update(reason, (count) => count + 1,
                   ifAbsent: () => 1);
               final fonts = <String>{
@@ -152,6 +168,10 @@ void _corpus(
               continue;
             }
             accepted++;
+            pages.add({
+              'id': '$suite/$relativeName page $pageIndex',
+              'route': 'flutter-gpu',
+            });
             try {
               final region = Offset.zero & scene.pageSize;
               final ratio = math.min(
@@ -215,11 +235,36 @@ void _corpus(
     // ignore: avoid_print
     print('$suite flutter_gpu missing-outline fonts: '
         '${{for (final entry in fonts) entry.key: entry.value}}');
+    pages.sort((a, b) => (a['id']! as String).compareTo(b['id']! as String));
+    _corpusReports[suite] = {
+      'accepted': accepted,
+      'rejected': rejected,
+      'pages': pages,
+      'rejectionReasons': {
+        for (final entry in grouped) entry.key: entry.value,
+      },
+      'missingOutlineFonts': {
+        for (final entry in fonts) entry.key: entry.value,
+      },
+    };
+    _writeCorpusReport();
     expect(accepted + rejected, greaterThan(0));
     // A zero acceptance rate would make the optional backend inert even if
     // all conservative-fallback tests passed.
     expect(accepted, greaterThan(0));
   });
+}
+
+void _writeCorpusReport() {
+  final path = Platform.environment['GPU_CORPUS_REPORT'];
+  if (path == null || path.isEmpty) return;
+  final file = File(path);
+  file.parent.createSync(recursive: true);
+  const encoder = JsonEncoder.withIndent('  ');
+  file.writeAsStringSync('${encoder.convert({
+        'schema': 1,
+        'suites': _corpusReports,
+      })}\n');
 }
 
 Future<void> _registerMacSystemFonts() async {

--- a/tool/gpu_corpus_summary.dart
+++ b/tool/gpu_corpus_summary.dart
@@ -1,0 +1,292 @@
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> arguments) {
+  if (arguments.length < 2) {
+    stderr.writeln(
+      'Usage: dart tool/gpu_corpus_summary.dart '
+      '<main.json> <pr.json> [--output <directory>] '
+      '[--markdown <file>]',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final baselinePath = arguments[0];
+  final currentPath = arguments[1];
+  String? outputDirectory;
+  String? markdownPath;
+  for (var index = 2; index < arguments.length; index++) {
+    switch (arguments[index]) {
+      case '--output':
+        outputDirectory = _nextValue(arguments, ++index, '--output');
+      case '--markdown':
+        markdownPath = _nextValue(arguments, ++index, '--markdown');
+      default:
+        throw FormatException('Unknown argument: ${arguments[index]}');
+    }
+  }
+
+  final comparison = GpuCorpusComparison(
+    baseline: GpuCorpusReport.parse(
+      jsonDecode(File(baselinePath).readAsStringSync()),
+    ),
+    current: GpuCorpusReport.parse(
+      jsonDecode(File(currentPath).readAsStringSync()),
+    ),
+  );
+  final headline = comparison.toHeadlineMarkdown();
+  final report = comparison.toMarkdown();
+  stdout.writeln(headline);
+
+  if (outputDirectory != null) {
+    final directory = Directory(outputDirectory)..createSync(recursive: true);
+    File('${directory.path}/gpu-corpus-headline.md')
+        .writeAsStringSync('$headline\n');
+    File('${directory.path}/gpu-corpus.md').writeAsStringSync('$report\n');
+  }
+  if (markdownPath != null) {
+    final file = File(markdownPath);
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync('$report\n', mode: FileMode.append);
+  }
+
+  if (comparison.hasRegressions) {
+    stderr.writeln(
+      'Flutter GPU corpus regression: ${comparison.regressions.length} '
+      'previously accepted page(s) now require Canvas fallback.',
+    );
+    exitCode = 1;
+  }
+}
+
+String _nextValue(List<String> arguments, int index, String flag) {
+  if (index >= arguments.length) {
+    throw FormatException('$flag requires a value');
+  }
+  return arguments[index];
+}
+
+class GpuCorpusReport {
+  GpuCorpusReport(this.suites);
+
+  factory GpuCorpusReport.parse(Object? value) {
+    if (value is! Map || value['schema'] != 1 || value['suites'] is! Map) {
+      throw const FormatException('Unsupported Flutter GPU corpus report');
+    }
+    final suites = <String, GpuCorpusSuite>{};
+    for (final entry in (value['suites'] as Map).entries) {
+      if (entry.key is! String) {
+        throw const FormatException('GPU corpus suite name is not a string');
+      }
+      suites[entry.key as String] = GpuCorpusSuite.parse(entry.value);
+    }
+    return GpuCorpusReport(suites);
+  }
+
+  final Map<String, GpuCorpusSuite> suites;
+}
+
+class GpuCorpusSuite {
+  GpuCorpusSuite(this.pages);
+
+  factory GpuCorpusSuite.parse(Object? value) {
+    if (value is! Map || value['pages'] is! List) {
+      throw const FormatException('Invalid Flutter GPU corpus suite');
+    }
+    final pages = <String, GpuCorpusPage>{};
+    for (final rawPage in value['pages'] as List) {
+      final page = GpuCorpusPage.parse(rawPage);
+      if (pages[page.id] != null) {
+        throw FormatException('Duplicate Flutter GPU corpus page: ${page.id}');
+      }
+      pages[page.id] = page;
+    }
+    final suite = GpuCorpusSuite(pages);
+    if (value['accepted'] != suite.accepted ||
+        value['rejected'] != suite.rejected) {
+      throw const FormatException(
+        'Flutter GPU corpus route totals do not match the page records',
+      );
+    }
+    return suite;
+  }
+
+  final Map<String, GpuCorpusPage> pages;
+
+  int get accepted => pages.values.where((page) => page.accepted).length;
+  int get rejected => pages.length - accepted;
+}
+
+class GpuCorpusPage {
+  const GpuCorpusPage({
+    required this.id,
+    required this.route,
+    this.reason,
+  });
+
+  factory GpuCorpusPage.parse(Object? value) {
+    if (value is! Map || value['id'] is! String || value['route'] is! String) {
+      throw const FormatException('Invalid Flutter GPU corpus page');
+    }
+    final route = value['route'] as String;
+    if (route != 'flutter-gpu' && route != 'canvas-fallback') {
+      throw FormatException('Unknown Flutter GPU corpus route: $route');
+    }
+    return GpuCorpusPage(
+      id: value['id'] as String,
+      route: route,
+      reason: value['reason'] as String?,
+    );
+  }
+
+  final String id;
+  final String route;
+  final String? reason;
+
+  bool get accepted => route == 'flutter-gpu';
+}
+
+class GpuCorpusComparison {
+  GpuCorpusComparison({required this.baseline, required this.current});
+
+  final GpuCorpusReport baseline;
+  final GpuCorpusReport current;
+
+  List<GpuCorpusPage> get regressions => _routeChanges(
+        baselineAccepted: true,
+        currentAccepted: false,
+      );
+
+  List<GpuCorpusPage> get improvements => _routeChanges(
+        baselineAccepted: false,
+        currentAccepted: true,
+      );
+
+  bool get hasRegressions => regressions.isNotEmpty;
+
+  String toHeadlineMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('### Flutter GPU corpus comparison with `main`')
+      ..writeln()
+      ..writeln(
+          '| Suite | Main accepted / fallback | PR accepted / fallback | Change |')
+      ..writeln('| --- | ---: | ---: | ---: |');
+    for (final name in _suiteNames) {
+      final main = baseline.suites[name];
+      final pullRequest = current.suites[name];
+      final mainAccepted = main?.accepted ?? 0;
+      final currentAccepted = pullRequest?.accepted ?? 0;
+      final delta = currentAccepted - mainAccepted;
+      buffer.writeln(
+        '| ${_escape(name)} | ${main?.accepted ?? 0} / '
+        '${main?.rejected ?? 0} | ${pullRequest?.accepted ?? 0} / '
+        '${pullRequest?.rejected ?? 0} | ${_signed(delta)} accepted |',
+      );
+    }
+    buffer
+      ..writeln()
+      ..writeln(
+        '**New GPU coverage:** ${_inlinePages(improvements, empty: 'none')}.',
+      )
+      ..writeln(
+        '**New Canvas fallbacks:** '
+        '${_inlinePages(regressions, empty: 'none')}.',
+      );
+    return buffer.toString().trimRight();
+  }
+
+  String toMarkdown() {
+    final buffer = StringBuffer(toHeadlineMarkdown());
+    _writeChanges(buffer, 'New GPU coverage', improvements);
+    _writeChanges(buffer, 'New Canvas fallbacks', regressions);
+
+    final fallbacks = <GpuCorpusPage>[
+      for (final suite in current.suites.values)
+        for (final page in suite.pages.values)
+          if (!page.accepted) page,
+    ]..sort((a, b) => a.id.compareTo(b.id));
+    buffer
+      ..writeln()
+      ..writeln()
+      ..writeln('#### Current conservative Canvas fallbacks')
+      ..writeln();
+    if (fallbacks.isEmpty) {
+      buffer.writeln('None.');
+    } else {
+      buffer
+        ..writeln('| Page | Reason |')
+        ..writeln('| --- | --- |');
+      for (final page in fallbacks) {
+        buffer.writeln(
+          '| `${_escape(page.id)}` | ${_escape(page.reason ?? 'unspecified')} |',
+        );
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+
+  List<String> get _suiteNames => {
+        ...baseline.suites.keys,
+        ...current.suites.keys,
+      }.toList()
+        ..sort();
+
+  List<GpuCorpusPage> _routeChanges({
+    required bool baselineAccepted,
+    required bool currentAccepted,
+  }) {
+    final result = <GpuCorpusPage>[];
+    for (final suiteName in _suiteNames) {
+      final mainPages = baseline.suites[suiteName]?.pages;
+      final currentPages = current.suites[suiteName]?.pages;
+      if (mainPages == null || currentPages == null) continue;
+      for (final entry in mainPages.entries) {
+        final pullRequest = currentPages[entry.key];
+        if (pullRequest != null &&
+            entry.value.accepted == baselineAccepted &&
+            pullRequest.accepted == currentAccepted) {
+          result.add(pullRequest);
+        }
+      }
+    }
+    result.sort((a, b) => a.id.compareTo(b.id));
+    return result;
+  }
+}
+
+void _writeChanges(
+  StringBuffer buffer,
+  String heading,
+  List<GpuCorpusPage> pages,
+) {
+  buffer
+    ..writeln()
+    ..writeln()
+    ..writeln('#### $heading')
+    ..writeln();
+  if (pages.isEmpty) {
+    buffer.writeln('None.');
+    return;
+  }
+  for (final page in pages) {
+    buffer.writeln(
+      '- `${page.id}`${page.reason == null ? '' : ' — ${page.reason}'}',
+    );
+  }
+}
+
+String _inlinePages(
+  List<GpuCorpusPage> pages, {
+  required String empty,
+  int limit = 4,
+}) {
+  if (pages.isEmpty) return empty;
+  final visible = pages.take(limit).map((page) => '`${page.id}`').join(', ');
+  final remaining = pages.length - limit;
+  return remaining > 0 ? '$visible, and $remaining more' : visible;
+}
+
+String _signed(int value) => value > 0 ? '+$value' : '$value';
+
+String _escape(String value) => value.replaceAll('|', r'\|');

--- a/tool/gpu_corpus_summary_test.dart
+++ b/tool/gpu_corpus_summary_test.dart
@@ -1,0 +1,143 @@
+import 'gpu_corpus_summary.dart' as summary;
+
+void main() {
+  final baseline = summary.GpuCorpusReport.parse({
+    'schema': 1,
+    'suites': {
+      'Ghent': {
+        'accepted': 1,
+        'rejected': 1,
+        'pages': [
+          {'id': 'Ghent/accepted.pdf page 0', 'route': 'flutter-gpu'},
+          {
+            'id': 'Ghent/fallback.pdf page 0',
+            'route': 'canvas-fallback',
+            'reason': 'unsupported blend',
+          },
+        ],
+      },
+      'PDF.js': {
+        'accepted': 1,
+        'rejected': 0,
+        'pages': [
+          {'id': 'PDF.js/stable.pdf page 0', 'route': 'flutter-gpu'},
+        ],
+      },
+    },
+  });
+  final current = summary.GpuCorpusReport.parse({
+    'schema': 1,
+    'suites': {
+      'Ghent': {
+        'accepted': 1,
+        'rejected': 1,
+        'pages': [
+          {
+            'id': 'Ghent/accepted.pdf page 0',
+            'route': 'canvas-fallback',
+            'reason': 'new rejection',
+          },
+          {'id': 'Ghent/fallback.pdf page 0', 'route': 'flutter-gpu'},
+        ],
+      },
+      'PDF.js': {
+        'accepted': 1,
+        'rejected': 0,
+        'pages': [
+          {'id': 'PDF.js/stable.pdf page 0', 'route': 'flutter-gpu'},
+        ],
+      },
+    },
+  });
+  final comparison = summary.GpuCorpusComparison(
+    baseline: baseline,
+    current: current,
+  );
+
+  _expect(comparison.hasRegressions, 'route regression is detected');
+  _expectEqual(
+    comparison.regressions.single.id,
+    'Ghent/accepted.pdf page 0',
+    'regressed page',
+  );
+  _expectEqual(
+    comparison.improvements.single.id,
+    'Ghent/fallback.pdf page 0',
+    'new coverage page',
+  );
+  final headline = comparison.toHeadlineMarkdown();
+  _expectContains(
+    headline,
+    '| Ghent | 1 / 1 | 1 / 1 | 0 accepted |',
+    'headline totals',
+  );
+  _expectContains(
+    headline,
+    '**New GPU coverage:** `Ghent/fallback.pdf page 0`.',
+    'headline improvement',
+  );
+  _expectContains(
+    headline,
+    '**New Canvas fallbacks:** `Ghent/accepted.pdf page 0`.',
+    'headline regression',
+  );
+  _expectContains(
+    comparison.toMarkdown(),
+    '| `Ghent/accepted.pdf page 0` | new rejection |',
+    'fallback detail',
+  );
+
+  final safe = summary.GpuCorpusComparison(
+    baseline: current,
+    current: current,
+  );
+  _expect(!safe.hasRegressions, 'stable routes are safe');
+  _expectContains(
+    safe.toHeadlineMarkdown(),
+    '**New Canvas fallbacks:** none.',
+    'safe headline',
+  );
+
+  _expectThrows(
+    () => summary.GpuCorpusReport.parse({
+      'schema': 1,
+      'suites': {
+        'Ghent': {
+          'accepted': 2,
+          'rejected': 0,
+          'pages': [
+            {'id': 'Ghent/one.pdf page 0', 'route': 'flutter-gpu'},
+          ],
+        },
+      },
+    }),
+    'mismatched route totals',
+  );
+
+  print('Flutter GPU corpus summarizer tests passed');
+}
+
+void _expect(bool value, String label) {
+  if (!value) throw StateError(label);
+}
+
+void _expectEqual(Object? actual, Object? expected, String label) {
+  if (actual != expected) {
+    throw StateError('$label: expected $expected, got $actual');
+  }
+}
+
+void _expectContains(String actual, String expected, String label) {
+  if (!actual.contains(expected)) {
+    throw StateError('$label: expected to find $expected in:\n$actual');
+  }
+}
+
+void _expectThrows(void Function() callback, String label) {
+  try {
+    callback();
+  } on FormatException {
+    return;
+  }
+  throw StateError('$label: expected a FormatException');
+}


### PR DESCRIPTION
## Headline

- Current Metal coverage remains **Ghent 48 accepted / 9 Canvas fallbacks** and **PDF.js 177 / 2**.
- Future GPU PRs now get an automatic page-by-page comparison with `main`; a previously accepted page moving to Canvas fails the GPU lane.

## What changed

- emit a machine-readable route inventory from the native GPU corpus test, including exact page ids and fallback reasons
- run the same report-capable harness against the PR base revision on the same Metal runner
- add a tested comparison tool that reports new GPU coverage and new Canvas fallbacks
- put the corpus comparison before the performance headline in the bot comment, with full route and timing details collapsed

The extra base corpus pass is roughly 30 seconds on the current Metal runner and removes the manual CI-log comparison from GPU merge decisions.

## Validation

- `fvm dart analyze`
- `fvm dart tool/gpu_corpus_summary_test.dart`
- full native Metal GPU corpus with report output: Ghent 48/9, PDF.js 177/2, all parity tests green
- end-to-end report CLI over the generated corpus JSON
