### PR TITLE
perf(gpu): import platform image textures directly

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+- Import compatible platform-decoded `ui.Image` textures directly into
+  Flutter GPU instead of reading their pixels back to the CPU and uploading
+  them again. CPU-backed and mipmapped images keep the proven upload fallback.
 - Stage proactive pipeline compilation: the context-wide idle pass now primes
   only common stencil, solid, and texture variants, while the existing live-
   scene warm-up compiles glyph, soft-mask, and destination-sampling variants

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -186,9 +186,10 @@ Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
 mask case keeps the base and mask as two GPU textures and combines them during
 tile replay; it never builds an eager full-size RGBA composite or reads pixels
-back to the CPU. Worker-retained RGBA uploads directly; locally
-platform-decoded images pay at most one readback before entering the shared
-texture cache. A
+back to the CPU. Worker-retained RGBA uploads directly; compatible locally
+platform-decoded images import their GPU texture directly into the shared
+cache without a pixel readback. CPU-backed images and the uncommon mipmapped
+bitmap-font path retain the existing readback/upload fallback. A
 backend-wide byte-budgeted LRU preserves decoded texture identity
 across scenes, pages, workers, zoom levels, and LoDs.
 Pinned scene textures count toward the same ceiling; if no unpinned entry can

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -6299,6 +6299,23 @@ FloatBuilder _imageVertices(PdfMatrix transform) {
 Future<_GpuImageTexture> _uploadImageTexture(
     gpu.GpuContext context, ui.Image image, FlutterGpuTileBackendStats stats,
     {PdfDecodedPixels? decoded, required int mipLevelCount}) async {
+  if (decoded == null && mipLevelCount == 1) {
+    try {
+      final texture = gpu.Texture.fromImage(context, image);
+      stats
+        ..textureImports += 1
+        ..texturesUploaded += 1;
+      return _GpuImageTexture(
+        texture,
+        texture.width,
+        texture.height,
+        texture.getBaseMipLevelSizeInBytes(),
+      );
+    } on Exception {
+      // CPU-backed or cross-context images cannot be wrapped. Preserve the
+      // established readback/upload path for those uncommon inputs.
+    }
+  }
   final ByteData bytes;
   if (decoded != null &&
       decoded.width == image.width &&

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -63,6 +63,7 @@ class FlutterGpuTileBackendStats {
   int transientAllocatedBytes = 0;
   int peakTransientTileBytes = 0;
   int texturesUploaded = 0;
+  int textureImports = 0;
   int textureDirectUploads = 0;
   int textureReadbacks = 0;
   int textureCacheHits = 0;
@@ -148,6 +149,7 @@ class FlutterGpuTileBackendStats {
         'transientAllocatedBytes': transientAllocatedBytes,
         'peakTransientTileBytes': peakTransientTileBytes,
         'texturesUploaded': texturesUploaded,
+        'textureImports': textureImports,
         'textureDirectUploads': textureDirectUploads,
         'textureReadbacks': textureReadbacks,
         'textureCacheHits': textureCacheHits,
@@ -230,6 +232,7 @@ class FlutterGpuTileBackendStats {
     transientAllocatedBytes = 0;
     peakTransientTileBytes = 0;
     texturesUploaded = 0;
+    textureImports = 0;
     textureDirectUploads = 0;
     textureReadbacks = 0;
     textureCacheHits = 0;
@@ -293,7 +296,8 @@ class FlutterGpuTileBackendStats {
       'transientEmplacedBytes=$transientEmplacedBytes '
       'transientAllocatedBytes=$transientAllocatedBytes '
       'peakTransientTileBytes=$peakTransientTileBytes '
-      'uploads=$texturesUploaded directUploads=$textureDirectUploads '
+      'uploads=$texturesUploaded imports=$textureImports '
+      'directUploads=$textureDirectUploads '
       'readbacks=$textureReadbacks textureHits=$textureCacheHits '
       'textureMisses=$textureCacheMisses evictions=$textureEvictions '
       'budgetFallbacks=$textureBudgetFallbacks '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -71,6 +71,7 @@ void main() {
       ..transientEmplacedBytes = 768 << 10
       ..transientAllocatedBytes = 1 << 20
       ..peakTransientTileBytes = 896 << 10
+      ..textureImports = 6
       ..analyticTextRuns = 7
       ..analyticGlyphQuads = 18
       ..analyticGlyphSlots = 4
@@ -120,6 +121,7 @@ void main() {
     expect(stats.toJson(), containsPair('transientEmplacedBytes', 768 << 10));
     expect(stats.toJson(), containsPair('transientAllocatedBytes', 1 << 20));
     expect(stats.toJson(), containsPair('peakTransientTileBytes', 896 << 10));
+    expect(stats.toJson(), containsPair('textureImports', 6));
     expect(stats.toJson(), containsPair('analyticGlyphQuads', 18));
     expect(stats.toJson(), containsPair('analyticGlyphSlots', 4));
     expect(stats.toJson(), containsPair('analyticAtlasBytes', 4096));
@@ -171,6 +173,7 @@ void main() {
     expect(stats.transientEmplacedBytes, 0);
     expect(stats.transientAllocatedBytes, 0);
     expect(stats.peakTransientTileBytes, 0);
+    expect(stats.textureImports, 0);
     expect(stats.analyticTextRuns, 0);
     expect(stats.analyticGlyphQuads, 0);
     expect(stats.analyticGlyphSlots, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1533,10 +1533,20 @@ void main() {
 
       final first = backend.createSession(scene)!;
       final firstImage = await first.rasterizeRegion(region, pixelRatio: 0.25);
-      await _pixels(firstImage);
+      final canvas = await scene.rasterizeRegion(region, pixelRatio: 0.25);
+      final expected = await _pixels(canvas);
+      final actual = await _pixels(firstImage);
+      var difference = 0;
+      for (var i = 0; i < expected.length; i++) {
+        difference += (expected[i] - actual[i]).abs();
+      }
+      expect(difference / expected.length, lessThan(4));
+      canvas.dispose();
       firstImage.dispose();
       first.dispose();
       expect(backend.stats.texturesUploaded, 1);
+      expect(backend.stats.textureImports, 1);
+      expect(backend.stats.textureReadbacks, 0);
       expect(backend.stats.textureBytes, greaterThan(0));
 
       final second = backend.createSession(scene)!;
@@ -1556,6 +1566,8 @@ void main() {
       thirdImage.dispose();
       third.dispose();
       expect(backend.stats.texturesUploaded, 2);
+      expect(backend.stats.textureImports, 2);
+      expect(backend.stats.textureReadbacks, 0);
     });
   });
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_ci_smoke_test.dart
@@ -60,6 +60,8 @@ void main() {
           expect(backend.stats.tilesRendered, 1);
           expect(backend.stats.rasterFallbacks, 0);
           expect(backend.stats.completedSubmissions, 1);
+          expect(backend.stats.textureImports, greaterThan(0));
+          expect(backend.stats.textureReadbacks, 0);
           expect(backend.stats.lastTileRoute, 'flutter_gpu');
         } finally {
           session?.dispose();


### PR DESCRIPTION
## Headline

Compared with main on image-heavy Ghent GWG167: image readbacks fall from 3 to 0, all 3 textures use direct platform import, and cold GPU time improves from 474.2 ms to 463.0 ms median (-2.4%). Canvas parity is unchanged at meanDiff 2.401.

<details>
<summary>Implementation and validation details</summary>

- Wrap compatible single-mip ui.Image resources with Texture.fromImage instead of reading RGBA back to the CPU and uploading it again.
- Keep the proven readback/upload fallback for CPU-backed, cross-context, and mipmapped images.
- Add textureImports diagnostics and require the designated native smoke fixture to import without a readback.
- Root analysis: clean.
- Designated native Flutter GPU smoke: passed after rebase onto main.
- Full native GPU suite: 305 passed, 4 intentionally skipped.
- GPU corpus routing unchanged: Ghent 49 accepted / 8 rejected; PDF.js 111 accepted / 68 rejected.
- Same-host GWG167 output dimensions and bytes are unchanged against the prior route.

The companion GPU package remains experimental; unsupported imports fall back without changing PDF output.

</details>