### PR TITLE
perf(gpu): retry exact overprint scenes off-thread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,10 +217,6 @@ jobs:
             cd "$destination"
             flutter pub get
           )
-          # Run the PR's report-capable corpus harness against main's package
-          # sources so route changes are compared page by page.
-          cp packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart \
-            "$destination/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_compare_test.dart"
           echo "dir=$destination" >> "$GITHUB_OUTPUT"
           echo "commit=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
@@ -236,7 +232,7 @@ jobs:
           set -euo pipefail
           cd "$BASE_WORKSPACE/packages/dart_pdf_editor_flutter_gpu"
           flutter test --enable-impeller --enable-flutter-gpu \
-            test/gpu_corpus_compare_test.dart --reporter expanded
+            test/gpu_corpus_test.dart --reporter expanded
 
       - name: Compare Flutter GPU corpus routes with main
         if: github.event_name == 'pull_request'
@@ -288,6 +284,7 @@ jobs:
                   "$label" == "advanced-blend-stress" ||
                   "$label" == "knockout-mask" ||
                   "$label" == "knockout-overlap" ||
+                  "$label" == "overprint-retry" ||
                   "$label" == "hairline" ]]; then
               route_change=1
             fi
@@ -369,6 +366,7 @@ jobs:
           advanced-blend-stress generated advanced-blend-stress
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
+          overprint-retry pdf ../../test_corpora/ghent/3-ICC-CMS/GWG164_Transp_Basic_BM_ICCbasedCMYK_x4.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           fi
@@ -406,6 +404,7 @@ jobs:
           advanced-blend-stress generated advanced-blend-stress
           knockout-mask pdf ../../test_corpora/pdfjs/knockout_smask.pdf
           knockout-overlap pdf ../../test_corpora/pdfjs/knockout_isolated_overlap.pdf
+          overprint-retry pdf ../../test_corpora/ghent/3-ICC-CMS/GWG164_Transp_Basic_BM_ICCbasedCMYK_x4.pdf
           hairline pdf ../../test_corpora/pdfjs/issue3458.pdf
           SCENARIOS
           done
@@ -462,6 +461,8 @@ jobs:
             --require-scenario-runs gpu-knockout-mask-page-0-canvas-tile=6
             --require-scenario-runs gpu-knockout-overlap-page-0-first-tile=6
             --require-scenario-runs gpu-knockout-overlap-page-0-canvas-tile=6
+            --require-scenario-runs gpu-overprint-retry-page-0-first-tile=6
+            --require-scenario-runs gpu-overprint-retry-page-0-canvas-tile=6
             --require-scenario-runs gpu-hairline-page-0-first-tile=6
             --require-scenario-runs gpu-hairline-page-0-canvas-tile=6
           )

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.0.0
 
+- Add an optional asynchronous tile-backend retry hook and exact retained-scene
+  re-recording, while preserving the existing Canvas fallback when a retry is
+  unavailable, fails, or remains inexact.
 - **Breaking:** classes that `implements PdfTileRasterBackend` must add
   `supportsWarmUp`, `supportsSessionWarmUp`, and `warmUp()`. Extending the base
   class keeps the default no-op implementations.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -3057,6 +3057,7 @@ class _PdfPageViewState extends State<PdfPageView>
           widget.tileRasterBackend.prefersDirectDecodedImageUploads,
       timing: timing,
       maxImagePixelRatio: maxImagePixelRatio,
+      allowOverprintRerecord: true,
     );
     if (timing != null) CanvasPdfDevice.debugResetTextShape();
     final replayClock = timing == null ? null : (Stopwatch()..start());
@@ -3404,6 +3405,7 @@ class _PdfPageViewState extends State<PdfPageView>
           widget.page,
           commands,
           plan: _renderPlan,
+          allowOverprintRerecord: true,
         );
         if (_superseded(generation, pageIndex)) {
           scene.dispose();
@@ -5384,6 +5386,23 @@ class _PdfPageViewState extends State<PdfPageView>
             'backend=${label()} error=$error',
           );
         }
+        if (preferred == null &&
+            initializationError == null &&
+            backend is PdfTileRasterRetryBackend) {
+          try {
+            final retry =
+                (backend as PdfTileRasterRetryBackend).retrySession(scene);
+            if (retry != null) {
+              preferred = _DeferredTileRasterSession(scene, retry);
+            }
+          } catch (error) {
+            initializationError = error;
+            PdfPerfLog.log(
+              'tile backend retry init fallback page=${widget.previewIndex} '
+              'backend=${label()} error=$error',
+            );
+          }
+        }
         final fallback =
             const PdfCanvasTileRasterBackend().createSession(scene);
         if (preferred == null) {
@@ -6077,6 +6096,108 @@ class _PdfPageViewState extends State<PdfPageView>
         );
       },
     );
