### PR TITLE
perf(gpu): stage specialized pipeline warm-up

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.0
 
+- Stage proactive pipeline compilation: the context-wide idle pass now primes
+  only common stencil, solid, and texture variants, while the existing live-
+  scene warm-up compiles glyph, soft-mask, and destination-sampling variants
+  only for pages that use them. This shortens the universal Metal warm-up
+  without moving compilation back onto the first real tile.
 - Retry only non-black-overprint scene rejections with a lazily re-recorded
   512-cell colourant grid. Exact scenes such as Ghent GWG164 move to native
   Flutter GPU, while any remaining mismatch continues through Canvas.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -200,11 +200,14 @@ fallback, never a reason to reject the page.
 
 After useful page pixels land and foreground work stays quiet for 750 ms, the
 viewer asks the backend to warm its context. The backend submits one transparent
-pixel through each tile pipeline and the nonzero stencil-cover state used by
-retained fills, moving Impeller/driver compilation out of the first deep-zoom
+pixel through the common stencil, solid, and texture pipelines and the nonzero
+stencil-cover state used by retained fills. Page-specific glyph, soft-mask, and
+destination-sampling blend variants wait for the live scene warm-up below, so
+an ordinary document does not pay one uninterrupted compile for every optional
+path. This moves Impeller/driver compilation out of the first deep-zoom
 interaction without delaying initial document paint or competing with an
-immediate scroll. This work is coalesced per native view and MSAA mode, even
-when several readers share the same process.
+immediate scroll. The common work is coalesced per native view and MSAA mode,
+even when several readers share the same process.
 
 Proactive warm-up defaults on for macOS, Windows, and Linux. Android and iOS
 stay on-demand by default because merely creating an Impeller GPU context can

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -168,12 +168,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   /// resources they are currently drawing.
   void clearImageCache() => _imageCache.clear(stats);
 
-  /// Compiles this view's tile pipelines with a one-pixel GPU submission.
+  /// Compiles the common tile pipelines with a one-pixel GPU submission.
   ///
