### PR TITLE
feat(gpu): retain nested composites inside groups

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -14,6 +14,13 @@
   bounded ping-pong attachments before group alpha and the outer blend are
   applied once. The programmable path now implements Multiply and Screen as
   well as the advanced modes instead of falling through to Exclusion.
+- Retain ordinary soft-masked images, fills, strokes, gradients, and text as
+  individual paints inside transparency groups. Common opaque vector/text mask
+  stacks expand into the parent with their exact stencil, composite, clip, and
+  conservative blend bounds instead of forcing the whole page onto Canvas.
+- Expand alpha-one nested knockout groups with a uniform declared backdrop into
+  an isolated parent attachment. The seed becomes a bounded first paint and
+  later siblings preserve their shape-limited source-replacement semantics.
 - Import compatible platform-decoded `ui.Image` textures directly into
   Flutter GPU instead of reading their pixels back to the CPU and uploading
   them again. CPU-backed and mipmapped images keep the proven upload fallback.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -110,9 +110,12 @@ paint types in the bounded offscreen tile pass before applying group alpha and
 the outer blend once. A nested one-image group with a transparent backdrop and
 Normal blend folds its group alpha into that image before joining its retained
 parent; the equivalent premultiplied source avoids a redundant nested pass.
-Opaque non-isolated knockout groups with a declared
-uniform backdrop also retain ordered vector fills and strokes: their bounded
-attachment is seeded with that color and clipped to the form BBox. The
+An alpha-one nested knockout group with a uniform declared backdrop can also
+join an isolated parent: the backdrop becomes its first bounded paint and the
+following shapes preserve source replacement in the parent's attachment.
+Opaque non-isolated knockout groups at page level retain ordered vector fills
+and strokes the same way: their bounded attachment is seeded with that color
+and clipped to the form BBox. The
 intermediate group target stays single-sample while
 the final page target retains 4x MSAA, avoiding a redundant color/stencil
 raster and resolve. Every PDF blend mode remains per-paint state inside that
@@ -144,11 +147,13 @@ group. An isolated multi-paint offscreen group preserves either a shared or a
 distinct arbitrary clip stack for every source paint before resolving the
 group alpha, preserving antialiased overlap coverage. Unisolated groups that
 need a page-backdrop-aware group result remain on Canvas.
-A single ordinary soft-masked source may itself sit inside a transparency
-group: the backend resolves that source in a bounded offscreen target and then
-applies the enclosing group alpha once. This exact route requires no explicit
-group backdrop, a Normal internal blend, and no enabled overprint; the other
-forms remain on Canvas.
+Ordinary image-, vector-, gradient-, and text-soft-masked sources may sit beside
+other retained paints inside a transparency group. Each mask resolves as one
+bounded parent paint before the enclosing group alpha is applied. The common
+opaque vector/text-mask stack also expands its base and nested image-masked
+paint directly into the parent while preserving the outer stencil and exact
+blend bounds. Enabled overprint and non-isolated groups that require the page
+backdrop remain on Canvas.
 Paints behind a degenerate or disjoint rectangular clip are discarded while
 capturing a transparency group, including balanced soft-mask content that can
 no longer affect a pixel. Save/restore still reinstates the prior clip for any

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -811,6 +811,9 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
     required this.paintClips,
     required this.paintBlends,
     this.paintPathClips = const [],
+    this.paintBounds = const {},
+    this.sourceReplacementPaints = const {},
+    this.paintComposites = const {},
     required this.contentClip,
     this.contentPathClips = const [],
     this.paintAlphaScales = const {},
@@ -824,6 +827,9 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
   final List<PdfRect?> paintClips;
   final List<PdfBlendMode> paintBlends;
   final List<List<_GpuPathClip>> paintPathClips;
+  final Map<int, PdfRect> paintBounds;
+  final Set<int> sourceReplacementPaints;
+  final Map<int, _GpuCompositeSpec> paintComposites;
   final Map<int, double> paintAlphaScales;
   final double groupAlpha;
   final bool offscreen;