+  }
+}
+
+/// Lazily resolves an optional backend's asynchronous exact-scene retry.
+///
+/// The public backend contract remains synchronous and Canvas stays ready in
+/// [_FallbackTileRasterSession]. Until the retry resolves, conservative GPU
+/// scheduling prevents a repaint burst from queueing a slab-sized batch.
+class _DeferredTileRasterSession
+    implements
+        PdfTileRasterSession,
+        PdfTileRasterScheduling,
+        PdfTileRasterWarmUp {
+  _DeferredTileRasterSession(this.scene, Future<PdfTileRasterSession?> retry) {
+    _session = _resolve(retry);
+  }
+
+  @override
+  final PdfRetainedScene scene;
+  late final Future<PdfTileRasterSession?> _session;
+  PdfTileRasterSession? _resolved;
+  Object? _resolutionError;
+  StackTrace? _resolutionStackTrace;
+  bool _disposed = false;
+
+  Future<PdfTileRasterSession?> _resolve(
+    Future<PdfTileRasterSession?> retry,
+  ) async {
+    try {
+      final session = await retry;
+      if (session == null) {
+        _resolutionError =
+            StateError('tile backend exact-scene retry declined');
+        return null;
+      }
+      if (_disposed) {
+        session.dispose();
+        _resolutionError =
+            StateError('tile backend exact-scene retry disposed');
+        return null;
+      }
+      return _resolved = session;
+    } catch (error, stackTrace) {
+      _resolutionError = error;
+      _resolutionStackTrace = stackTrace;
+      return null;
+    }
+  }
+
+  Future<PdfTileRasterSession> _requireSession() async {
+    final session = await _session;
+    if (session != null) return session;
+    Error.throwWithStackTrace(
+      _resolutionError ??
+          StateError('tile backend exact-scene retry unavailable'),
+      _resolutionStackTrace ?? StackTrace.current,
+    );
+  }
+
+  @override
+  bool get batchAdjacentTiles {
+    final session = _resolved;
+    return session is PdfTileRasterScheduling
+        ? (session as PdfTileRasterScheduling).batchAdjacentTiles
+        : false;
+  }
+
+  @override
+  int? get maxNewTilesPerPaint {
+    final session = _resolved;
+    return session is PdfTileRasterScheduling
+        ? (session as PdfTileRasterScheduling).maxNewTilesPerPaint
+        : 1;
+  }
+
+  @override
+  Future<void> warmUp() async {
+    final session = await _requireSession();
+    if (session is PdfTileRasterWarmUp) {
+      await (session as PdfTileRasterWarmUp).warmUp();
+    }
+  }
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) async {
+    final session = await _requireSession();
+    return session.rasterizeRegion(
+      region,
+      pixelRatio: pixelRatio,
+      tracePage: tracePage,
+    );
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _resolved?.dispose();
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -13,6 +13,7 @@
 /// runs after [record] returns.
 library;
 
+import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -29,6 +30,8 @@ import 'renderer.dart';
 import 'render_worker.dart';
 import 'region_replay_index.dart';
 import 'strips/strip_device.dart';
+
+const _overprintRerecordMaxSourceBytes = 64 << 20;
 
 /// Mutable carrier for the image-decode half of a [PdfRetainedScene.fromCommands]
 /// build, so the perf log can split the render 'build' phase into decode vs
@@ -65,10 +68,15 @@ class PdfRetainedScene {
     this.page,
     this.plan,
     this.commands,
-    this._images, [
-    this._retainedDecodedRequests,
+    this._images, {
+    List<PdfImageRequest>? retainedDecodedRequests,
     this.imageDecodingAttempted = true,
-  ]);
+    ({
+      double? maxImagePixelRatio,
+      double imageDecodeHeadroom
+    })? recordingOptions,
+  })  : _retainedDecodedRequests = retainedDecodedRequests,
+        _recordingOptions = recordingOptions;
 
   /// Whether image requests were passed through the decoder for this scene.
   ///
