### PR TITLE
fix(gpu): guard GLES and trace native Patrol

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -235,6 +235,7 @@ jobs:
           name: patrol-android-report
           path: |
             ${{ env.EXAMPLE_DIR }}/build/app/reports/androidTests
+            ${{ env.EXAMPLE_DIR }}/build/app/outputs/androidTest-results
             ${{ env.EXAMPLE_DIR }}/test-results/perf/android
           if-no-files-found: ignore
 

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -217,6 +217,11 @@ jobs:
             --markdown "$GITHUB_STEP_SUMMARY"
             --label Android
             --require-scenario-runs "native-mobile-tiles=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-pipeline-warm=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-scene-warm=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-first-tile=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-canvas-tile=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-reused-tile=$PATROL_NATIVE_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then
@@ -294,6 +299,11 @@ jobs:
               "$attempt_log" \
               --output "$RUNNER_TEMP/patrol-ios-perf-${attempt}-summary" \
               --require-scenario-runs native-mobile-tiles=1 \
+              --require-scenario-runs gpu-native-pipeline-warm=1 \
+              --require-scenario-runs gpu-native-page-0-scene-warm=1 \
+              --require-scenario-runs gpu-native-page-0-first-tile=1 \
+              --require-scenario-runs gpu-native-page-0-canvas-tile=1 \
+              --require-scenario-runs gpu-native-page-0-reused-tile=1 \
               >/dev/null 2>&1; then
               tee -a "$RUNNER_TEMP/patrol-ios.log" < "$attempt_log" >/dev/null
               completed=$((completed + 1))
@@ -346,6 +356,11 @@ jobs:
             --markdown "$GITHUB_STEP_SUMMARY"
             --label "iOS Simulator"
             --require-scenario-runs "native-mobile-tiles=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-pipeline-warm=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-scene-warm=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-first-tile=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-canvas-tile=$PATROL_NATIVE_PERF_REPETITIONS"
+            --require-scenario-runs "gpu-native-page-0-reused-tile=$PATROL_NATIVE_PERF_REPETITIONS"
           )
           baseline="${{ steps.patrol-baseline.outputs.json }}"
           if [[ -f "$baseline" ]]; then

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -416,15 +416,33 @@ class _DemoHarness {
     // be present in the tree while their tap target is covered by the dock on
     // a short Android viewport. Frame the widget before tapping it, just as a
     // user would scroll the field into view.
-    await viewer.showRect(page, rect!);
-    await $.pump(const Duration(milliseconds: 350));
     final target = find.byKey(
       ValueKey(
         'pdf-form-field-$page-$name-$widgetIndex',
       ),
     );
-    await waitForFinder(target);
-    await tester.tap(target);
+    final hitTarget = target.hitTestable();
+    // On a loaded-down Android emulator the viewer's zoom animation can
+    // advance more slowly than its scroll animation. Do not tap a stale
+    // target that is still under the floating editing dock: that activates
+    // the dock and leaves its modal sheet covering the retry. Re-frame until
+    // Flutter confirms that the live form widget owns its centre point.
+    for (var attempt = 0;
+        attempt < 3 && hitTarget.evaluate().isEmpty;
+        attempt++) {
+      await viewer.showRect(page, rect!);
+      await $.pump(const Duration(milliseconds: 350));
+      await waitForFinder(target);
+      for (var i = 0; i < 10 && hitTarget.evaluate().isEmpty; i++) {
+        await $.pump(const Duration(milliseconds: 100));
+      }
+    }
+    expect(
+      hitTarget,
+      findsOneWidget,
+      reason: '$name widget $widgetIndex should be visible and unobscured',
+    );
+    await tester.tap(hitTarget);
     await $.pump(const Duration(milliseconds: 400));
   }
 

--- a/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
@@ -5,10 +5,12 @@
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 const _buildCommit = String.fromEnvironment('PDF_BUILD_COMMIT');
 const _mb = 1024 * 1024;
@@ -25,17 +27,191 @@ void main() {
     await $.pumpWidget(const SizedBox());
     await $.pump(const Duration(milliseconds: 50));
   });