@@ -836,6 +842,9 @@ class _GroupPaintSpec extends _GpuCompositeSpec {
 
   List<_GpuPathClip> pathClipsForPaint(int index) =>
       paintPathClips.isEmpty ? contentPathClips : paintPathClips[index];
+
+  bool sourceReplacesAt(int index) =>
+      sourceReplacementPaints.contains(index) || (knockout && index > 0);
 }
 
 class _KnockoutSoftMaskFillSpec extends _GpuCompositeSpec {
@@ -1694,7 +1703,10 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
     final paints =
         <(int?, PdfRenderCommand, PdfRect?, PdfBlendMode, bool, bool)>[];
     final paintPathClips = <List<_GpuPathClip>>[];
+    final paintBounds = <int, PdfRect>{};
     final paintAlphaScales = <int, double>{};
+    final sourceReplacementPaints = <int>{};
+    final paintComposites = <int, _GpuCompositeSpec>{};
     PdfEndSoftMaskedCommand? softEnd;
     var softDepth = 0;
     var softCount = 0;
@@ -1763,6 +1775,83 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
             ]);
           }
         case PdfBeginSoftMaskedCommand():
+          final nestedEnd = _matchingSoftMaskEnd(commands, i, end);
+          if (nestedEnd == null) {
+            return (null, 'unterminated nested soft-mask group');
+          }
+          final nestedEnablesOverprint = commands
+              .getRange(i + 1, nestedEnd)
+              .whereType<PdfSetOverprintCommand>()
+              .any((state) => state.fill || state.stroke);
+          final nested = _parseComposite(
+            commands,
+            i,
+            nestedEnd,
+            initialClip: clip,
+            initialFillOverprint: fillOverprint,
+            initialStrokeOverprint: strokeOverprint,
+            initialBlend: blend,
+          );
+          final nestedPaint = _nestedSoftMaskPaint(nested.$1);
+          if (nestedEnablesOverprint &&
+              (nestedPaint != null || nested.$1 is _FlattenSoftMaskSpec)) {
+            return (null, 'soft-mask group contains enabled overprint');
+          }
+          if (nestedPaint != null) {
+            if (emptyClipOnly) {
+              skippedEmptyPaint = true;
+              i = nestedEnd;
+              break;
+            }
+            final paintIndex = paints.length;
+            final spec = nested.$1!;
+            paints.add((
+              null,
+              nestedPaint.command,
+              spec.contentClip,
+              blend,
+              nestedPaint.fill && fillOverprint,
+              nestedPaint.stroke && strokeOverprint,
+            ));
+            paintPathClips.add(List.unmodifiable([
+              ...pathClips,
+              ...spec.contentPathClips,
+            ]));
+            paintComposites[paintIndex] = spec;
+            contentClip = spec.contentClip;
+            i = nestedEnd;
+            break;
+          }
+          if (nested.$1 case _FlattenSoftMaskSpec(paints: final flattenedPaints)
+              when flattenedPaints.isNotEmpty) {
+            for (final paint in flattenedPaints) {
+              final paintIndex = paints.length;
+              final paintCommand = commands[paint.commandIndex];
+              paints.add((
+                null,
+                paintCommand,
+                paint.clip,
+                paint.blendMode,
+                false,
+                false,
+              ));
+              paintPathClips.add(List.unmodifiable([
+                ...pathClips,
+                if (paint.pathClip case final path?)
+                  (path: path, rule: PdfFillRule.nonzero),
+              ]));
+              final composite = paint.composite;
+              if (composite != null) {
+                paintComposites[paintIndex] = composite;
+              }
+              paintBounds[paintIndex] = paint.bounds;
+              contentClip = paint.clip;
+            }
+            i = nestedEnd;
+            break;
+          }
+          // Preserve the established single-image group parser for variants
+          // not retained as an ordinary group paint above.
           softDepth++;
           softCount++;
         case PdfEndSoftMaskedCommand():
@@ -1847,11 +1936,10 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
         case PdfSetOverprintCommand(:final fill, :final stroke):
           fillOverprint = fill;
           strokeOverprint = stroke;
-        case PdfBeginGroupCommand(:final backdropColor):
+        case PdfBeginGroupCommand():
           if (blend != PdfBlendMode.normal ||
               fillOverprint ||
-              strokeOverprint ||
-              backdropColor != null) {
+              strokeOverprint) {
             return (null, 'nested image group');
           }
           final nestedEnd = _matchingGroupEnd(commands, i, end);
