### PR TITLE
perf(gpu): retain local pixels for mip uploads

### DIFF
--- a/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
@@ -47,8 +47,12 @@ typedef _NativeGpuRaster = ({
 Future<void> runNativeGpuPerfScenario() async {
   final platform = _platformName();
   final document = PdfDocument.open(buildEmbeddedFontImagePdf());
-  final scene = await PdfRetainedScene.record(document.page(0));
   final backend = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
+  final scene = await PdfRetainedScene.record(
+    document.page(0),
+    retainDecodedPixelsForCommands:
+        backend.shouldRetainLocallyDecodedImagePixels,
+  );
   PdfTileRasterSession? session;
   try {
     await _measureNativeGpuScenario(

--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -328,12 +328,17 @@ class ImageCollector implements PdfDevice, PdfTiledCellSink {
 /// the draw. This avoids a GPU readback and a second upload. Set it to false
 /// for consumers that inspect the returned image directly (for example with
 /// [ui.Image.toByteData]) instead of drawing it through [CanvasPdfDevice].
+///
+/// When [retainDecodedPixels] is true, portable decoder results stay attached
+/// to their requests until the retained-scene owner has uploaded or released
+/// them. Platform-codec images still carry no CPU copy.
 Future<Map<Object, ui.Image>> decodeImages(
     CosDocument cos, Iterable<PdfImageRequest> requests,
     {PdfImageCache? cache,
     double? maxImagePixelRatio,
     double imageDecodeHeadroom = 2,
-    bool deferSimpleDctSoftMasks = true}) async {
+    bool deferSimpleDctSoftMasks = true,
+    bool retainDecodedPixels = false}) async {
   final batchClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
   installPdfJpegAccelerator();
   final grayDctImages = _DctGrayBatchCache();
@@ -383,11 +388,17 @@ Future<Map<Object, ui.Image>> decodeImages(
     final hit = cache?.take(cacheKey);
     if (hit != null) {
       cacheHits++;
-      out[key] = hit;
+      if (retainDecodedPixels && sourceRequest.decoded == null) {
+        pending.add(_PendingDecode(key, cacheKey, request, sourceRequest,
+            target, deferSimpleDctSoftMasks,
+            cachedImage: hit));
+      } else {
+        out[key] = hit;
+      }
       continue;
     }
-    pending.add(_PendingDecode(
-        key, cacheKey, sourceRequest, target, deferSimpleDctSoftMasks));
+    pending.add(_PendingDecode(key, cacheKey, request, sourceRequest, target,
+        deferSimpleDctSoftMasks));
   }
   final planUs = batchClock?.elapsedMicroseconds ?? 0;
   // Decode the misses concurrently. `instantiateImageCodec` / the browser codec
@@ -399,6 +410,23 @@ Future<Map<Object, ui.Image>> decodeImages(
   try {
     await Future.wait(pending.map((p) async {
       try {
+        final cachedImage = p.cachedImage;
+        if (cachedImage != null) {
+          out[p.key] = cachedImage;
+          final pixels = await _decodePortablePixels(
+            cos,
+            p.request.stream,
+            targetWidth: p.target?.$1,
+            targetHeight: p.target?.$2,
+            luminosityMask: p.request.isLuminosityMask,
+          );
+          if (pixels != null &&
+              pixels.width == cachedImage.width &&
+              pixels.height == cachedImage.height) {
+            p.originalRequest.retainDecodedPixels(pixels);
+          }
+          return;
+        }
         final decoded = p.request.decoded;
         ui.Image? image;
         if (decoded != null) {
@@ -416,7 +444,10 @@ Future<Map<Object, ui.Image>> decodeImages(
               targetHeight: p.target?.$2,
               luminosityMask: p.request.isLuminosityMask,
               deferSimpleDctSoftMask: p.deferSimpleDctSoftMask,
-              grayDctImages: grayDctImages);
+              grayDctImages: grayDctImages,
+              onDecodedPixels: retainDecodedPixels
+                  ? p.originalRequest.retainDecodedPixels
+                  : null);
         }
         if (image != null) {
           out[p.key] = cache == null ? image : cache.put(p.cacheKey, image);
@@ -470,13 +501,16 @@ PdfImageRequest _resolveReferencedImage(
 /// One image whose decode was deferred so [decodeImages] can run the misses
 /// concurrently. Holds everything the synchronous planning pass resolved.
 class _PendingDecode {
-  _PendingDecode(this.key, this.cacheKey, this.request, this.target,
-      this.deferSimpleDctSoftMask);
+  _PendingDecode(this.key, this.cacheKey, this.originalRequest, this.request,
+      this.target, this.deferSimpleDctSoftMask,
+      {this.cachedImage});
   final Object key;
   final Object cacheKey;
+  final PdfImageRequest originalRequest;
   final PdfImageRequest request;
   final (int, int)? target;
   final bool deferSimpleDctSoftMask;
+  final ui.Image? cachedImage;
 }
 
 final class _DctGrayBatchKey {
@@ -607,6 +641,35 @@ final class _DctGrayBatchCache {
 
 int? _intOrNull(CosObject? o) => o is CosInteger ? o.value : null;
 
+Future<PdfDecodedPixels?> _decodePortablePixels(
+  CosDocument cos,
+  CosStream stream, {
+  int? targetWidth,
+  int? targetHeight,
+  required bool luminosityMask,
+}) async {
+  final filters = pdfImageFilters(cos, stream.dictionary);
+  // The UI-side residual path owns bases that a worker intentionally left for
+  // the platform JPEG codec (notably Flate DeviceN under a DCT soft mask).
+  // Warm a simple Flate base with the same native browser inflater used for
+  // portable masks before entering the synchronous colour conversion below.
+  await _seedBrowserFlateImage(cos, stream, filters);
+  if (pdfImageDctSoftMaskBytes(cos, stream.dictionary) != null) return null;
+  return targetWidth != null && targetHeight != null
+      ? decodePdfImage(
+          cos,
+          stream,
+          targetWidth: targetWidth,
+          targetHeight: targetHeight,
+          luminosityMask: luminosityMask,
+        )
+      : decodePdfImagePixels(
+          cos,
+          stream,
+          luminosityMask: luminosityMask,
+        );
+}
+
 /// Decodes one image XObject to a [ui.Image]. The pure-Dart decode
 /// ([decodePdfImagePixels]) covers everything but the platform JPEG codec;
 /// the residual path here decodes a non-CMYK DCTDecode base and applies
@@ -623,30 +686,26 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
     int? targetHeight,
     bool luminosityMask = false,
     bool deferSimpleDctSoftMask = true,
-    _DctGrayBatchCache? grayDctImages}) async {
+    _DctGrayBatchCache? grayDctImages,
+    void Function(PdfDecodedPixels)? onDecodedPixels}) async {
   final scaled = targetWidth != null && targetHeight != null;
   final dict = stream.dictionary;
   final filters = pdfImageFilters(cos, dict);
-  // The UI-side residual path owns bases that a worker intentionally left for
-  // the platform JPEG codec (notably Flate DeviceN under a DCT soft mask).
-  // Warm a simple Flate base with the same native browser inflater used for
-  // portable masks before entering the synchronous colour conversion below.
-  await _seedBrowserFlateImage(cos, stream, filters);
   final dctMaskBytes = pdfImageDctSoftMaskBytes(cos, dict);
   // pdf_graphics can decode DCT masks portably for worker isolates. Once back
   // in a dart:ui isolate, keep the platform-codec path: it avoids running the
   // JPEG decoder synchronously here and lets the engine/browser codec handle
   // entropy decode before the unavoidable alpha readback.
   final pureClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-  final pixels = dctMaskBytes != null
-      ? null
-      : scaled
-          ? decodePdfImage(cos, stream,
-              targetWidth: targetWidth,
-              targetHeight: targetHeight,
-              luminosityMask: luminosityMask)
-          : decodePdfImagePixels(cos, stream, luminosityMask: luminosityMask);
+  final pixels = await _decodePortablePixels(
+    cos,
+    stream,
+    targetWidth: targetWidth,
+    targetHeight: targetHeight,
+    luminosityMask: luminosityMask,
+  );
   if (pixels != null) {
+    onDecodedPixels?.call(pixels);
     final decodeMs =
         pureClock == null ? null : pureClock.elapsedMicroseconds / 1000.0;
     final uploadClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -2923,7 +2923,9 @@ class _PdfPageViewState extends State<PdfPageView>
     final scene = await PdfRetainedScene.record(widget.page,
         plan: _renderPlan,
         maxImagePixelRatio: localImageRatio,
-        imageDecodeHeadroom: 1);
+        imageDecodeHeadroom: 1,
+        retainDecodedPixelsForCommands:
+            widget.tileRasterBackend.shouldRetainLocallyDecodedImagePixels);
     _lastInterpretResultBytes = _logImageStats(pageIndex, scene.commands);
     if (!_retainScene(scene.commands)) {
       // Too dense or too fragmented to replay per zoom settle: take the 1:1
@@ -3055,6 +3057,8 @@ class _PdfPageViewState extends State<PdfPageView>
       plan: _renderPlan,
       retainDecodedPixels:
           widget.tileRasterBackend.prefersDirectDecodedImageUploads,
+      retainLocallyDecodedPixels: widget.tileRasterBackend
+          .shouldRetainLocallyDecodedImagePixels(commands),
       timing: timing,
       maxImagePixelRatio: maxImagePixelRatio,
       allowOverprintRerecord: true,
@@ -4988,6 +4992,8 @@ class _PdfPageViewState extends State<PdfPageView>
         plan: _renderPlan,
         retainDecodedPixels:
             widget.tileRasterBackend.prefersDirectDecodedImageUploads,
+        retainLocallyDecodedPixels: widget.tileRasterBackend
+            .shouldRetainLocallyDecodedImagePixels(commands),
         maxImagePixelRatio: imageRatio,
       );
       if (!mounted ||

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -364,6 +364,13 @@ class PdfRetainedScene {
   /// display resolution, as in [decodeImages] - the local twin of the render
   /// worker's own cap, so a JPEG the worker declined does not decode at full
   /// native resolution on the UI thread.
+  ///
+  /// [retainDecodedPixels] keeps portable decoder output until an accelerated
+  /// backend uploads it. Platform-codec images still retain only their
+  /// [ui.Image].
+  /// [retainDecodedPixelsForCommands] can opt in after recording has exposed
+  /// the complete command mix, allowing a backend to keep pixels only for
+  /// scenes whose upload strategy needs them.
   static Future<PdfRetainedScene> record(
     PdfPage page, {
     PdfPageRenderPlan plan = const PdfPageRenderPlan(),
@@ -371,6 +378,8 @@ class PdfRetainedScene {
     int overprintMaxDimension = 384,
     double? maxImagePixelRatio,
     double imageDecodeHeadroom = 2,
+    bool retainDecodedPixels = false,
+    bool Function(List<PdfRenderCommand>)? retainDecodedPixelsForCommands,
     PdfSceneBuildTiming? timing,
   }) async {
     final cos = page.document.cos;
@@ -381,11 +390,14 @@ class PdfRetainedScene {
       overprintMaxDimension: overprintMaxDimension,
     )..drawPageContent(page, page.contentBytes());
     if (plan.annotations) recording.drawAnnotations(page, skip: skipAnnotation);
+    final keepDecodedPixels = retainDecodedPixels ||
+        (retainDecodedPixelsForCommands?.call(recorder.commands) ?? false);
     final clock = timing == null ? null : (Stopwatch()..start());
     final images = await decodeImages(cos, recorder.imageRequests,
         cache: PdfImageCache.instance,
         maxImagePixelRatio: maxImagePixelRatio,
-        imageDecodeHeadroom: imageDecodeHeadroom);
+        imageDecodeHeadroom: imageDecodeHeadroom,
+        retainDecodedPixels: keepDecodedPixels);
     if (clock != null) {
       timing!.decodeMs = clock.elapsedMicroseconds / 1000.0;
     }
@@ -394,6 +406,14 @@ class PdfRetainedScene {
       plan,
       recorder.commands,
       images,
+      retainedDecodedRequests: !keepDecodedPixels
+          ? null
+          : <PdfImageRequest>[
+              for (final request in recorder.imageRequests)
+                if (request.decoded != null &&
+                    images.containsKey(pdfImageKey(request)))
+                  request,
+            ],
       recordingOptions: skipAnnotation == null
           ? (
               maxImagePixelRatio: maxImagePixelRatio,
@@ -495,6 +515,9 @@ class PdfRetainedScene {
   /// ([decodeImages]). This is the path that pays for a JPEG the worker shipped
   /// un-decoded (it cannot run the platform codec); the cap keeps that UI-thread
   /// decode at display size instead of the image's full native resolution.
+  /// [retainDecodedPixels] preserves pixels already carried by a worker;
+  /// [retainLocallyDecodedPixels] separately controls portable decoding done in
+  /// this isolate and defaults to the same value.
   static Future<PdfRetainedScene> fromCommands(
     PdfPage page,
     List<PdfRenderCommand> commands, {
@@ -502,9 +525,11 @@ class PdfRetainedScene {
     bool includeImages = true,
     bool allowOverprintRerecord = false,
     bool retainDecodedPixels = false,
+    bool? retainLocallyDecodedPixels,
     PdfSceneBuildTiming? timing,
     double? maxImagePixelRatio,
   }) async {
+    final keepLocalPixels = retainLocallyDecodedPixels ?? retainDecodedPixels;
     Map<Object, ui.Image> images = const <Object, ui.Image>{};
     final requests = <PdfImageRequest>[];
     if (includeImages) {
@@ -515,15 +540,16 @@ class PdfRetainedScene {
       images = await decodeImages(page.document.cos, requests,
           cache: PdfImageCache.instance,
           maxImagePixelRatio: maxImagePixelRatio,
-          imageDecodeHeadroom: 1);
-      if (!retainDecodedPixels) {
+          imageDecodeHeadroom: 1,
+          retainDecodedPixels: keepLocalPixels);
+      if (!retainDecodedPixels && !keepLocalPixels) {
         _releaseDecodedImagePixels(requests, images);
       }
       if (clock != null) {
         timing!.decodeMs = clock.elapsedMicroseconds / 1000.0;
       }
     }
-    final retainedRequests = !retainDecodedPixels
+    final retainedRequests = !retainDecodedPixels && !keepLocalPixels
         ? null
         : <PdfImageRequest>[
             for (final request in requests)
@@ -547,8 +573,8 @@ class PdfRetainedScene {
     );
   }
 
-  /// Releases worker-carried RGBA after an accelerated backend has uploaded
-  /// its scene textures.
+  /// Releases worker-carried or locally retained RGBA after an accelerated
+  /// backend has uploaded its scene textures.
   ///
   /// Retained Canvas replay continues to use [_images]. The command requests
   /// keep their decoded dimensions, so inline-image lookup identity remains

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:ui' as ui;
 
 import 'package:flutter/painting.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'retained_scene.dart';
 import 'tile_store.dart';
@@ -38,10 +39,18 @@ abstract class PdfTileRasterBackend {
   ///
   /// The Canvas backend only needs the engine [ui.Image], so dropping the
   /// duplicate worker payload immediately saves memory. A backend that can
-  /// upload those bytes directly may opt in and release them after its
-  /// one-time scene compilation through
+  /// upload those bytes directly may opt in and release them after its one-time
+  /// scene compilation through
   /// [PdfRetainedScene.releaseDecodedImagePixels].
   bool get prefersDirectDecodedImageUploads => false;
+
+  /// Whether this command mix needs locally decoded RGBA retained for upload.
+  ///
+  /// Returning false lets compatible engine images stay on a zero-copy import
+  /// route. Backends should return true only when scene resources require a CPU
+  /// representation, such as a hand-built mip chain.
+  bool shouldRetainLocallyDecodedImagePixels(List<PdfRenderCommand> commands) =>
+      false;
 
   /// Whether [warmUp] performs useful process- or view-scoped preparation.
   ///

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -84,6 +84,35 @@ void main() {
     });
   });
 
+  testWidgets(
+      'cached local scene can recover portable pixels for accelerated upload',
+      (tester) async {
+    await tester.runAsync(() async {
+      PdfImageCache.instance.clear();
+      addTearDown(PdfImageCache.instance.clear);
+      final page = PdfDocument.open(buildEmbeddedFontImagePdf()).page(0);
+      final warm = await PdfRetainedScene.record(page);
+      warm.dispose();
+
+      final scene = await PdfRetainedScene.record(
+        page,
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final request =
+          scene.commands.whereType<PdfDrawImageCommand>().first.request;
+
+      expect(request.decoded, isNotNull);
+      expect(request.decoded!.width, scene.imageFor(request)!.width);
+      expect(request.decoded!.height, scene.imageFor(request)!.height);
+
+      scene.releaseDecodedImagePixels();
+      expect(request.decoded, isNull);
+      expect(scene.imageFor(request), isNotNull,
+          reason: 'Canvas replay keeps the engine image after CPU release');
+    });
+  });
+
   testWidgets('local retained scenes can be re-recorded for overprint retry',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+- Retain portable decoder RGBA only for scenes whose tiled bitmap-font images
+  need a hand-built mip chain, upload those pixels directly, and release them
+  after scene compilation. Ordinary images continue through zero-copy platform
+  texture import; mipmapped scenes avoid a GPU-to-CPU readback per image.
 - Import compatible platform-decoded `ui.Image` textures directly into
   Flutter GPU instead of reading their pixels back to the CPU and uploading
   them again. CPU-backed and mipmapped images keep the proven upload fallback.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -188,8 +188,10 @@ mask case keeps the base and mask as two GPU textures and combines them during
 tile replay; it never builds an eager full-size RGBA composite or reads pixels
 back to the CPU. Worker-retained RGBA uploads directly; compatible locally
 platform-decoded images import their GPU texture directly into the shared
-cache without a pixel readback. CPU-backed images and the uncommon mipmapped
-bitmap-font path retain the existing readback/upload fallback. A
+cache without a pixel readback. For the uncommon tiled bitmap-font path, the
+local portable decoder keeps RGBA just long enough to upload the hand-built mip
+chain directly, then releases it. CPU-backed platform images retain the proven
+readback/upload fallback. A
 backend-wide byte-budgeted LRU preserves decoded texture identity
 across scenes, pages, workers, zoom levels, and LoDs.
 Pinned scene textures count toward the same ceiling; if no unpinned entry can

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -225,6 +225,10 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   bool get prefersDirectDecodedImageUploads => true;
 
   @override
+  bool shouldRetainLocallyDecodedImagePixels(List<PdfRenderCommand> commands) =>
+      _requiresMipmappedImages(_dropInvisibleGroups(commands));
+
+  @override
   PdfTileRasterSession? createSession(PdfRetainedScene scene) {
     _lastSessionRejection = null;
     try {
@@ -1192,7 +1196,7 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
   const maxExpandedCommands = 1000000;
   source = _dropInvisibleGroups(source);
   var hasTiledCell = false;
-  var mipmapImages = false;
+  final mipmapImages = _requiresMipmappedImages(source);
 
   int count(List<PdfRenderCommand> commands, Set<Object> active,
       {bool inTiledCell = false}) {
@@ -1215,15 +1219,6 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
         }
         total += cellCount * originsX.length;
       } else {
-        if (inTiledCell &&
-            command is PdfDrawImageCommand &&
-            command.request.isStencil) {
-          // Canvas uses FilterQuality.medium for every image on the page.
-          // Once a retained bitmap-font cell needs minification, match that
-          // sampling mode for the whole GPU scene; mixing base-only and
-          // mipmapped images on the same Ghent page is measurably less exact.
-          mipmapImages = true;
-        }
         total++;
       }
       if (total > maxExpandedCommands) {
@@ -1282,6 +1277,34 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
     null,
     mipmapImages: mipmapImages,
   );
+}
+
+/// Whether Canvas parity requires the scene-wide hand-built mip chain.
+///
+/// Canvas uses FilterQuality.medium for every image on the page. Once a
+/// retained bitmap-font cell needs minification, matching that sampling mode
+/// for the whole GPU scene is measurably more exact than mixing base-only and
+/// mipmapped images on the same Ghent page.
+bool _requiresMipmappedImages(List<PdfRenderCommand> commands,
+    {bool inTiledCell = false, Set<Object>? active}) {
+  active ??= Set<Object>.identity();
+  if (!active.add(commands)) return false;
+  for (final command in commands) {
+    if (command case PdfDrawTiledCellCommand(:final cellCommands)) {
+      if (_requiresMipmappedImages(cellCommands,
+          inTiledCell: true, active: active)) {
+        active.remove(commands);
+        return true;
+      }
+    } else if (inTiledCell &&
+        command is PdfDrawImageCommand &&
+        command.request.isStencil) {
+      active.remove(commands);
+      return true;
+    }
+  }
+  active.remove(commands);
+  return false;
 }
 
 /// Removes transparency groups whose alpha is zero or whose declared

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1609,6 +1609,70 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('local portable pixels upload without an image readback',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final scene = await PdfRetainedScene.record(
+        PdfDocument.open(buildEmbeddedFontImagePdf()).page(0),
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final request =
+          scene.commands.whereType<PdfDrawImageCommand>().first.request;
+      expect(request.decoded, isNotNull);
+
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene)!;
+      addTearDown(session.dispose);
+      final image = await session.rasterizeRegion(
+        Offset.zero & scene.pageSize,
+        pixelRatio: 0.25,
+      );
+      addTearDown(image.dispose);
+      await _pixels(image);
+
+      expect(backend.stats.textureDirectUploads, 1);
+      expect(backend.stats.textureImports, 0);
+      expect(backend.stats.textureReadbacks, 0);
+      expect(request.decoded, isNull,
+          reason: 'scene compilation releases the temporary CPU payload');
+    });
+  });
+
+  test('local retention targets only mipmapped tiled stencil scenes', () {
+    final backend = FlutterGpuTileRasterBackend();
+    final stream = CosStream(CosDictionary(), Uint8List(0));
+    PdfDrawImageCommand image({required bool stencil}) =>
+        PdfDrawImageCommand(PdfImageRequest(
+          stream: stream,
+          transform: PdfMatrix.identity,
+          isStencil: stencil,
+        ));
+    List<PdfRenderCommand> tiled(PdfDrawImageCommand command) => [
+          PdfDrawTiledCellCommand(
+            [command],
+            Float64List.fromList([0]),
+            Float64List.fromList([0]),
+          ),
+        ];
+
+    expect(
+        backend.shouldRetainLocallyDecodedImagePixels([image(stencil: true)]),
+        isFalse);
+    expect(
+        backend.shouldRetainLocallyDecodedImagePixels(
+            tiled(image(stencil: false))),
+        isFalse);
+    expect(
+        backend
+            .shouldRetainLocallyDecodedImagePixels(tiled(image(stencil: true))),
+        isTrue);
+  });
+
   testWidgets('content identity survives worker-reconstructed scenes',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -71,10 +71,13 @@ void main() {
         return;
       }
 
-      final scene = await PdfRetainedScene.record(
-          PdfDocument.open(buildEmbeddedFontImagePdf()).page(0));
-      addTearDown(scene.dispose);
       final backend = FlutterGpuTileRasterBackend();
+      final scene = await PdfRetainedScene.record(
+        PdfDocument.open(buildEmbeddedFontImagePdf()).page(0),
+        retainDecodedPixelsForCommands:
+            backend.shouldRetainLocallyDecodedImagePixels,
+      );
+      addTearDown(scene.dispose);
       final session = backend.createSession(scene);
       expect(session, isNotNull, reason: backend.stats.lastRejection);
       addTearDown(session!.dispose);

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -136,20 +136,24 @@ void _corpus(
         );
         final limit = math.min(document.pageCount, maxPages);
         for (var pageIndex = 0; pageIndex < limit; pageIndex++) {
-          final scene = await PdfRetainedScene.record(document.page(pageIndex));
+          final PdfTileRasterBackend backend = FlutterGpuTileRasterBackend(
+            analyticText:
+                Platform.environment['GPU_CORPUS_ANALYTIC_TEXT'] != '0',
+            systemTextOutlines:
+                Platform.environment['GPU_CORPUS_SYSTEM_TEXT'] == '1',
+            overprintRetryMaxDimension: int.tryParse(
+                  Platform.environment[
+                          'GPU_CORPUS_OVERPRINT_RETRY_DIMENSION'] ??
+                      '',
+                ) ??
+                512,
+          );
+          final scene = await PdfRetainedScene.record(
+            document.page(pageIndex),
+            retainDecodedPixelsForCommands:
+                backend.shouldRetainLocallyDecodedImagePixels,
+          );
           try {
-            final PdfTileRasterBackend backend = FlutterGpuTileRasterBackend(
-              analyticText:
-                  Platform.environment['GPU_CORPUS_ANALYTIC_TEXT'] != '0',
-              systemTextOutlines:
-                  Platform.environment['GPU_CORPUS_SYSTEM_TEXT'] == '1',
-              overprintRetryMaxDimension: int.tryParse(
-                    Platform.environment[
-                            'GPU_CORPUS_OVERPRINT_RETRY_DIMENSION'] ??
-                        '',
-                  ) ??
-                  512,
-            );
             var session = backend.createSession(scene);
             if (session == null && backend is PdfTileRasterRetryBackend) {
               final retry =

--- a/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/real_document_benchmark_test.dart
@@ -265,6 +265,8 @@ void main() {
         final record = Stopwatch()..start();
         final scene = await PdfRetainedScene.record(
           document.page(pageIndex),
+          retainDecodedPixelsForCommands:
+              gpuBackend.shouldRetainLocallyDecodedImagePixels,
           timing: timing,
         );
         record.stop();

--- a/packages/pdf_graphics/lib/src/device.dart
+++ b/packages/pdf_graphics/lib/src/device.dart
@@ -214,6 +214,20 @@ class PdfImageRequest {
         decodedWidth = decoded?.width,
         decodedHeight = decoded?.height;
 
+  PdfImageRequest._copy({
+    required this.stream,
+    required this.transform,
+    required this.alpha,
+    required this.isStencil,
+    required this.stencilColor,
+    required this.isInline,
+    required this.isLuminosityMask,
+    required PdfDecodedPixels? decoded,
+    required this.decodedWidth,
+    required this.decodedHeight,
+    required this.sourceReference,
+  }) : _decoded = decoded;
+
   final CosStream stream;
 
   /// Indirect object identity for a worker command that deliberately omitted
@@ -254,6 +268,37 @@ class PdfImageRequest {
   /// image view from pinning the whole transferred command buffer. Rendering
   /// remains reproducible from [stream] or [sourceReference].
   void releaseDecodedPixels() => _decoded = null;
+
+  /// Keeps locally decoded RGBA available for a one-time accelerated upload.
+  ///
+  /// Unlike worker-carried pixels, these dimensions are deliberately not
+  /// folded into [decodedWidth]/[decodedHeight]: the request may already have
+  /// been used as an image-map key before the local decoder produced them.
+  /// Callers must only attach pixels matching the engine image built for this
+  /// request, and release them with [releaseDecodedPixels] after upload.
+  void retainDecodedPixels(PdfDecodedPixels pixels) {
+    _decoded ??= pixels;
+  }
+
+  /// Copies this request with new geometry while preserving its image-map key.
+  ///
+  /// Local retained pixels are attached after the original request has keyed
+  /// an image map, so reconstructing through the public constructor would
+  /// incorrectly infer sized-key dimensions from them. Geometry adapters use
+  /// this method to keep worker-sized and locally-unsized identities intact.
+  PdfImageRequest withTransform(PdfMatrix value) => PdfImageRequest._copy(
+        stream: stream,
+        transform: value,
+        alpha: alpha,
+        isStencil: isStencil,
+        stencilColor: stencilColor,
+        isInline: isInline,
+        isLuminosityMask: isLuminosityMask,
+        decoded: decoded,
+        decodedWidth: decodedWidth,
+        decodedHeight: decodedHeight,
+        sourceReference: sourceReference,
+      );
 
   /// True for inline images (`BI .. ID .. EI`). Their [stream] is
   /// synthesized fresh on every interpretation pass, so consumers that

--- a/packages/pdf_graphics/lib/src/translating_device.dart
+++ b/packages/pdf_graphics/lib/src/translating_device.dart
@@ -113,17 +113,8 @@ class TranslatingPdfDevice implements PdfDevice {
       ));
 
   @override
-  void drawImage(PdfImageRequest request) => target.drawImage(PdfImageRequest(
-        stream: request.stream,
-        transform: _matrix(request.transform),
-        alpha: request.alpha,
-        isStencil: request.isStencil,
-        stencilColor: request.stencilColor,
-        isInline: request.isInline,
-        isLuminosityMask: request.isLuminosityMask,
-        decoded: request.decoded,
-        sourceReference: request.sourceReference,
-      ));
+  void drawImage(PdfImageRequest request) =>
+      target.drawImage(request.withTransform(_matrix(request.transform)));
 
   @override
   void setBlendMode(PdfBlendMode mode) => target.setBlendMode(mode);

--- a/packages/pdf_graphics/test/render_command_test.dart
+++ b/packages/pdf_graphics/test/render_command_test.dart
@@ -149,6 +149,28 @@ void main() {
     });
   });
 
+  test('translated image preserves a late retained-pixel cache identity', () {
+    final request = PdfImageRequest(
+      stream: CosStream(CosDictionary(), Uint8List(0)),
+      transform: PdfMatrix.identity,
+      isInline: true,
+    );
+    request.retainDecodedPixels(
+      PdfDecodedPixels(Uint8List.fromList([10, 20, 30, 255]), 1, 1),
+    );
+    final recorder = RecordingPdfDevice();
+
+    TranslatingPdfDevice(recorder, 12, 34).drawImage(request);
+
+    final translated =
+        (recorder.commands.single as PdfDrawImageCommand).request;
+    expect(translated.decoded, same(request.decoded));
+    expect(translated.decodedWidth, isNull);
+    expect(translated.decodedHeight, isNull);
+    expect(translated.transform.e, 12);
+    expect(translated.transform.f, 34);
+  });
+
   // Real pages exercise the serialization-fragile callbacks the synthetic
   // cases can't reach: transparency groups, soft masks (luminosity + alpha,
   // with their drawMask content), blend modes, mesh and axial/radial shadings,


### PR DESCRIPTION
Compared with main on image-heavy Ghent GWG090: image readbacks fall from **30 to 0**, cold GPU time improves from **522.8 ms to 514.9 ms median (-1.5%)**, and retained geometry plus Canvas parity stay unchanged (**95,865 vertices; meanDiff 10.760**). Ordinary GWG167 images still use the zero-copy route (**3 imports, 0 readbacks**).

<details>
<summary>What changed</summary>

- Let tile backends request locally decoded pixels from the retained command transcript.
- Retain portable decoder RGBA only when a tiled stencil image needs a hand-built mip chain.
- Recover those pixels deterministically on image-cache hits without replacing the engine image.
- Preserve the original image cache identity when translated commands carry pixels attached after decode.
- Release retained CPU pixels after GPU scene compilation.

Platform-codec images remain eligible for `Texture.fromImage`; ordinary scenes do not retain an extra CPU copy.

</details>

<details>
<summary>Validation</summary>

- `fvm dart analyze`: clean
- `pdf_graphics/test/render_command_test.dart`: 14 passed
- `dart_pdf_editor/test/retained_scene_test.dart`: 8 passed
- production retention-selector regression: passed
- complete native Flutter GPU suite: 307 passed, 4 expected skips
- Ghent routes: 49 GPU / 8 conservative fallbacks
- PDF.js routes: 111 GPU / 68 conservative fallbacks without host fonts
- GWG167 control: 3 direct imports, 0 readbacks, meanDiff 2.401

The refreshed warm samples were noisy (candidate median +4.5%) and do not correspond to a changed warm-render path, so they are not treated as an improvement claim. The deterministic result is removal of all 30 readbacks; the cold median is the timing comparison.

</details>