-  /// The driver otherwise compiles the pipelines on the first deep-zoom tile,
-  /// which can leave the coarse page visible for hundreds of milliseconds.
-  /// This is safe to call repeatedly: work is shared per Impeller context and
-  /// MSAA mode, including between backend instances.
+  /// The driver otherwise compiles the stencil, solid, and texture pipelines
+  /// on the first deep-zoom tile, which can leave the coarse page visible for
+  /// hundreds of milliseconds. Page-specific glyph, soft-mask, and advanced-
+  /// blend variants are compiled by the later scene warm-up instead of making
+  /// every document pay for them. This is safe to call repeatedly: work is
+  /// shared per Impeller context and MSAA mode, including between backend
+  /// instances.
   @override
   Future<void> warmUp() async {
     final clock = Stopwatch()..start();
@@ -8107,24 +8110,6 @@ class _GpuPipelines {
       1,
       format: gpu.PixelFormat.r8g8b8a8UNormInt,
     );
-    final blendTarget = context.createTexture(
-      gpu.StorageMode.devicePrivate,
-      1,
-      1,
-      format: context.defaultColorFormat,
-    );
-    final blendBackdrop = context.createTexture(
-      gpu.StorageMode.devicePrivate,
-      1,
-      1,
-      format: context.defaultColorFormat,
-    );
-    final blendSource = context.createTexture(
-      gpu.StorageMode.devicePrivate,
-      1,
-      1,
-      format: context.defaultColorFormat,
-    );
     sample.overwrite(ByteData.sublistView(Uint8List.fromList(
       const [255, 255, 255, 255],
     )));
@@ -8195,79 +8180,6 @@ class _GpuPipelines {
     final textureInfo = transient.emplace(ByteData.sublistView(
       Float32List.fromList(const [1, 1, 1, 1, 0, 0, 0, 0]),
     ));
-    final glyphVertices = transient.emplace(ByteData.sublistView(
-      Float32List.fromList(const [
-        -1,
-        -1,
-        0,
-        0,
-        0,
-        1,
-        1,
-        1,
-        1,
-        3,
-        -1,
-        1,
-        0,
-        0,
-        1,
-        1,
-        1,
-        1,
-        -1,
-        3,
-        0,
-        1,
-        0,
-        1,
-        1,
-        1,
-        1,
-      ]),
-    ));
-    final glyphInfo = transient.emplace(ByteData.sublistView(
-      Float32List.fromList(const [1, 1]),
-    ));
-    final softMaskInfo = Float32List(36)
-      ..setRange(0, 16, const [
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-      ])
-      ..setRange(16, 20, const [1, 1, 1, 1])
-      ..setRange(20, 24, const [1, 1, 1, 1])
-      ..setRange(24, 28, const [0, 0, 0, 1])
-      ..setRange(28, 32, const [1, 0, 0, 0])
-      ..setRange(32, 36, const [-1, -1, 1, 1]);
-    final softMaskUniform =
-        transient.emplace(ByteData.sublistView(softMaskInfo));
-    final blendInfo = transient.emplace(ByteData.sublistView(
-      Float32List.fromList([
-        PdfBlendMode.overlay.index.toDouble(),
-        0,
-        0,
-        0,
-        0,
-        0,
-        1,
-        1,
-      ]),
-    ));
-
     final commandBuffer = context.createCommandBuffer();
     final pass = commandBuffer.createRenderPass(gpu.RenderTarget(
       colorAttachments: [
@@ -8337,67 +8249,7 @@ class _GpuPipelines {
       ..bindUniform(this.textureInfo, textureInfo)
       ..bindTexture(textureSampler, sample);
     _warmUpDraw(pass, textureVertices, 3);
-    pass
-      ..clearBindings()
-      ..bindPipeline(glyph)
-      ..bindUniform(glyphTransform, transform)
-      ..bindUniform(this.glyphInfo, glyphInfo)
-      ..bindTexture(
-        glyphSampler,
-        sample,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-          mipFilter: gpu.MipFilter.nearest,
-        ),
-      );
-    _warmUpDraw(pass, glyphVertices, 3);
-    pass
-      ..clearBindings()
-      ..bindPipeline(softMask)
-      ..bindUniform(softMaskTransform, transform)
-      ..bindUniform(this.softMaskInfo, softMaskUniform)
-      ..bindTexture(softMaskContentSampler, sample)
-      ..bindTexture(softMaskMaskSampler, sample);
-    _warmUpDraw(pass, textureVertices, 3);
     pass.clearBindings();
-
-    // Destination-sampling blends render without fixed-function blending or
-    // a stencil attachment. Metal keys pipeline state on those attachment and
-    // blend settings, so touching the same shaders in the page pass above does
-    // not compile the variants used by [_CompiledScene._renderAdvanced].
-    // Prime both its page-copy and PDF-blend draws while the viewer is idle;
-    // otherwise the first advanced-blend tile still waits on the driver even
-    // after this general warm-up completed.
-    // Flutter GPU 3.47 cannot safely encode two render passes into this
-    // experimental command-buffer wrapper on Metal. Queue the independent
-    // no-blend variant after the general pass instead; submission order keeps
-    // the completion callback a fence for both.
-    final blendCommandBuffer = context.createCommandBuffer();
-    final blendPass = blendCommandBuffer.createRenderPass(
-      gpu.RenderTarget.singleColor(gpu.ColorAttachment(
-        texture: blendTarget,
-        clearValue: vm.Vector4.zero(),
-      )),
-    )
-      ..setCullMode(gpu.CullMode.none)
-      ..setWindingOrder(gpu.WindingOrder.counterClockwise)
-      ..setPrimitiveType(gpu.PrimitiveType.triangle)
-      ..setColorBlendEnable(false)
-      ..bindPipeline(texture)
-      ..bindUniform(textureTransform, transform)
-      ..bindUniform(this.textureInfo, textureInfo)
-      ..bindTexture(textureSampler, sample);
-    _warmUpDraw(blendPass, textureVertices, 3);
-    blendPass
-      ..clearBindings()
-      ..bindPipeline(blend)
-      ..bindUniform(blendTransform, transform)
-      ..bindUniform(this.blendInfo, blendInfo)
-      ..bindTexture(blendBackdropSampler, blendBackdrop)
-      ..bindTexture(blendSourceSampler, blendSource);
-    _warmUpDraw(blendPass, textureVertices, 3);
-    blendPass.clearBindings();
 
     final completer = Completer<void>();
     // Keep every command-buffer resource strongly reachable until Impeller's
@@ -8407,26 +8259,16 @@ class _GpuPipelines {
       color,
       stencilTexture,
       sample,
-      blendTarget,
-      blendBackdrop,
-      blendSource,
       transient,
       commandBuffer,
-      blendCommandBuffer,
       pass,
-      blendPass,
     ];
     transient.flush();
     try {
-      var completed = 0;
-      var succeeded = true;
       void complete(bool success) {
         resources.length;
         if (completer.isCompleted) return;
-        succeeded = succeeded && success;
-        completed++;
-        if (completed != 2) return;
-        if (succeeded) {
+        if (success) {
           completer.complete();
         } else {
           completer.completeError(StateError('GPU pipeline warm-up failed'));
@@ -8434,7 +8276,6 @@ class _GpuPipelines {
       }
 
       commandBuffer.submit(completionCallback: complete);
-      blendCommandBuffer.submit(completionCallback: complete);
     } catch (error, stack) {
       if (!completer.isCompleted) completer.completeError(error, stack);
     }


### PR DESCRIPTION
## Headline

- Common Metal pipeline warm-up median: **492 ms → 227 ms (-54%)** across five same-host samples.
- Ordinary tiling scene warm-up: **79 ms → 80 ms**; first tile remains **6–7 ms**.
- Advanced-blend combined idle preparation: **644 ms → 558 ms (-13%)**; longest uninterrupted phase: **490 ms → 335 ms (-32%)**; first tile remains about **8 ms**.

## Change

The context-wide idle pass now primes only the common stencil, solid, and texture pipeline variants. The existing live-scene warm-up renders its one-pixel full-page probe and compiles glyph, soft-mask, and destination-sampling variants only for pages that actually use them.

This keeps specialized compilation off the first real tile while avoiding one universal compile containing every optional GPU path.

<details>
<summary>Validation details</summary>

- `fvm dart analyze`
- `backend_stats_test.dart`
- native GPU CI smoke
- full native backend suite: 72 passed, 1 expected skip
- GPU corpus with CI system-font matrix: Ghent 49 accepted / 8 exact fallbacks; PDF.js 177 / 2; all 218 cases passed
- same-host main/candidate benchmarks for tiling, analytic system text, and destination-sampling advanced blend
- no route, structural counter, or pixel-parity change

</details>
