### PR TITLE
feat(gpu): retain per-paint group clips

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -6,6 +6,9 @@
   need a hand-built mip chain, upload those pixels directly, and release them
   after scene compilation. Ordinary images continue through zero-copy platform
   texture import; mipmapped scenes avoid a GPU-to-CPU readback per image.
+- Preserve a distinct arbitrary path-clip stack for every paint in an isolated
+  offscreen transparency group. Each paint rebuilds its exact stencil before
+  the group alpha is resolved, rather than forcing the page onto Canvas.
 - Import compatible platform-decoded `ui.Image` textures directly into
   Flutter GPU instead of reading their pixels back to the CPU and uploading
   them again. CPU-backed and mipmapped images keep the proven upload fallback.
@@ -66,8 +69,7 @@
   the alpha/luminosity backdrop and transfer function prove that the mask is
   zero outside the clip. Non-zero outside-mask values remain on Canvas.
 - Retain arbitrary path clips around one fill, stroke, text run, image,
-  gradient, or mesh inside a single-paint transparency group. Multi-paint
-  groups with path clips remain conservative Canvas fallbacks.
+  gradient, or mesh inside a single-paint transparency group.
 - Consume `pdf_graphics` exact region-clipped spatial overprint strokes as
   ordinary retained clip and stroke commands. Three additional Ghent pages
   stay on the GPU path; unresolved non-black overprint remains on Canvas.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -138,10 +138,11 @@ mask clips remain the bounded shader scissor; arbitrary mask clips with a
 non-zero outside value still use Canvas.
 The same composite stencil retains an arbitrary path clip around one fill,
 stroke, text run, image, gradient, or mesh inside a single-paint transparency
-group. An isolated multi-paint offscreen group can share one arbitrary path
-clip: the backend rebuilds that stencil for every source paint before resolving
-the group alpha, preserving antialiased overlap coverage. Groups whose
-separately ordered paints carry distinct path clips remain on Canvas.
+group. An isolated multi-paint offscreen group preserves either a shared or a
+distinct arbitrary clip stack for every source paint before resolving the
+group alpha, preserving antialiased overlap coverage. Unisolated groups that
+need a backdrop-aware group result, and offscreen groups with advanced
+per-paint blend modes, remain on Canvas.
 A single ordinary soft-masked source may itself sit inside a transparency
 group: the backend resolves that source in a bounded offscreen target and then
 applies the enclosing group alpha once. This exact route requires no explicit

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -810,6 +810,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     required this.commands,
     required this.paintClips,
     required this.paintBlends,
+    this.paintPathClips = const [],
     required this.contentClip,
     this.contentPathClips = const [],
     this.paintAlphaScales = const {},
@@ -822,6 +823,7 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final List<PdfRenderCommand> commands;
   final List<PdfRect?> paintClips;
   final List<PdfBlendMode> paintBlends;
+  final List<List<_GpuPathClip>> paintPathClips;
   final Map<int, double> paintAlphaScales;
   final double groupAlpha;
   final bool offscreen;
@@ -831,6 +833,9 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final PdfRect? contentClip;
   @override
   final List<_GpuPathClip> contentPathClips;
+
+  List<_GpuPathClip> pathClipsForPaint(int index) =>
+      paintPathClips.isEmpty ? contentPathClips : paintPathClips[index];
 }
 
 class _KnockoutSoftMaskFillSpec extends _GpuCompositeSpec {
@@ -1923,7 +1928,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 if (nestedAlphaScale != null) {
                   paintAlphaScales[paints.length - 1] = nestedAlphaScale;
                 }
-                paintPathClips.add(nestedSpec.contentPathClips);
+                paintPathClips.add(nestedSpec.pathClipsForPaint(nestedIndex));
               }
             case _GroupPaintSpec(
                   commands: [PdfDrawImageCommand(:final request)],
@@ -1946,7 +1951,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
               ));
               paintAlphaScales[paints.length - 1] =
                   (nestedSpec.paintAlphaScales[0] ?? 1) * nestedSpec.groupAlpha;
-              paintPathClips.add(nestedSpec.contentPathClips);
+              paintPathClips.add(nestedSpec.pathClipsForPaint(0));
             default:
               return (null, nested.$2 ?? 'nested image group');
           }
@@ -2135,7 +2140,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           null,
         );
       }