@@ -77,6 +85,15 @@ class PdfRetainedScene {
   /// vector-only progressive buffer and a later complete scene may still
   /// supply the image.
   final bool imageDecodingAttempted;
+
+  final ({
+    double? maxImagePixelRatio,
+    double imageDecodeHeadroom
+  })? _recordingOptions;
+
+  /// Whether this scene retains enough complete recording inputs for an exact
+  /// overprint-resolution retry.
+  bool get canRerecordWithOverprint => !_disposed && _recordingOptions != null;
 
   /// Scenes holding sheddable spatial metadata (a region index or banded
   /// transcript), weakly held so a coordinated memory-pressure sweep can drop
@@ -351,14 +368,18 @@ class PdfRetainedScene {
     PdfPage page, {
     PdfPageRenderPlan plan = const PdfPageRenderPlan(),
     bool Function(PdfAnnotation)? skipAnnotation,
+    int overprintMaxDimension = 384,
     double? maxImagePixelRatio,
     double imageDecodeHeadroom = 2,
     PdfSceneBuildTiming? timing,
   }) async {
     final cos = page.document.cos;
     final recorder = RecordingPdfDevice();
-    final recording = PdfInterpreter(cos: cos, device: recorder)
-      ..drawPageContent(page, page.contentBytes());
+    final recording = PdfInterpreter(
+      cos: cos,
+      device: recorder,
+      overprintMaxDimension: overprintMaxDimension,
+    )..drawPageContent(page, page.contentBytes());
     if (plan.annotations) recording.drawAnnotations(page, skip: skipAnnotation);
     final clock = timing == null ? null : (Stopwatch()..start());
     final images = await decodeImages(cos, recorder.imageRequests,
@@ -368,7 +389,93 @@ class PdfRetainedScene {
     if (clock != null) {
       timing!.decodeMs = clock.elapsedMicroseconds / 1000.0;
     }
-    return PdfRetainedScene._(page, plan, recorder.commands, images);
+    return PdfRetainedScene._(
+      page,
+      plan,
+      recorder.commands,
+      images,
+      recordingOptions: skipAnnotation == null
+          ? (
+              maxImagePixelRatio: maxImagePixelRatio,
+              imageDecodeHeadroom: imageDecodeHeadroom,
+            )
+          : null,
+    );
+  }
+
+  /// Repeats a complete scene with a denser overprint colorant grid.
+  ///
+  /// The pure-Dart page walk and image-command serialization run on a temporary
+  /// isolate so a difficult overprint page cannot stall the UI isolate. The
+  /// ordinary page walk never retries by itself; an optional tile backend can
+  /// use this only after conservatively rejecting the default transcript.
+  ///
+  /// Returns null for partial/imported command buffers, encrypted sources (the
+  /// parsed document does not retain its password), sources above 64 MiB (to
+  /// keep the isolate hand-off bounded), recordings that skipped annotations,
+  /// and pages no longer reachable from their document.
+  Future<PdfRetainedScene>? rerecordWithOverprintMaxDimension(
+    int maxDimension,
+  ) {
+    final options = _recordingOptions;
+    final document = page.document;
+    if (_disposed ||
+        options == null ||
+        maxDimension <= 0 ||
+        document.cos.isEncrypted ||
+        document.cos.bytes.length > _overprintRerecordMaxSourceBytes) {
+      return null;
+    }
+    final pageIndex = document.pageIndexOf(page.dict);
+    if (pageIndex < 0) return null;
+    return _rerecordWithOverprint(
+      pageIndex,
+      maxDimension,
+      options,
+    );
+  }
+
+  Future<PdfRetainedScene> _rerecordWithOverprint(
+    int pageIndex,
+    int maxDimension,
+    ({double? maxImagePixelRatio, double imageDecodeHeadroom}) options,
+  ) async {
+    final source = TransferableTypedData.fromList([page.document.cos.bytes]);
+    final annotations = plan.annotations;
+    final decodeRatio = options.maxImagePixelRatio == null
+        ? null
+        : options.maxImagePixelRatio! * options.imageDecodeHeadroom;
+    final encoded = await Isolate.run(() {
+      final document = PdfDocument.open(source.materialize().asUint8List());
+      if (pageIndex >= document.pageCount) return null;
+      final retryPage = document.page(pageIndex);
+      final recorder = RecordingPdfDevice();
+      final interpreter = PdfInterpreter(
+        cos: document.cos,
+        device: recorder,
+        overprintMaxDimension: maxDimension,
+      )..drawPageContent(retryPage, retryPage.contentBytes());
+      if (annotations) interpreter.drawAnnotations(retryPage);
+      return serializeCommands(
+        recorder.commands,
+        cos: document.cos,
+        decodeImages: true,
+        maxImagePixelRatio: decodeRatio,
+        pageRasterPixels: pdfPageRasterPixels(
+          retryPage.cropBox,
+          decodeRatio,
+        ),
+      );
+    });
+    if (encoded == null) {
+      throw StateError('overprint retry command buffer is not transferable');
+    }
+    return fromCommands(
+      page,
+      deserializeCommands(encoded),
+      plan: plan,
+      maxImagePixelRatio: options.maxImagePixelRatio,
+    );
   }
 
   /// Builds a scene from an already-recorded [commands] buffer (e.g. one a
@@ -376,6 +483,8 @@ class PdfRetainedScene {
   /// must have been recorded for [page] under [plan]. Set [includeImages] to
   /// false for a deliberate vector-only progressive buffer; image draws then
   /// stay transparent until a complete scene replaces it.
+  /// [allowOverprintRerecord] marks a complete, unfiltered worker transcript
+  /// as reconstructible for an optional exact overprint retry.
   ///
   /// [timing], when non-null, receives the duration of the decode pass - the
   /// perf log's way of splitting the render 'build' phase into image decode
@@ -391,6 +500,7 @@ class PdfRetainedScene {
     List<PdfRenderCommand> commands, {
     PdfPageRenderPlan plan = const PdfPageRenderPlan(),
     bool includeImages = true,
+    bool allowOverprintRerecord = false,
     bool retainDecodedPixels = false,
     PdfSceneBuildTiming? timing,
     double? maxImagePixelRatio,
@@ -426,8 +536,14 @@ class PdfRetainedScene {
       plan,
       commands,
       images,
-      retainedRequests,
-      includeImages,
+      retainedDecodedRequests: retainedRequests,
+      imageDecodingAttempted: includeImages,
+      recordingOptions: allowOverprintRerecord && includeImages
+          ? (
+              maxImagePixelRatio: maxImagePixelRatio,
+              imageDecodeHeadroom: 1,
+            )
+          : null,
     );
   }
 

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -74,6 +74,18 @@ abstract class PdfTileRasterBackend {
   PdfTileRasterSession? createSession(PdfRetainedScene scene);
 }
 
+/// Optional asynchronous second chance after [PdfTileRasterBackend.createSession]
+/// conservatively declines a retained scene.
+///
+/// The viewer calls [retrySession] immediately after the synchronous result is
+/// null. Returning null keeps the normal Canvas fallback. Returning a future
+/// starts the extra work asynchronously; if that future later completes with
+/// null or throws, the same exact Canvas fallback takes over.
+/// This is intended for bounded re-recording strategies, not approximations.
+abstract interface class PdfTileRasterRetryBackend {
+  Future<PdfTileRasterSession?>? retrySession(PdfRetainedScene scene);
+}
+
 /// Scene-lifetime resources used to rasterize many tile regions.
 abstract class PdfTileRasterSession {
   /// The retained scene this session was built for.

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -84,6 +84,52 @@ void main() {
     });
   });
 
+  testWidgets('local retained scenes can be re-recorded for overprint retry',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final source = await PdfRetainedScene.record(
+        page,
+        maxImagePixelRatio: 1.5,
+        imageDecodeHeadroom: 1,
+      );
+      final retryFuture = source.rerecordWithOverprintMaxDimension(768);
+      expect(retryFuture, isNotNull);
+      final retry = await retryFuture!;
+      expect(retry.page, same(source.page));
+      expect(retry.plan, same(source.plan));
+      expect(retry.commands.length, source.commands.length);
+
+      final imported = await PdfRetainedScene.fromCommands(
+        page,
+        source.commands,
+        includeImages: false,
+      );
+      final completeImported = await PdfRetainedScene.fromCommands(
+        page,
+        source.commands,
+        allowOverprintRerecord: true,
+      );
+      final filtered = await PdfRetainedScene.record(
+        page,
+        skipAnnotation: (_) => false,
+      );
+      expect(imported.rerecordWithOverprintMaxDimension(768), isNull);
+      final importedRetryFuture =
+          completeImported.rerecordWithOverprintMaxDimension(768);
+      expect(importedRetryFuture, isNotNull);
+      final importedRetry = await importedRetryFuture!;
+      expect(filtered.rerecordWithOverprintMaxDimension(768), isNull);
+
+      filtered.dispose();
+      importedRetry.dispose();
+      completeImported.dispose();
+      imported.dispose();
+      retry.dispose();
+      source.dispose();
+    });
+  });
+
   testWidgets('retained scene releases uploaded worker RGBA', (tester) async {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildEmbeddedFontImagePdf()).page(0);

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -251,6 +251,105 @@ void main() {
     expect(pageDiagnostic['lastTile'], isA<Map<String, Object?>>());
   });
 