+
+  patrolTest('warms and rasterizes a real native flutter_gpu scene', ($) async {
+    expect($.isWeb, isFalse);
+    await $.pumpWidget(const MaterialApp(home: SizedBox()));
+    await runNativeGpuPerfScenario();
+    await $.pumpWidget(const SizedBox());
+    await $.pump(const Duration(milliseconds: 50));
+  });
 }
+
+typedef _NativeGpuRaster = ({
+  ByteData pixels,
+  int width,
+  int height,
+});
+
+@visibleForTesting
+Future<void> runNativeGpuPerfScenario() async {
+  final platform = _platformName();
+  final document = PdfDocument.open(buildEmbeddedFontImagePdf());
+  final scene = await PdfRetainedScene.record(document.page(0));
+  final backend = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
+  PdfTileRasterSession? session;
+  try {
+    await _measureNativeGpuScenario(
+      'gpu-native-pipeline-warm',
+      platform,
+      () async {
+        await backend.warmUp();
+        return null;
+      },
+    );
+    expect(backend.stats.warmUpRequests, 1);
+    expect(backend.stats.warmUpCompletions, 1);
+    expect(backend.stats.warmUpFailures, 0);
+
+    session = backend.createSession(scene);
+    expect(session, isA<PdfTileRasterWarmUp>(),
+        reason: backend.lastSessionRejection);
+    final accelerated = session!;
+    await _measureNativeGpuScenario(
+      'gpu-native-page-0-scene-warm',
+      platform,
+      () async {
+        await (accelerated as PdfTileRasterWarmUp).warmUp();
+        return null;
+      },
+    );
+    expect(backend.stats.sceneWarmUpRequests, 1);
+    expect(backend.stats.sceneWarmUpCompletions, 1);
+    expect(backend.stats.sceneWarmUpFailures, 0);
+    expect(backend.stats.scenesCompiled, 1);
+    expect(backend.stats.tilesRendered, 0,
+        reason: 'the one-pixel scene warm-up is not a visible tile');
+
+    const firstRegion = Rect.fromLTWH(40, 40, 256, 192);
+    final firstGpu = await _measureNativeGpuScenario(
+      'gpu-native-page-0-first-tile',
+      platform,
+      () => _rasterAndReadback(
+        () => accelerated.rasterizeRegion(
+          firstRegion,
+          pixelRatio: 2,
+          tracePage: 0,
+        ),
+      ),
+    );
+    final canvas = await _measureNativeGpuScenario(
+      'gpu-native-page-0-canvas-tile',
+      platform,
+      () => _rasterAndReadback(
+        () => scene.rasterizeRegion(firstRegion, pixelRatio: 2),
+      ),
+    );
+    expect(firstGpu, isNotNull);
+    expect(canvas, isNotNull);
+    expect(firstGpu!.width, canvas!.width);
+    expect(firstGpu.height, canvas.height);
+    final meanDifference =
+        _meanChannelDifference(firstGpu.pixels, canvas.pixels);
+    expect(
+      meanDifference,
+      lessThan(12),
+      reason: 'native GPU pixels must agree with Canvas apart from AA edges',
+    );
+
+    const reusedRegion = Rect.fromLTWH(72, 64, 256, 192);
+    await _measureNativeGpuScenario(
+      'gpu-native-page-0-reused-tile',
+      platform,
+      () => _rasterAndReadback(
+        () => accelerated.rasterizeRegion(
+          reusedRegion,
+          pixelRatio: 2,
+          tracePage: 0,
+        ),
+      ),
+    );
+
+    expect(backend.stats.contextsSeen, 1);
+    expect(backend.stats.sessionsCreated, 1);
+    expect(backend.stats.sessionsRejected, 0);
+    expect(backend.stats.rasterFallbacks, 0);
+    expect(backend.stats.tilesRendered, 2);
+    expect(backend.stats.completedSubmissions, greaterThanOrEqualTo(3));
+    expect(backend.stats.failedSubmissions, 0);
+    expect(backend.stats.inFlightSubmissions, 0,
+        reason: 'the readbacks must settle every GPU submission');
+    expect(backend.stats.lastTileRoute, 'flutter_gpu');
+    PdfPerfLog.log(
+      'gpu native stats platform=$platform '
+      'warmUs=${backend.stats.warmUpMicros} '
+      'sceneWarmUs=${backend.stats.sceneWarmUpMicros} '
+      'compileUs=${backend.stats.compileMicros} '
+      'completeUs=${backend.stats.completionMicros} '
+      'tiles=${backend.stats.tilesRendered} '
+      'submissions=${backend.stats.completedSubmissions} '
+      'fallbacks=${backend.stats.rasterFallbacks} '
+      'meanDifference=${meanDifference.toStringAsFixed(3)}',
+    );
+  } finally {
+    session?.dispose();
+    backend.clearImageCache();
+    scene.dispose();
+  }
+}
+
+Future<_NativeGpuRaster?> _measureNativeGpuScenario(
+  String name,
+  String platform,
+  Future<_NativeGpuRaster?> Function() operation,
+) async {
+  PdfPerfLog.log(
+    'scenario name=$name phase=start platform=$platform',
+  );
+  final clock = Stopwatch()..start();
+  final result = await operation();
+  clock.stop();
+  PdfPerfLog.log(
+    'raster page=${name.contains('page-0') ? 0 : '-'} kind=$name '
+    'platform=$platform '
+    'ms=${(clock.elapsedMicroseconds / 1000).toStringAsFixed(1)}'
+    '${result == null ? '' : ' img=${result.width}x${result.height}'}',
+  );
+  PdfPerfLog.log(
+    'scenario name=$name phase=validated platform=$platform',
+  );
+  return result;
+}
+
+Future<_NativeGpuRaster> _rasterAndReadback(
+  Future<ui.Image> Function() rasterize,
+) async {
+  final image = await rasterize();
+  try {
+    final pixels = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    if (pixels == null) fail('native raster RGBA readback returned null');
+    return (pixels: pixels, width: image.width, height: image.height);
+  } finally {
+    image.dispose();
+  }
+}
+
+double _meanChannelDifference(ByteData a, ByteData b) {
+  final aa = a.buffer.asUint8List(a.offsetInBytes, a.lengthInBytes);
+  final bb = b.buffer.asUint8List(b.offsetInBytes, b.lengthInBytes);
+  expect(aa, hasLength(bb.length));
+  var total = 0;
+  for (var i = 0; i < aa.length; i++) {
+    total += (aa[i] - bb[i]).abs();
+  }
+  return total / aa.length;
+}
+
+String _platformName() => switch (defaultTargetPlatform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      _ => defaultTargetPlatform.name,
+    };
 
 @visibleForTesting
 Future<void> runNativeTilePerfScenario({
   required Future<void> Function(Duration duration) pump,
 }) async {
-  final platform = switch (defaultTargetPlatform) {
-    TargetPlatform.android => 'android',
-    TargetPlatform.iOS => 'ios',
-    _ => defaultTargetPlatform.name,
-  };
+  final platform = _platformName();
   final store = PdfTileStore(registerForMemoryPressure: false);
   final mobile = defaultTargetPlatform == TargetPlatform.android ||
       defaultTargetPlatform == TargetPlatform.iOS;

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -61,6 +61,13 @@ this inside the Android `<application>` element:
   android:value="true" />
 ```
 
+The retained backend currently activates only on Metal and Vulkan contexts.
+Flutter 3.47's OpenGLES `flutter_gpu` pipeline path can terminate the process
+before Dart receives an error, so the backend detects the GLES capability set
+before creating shaders and uses the exact Canvas fallback instead. Android
+hosts do not need to force Vulkan: capable devices normally select it through
+Impeller, while GLES-only devices remain safe on Canvas.
+
 For a desktop development launch, pass both engine opt-ins:
 
 ```sh
@@ -73,10 +80,10 @@ before the engine starts. The DartPDF PR preview workflow demonstrates this
 with profile-mode Windows/Linux bundles and also publishes a macOS DMG.
 
 No master SDK, native-assets hook, or runtime shader compiler is required. The
-Metal, GLES/GLES3, and Vulkan runtime stages are compiled offline and checked in
-as a package asset. Unsupported platforms, disabled contexts, and unsupported
-PDF features return to the Canvas tile backend automatically. Web gets a
-compile-time stub and therefore preserves the all-platform host surface.
+Metal and Vulkan runtime stages are compiled offline and checked in as a
+package asset. Unsupported platforms or contexts, disabled contexts, and
+unsupported PDF features return to the Canvas tile backend automatically. Web
+gets a compile-time stub and therefore preserves the all-platform host surface.
 
 The current exact subset is solid paths and strokes (including zero-width PDF
 hairlines that stay one device pixel at every LoD), filled and stroked
@@ -209,12 +216,12 @@ interaction without delaying initial document paint or competing with an
 immediate scroll. The common work is coalesced per native view and MSAA mode,
 even when several readers share the same process.
 
-Proactive warm-up defaults on for macOS, Windows, and Linux. Android and iOS
-stay on-demand by default because merely creating an Impeller GPU context can
-reserve significant memory before a page is known to be GPU-compatible. A host
-that has validated its mobile device range can opt in with
+Proactive warm-up defaults on for macOS, Windows, and Linux. Vulkan Android and
+iOS stay on-demand by default because merely creating an Impeller GPU context
+can reserve significant memory before a page is known to be GPU-compatible. A
+host that has validated its mobile device range can opt in with
 `enableProactiveWarmUp: true`; normal on-demand GPU tiles remain available when
-the option is false.
+the option is false. OpenGLES contexts skip warm-up and retain Canvas.
 
 The same idle gate then prepares the live page's retained tile session: scene
 geometry and decoded-image uploads are compiled once and every scene pipeline

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -137,6 +137,17 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   gpu.GpuContext? _lastContext;
   String? _lastSessionRejection;
 
+  // Flutter GPU does not expose its active Impeller backend directly. This
+  // capability is documented as true on Metal/Vulkan and false on GLES. The
+  // current GLES implementation can terminate the process while loading or
+  // submitting this package's shader pipelines, which cannot be caught in
+  // Dart. Decline it before creating a pipeline future so the exact Canvas
+  // fallback remains available.
+  static bool _supportsContext(gpu.GpuContext context) =>
+      context.doesSupportFramebufferRenderMipmap;
+  static const _unsupportedContextReason =
+      'OpenGLES flutter_gpu contexts require Canvas fallback';
+
   @override
   String? get lastSessionRejection => _lastSessionRejection;
 
@@ -183,6 +194,13 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     stats.warmUpRequests++;
     try {
       final context = gpu.gpuContext;
+      if (!_supportsContext(context)) {
+        stats.warmUpCompletions++;
+        PdfPerfLog.log(
+          'tile gpu pipeline warm skipped reason=opengles-context',
+        );
+        return;
+      }
       final pipelines = await _GpuPipelines.instance(context);
       final submitted = await pipelines.warmUp(
         context,
@@ -221,6 +239,13 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
       }
       _lastContext = context;
       stats.lastContextIdentity = identityHashCode(context);
+      if (!_supportsContext(context)) {
+        _lastSessionRejection = _unsupportedContextReason;
+        stats.lastRejection = _unsupportedContextReason;
+        stats.lastTileRoute = 'canvas-fallback';
+        stats.sessionsRejected++;
+        return null;
+      }
       final outlinedCommands = textOutliner == null
           ? scene.commands
           : _outlineGpuTextCommands(scene.commands, textOutliner!);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -117,16 +117,23 @@ void main() {
       }
       final first = FlutterGpuTileRasterBackend();
       await first.warmUp();
+      final supportsPipelineWarmUp =
+          gpu.gpuContext.doesSupportFramebufferRenderMipmap;
       expect(first.stats.warmUpRequests, 1);
-      expect(first.stats.warmUpSubmissions, 1);
+      expect(first.stats.warmUpSubmissions, supportsPipelineWarmUp ? 1 : 0);
       expect(first.stats.warmUpCompletions, 1);
       expect(first.stats.warmUpFailures, 0);
       expect(first.stats.warmUpMicros, greaterThan(0));
 
       await first.warmUp();
       expect(first.stats.warmUpRequests, 2);
-      expect(first.stats.warmUpSubmissions, 1,
-          reason: 'the same backend reuses the completed context warm-up');
+      expect(
+        first.stats.warmUpSubmissions,
+        supportsPipelineWarmUp ? 1 : 0,
+        reason: supportsPipelineWarmUp
+            ? 'the same backend reuses the completed context warm-up'
+            : 'GLES must never submit the process-fatal synthetic warm-up',
+      );
 
       final second = FlutterGpuTileRasterBackend();
       await second.warmUp();
@@ -136,6 +143,31 @@ void main() {
       expect(second.stats.warmUpCompletions, 1);
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('OpenGLES context declines before pipeline creation',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      if (gpu.gpuContext.doesSupportFramebufferRenderMipmap) {
+        markTestSkipped('this assertion targets an OpenGLES context');
+        return;
+      }
+      final scene = await PdfRetainedScene.record(
+          PdfDocument.open(buildEmbeddedFontImagePdf()).page(0));
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(scene), isNull);
+      expect(
+        backend.lastSessionRejection,
+        'OpenGLES flutter_gpu contexts require Canvas fallback',
+      );
+      expect(backend.stats.sessionsRejected, 1);
+      expect(backend.stats.lastTileRoute, 'canvas-fallback');
+    });
+  });
 
   testWidgets('scene warm-up prepares retained resources before the first tile',
       (tester) async {

--- a/tool/android_patrol_vulkan_manifest.xml
+++ b/tool/android_patrol_vulkan_manifest.xml
@@ -3,6 +3,6 @@
     <application>
         <meta-data
             android:name="io.flutter.embedding.android.ImpellerBackend"
-            android:value="Vulkan" />
+            android:value="vulkan" />
     </application>
 </manifest>

--- a/tool/android_patrol_vulkan_manifest.xml
+++ b/tool/android_patrol_vulkan_manifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application>
+        <meta-data
+            android:name="io.flutter.embedding.android.ImpellerBackend"
+            android:value="Vulkan" />
+    </application>
+</manifest>

--- a/tool/run_android_patrol_ci.sh
+++ b/tool/run_android_patrol_ci.sh
@@ -11,6 +11,14 @@ if ! [[ "$PATROL_NATIVE_PERF_REPETITIONS" =~ ^[1-9][0-9]*$ ]]; then
   exit 64
 fi
 
+# The GitHub emulator otherwise selects Impeller OpenGLES. flutter_gpu's
+# current GLES shader-pipeline path can terminate the instrumentation process
+# before Dart can report a fallback, so the GPU-specific Patrol cohort uses
+# the emulator's Vulkan/SwiftShader backend. The checked-in example manifest
+# remains device-default for ordinary users and local development.
+cp ../../../tool/android_patrol_vulkan_manifest.xml \
+  android/app/src/debug/AndroidManifest.xml
+
 patrol test \
   --device emulator-5554 \
   --target patrol_test/demo_e2e_test.dart \


### PR DESCRIPTION
## Summary

- exercise the real flutter_gpu retained-scene backend in every Android and iOS Patrol performance repetition
- measure pipeline warm-up, scene warm-up, first tile, Canvas control, and retained follow-up tile with forced readback
- verify GPU/Canvas pixel agreement, completed submissions, and zero fallback routing
- decline OpenGLES contexts before shader-pipeline creation because the Flutter 3.47 GLES path can terminate the process; preserve the exact Canvas fallback
- run the CI-only Android cohort on Vulkan/SwiftShader and retain detailed instrumentation crash outputs
- wait for form overlays to be genuinely hit-testable in the existing Android demo journey so a slow zoom cannot redirect a tap into the floating toolbar

This establishes the first native mobile GPU baseline for future GPU PR comparisons.

## Validation

- targeted analysis: clean
- flutter_gpu backend suite: 72 passed, 2 platform skips
- existing native tile pressure widget test: passed
- Patrol performance summarizer tests: passed
- workflow/script/XML validation: passed
- local Impeller/flutter_gpu probe on Metal: first tile 4.4 ms vs Canvas 214.9 ms, retained tile 2.7 ms, zero fallbacks

## CI findings addressed

The first Android Patrol run selected Impeller OpenGLES and the instrumentation process terminated during synthetic pipeline warm-up before Dart could report an exception. The backend now rejects that context up front. The first Vulkan override used an engine value with the wrong case; Flutter 3.47 compares against lowercase `vulkan`, which this revision now supplies.

The next run stopped earlier in the existing form journey: its first checkbox tap landed on the floating Hand toolbar while the zoom animation was still settling, then the retry hit the modal sheet opened by that tap. The helper now re-frames and waits for the actual form overlay to own its hit-test point before tapping.