### PR TITLE
perf(gpu): retain adjacent glyph bindings

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+- Retain the glyph pipeline, transform, atlas metadata, and sampler bindings
+  across adjacent analytic text runs. Intervening geometry invalidates that
+  state, while dense text tiles avoid five redundant native calls per run.
 - Retain portable decoder RGBA only for scenes whose tiled bitmap-font images
   need a hand-built mip chain, upload those pixels directly, and release them
   after scene compilation. Ordinary images continue through zero-copy platform

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -4840,6 +4840,7 @@ class _CompiledScene {
       final groupEncoder = _GpuEncoder(
         pass: groupPass,
         pipelines: pipelines,
+        stats: stats,
         transform: transient.emplace(_tileTransform(
           pageToRaster,
           groupRegion,
@@ -4970,6 +4971,7 @@ class _CompiledScene {
     _GpuEncoder encoderFor(gpu.RenderPass pass) => _GpuEncoder(
           pass: pass,
           pipelines: pipelines,
+          stats: stats,
           transform: transient.emplace(_tileTransform(
             pageToRaster,
             groupRegion,
@@ -5294,6 +5296,7 @@ class _CompiledScene {
         _GpuEncoder(
           pass: pass,
           pipelines: pipelines,
+          stats: stats,
           transform: transient.emplace(_tileTransform(
             pageToRaster,
             targetRegion,
@@ -5676,6 +5679,7 @@ class _CompiledScene {
         _GpuEncoder(
           pass: pass,
           pipelines: pipelines,
+          stats: stats,
           transform: transient.emplace(_tileTransform(
             pageToRaster,
             targetRegion,
@@ -8218,6 +8222,7 @@ class _GpuEncoder {
   _GpuEncoder({
     required this.pass,
     required this.pipelines,
+    required this.stats,
     required this.transform,
     required this.pageToRaster,
     required this.region,
@@ -8231,6 +8236,7 @@ class _GpuEncoder {
 
   final gpu.RenderPass pass;
   final _GpuPipelines pipelines;
+  final FlutterGpuTileBackendStats stats;
   final gpu.BufferView transform;
   final PdfMatrix pageToRaster;
   final Rect region;
@@ -8255,6 +8261,7 @@ class _GpuEncoder {
   int clipMaskRebuilds = 0;
   bool? _separateVertexCountApi;
   gpu.ColorBlendEquation _paintBlend = _srcOver;
+  _GpuGlyphAtlas? _boundGlyphAtlas;
 
   static final _srcOver = gpu.ColorBlendEquation(
     sourceColorBlendFactor: gpu.BlendFactor.one,
@@ -8382,6 +8389,7 @@ class _GpuEncoder {
   }
 
   void solid(_GpuBuffer vertices) {
+    _dropRetainedGlyphBindings();
     _defaultStencil();
     pass
       ..setColorBlendEquation(_paintBlend)
@@ -8518,6 +8526,7 @@ class _GpuEncoder {
     required bool union,
     required int requiredClipBit,
   }) {
+    _dropRetainedGlyphBindings();
     final compare = requiredClipBit == 0
         ? gpu.CompareFunction.always
         : gpu.CompareFunction.equal;
@@ -8554,6 +8563,7 @@ class _GpuEncoder {
 
   void _clearStencil(int mask) {
     if (mask == 0) return;
+    _dropRetainedGlyphBindings();
     pass
       ..setStencilReference(0)
       ..setColorBlendEquation(_noWrite)
@@ -8569,6 +8579,7 @@ class _GpuEncoder {
   }
 
   void texture(_GpuBuffer vertices, gpu.Texture texture, gpu.BufferView info) {
+    _dropRetainedGlyphBindings();
     _defaultStencil();
     pass
       ..setColorBlendEquation(_paintBlend)
@@ -8593,6 +8604,7 @@ class _GpuEncoder {
   /// sampling is a one-to-one texel copy; [alpha] and [_paintBlend] apply to
   /// the completed group once, as required by PDF transparency semantics.
   void tileTexture(gpu.Texture texture, Rect textureRegion, double alpha) {
+    _dropRetainedGlyphBindings();
     final vertices = _tileTextureVertices(textureRegion);
     final info = Float32List(8)..[3] = alpha.clamp(0.0, 1.0);
     _defaultStencil();
@@ -8618,6 +8630,7 @@ class _GpuEncoder {
   /// the PDF blend equations. This runs in a separate pass because Flutter GPU
   /// deliberately forbids sampling the color attachment being written.
   void copyTile(gpu.Texture texture) {
+    _dropRetainedGlyphBindings();
     final vertices = _tileTextureVertices(region);
     final info = Float32List(8)..[3] = 1;
     pass
@@ -8645,6 +8658,7 @@ class _GpuEncoder {
     PdfBlendMode mode,
     PdfRect? bounds,
   ) {
+    _dropRetainedGlyphBindings();
     final vertices = _tileTextureVertices(region);
     final info = Float32List(8)
       ..[0] = mode.index.toDouble()
@@ -8736,26 +8750,32 @@ class _GpuEncoder {
 
   void glyphs(_GpuBuffer vertices, _GpuGlyphAtlas atlas) {
     _defaultStencil();
-    pass
-      ..setColorBlendEquation(_paintBlend)
-      ..bindPipeline(pipelines.glyph)
-      ..bindUniform(pipelines.glyphTransform, transform)
-      ..bindUniform(pipelines.glyphInfo, atlas.info)
-      ..bindTexture(
-        pipelines.glyphSampler,
-        atlas.texture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-          mipFilter: gpu.MipFilter.nearest,
-        ),
-      );
+    pass.setColorBlendEquation(_paintBlend);
+    if (identical(_boundGlyphAtlas, atlas)) {
+      stats.glyphBindingReuses++;
+    } else {
+      pass
+        ..clearBindings()
+        ..bindPipeline(pipelines.glyph)
+        ..bindUniform(pipelines.glyphTransform, transform)
+        ..bindUniform(pipelines.glyphInfo, atlas.info)
+        ..bindTexture(
+          pipelines.glyphSampler,
+          atlas.texture,
+          sampler: gpu.SamplerOptions(
+            minFilter: gpu.MinMagFilter.nearest,
+            magFilter: gpu.MinMagFilter.nearest,
+            mipFilter: gpu.MipFilter.nearest,
+          ),
+        );
+      _boundGlyphAtlas = atlas;
+    }
     _drawBuffer(vertices);
-    pass.clearBindings();
   }
 
   void softMask(_GpuBuffer vertices, gpu.Texture contentTexture,
       gpu.Texture maskTexture, gpu.BufferView info) {
+    _dropRetainedGlyphBindings();
     _defaultStencil();
     final sampler = gpu.SamplerOptions(
       minFilter: gpu.MinMagFilter.linear,
@@ -8811,6 +8831,12 @@ class _GpuEncoder {
     _drawBuffer(cover);
     pass.clearBindings();
     _clearStencil(_pathMask);
+  }
+
+  void _dropRetainedGlyphBindings() {
+    if (_boundGlyphAtlas == null) return;
+    pass.clearBindings();
+    _boundGlyphAtlas = null;
   }
 
   // flutter_gpu is experimental. Flutter 3.47 split vertex count out of

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -39,6 +39,7 @@ class FlutterGpuTileBackendStats {
   int analyticAtlasFallbacks = 0;
   int analyticSparseAtlasSkips = 0;
   int analyticTextFallbackRuns = 0;
+  int glyphBindingReuses = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
@@ -125,6 +126,7 @@ class FlutterGpuTileBackendStats {
         'analyticAtlasFallbacks': analyticAtlasFallbacks,
         'analyticSparseAtlasSkips': analyticSparseAtlasSkips,
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
+        'glyphBindingReuses': glyphBindingReuses,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
@@ -210,6 +212,7 @@ class FlutterGpuTileBackendStats {
     analyticAtlasFallbacks = 0;
     analyticSparseAtlasSkips = 0;
     analyticTextFallbackRuns = 0;
+    glyphBindingReuses = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
@@ -275,6 +278,7 @@ class FlutterGpuTileBackendStats {
       'analyticAtlasFallbacks=$analyticAtlasFallbacks '
       'analyticSparseSkips=$analyticSparseAtlasSkips '
       'analyticFallbackRuns=$analyticTextFallbackRuns '
+      'glyphBindingReuses=$glyphBindingReuses '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -5493,6 +5493,64 @@ void main() {
     });
   });
 
+  testWidgets('retains analytic glyph bindings only across adjacent runs',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final face = FlutterGpuTrueTypeFontFace(buildTestTrueTypeFont());
+      final outliner = FlutterGpuTrueTypeTextOutliner((_) => face);
+      PdfDrawTextCommand text(double x, double y, PdfColor color) {
+        final run = PdfTextRun(
+          text: 'AB',
+          transform: PdfMatrix(36, 0, 0, 36, x, y),
+          color: color,
+          width: 1.2,
+          fontName: 'Helvetica',
+          fontSize: 36,
+          charOffsets: const [0, 0.6, 1.2],
+        );
+        return PdfDrawTextCommand(outliner.outline(run)!);
+      }
+
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        text(60, 700, const PdfColor(0.15, 0.25, 0.75)),
+        text(160, 700, const PdfColor(0.75, 0.25, 0.15)),
+        PdfFillPathCommand(
+          _rect(260, 680, 320, 730),
+          const PdfColor(0.2, 0.7, 0.35),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        text(360, 700, const PdfColor(0.55, 0.2, 0.65)),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final expectedPixels = await _pixels(expected);
+      final actualPixels = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < expectedPixels.length; index++) {
+        difference += (expectedPixels[index] - actualPixels[index]).abs();
+      }
+      expect(difference / expectedPixels.length, lessThan(8));
+      expect(backend.stats.analyticTextRuns, 3);
+      expect(backend.stats.glyphBindingReuses, 1,
+          reason: 'the solid draw must invalidate the retained atlas state');
+    });
+  });
+
   testWidgets('unsupported pages are rejected instead of approximated',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -127,6 +127,70 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('reports dense analytic text submission cost', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final face = FlutterGpuTrueTypeFontFace(buildTestTrueTypeFont());
+      final outliner = FlutterGpuTrueTypeTextOutliner((_) => face);
+      final commands = <PdfRenderCommand>[];
+      for (var row = 0; row < 16; row++) {
+        for (var column = 0; column < 16; column++) {
+          final run = PdfTextRun(
+            text: 'AB',
+            transform: PdfMatrix(
+              12,
+              0,
+              0,
+              12,
+              18 + column * 34,
+              760 - row * 44,
+            ),
+            color: PdfColor(
+              0.1 + (column % 4) * 0.15,
+              0.2 + (row % 4) * 0.12,
+              0.55,
+            ),
+            width: 1.2,
+            fontName: 'Helvetica',
+            fontSize: 12,
+            charOffsets: const [0, 0.6, 1.2],
+          );
+          commands.add(PdfDrawTextCommand(outliner.outline(run)!));
+        }
+      }
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final warm = await session.rasterizeRegion(region, pixelRatio: 0.5);
+      await warm.toByteData(format: ui.ImageByteFormat.rawRgba);
+      warm.dispose();
+      expect(backend.stats.analyticTextRuns, commands.length);
+
+      backend.stats.reset();
+      final settled = <int>[];
+      for (var index = 0; index < 15; index++) {
+        settled.add(await _timeSettledImage(
+          () => session.rasterizeRegion(region, pixelRatio: 0.5),
+        ));
+      }
+      // ignore: avoid_print
+      print('flutter_gpu analytic text benchmark: runs=${commands.length} '
+          'settledMedian=${_median(settled).toStringAsFixed(0)}us '
+          'issueMean=${(backend.stats.issueMicros / settled.length).toStringAsFixed(0)}us '
+          '${backend.stats}');
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
   testWidgets('reports content-free interior tile settle', (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {


### PR DESCRIPTION
Compared with the stacked #823 base on the same host, the 256-run analytic-text benchmark improves CPU issue mean from 1.895 ms to 1.569 ms (-17.2%) and settled median from 7.658 ms to 7.381 ms (-3.6%). Corpus routing is unchanged.

<details>
<summary>Implementation and validation</summary>

- Retains the glyph pipeline, transform, atlas metadata, and sampler across adjacent analytic text draws.
- Clears the retained state before intervening solid, stencil, texture, blend, or soft-mask work.
- Adds glyphBindingReuses diagnostics and a focused parity/invalidation regression.
- Adds a reproducible dense analytic-text benchmark.
- Full native package suite: 315 passed, 4 expected environment skips.
- Non-GPU fallback package suite: 12 passed, 90 expected GPU/environment skips.
- Root analysis: clean.
- Ghent route: 49 accepted / 8 conservative fallbacks.
- PDF.js route: 111 accepted / 68 conservative fallbacks.

This PR is stacked on #823 and should be retargeted to main after that PR lands.

</details>