+  testWidgets('a declined backend can asynchronously retry an exact scene',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final backend = _RetryTileRasterBackend();
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 6120,
+            child: PdfPageView(
+              page: doc.page(0),
+              tileRasterBackend: backend,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      final exception = tester.takeException();
+      if (exception != null) fail('deferred backend retry failed: $exception');
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(backend.sessionCreates, 1);
+    expect(backend.retryCreates, 1);
+    expect(backend.rasterizations, greaterThan(0));
+    expect(store.tileCount, greaterThan(0));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(backend.sessionDisposals, 1);
+  });
+
+  for (final outcome in [_RetryOutcome.decline, _RetryOutcome.error]) {
+    testWidgets('an async ${outcome.name} keeps the exact Canvas fallback',
+        (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final store =
+          PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+      final backend = _RetryTileRasterBackend(outcome: outcome);
+      PdfPageView.tileStoreDetail = true;
+      PdfPageView.debugTileStoreOverride = store;
+      addTearDown(() {
+        PdfPageView.tileStoreDetail = false;
+        PdfPageView.debugTileStoreOverride = null;
+        store.dispose();
+      });
+
+      final doc = PdfDocument.open(buildClassicPdf());
+      await tester.pumpWidget(
+        Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: SizedBox(
+              width: 6120,
+              child: PdfPageView(
+                page: doc.page(0),
+                tileRasterBackend: backend,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+        await tester.pump();
+        final exception = tester.takeException();
+        if (exception != null) fail('Canvas fallback failed: $exception');
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 10)));
+      }
+
+      expect(backend.sessionCreates, 1);
+      expect(backend.retryCreates, 1);
+      expect(backend.rasterizations, 0);
+      expect(store.tileCount, greaterThan(0));
+    });
+  }
+
   testWidgets('tile path composites deep-zoom tiles instead of the patch',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;
@@ -948,6 +1047,82 @@ void main() {
       scene.dispose();
     });
   });