@@ -1867,6 +1955,73 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           );
           final nestedSpec = nested.$1;
           switch (nestedSpec) {
+            case _GroupPaintSpec(
+                  :final commands,
+                  :final paintClips,
+                  :final paintBlends,
+                  paintAlphaScales: final nestedPaintAlphaScales,
+                  paintBounds: final nestedPaintBounds,
+                  :final contentClip,
+                  :final groupAlpha,
+                  :final knockout,
+                  :final backdropColor,
+                )
+                when groupAlpha == 1 &&
+                    knockout &&
+                    backdropColor != null &&
+                    contentClip != null &&
+                    pathClips.isEmpty &&
+                    paintBlends.every(
+                      (mode) => mode == PdfBlendMode.normal,
+                    ):
+              final backdropClip = clip == null
+                  ? contentClip
+                  : _pdfIntersection(clip, contentClip);
+              paints.add((
+                null,
+                PdfFillPathCommand(
+                  _pdfRectPath(contentClip),
+                  backdropColor,
+                  PdfFillRule.nonzero,
+                  1,
+                ),
+                backdropClip,
+                PdfBlendMode.normal,
+                false,
+                false,
+              ));
+              paintPathClips.add(const []);
+              for (var nestedIndex = 0;
+                  nestedIndex < commands.length;
+                  nestedIndex++) {
+                final outerIndex = paints.length;
+                paints.add((
+                  null,
+                  commands[nestedIndex],
+                  paintClips[nestedIndex],
+                  paintBlends[nestedIndex],
+                  false,
+                  false,
+                ));
+                final nestedAlphaScale = nestedPaintAlphaScales[nestedIndex];
+                if (nestedAlphaScale != null) {
+                  paintAlphaScales[outerIndex] = nestedAlphaScale;
+                }
+                if (nestedSpec.sourceReplacesAt(nestedIndex)) {
+                  sourceReplacementPaints.add(outerIndex);
+                }
+                final nestedBounds = nestedPaintBounds[nestedIndex];
+                if (nestedBounds != null) {
+                  paintBounds[outerIndex] = nestedBounds;
+                }
+                final nestedComposite = nestedSpec.paintComposites[nestedIndex];
+                if (nestedComposite != null) {
+                  paintComposites[outerIndex] = nestedComposite;
+                }
+                paintPathClips.add(
+                  nestedSpec.pathClipsForPaint(nestedIndex),
+                );
+              }
             case _FlattenGroupSpec(paints: final nestedPaints):
               for (final nestedPaint in nestedPaints) {
                 paints.add((
@@ -1916,10 +2071,12 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 )
                 when nestedSpec.groupAlpha == 1 &&
                     !nestedSpec.knockout &&
+                    nestedSpec.backdropColor == null &&
                     paintBlends.every((mode) => mode == PdfBlendMode.normal):
               for (var nestedIndex = 0;
                   nestedIndex < commands.length;
                   nestedIndex++) {
+                final outerIndex = paints.length;
                 paints.add((
                   null,
                   commands[nestedIndex],
@@ -1931,7 +2088,18 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
                 final nestedAlphaScale =
                     nestedSpec.paintAlphaScales[nestedIndex];
                 if (nestedAlphaScale != null) {
-                  paintAlphaScales[paints.length - 1] = nestedAlphaScale;
+                  paintAlphaScales[outerIndex] = nestedAlphaScale;
+                }
+                if (nestedSpec.sourceReplacesAt(nestedIndex)) {
+                  sourceReplacementPaints.add(outerIndex);
+                }
+                final nestedBounds = nestedSpec.paintBounds[nestedIndex];
+                if (nestedBounds != null) {
+                  paintBounds[outerIndex] = nestedBounds;
+                }
+                final nestedComposite = nestedSpec.paintComposites[nestedIndex];
+                if (nestedComposite != null) {
+                  paintComposites[outerIndex] = nestedComposite;
                 }
                 paintPathClips.add(nestedSpec.pathClipsForPaint(nestedIndex));
               }
@@ -2016,6 +2184,32 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           );
         }
         return (null, 'non-identity single-paint transparency group');
+      }
+      final composite = paintComposites[0];
+      if (composite != null) {
+        // A single paint inside an isolated group sees a transparent
+        // backdrop, so every PDF blend function reduces to the source. A
+        // non-isolated group instead blends against the page backdrop; that
+        // backdrop is not available to this bounded retained target.
+        if (!isolated && paint.$4 != PdfBlendMode.normal) {
+          return (
+            null,
+            'non-isolated soft-mask group requires page backdrop',
+          );
+        }
+        return (
+          _GroupPaintSpec(
+            commands: [paint.$2],
+            paintClips: [paint.$3],
+            paintBlends: const [PdfBlendMode.normal],
+            paintComposites: {0: composite},
+            contentClip: paint.$3,
+            contentPathClips: paintPaths,
+            groupAlpha: alpha,
+            offscreen: alpha != 1,
+          ),
+          null,
+        );
       }
       return switch (paint.$2) {
         PdfFillPathCommand content => (
@@ -2114,6 +2308,7 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           ]);
       final canFlatten = alpha == 1 &&
           !knockout &&
+          sourceReplacementPaints.isEmpty &&
           backdropColor == null &&
           normalPaints &&
           (initialBlend == PdfBlendMode.normal || disjointOuterBlend);
@@ -2192,6 +2387,9 @@ _GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
           paintPathClips: commonPaintPathClip
               ? const []
               : List.unmodifiable(paintPathClips),
+          paintBounds: Map.unmodifiable(paintBounds),
+          sourceReplacementPaints: Set.unmodifiable(sourceReplacementPaints),
+          paintComposites: Map.unmodifiable(paintComposites),
           paintAlphaScales: Map.unmodifiable(paintAlphaScales),
           contentClip: canRenderSeededKnockout
               ? groupBounds
@@ -2754,6 +2952,52 @@ int? _matchingGroupEnd(
   }
   return null;
 }
+
+int? _matchingSoftMaskEnd(
+  List<PdfRenderCommand> commands,
+  int start,
+  int outerEnd,
+) {
+  var depth = 1;
+  for (var index = start + 1; index < outerEnd; index++) {
+    switch (commands[index]) {
+      case PdfBeginSoftMaskedCommand():
+        depth++;
+      case PdfEndSoftMaskedCommand():
+        depth--;
+        if (depth == 0) return index;
+      default:
+        break;
+    }
+  }
+  return null;
+}
+
+({PdfRenderCommand command, bool fill, bool stroke})? _nestedSoftMaskPaint(
+  _GpuCompositeSpec? spec,
+) =>
+    switch (spec) {
+      _SoftMaskFillSpec(:final content) ||
+      _SoftMaskVectorFillSpec(:final content) ||
+      _SoftMaskGradientFillSpec(:final content) =>
+        (command: content, fill: true, stroke: false),
+      _SoftMaskStrokeSpec(:final content) ||
+      _SoftMaskGradientStrokeSpec(:final content) =>
+        (command: content, fill: false, stroke: true),
+      _SoftMaskTextSpec(:final content) ||
+      _SoftMaskGradientTextSpec(:final content) =>
+        (
+          command: content,
+          fill: content.run.fill,
+          stroke: content.run.strokeColor != null,
+        ),
+      _SoftMaskImageSpec(:final content) => (
+          command: PdfDrawImageCommand(content),
+          fill: false,
+          stroke: false,
+        ),
+      _ => null,
+    };
 
 /// Flattens one narrow nested-mask shape without allocating an offscreen
 /// group: an opaque Normal base covering a binary white vector mask, followed
@@ -3537,6 +3781,14 @@ PdfRect _pdfUnion(PdfRect? a, PdfRect b) => a == null
         a.right > b.right ? a.right : b.right,
         a.top > b.top ? a.top : b.top,
       );