-      if (!commonPaintPathClip) {
+      if (!commonPaintPathClip && !canRenderOffscreen) {
         return (null, 'non-rectangular multi-paint transparency group clip');
       }
       // A shared path clip can stay active across a flattened draw sequence,
@@ -2168,13 +2173,16 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           paintClips: List.unmodifiable([for (final paint in paints) paint.$3]),
           paintBlends:
               List.unmodifiable([for (final paint in paints) paint.$4]),
+          paintPathClips: commonPaintPathClip
+              ? const []
+              : List.unmodifiable(paintPathClips),
           paintAlphaScales: Map.unmodifiable(paintAlphaScales),
           contentClip: canRenderSeededKnockout
               ? groupBounds
               : canFlatten && commonPaintClip
                   ? commonClip
                   : null,
-          contentPathClips: commonPathClips,
+          contentPathClips: commonPaintPathClip ? commonPathClips : const [],
           groupAlpha: alpha,
           offscreen: !canFlatten || !commonPaintClip,
           knockout: canRenderKnockout || canRenderSeededKnockout,
@@ -4009,32 +4017,42 @@ class _CompiledScene {
       for (final unit in units) {
         final command = commands[unit.commandIndex];
         List<_GpuClipState>? offscreenPaintClips;
-        if (unit.composite
-            case _GroupPaintSpec(
-              offscreen: true,
-              :final contentPathClips,
-              :final paintClips,
-            ) when contentPathClips.isNotEmpty) {
-          var commonState = unit.clip;
-          for (final pathClip in contentPathClips) {
-            commonState = _pushGpuClip(
-              commonState,
-              pathClip.path,
-              pathClip.rule,
-            );
-          }
-          offscreenPaintClips = [
-            for (final paintClip in paintClips)
-              _withGpuRectClip(commonState, paintClip),
+        final composite = unit.composite;
+        if (composite is _GroupPaintSpec && composite.offscreen) {
+          final pathClipStacks = [
+            for (var index = 0; index < composite.commands.length; index++)
+              composite.pathClipsForPaint(index),
           ];
-          for (_GpuClipNode? node = commonState.node;
-              node != null;
-              node = node.previous) {
-            final clipNode = node;
-            clipDraws.putIfAbsent(
-              clipNode,
-              () => _compileClip(geometry, clipNode),
-            );
+          if (pathClipStacks.any((clips) => clips.isNotEmpty)) {
+            final stackStates =
+                HashMap<List<_GpuPathClip>, _GpuClipState>.identity();
+            offscreenPaintClips = [];
+            for (var index = 0; index < pathClipStacks.length; index++) {
+              final stack = pathClipStacks[index];
+              final stackState = stackStates.putIfAbsent(stack, () {
+                var state = unit.clip;
+                for (final pathClip in stack) {
+                  state = _pushGpuClip(
+                    state,
+                    pathClip.path,
+                    pathClip.rule,
+                  );
+                }
+                return state;
+              });
+              offscreenPaintClips.add(
+                _withGpuRectClip(stackState, composite.paintClips[index]),
+              );
+              for (_GpuClipNode? node = stackState.node;
+                  node != null;
+                  node = node.previous) {
+                final clipNode = node;
+                clipDraws.putIfAbsent(
+                  clipNode,
+                  () => _compileClip(geometry, clipNode),
+                );
+              }
+            }
           }
         }
         if (unit.composite == null && command is PdfStrokePathCommand) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3486,7 +3486,7 @@ void main() {
     });
   });
 
-  testWidgets('flattened groups retain exact shared content clips',
+  testWidgets('groups retain exact shared and per-paint content clips',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -3505,13 +3505,14 @@ void main() {
       Future<void> expectParity(
         PdfRetainedScene scene, {
         int expectedClipPaths = 1,
+        int? expectedOffscreenGroupPasses,
       }) async {
         addTearDown(scene.dispose);
         final backend = FlutterGpuTileRasterBackend();
         final session = backend.createSession(scene);
         expect(session, isNotNull, reason: backend.stats.lastRejection);
         addTearDown(session!.dispose);
-        const region = Rect.fromLTWH(30, 70, 220, 220);
+        const region = Rect.fromLTWH(30, 500, 220, 220);
         final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
         final actual = await session.rasterizeRegion(region, pixelRatio: 1.5);
         addTearDown(expected.dispose);
@@ -3523,6 +3524,12 @@ void main() {
         }
         expect(difference / a.length, lessThan(8));
         expect(backend.stats.clipPathsCompiled, expectedClipPaths);
+        if (expectedOffscreenGroupPasses != null) {
+          expect(
+            backend.stats.offscreenGroupPasses,
+            expectedOffscreenGroupPasses,
+          );
+        }
       }
 
       await expectParity(await PdfRetainedScene.fromCommands(page, [
@@ -3647,6 +3654,42 @@ void main() {
         const PdfEndGroupCommand(),
       ]);
       await expectParity(distinctClips, expectedClipPaths: 2);
+
+      final distinctOffscreenClips = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(0.45, isolated: true),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(diamond, PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rect(40, 80, 180, 280),
+          const PdfColor(0.1, 0.65, 0.3),
+          PdfFillRule.nonzero,
+          0.85,
+        ),
+        const PdfRestoreCommand(),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(
+          PdfPath([
+            PdfMoveTo(100, 100),
+            PdfLineTo(240, 180),
+            PdfLineTo(100, 260),
+            PdfClosePath(),
+          ]),
+          PdfFillRule.evenOdd,
+        ),
+        PdfFillPathCommand(
+          _rect(80, 100, 240, 260),
+          const PdfColor(0.8, 0.2, 0.3),
+          PdfFillRule.nonzero,
+          0.7,
+        ),
+        const PdfRestoreCommand(),
+        const PdfEndGroupCommand(),
+      ]);
+      await expectParity(
+        distinctOffscreenClips,
+        expectedClipPaths: 2,
+        expectedOffscreenGroupPasses: 1,
+      );
     });
   });
 


### PR DESCRIPTION
## Performance and coverage

Compared with main, the established mixed group and blend benchmark remains within same-host noise. This focused route expansion does not change the checked-corpus acceptance totals: Ghent remains 49 accepted / 8 rejected and PDF.js remains 177 / 2 when system fonts are enabled.

## What changed

- retain each paint-specific arbitrary clip in isolated offscreen groups
- compile and cache the corresponding stencil state per paint
- preserve the shared-clip fast path and existing Canvas safety gates
- update the fallback documentation
- add pixel-parity coverage for two distinct non-rectangular clips inside one translucent group

<details>
<summary>Validation</summary>

- fvm dart analyze packages/dart_pdf_editor_flutter_gpu
- complete dart_pdf_editor_flutter_gpu test suite with Impeller and flutter_gpu: 308 passed, 4 environment skips
- focused Canvas parity tests
- full Ghent and PDF.js GPU corpus sweep
- no accepted-page or rejection-count regression

</details>