+}
+
+enum _RetryOutcome { success, decline, error }
+
+class _RetryTileRasterBackend extends PdfTileRasterBackend
+    implements PdfTileRasterRetryBackend {
+  _RetryTileRasterBackend({this.outcome = _RetryOutcome.success});
+
+  final _RetryOutcome outcome;
+  int sessionCreates = 0;
+  int retryCreates = 0;
+  int rasterizations = 0;
+  int sessionDisposals = 0;
+
+  @override
+  String get debugLabel => 'retry';
+
+  @override
+  String? get lastSessionRejection => 'default transcript unsupported';
+
+  @override
+  PdfTileRasterSession? createSession(PdfRetainedScene scene) {
+    sessionCreates++;
+    return null;
+  }
+
+  @override
+  Future<PdfTileRasterSession?>? retrySession(PdfRetainedScene scene) {
+    retryCreates++;
+    return Future<PdfTileRasterSession?>.microtask(() => switch (outcome) {
+          _RetryOutcome.success => _RetryTileRasterSession(this, scene),
+          _RetryOutcome.decline => null,
+          _RetryOutcome.error => throw StateError('retry failed'),
+        });
+  }
+}
+
+class _RetryTileRasterSession
+    implements PdfTileRasterSession, PdfTileRasterScheduling {
+  _RetryTileRasterSession(this.backend, this.scene);
+
+  final _RetryTileRasterBackend backend;
+
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  bool get batchAdjacentTiles => false;
+
+  @override
+  int get maxNewTilesPerPaint => 1;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) async {
+    backend.rasterizations++;
+    final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
+    final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawRect(
+      Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+      ui.Paint()..color = const Color(0xFFFF00FF),
+    );
+    final picture = recorder.endRecording();
+    try {
+      return await picture.toImage(width, height);
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  @override
+  void dispose() => backend.sessionDisposals++;
 }
 
 class _SolidTileRasterBackend extends PdfCanvasTileRasterBackend {

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+- Retry only non-black-overprint scene rejections with a lazily re-recorded
+  512-cell colourant grid. Exact scenes such as Ghent GWG164 move to native
+  Flutter GPU, while any remaining mismatch continues through Canvas.
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -38,10 +38,12 @@ import 'text_outliner.dart';
 /// pixels reject the whole scene. Zero-width PDF hairlines are expanded at
 /// tile submission time so they remain exactly one device pixel at every LoD.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
-class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
+class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
+    implements PdfTileRasterRetryBackend {
   FlutterGpuTileRasterBackend({
     this.msaa = true,
     this.allowOverprintApproximation = false,
+    this.overprintRetryMaxDimension = 512,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
     this.enableProactiveWarmUp,
@@ -49,7 +51,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     FlutterGpuTextOutliner? textOutliner,
     this.systemTextOutlines = false,
     FlutterGpuTileBackendStats? stats,
-  })  : stats = stats ?? FlutterGpuTileBackendStats(),
+  })  : assert(overprintRetryMaxDimension == null ||
+            overprintRetryMaxDimension > 0),
+        stats = stats ?? FlutterGpuTileBackendStats(),
         textOutliner = textOutliner ??
             (systemTextOutlines
                 ? FlutterGpuSystemTextOutliner.tryCreate()
@@ -68,6 +72,14 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   /// channels as PDF overprint requires. Keep this for controlled benchmarking
   /// only; ordinary clients get the exact Canvas fallback instead.
   final bool allowOverprintApproximation;
+
+  /// Long-side colorant-grid size for one exact retry after the default scene
+  /// is rejected specifically for unresolved non-black overprint.
+  ///
+  /// Null disables the retry. It is lazy—the ordinary 384-cell page walk and
+  /// every already-accepted scene are unchanged—and a retry that remains
+  /// unsupported is handed back to the viewer's exact Canvas fallback.
+  final int? overprintRetryMaxDimension;
 
   /// Byte budget for decoded image textures shared by every scene/session
   /// created from this backend instance. Cached and active scene leases both
@@ -267,6 +279,49 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       stats.sessionsRejected++;
       return null;
     }
+  }
+
+  @override
+  Future<PdfTileRasterSession?>? retrySession(PdfRetainedScene scene) {
+    final maxDimension = overprintRetryMaxDimension;
+    if (maxDimension == null ||
+        _lastSessionRejection !=
+            'non-black overprint requires Canvas fallback' ||
+        !scene.canRerecordWithOverprint) {
+      return null;
+    }
+    stats
+      ..overprintRetryRequests += 1
+      ..lastTileRoute = 'flutter_gpu-overprint-retry';
+    return Future<PdfTileRasterSession?>.microtask(() async {
+      final clock = Stopwatch()..start();
+      PdfRetainedScene? retried;
+      try {
+        final retry = scene.rerecordWithOverprintMaxDimension(maxDimension);
+        if (retry == null) {
+          stats.overprintRetryFallbacks++;
+          return null;
+        }
+        retried = await retry;
+        final session = createSession(retried);
+        if (session == null) {
+          stats.overprintRetryFallbacks++;
+          retried.dispose();
+          return null;
+        }
+        stats.overprintRetrySuccesses++;
+        return _RetriedSceneTileRasterSession(session, retried);
+      } catch (error) {
+        retried?.dispose();
+        stats
+          ..overprintRetryFallbacks += 1
+          ..lastRejection = 'overprint retry failed: $error'
+          ..lastTileRoute = 'canvas-fallback';
+        return null;
+      } finally {
+        stats.overprintRetryMicros += clock.elapsedMicroseconds;
+      }
+    });
   }
 
   static String? _unsupportedReason(
@@ -3533,6 +3588,62 @@ bool _commandNeedsDarken(
               nonBlack(run.strokeColor!)),
     _ => false,
   };