+
+PdfPath _pdfRectPath(PdfRect rect) => PdfPath([
+      PdfMoveTo(rect.left, rect.bottom),
+      PdfLineTo(rect.right, rect.bottom),
+      PdfLineTo(rect.right, rect.top),
+      PdfLineTo(rect.left, rect.top),
+      const PdfClosePath(),
+    ]);
 
 PdfRect _inflatePdf(PdfRect r, double amount) => PdfRect(
       r.left - amount,
@@ -5791,7 +6043,63 @@ Future<_GpuDraw?> _compileGroupPaint(
     }
     final alphaScale = spec.paintAlphaScales[index] ?? 1;
     final _GpuDraw? draw;
-    if (command case PdfDrawImageCommand(:final request) when alphaScale != 1) {
+    final composite = spec.paintComposites[index];
+    if (composite != null) {
+      draw = switch (composite) {
+        _SoftMaskImageSpec spec => await _compileSoftMaskImage(
+            context,
+            geometry,
+            scene,
+            spec,
+            stats,
+            imageCache,
+            textureLeases,
+            mipmapImages: mipmapImages,
+          ),
+        _SoftMaskFillSpec spec => await _compileSoftMaskFill(
+            context,
+            geometry,
+            scene,
+            spec,
+            stats,
+            imageCache,
+            textureLeases,
+            mipmapImages: mipmapImages,
+          ),
+        _SoftMaskStrokeSpec spec => await _compileSoftMaskStroke(
+            context,
+            geometry,
+            scene,
+            spec,
+            stats,
+            imageCache,
+            textureLeases,
+            mipmapImages: mipmapImages,
+          ),
+        _SoftMaskVectorFillSpec spec =>
+          _compileSoftMaskVectorFill(geometry, spec),
+        _SoftMaskGradientFillSpec spec =>
+          _compileSoftMaskGradientFill(geometry, spec),
+        _SoftMaskGradientStrokeSpec spec =>
+          _compileSoftMaskGradientStroke(geometry, spec),
+        _SoftMaskTextSpec spec => await _compileSoftMaskText(
+            context,
+            geometry,
+            scene,
+            spec,
+            stats,
+            imageCache,
+            textureLeases,
+            mipmapImages: mipmapImages,
+          ),
+        _SoftMaskGradientTextSpec spec =>
+          _compileSoftMaskGradientText(geometry, spec),
+        _ => throw StateError(
+            'unsupported retained group paint ${composite.runtimeType}',
+          ),
+      };
+    } else if (command case PdfDrawImageCommand(:final request)
+        when alphaScale != 1) {
       draw = await _compileImageCommand(
         context,
         geometry,
@@ -5819,7 +6127,7 @@ Future<_GpuDraw?> _compileGroupPaint(
     }
     if (draw != null) {
       final clip = spec.paintClips[index];
-      final bounds = pdfRenderCommandBounds(command);
+      final bounds = spec.paintBounds[index] ?? pdfRenderCommandBounds(command);
       final clippedBounds = bounds == null || clip == null
           ? bounds
           : _pdfIntersection(bounds, clip);
@@ -5827,7 +6135,7 @@ Future<_GpuDraw?> _compileGroupPaint(
         draw: draw,
         clip: clip,
         blendMode: spec.paintBlends[index],
-        sourceReplacement: spec.knockout && index > 0,
+        sourceReplacement: spec.sourceReplacesAt(index),
         clipState: paintClipStates?[index],
         // Match the page unit's conservative antialias/stroke fringe. A
         // wider blend scissor is harmless because the source target is clear

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -3259,6 +3259,342 @@ void main() {
     });
   });
 
+  testWidgets('isolated groups retain nested seeded knockout paints',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const backdrop = PdfColor(0.24, 0.58, 0.72);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfBeginGroupCommand(
+          0.76,
+          isolated: true,
+          bounds: PdfRect(35, 85, 345, 385),
+        ),
+        PdfFillPathCommand(
+          _rect(45, 95, 335, 375),
+          const PdfColor(0.12, 0.2, 0.32),
+          PdfFillRule.nonzero,
+          0.9,
+        ),
+        const PdfBeginGroupCommand(
+          1,
+          knockout: true,
+          bounds: PdfRect(60, 120, 320, 350),
+          backdropColor: backdrop,
+        ),
+        PdfFillPathCommand(
+          _rect(75, 140, 235, 320),
+          const PdfColor(0.95, 0.25, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(150, 160, 300, 335),
+          const PdfColor(0.15, 0.42, 0.95),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfStrokePathCommand(
+          _rect(115, 180, 275, 305),
+          const PdfColor(0.2, 0.85, 0.38),
+          const PdfStroke(width: 10),
+          1,
+        ),
+        const PdfEndGroupCommand(),
+        PdfFillPathCommand(
+          _rect(240, 105, 330, 195),
+          const PdfColor(0.86, 0.7, 0.12),
+          PdfFillRule.nonzero,
+          0.8,
+        ),
+        const PdfEndGroupCommand(),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 390, 350, 350);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
+  testWidgets('offscreen Multiply and Screen sample translucent backdrops',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      for (final mode in [PdfBlendMode.multiply, PdfBlendMode.screen]) {
+        final scene = await PdfRetainedScene.fromCommands(page, [
+          PdfFillPathCommand(
+            _rect(35, 85, 325, 365),
+            const PdfColor(0.14, 0.42, 0.82),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfBeginGroupCommand(
+            0.83,
+            isolated: true,
+            bounds: PdfRect(55, 105, 305, 345),
+          ),
+          PdfFillPathCommand(
+            _rect(65, 115, 295, 335),
+            const PdfColor(0.92, 0.7, 0.18),
+            PdfFillRule.nonzero,
+            0.48,
+          ),
+          PdfSetBlendModeCommand(mode),
+          PdfFillPathCommand(
+            _rect(85, 135, 285, 325),
+            const PdfColor(0.18, 0.76, 0.42),
+            PdfFillRule.nonzero,
+            0.72,
+          ),
+          const PdfEndGroupCommand(),
+        ]);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull,
+            reason: '${mode.name}: ${backend.stats.lastRejection}');
+        const region = Rect.fromLTWH(45, 435, 270, 270);
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+        final actual = await session!.rasterizeRegion(
+          region,
+          pixelRatio: 1.5,
+        );
+        try {
+          final a = await _pixels(expected), b = await _pixels(actual);
+          var difference = 0;
+          for (var index = 0; index < a.length; index++) {
+            difference += (a[index] - b[index]).abs();
+          }
+          expect(difference / a.length, lessThan(3), reason: mode.name);
+          expect(backend.stats.offscreenGroupPasses, 1, reason: mode.name);
+          expect(backend.stats.advancedBlendPasses, 1, reason: mode.name);
+        } finally {
+          expected.dispose();
+          actual.dispose();
+          session.dispose();
+          scene.dispose();
+        }
+      }
+    });
+  });
+
+  testWidgets('offscreen groups retain nested soft-mask paints',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final mask = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+        ]),
+        const PdfMatrix(190, 0, 0, 190, 85, 125),
+        'nested-group-mask',
+      );
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(
+            0.72,
+            isolated: true,
+            bounds: PdfRect(40, 90, 330, 370),
+          ),
+          PdfFillPathCommand(
+            _rect(50, 100, 210, 300),
+            const PdfColor(0.9, 0.24, 0.14),
+            PdfFillRule.nonzero,
+            0.82,
+          ),
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(85, 125, 275, 315),
+            const PdfColor(0.12, 0.48, 0.92),
+            PdfFillRule.nonzero,
+            0.9,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: [mask],
+          ),
+          PdfFillPathCommand(
+            _rect(195, 185, 320, 355),
+            const PdfColor(0.18, 0.8, 0.34),
+            PdfFillRule.nonzero,
+            0.75,
+          ),
+          const PdfEndGroupCommand(),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 390, 350, 350);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+    });
+  });
+
+  testWidgets('offscreen groups retain flattened nested soft-mask stacks',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final mask = _decodedImage(
+        Uint8List.fromList([
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+          0,
+          0,
+          0,
+          255,
+          255,
+          255,
+          255,
+          255,
+        ]),
+        const PdfMatrix(180, 0, 0, 180, 70, 115),
+        'nested-group-flattened-mask',
+      );
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(
+            0.74,
+            isolated: true,
+            bounds: PdfRect(35, 80, 330, 365),
+          ),
+          PdfFillPathCommand(
+            _rect(45, 90, 300, 340),
+            const PdfColor(0.16, 0.38, 0.88),
+            PdfFillRule.nonzero,
+            0.9,
+          ),
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(65, 110, 250, 300),
+            const PdfColor(0.95, 0.76, 0.15),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+          const PdfBeginSoftMaskedCommand(),
+          PdfFillPathCommand(
+            _rect(55, 100, 265, 315),
+            const PdfColor(0.22, 0.72, 0.38),
+            PdfFillRule.nonzero,
+            0.78,
+          ),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: [mask],
+          ),
+          const PdfSetBlendModeCommand(PdfBlendMode.normal),
+          PdfEndSoftMaskedCommand(
+            luminosity: true,
+            backdrop: page.cropBox,
+            maskCommands: [
+              PdfFillPathCommand(
+                _rect(65, 110, 250, 300),
+                const PdfColor(1, 1, 1),
+                PdfFillRule.nonzero,
+                1,
+              ),
+            ],
+          ),
+          PdfFillPathCommand(
+            _rect(235, 145, 320, 335),
+            const PdfColor(0.9, 0.24, 0.18),
+            PdfFillRule.nonzero,
+            0.82,
+          ),
+          const PdfEndGroupCommand(),
+        ],
+        retainDecodedPixels: true,
+      );
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      const region = Rect.fromLTWH(20, 400, 340, 340);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1.25);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1.25);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.offscreenGroupPasses, 1);
+      expect(backend.stats.advancedBlendPasses, 1);
+    });
+  });
+
   testWidgets('isolated knockout groups retain a vector-soft-masked fill',
       (tester) async {
     await tester.runAsync(() async {
@@ -4696,7 +5032,7 @@ void main() {
       expect(conservative.createSession(unsafe), isNull);
       expect(
         conservative.lastSessionRejection,
-        contains('soft-mask group contains'),
+        contains('requires page backdrop'),
       );
 
       final overprint = await PdfRetainedScene.fromCommands(page, [


### PR DESCRIPTION
Compared with parent #822 on the same host, isolated-group settle was 10.16 ms vs 9.93 ms (+2.3%) and internal advanced-group settle was 12.92 ms vs 12.64 ms (+2.2%). The paired Canvas controls slowed by 5-6%, so normalized GPU/Canvas ratios improved from 0.74x to 0.72x and from 1.18x to 1.14x respectively.

Depends on #822.

## Summary

- retain image, fill, stroke, gradient, and text soft-mask composites as individual paints inside transparency groups
- expand the existing opaque vector/text-mask stack into its parent while preserving per-paint clips, exact composite specs, and conservative advanced-blend bounds
- materialize alpha-one nested knockout groups with a uniform declared backdrop inside an isolated parent, preserving shape-limited source replacement
- keep enabled overprint and non-isolated backdrop-dependent variants on the exact Canvas fallback

The change removes the remaining `nested image group` blocker from the Ghent composite page. That page still falls back at the next independent exactness gate, `soft-mask group contains enabled overprint`; this PR does not admit the controlled overprint approximation into production.

<details>
<summary>Validation and benchmark details</summary>

- `fvm dart analyze`: clean
- complete package suite with Flutter GPU enabled: 313 passed, 4 intentional environment skips
- macOS system-font corpus: Ghent 49 accepted / 8 rejected; PDF.js 177 / 2
- parent corpus: identical acceptance counts, with the one Ghent rejection changing from `nested image group` to the more precise enabled-overprint gate
- flattened nested soft-mask parity: mean absolute difference 0.09/channel against Canvas in the focused regression
- all retained nested-group parity regressions pass, including seeded knockout, ordinary soft-mask paints, flattened nested masks, group alpha, clips, and conservative overprint rejection

Same-host controls (parent #822 -> candidate):

| Workload | Cold | Issue median | Settle median | Canvas median | GPU/Canvas |
| --- | ---: | ---: | ---: | ---: | ---: |
| Isolated group | 307.10 -> 270.60 ms | 0.87 -> 0.46 ms | 9.93 -> 10.16 ms | 13.36 -> 14.14 ms | 0.74x -> 0.72x |
| Advanced blend in group | 97.97 -> 98.42 ms | 0.41 -> 0.83 ms | 12.64 -> 12.92 ms | 10.69 -> 11.33 ms | 1.18x -> 1.14x |

The sub-millisecond issue medians are noisy; settled readback and the paired Canvas control are the decision metrics.

</details>