+}
+
+/// Couples a successful denser re-recording to the GPU session built from it.
+/// The original retained scene remains owned by the viewer for its base image
+/// and ready Canvas fallback; this wrapper owns only the retry transcript.
+class _RetriedSceneTileRasterSession
+    implements
+        PdfTileRasterSession,
+        PdfTileRasterScheduling,
+        PdfTileRasterWarmUp {
+  _RetriedSceneTileRasterSession(this._session, this.scene) {
+    assert(identical(_session.scene, scene));
+  }
+
+  final PdfTileRasterSession _session;
+
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  bool get batchAdjacentTiles => _session is PdfTileRasterScheduling
+      ? (_session as PdfTileRasterScheduling).batchAdjacentTiles
+      : true;
+
+  @override
+  int? get maxNewTilesPerPaint => _session is PdfTileRasterScheduling
+      ? (_session as PdfTileRasterScheduling).maxNewTilesPerPaint
+      : null;
+
+  @override
+  Future<void> warmUp() async {
+    if (_session is PdfTileRasterWarmUp) {
+      await (_session as PdfTileRasterWarmUp).warmUp();
+    }
+  }
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) =>
+      _session.rasterizeRegion(
+        region,
+        pixelRatio: pixelRatio,
+        tracePage: tracePage,
+      );
+
+  @override
+  void dispose() {
+    try {
+      _session.dispose();
+    } finally {
+      scene.dispose();
+    }
+  }
 }
 
 class _FlutterGpuTileSession

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -20,6 +20,10 @@ class FlutterGpuTileBackendStats {
   int sessionsCreated = 0;
   int sessionsRejected = 0;
   int sessionsDisposed = 0;
+  int overprintRetryRequests = 0;
+  int overprintRetrySuccesses = 0;
+  int overprintRetryFallbacks = 0;
+  int overprintRetryMicros = 0;
   int rasterFallbacks = 0;
   int activeSessions = 0;
   int peakActiveSessions = 0;
@@ -101,6 +105,10 @@ class FlutterGpuTileBackendStats {
         'sessionsCreated': sessionsCreated,
         'sessionsRejected': sessionsRejected,
         'sessionsDisposed': sessionsDisposed,
+        'overprintRetryRequests': overprintRetryRequests,
+        'overprintRetrySuccesses': overprintRetrySuccesses,
+        'overprintRetryFallbacks': overprintRetryFallbacks,
+        'overprintRetryMicros': overprintRetryMicros,
         'rasterFallbacks': rasterFallbacks,
         'activeSessions': activeSessions,
         'peakActiveSessions': peakActiveSessions,
@@ -170,6 +178,10 @@ class FlutterGpuTileBackendStats {
     sessionsCreated = 0;
     sessionsRejected = 0;
     sessionsDisposed = 0;
+    overprintRetryRequests = 0;
+    overprintRetrySuccesses = 0;
+    overprintRetryFallbacks = 0;
+    overprintRetryMicros = 0;
     rasterFallbacks = 0;
     contextSwitches = 0;
     warmUpRequests = 0;

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -8,6 +8,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
     this.msaa = true,
     this.allowOverprintApproximation = false,
+    this.overprintRetryMaxDimension = 512,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
     this.enableProactiveWarmUp,
@@ -15,10 +16,13 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     this.textOutliner,
     this.systemTextOutlines = false,
     FlutterGpuTileBackendStats? stats,
-  }) : stats = stats ?? FlutterGpuTileBackendStats();
+  })  : assert(overprintRetryMaxDimension == null ||
+            overprintRetryMaxDimension > 0),
+        stats = stats ?? FlutterGpuTileBackendStats();
 
   final bool msaa;
   final bool allowOverprintApproximation;
+  final int? overprintRetryMaxDimension;
   final int maxTextureBytes;
   final int maxGeometryBytes;
   final bool? enableProactiveWarmUp;

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -16,6 +16,12 @@ void main() {
       final desktop = FlutterGpuTileRasterBackend();
       expect(desktop.supportsWarmUp, isTrue);
       expect(desktop.supportsSessionWarmUp, isTrue);
+      expect(desktop.overprintRetryMaxDimension, 512);
+      expect(
+        FlutterGpuTileRasterBackend(overprintRetryMaxDimension: null)
+            .overprintRetryMaxDimension,
+        isNull,
+      );
 
       final optedIn = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
       expect(optedIn.supportsWarmUp, isTrue);
@@ -34,6 +40,10 @@ void main() {
       ..sessionsCreated = 4
       ..sessionsRejected = 2
       ..sessionsDisposed = 1
+      ..overprintRetryRequests = 3
+      ..overprintRetrySuccesses = 2
+      ..overprintRetryFallbacks = 1
+      ..overprintRetryMicros = 24000
       ..rasterFallbacks = 1
       ..lastContextIdentity = 1234
       ..contextsSeen = 2
@@ -87,6 +97,10 @@ void main() {
       ..lastRejection = 'test fallback';
 
     expect(stats.toJson(), containsPair('rasterFallbacks', 1));
+    expect(stats.toJson(), containsPair('overprintRetryRequests', 3));
+    expect(stats.toJson(), containsPair('overprintRetrySuccesses', 2));
+    expect(stats.toJson(), containsPair('overprintRetryFallbacks', 1));
+    expect(stats.toJson(), containsPair('overprintRetryMicros', 24000));
     expect(stats.toJson(), containsPair('lastRejection', 'test fallback'));
     expect(stats.toJson(), containsPair('lastTileRoute', 'canvas-fallback'));
     expect(stats.toJson(), containsPair('completedSubmissions', 8));
@@ -125,6 +139,10 @@ void main() {
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
+    expect(stats.overprintRetryRequests, 0);
+    expect(stats.overprintRetrySuccesses, 0);
+    expect(stats.overprintRetryFallbacks, 0);
+    expect(stats.overprintRetryMicros, 0);
     expect(stats.rasterFallbacks, 0);
     expect(stats.lastContextIdentity, 1234);
     expect(stats.contextsSeen, 2);

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -138,13 +138,24 @@ void _corpus(
         for (var pageIndex = 0; pageIndex < limit; pageIndex++) {
           final scene = await PdfRetainedScene.record(document.page(pageIndex));
           try {
-            final backend = FlutterGpuTileRasterBackend(
+            final PdfTileRasterBackend backend = FlutterGpuTileRasterBackend(
               analyticText:
                   Platform.environment['GPU_CORPUS_ANALYTIC_TEXT'] != '0',
               systemTextOutlines:
                   Platform.environment['GPU_CORPUS_SYSTEM_TEXT'] == '1',
+              overprintRetryMaxDimension: int.tryParse(
+                    Platform.environment[
+                            'GPU_CORPUS_OVERPRINT_RETRY_DIMENSION'] ??
+                        '',
+                  ) ??
+                  512,
             );
-            final session = backend.createSession(scene);
+            var session = backend.createSession(scene);
+            if (session == null && backend is PdfTileRasterRetryBackend) {
+              final retry =
+                  (backend as PdfTileRasterRetryBackend).retrySession(scene);
+              if (retry != null) session = await retry;
+            }
             if (session == null) {
               rejected++;
               final reason = backend.lastSessionRejection ?? 'unspecified';

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -232,7 +232,7 @@ void main() {
       final msaa = Platform.environment['PDF_GPU_BENCHMARK_MSAA'] != '0';
       final approximateOverprint =
           Platform.environment['PDF_GPU_BENCHMARK_OVERPRINT'] != '0';
-      final backend = FlutterGpuTileRasterBackend(
+      final gpuBackend = FlutterGpuTileRasterBackend(
         msaa: msaa,
         allowOverprintApproximation: approximateOverprint,
         analyticText:
@@ -246,7 +246,7 @@ void main() {
             : _scenarioName(scenarioLabel, 'pipeline-warm');
         _startScenario(scenario);
         final warmUp = Stopwatch()..start();
-        await backend.warmUp();
+        await gpuBackend.warmUp();
         final elapsedUs = warmUp.elapsedMicroseconds;
         // ignore: avoid_print
         print('REAL_GPU_BENCHMARK warmUpUs=$elapsedUs');
@@ -254,6 +254,7 @@ void main() {
       }
       final output = Platform.environment['PDF_GPU_BENCHMARK_OUT'];
       if (output != null) Directory(output).createSync(recursive: true);
+      final PdfTileRasterBackend backend = gpuBackend;
       final rssStart = ProcessInfo.currentRss;
       var peakRss = rssStart;
       final rows = <String>[];
@@ -277,9 +278,15 @@ void main() {
             height: math.min(size.height, 512 / lod1),
           );
           final sessionClock = Stopwatch()..start();
-          final session = backend.createSession(scene);
+          var session = backend.createSession(scene);
+          if (session == null && backend is PdfTileRasterRetryBackend) {
+            final retry =
+                (backend as PdfTileRasterRetryBackend).retrySession(scene);
+            if (retry != null) session = await retry;
+          }
           sessionClock.stop();
-          if (session == null) {
+          final accelerated = session;
+          if (accelerated == null) {
             final firstScenario = _scenarioName(
               scenarioLabel,
               'first-tile',
@@ -317,7 +324,7 @@ void main() {
             rows.add('page=$pageIndex recordUs=${record.elapsedMicroseconds} '
                 'decodeUs=${(timing.decodeMs * 1000).round()} '
                 'sessionUs=${sessionClock.elapsedMicroseconds} '
-                'gpu=rejected reason=${backend.stats.lastRejection} '
+                'gpu=rejected reason=${gpuBackend.stats.lastRejection} '
                 'firstRoute=canvas-fallback firstUs=${fallback.$1} '
                 'canvasUs=${canvas.$1} '
                 'meanDiff=${_meanDiff(fallback.$2, canvas.$2).toStringAsFixed(3)} '
@@ -325,8 +332,11 @@ void main() {
             continue;
           }
           try {
+            final warmable = accelerated is PdfTileRasterWarmUp
+                ? accelerated as PdfTileRasterWarmUp
+                : null;
             if (Platform.environment['PDF_GPU_BENCHMARK_SCENE_WARMUP'] == '1' &&
-                session is PdfTileRasterWarmUp) {
+                warmable != null) {
               // Route-change cohorts compare a Canvas base with a GPU
               // candidate, so only one side can produce a scene-warm timing.
               // Still perform the warm-up—the viewer does—while suppressing
@@ -340,7 +350,7 @@ void main() {
                     );
               _startScenario(scenario);
               final warmUp = Stopwatch()..start();
-              await (session as PdfTileRasterWarmUp).warmUp();
+              await warmable.warmUp();
               final elapsedUs = warmUp.elapsedMicroseconds;
               // ignore: avoid_print
               print('REAL_GPU_BENCHMARK sceneWarmUpUs=$elapsedUs');
@@ -354,7 +364,7 @@ void main() {
               );
               _startScenario(coldScenario);
               final coldGpu = await _render(
-                () => session.rasterizeRegion(region1, pixelRatio: lod1),
+                () => accelerated.rasterizeRegion(region1, pixelRatio: lod1),
                 pngPath:
                     output == null ? null : '$output/page-$pageIndex-gpu.png',
               );
@@ -392,7 +402,7 @@ void main() {
                 height: math.min(size.height, 512 / lod2),
               );
               final warmGpu = await _render(
-                  () => session.rasterizeRegion(region2, pixelRatio: lod2));
+                  () => accelerated.rasterizeRegion(region2, pixelRatio: lod2));
               peakRss = math.max(peakRss, ProcessInfo.currentRss);
               rows.add('page=$pageIndex recordUs=${record.elapsedMicroseconds} '
                   'decodeUs=${(timing.decodeMs * 1000).round()} '
@@ -412,7 +422,7 @@ void main() {
                   'error=${error.toString().replaceAll('\n', ' ')}');
             }
           } finally {
-            session.dispose();
+            accelerated.dispose();
           }
         } finally {
           scene.dispose();
@@ -428,7 +438,7 @@ void main() {
       }
       // ignore: avoid_print
       print('REAL_GPU_BENCHMARK rssStart=$rssStart peakRss=$peakRss '
-          'delta=${peakRss - rssStart} stats=${backend.stats}');
+          'delta=${peakRss - rssStart} stats=${gpuBackend.stats}');
       expect(rows, isNotEmpty);
       if (scenarioLabel == _advancedBlendStressScenario) {
         final sceneWarmUp =
@@ -436,10 +446,10 @@ void main() {
         // The two measured LoDs each coalesce the twelve disjoint strokes
         // into one blend. A one-pixel scene warm-up deliberately stays
         // conservative because all strokes resolve into the same pixel.
-        expect(backend.stats.advancedBlendPasses, sceneWarmUp ? 14 : 2);
+        expect(gpuBackend.stats.advancedBlendPasses, sceneWarmUp ? 14 : 2);
         expect(
-          backend.stats.advancedBlendBlits,
-          backend.stats.advancedBlendPasses,
+          gpuBackend.stats.advancedBlendBlits,
+          gpuBackend.stats.advancedBlendPasses,
         );
       }
     });

--- a/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
@@ -8,6 +8,7 @@ void main() {
 
     expect(backend.debugLabel, contains('flutter_gpu'));
     expect(backend.msaa, isFalse);
+    expect(backend.overprintRetryMaxDimension, 512);
     expect(backend.stats, same(stats));
   });
 }

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0
 
+- Allow retained renderers to request a larger overprint colourant grid when
+  retrying a scene that the default exact-GPU route conservatively rejected.
 - **Breaking:** `PdfOverprintCompositor.image` now requires the image
   transform, source dimensions, and a spatial resolver. Custom compositor
   callers must pass those values so one image can be resolved against several

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -272,9 +272,11 @@ class PdfInterpreter {
       required this.device,
       bool scanImagesOnly = false,
       this.resolveOverprint = true,
+      this.overprintMaxDimension = 384,
       this.collectCharOffsets = false,
       this.cancellation})
-      : _scanImagesOnly = scanImagesOnly,
+      : assert(overprintMaxDimension > 0),
+        _scanImagesOnly = scanImagesOnly,
         _scanImages = scanImagesOnly,
         _colorContext = PdfColorContext.forDocument(cos) {
     _state = _GraphicsState(_colorContext);
@@ -303,6 +305,12 @@ class PdfInterpreter {
   /// colour (text extraction, the image-collect scan), which would only pay
   /// for the buffer.
   final bool resolveOverprint;
+
+  /// Long-side cell count for the device-colorant buffer used to resolve
+  /// overprint. The default is the normal low-cost page walk; callers may
+  /// request a denser retry when a renderer can prove the default transcript
+  /// is otherwise unsupported.
+  final int overprintMaxDimension;
 
   /// Whether to fill in [PdfTextRun.charOffsets] - the em-space pen position
   /// of every character boundary in a run (issue #647) - for *every* run.
@@ -2220,7 +2228,7 @@ class PdfInterpreter {
     final box = page.cropBox;
     _overprint = PdfOverprintCompositor.forPageBox(
         box.left, box.bottom, box.right, box.top,
-        colorContext: _colorContext);
+        maxDimension: overprintMaxDimension, colorContext: _colorContext);
     // The buffer needs paths, clips and colours, none of which the scan-only
     // walk builds - and the substitute streams it produces have to be the ones
     // the collect pass decodes. So a page that opens a buffer is walked in


### PR DESCRIPTION
## Headline

| Measure | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Ghent GPU / Canvas routes | 48 / 9 | 49 / 8 | **+1 exact GPU route** |
| PDF.js GPU / Canvas routes | 177 / 2 | 177 / 2 | unchanged |
| GWG164 cold first tile | 430 ms Canvas | 177 ms retry + 76 ms scene warm + 9 ms GPU | **~39% lower end-to-end** |
| GWG164 warm tile | 22 ms Canvas | 13 ms GPU | **~41% faster** |

Moves `GWG164_Transp_Basic_BM_ICCbasedCMYK_x4.pdf` from Canvas to exact native GPU rendering. There are no new Canvas fallbacks and the measured GPU/Canvas mean pixel difference is 9.755, below the exact-rendering gate of 16.

## What changed

- Retry only the exact `non-black overprint requires Canvas fallback` rejection with a higher-resolution 512-cell colourant grid.
- Re-record the scene from immutable source bytes in an isolate, keeping interpretation and image decoding off the UI isolate.
- Preserve immediate Canvas fallback while the retry is pending; any declined, failed, disposed, encrypted, partial, filtered, or over-64-MiB source stays on Canvas.
- Retain retry-owned scene resources until the GPU session is disposed.
- Add retry request/success/fallback/time counters.
- Add GWG164 to the six-run main-vs-PR performance matrix, including required GPU and Canvas control samples.

<details>
<summary>Validation details</summary>

- Full native Metal corpus: Ghent 49 GPU / 8 Canvas; PDF.js 177 / 2; 218 tests passed.
- Route comparison: only GWG164 gains GPU coverage; no new fallback.
- All 54 ordinary Ghent Canvas baselines pass.
- `fvm dart analyze`: no issues.
- Retained-scene and deferred-fallback tests: 25 passed.
- GPU stats, web stub, and benchmark-harness tests pass.
- Web render worker compiles.
- A 448-cell candidate was rejected after the full corpus exposed a non-monotonic GWG161 pixel failure. The 512-cell setting keeps GWG161 conservatively on Canvas while rendering GWG164 exactly.

The local GWG164 comparison was run on the same host. `main` cold Canvas was 430 ms. This PR spent 177 ms on the off-thread retry, 76 ms warming the retried scene, and 9 ms on the cold GPU tile (about 262 ms total); subsequent GPU tiles were 13 ms versus 22 ms on Canvas.

</details>
