### PR TITLE
perf(gpu): retain adjacent image bindings

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+- Retain the image pipeline and page transform across adjacent image draws,
+  reusing an unchanged texture/sampler while updating only per-image metadata.
+  Intervening geometry invalidates the retained bindings.
 - Retain the glyph pipeline, transform, atlas metadata, and sampler bindings
   across adjacent analytic text runs. Intervening geometry invalidates that
   state, while dense text tiles avoid five redundant native calls per run.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8218,6 +8218,8 @@ class _SoftMaskFillDraw implements _GpuDraw {
       encoder.softMaskFill(fan, cover, rule, maskTexture, info);
 }
 
+enum _GpuRetainedBindingKind { glyph, image }
+
 class _GpuEncoder {
   _GpuEncoder({
     required this.pass,
@@ -8261,7 +8263,9 @@ class _GpuEncoder {
   int clipMaskRebuilds = 0;
   bool? _separateVertexCountApi;
   gpu.ColorBlendEquation _paintBlend = _srcOver;
+  _GpuRetainedBindingKind? _retainedBindingKind;
   _GpuGlyphAtlas? _boundGlyphAtlas;
+  gpu.Texture? _boundImageTexture;
 
   static final _srcOver = gpu.ColorBlendEquation(
     sourceColorBlendFactor: gpu.BlendFactor.one,
@@ -8389,7 +8393,7 @@ class _GpuEncoder {
   }
 
   void solid(_GpuBuffer vertices) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     _defaultStencil();
     pass
       ..setColorBlendEquation(_paintBlend)
@@ -8526,7 +8530,7 @@ class _GpuEncoder {
     required bool union,
     required int requiredClipBit,
   }) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     final compare = requiredClipBit == 0
         ? gpu.CompareFunction.always
         : gpu.CompareFunction.equal;
@@ -8563,7 +8567,7 @@ class _GpuEncoder {
 
   void _clearStencil(int mask) {
     if (mask == 0) return;
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     pass
       ..setStencilReference(0)
       ..setColorBlendEquation(_noWrite)
@@ -8579,14 +8583,23 @@ class _GpuEncoder {
   }
 
   void texture(_GpuBuffer vertices, gpu.Texture texture, gpu.BufferView info) {
-    _dropRetainedGlyphBindings();
     _defaultStencil();
-    pass
-      ..setColorBlendEquation(_paintBlend)
-      ..bindPipeline(pipelines.texture)
-      ..bindUniform(pipelines.textureTransform, transform)
-      ..bindUniform(pipelines.textureInfo, info)
-      ..bindTexture(
+    pass.setColorBlendEquation(_paintBlend);
+    // Every ordinary image shares this pass transform and pipeline. Keep
+    // those bindings across adjacent draws; only the fragment metadata and,
+    // when it changes, the source texture need another Dart-to-native call.
+    final retained = _retainedBindingKind == _GpuRetainedBindingKind.image;
+    if (retained) {
+      stats.imageBindingReuses++;
+    } else {
+      _replaceRetainedBindings(_GpuRetainedBindingKind.image);
+      pass
+        ..bindPipeline(pipelines.texture)
+        ..bindUniform(pipelines.textureTransform, transform);
+    }
+    pass.bindUniform(pipelines.textureInfo, info);
+    if (!retained || !identical(_boundImageTexture, texture)) {
+      pass.bindTexture(
         pipelines.textureSampler,
         texture,
         sampler: gpu.SamplerOptions(
@@ -8595,8 +8608,9 @@ class _GpuEncoder {
           mipFilter: gpu.MipFilter.linear,
         ),
       );
+      _boundImageTexture = texture;
+    }
     _drawBuffer(vertices);
-    pass.clearBindings();
   }
 
   /// Samples a tile-sized offscreen group back into the same raster region.
@@ -8604,7 +8618,7 @@ class _GpuEncoder {
   /// sampling is a one-to-one texel copy; [alpha] and [_paintBlend] apply to
   /// the completed group once, as required by PDF transparency semantics.
   void tileTexture(gpu.Texture texture, Rect textureRegion, double alpha) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     final vertices = _tileTextureVertices(textureRegion);
     final info = Float32List(8)..[3] = alpha.clamp(0.0, 1.0);
     _defaultStencil();
@@ -8630,7 +8644,7 @@ class _GpuEncoder {
   /// the PDF blend equations. This runs in a separate pass because Flutter GPU
   /// deliberately forbids sampling the color attachment being written.
   void copyTile(gpu.Texture texture) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     final vertices = _tileTextureVertices(region);
     final info = Float32List(8)..[3] = 1;
     pass
@@ -8658,7 +8672,7 @@ class _GpuEncoder {
     PdfBlendMode mode,
     PdfRect? bounds,
   ) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     final vertices = _tileTextureVertices(region);
     final info = Float32List(8)
       ..[0] = mode.index.toDouble()
@@ -8751,11 +8765,12 @@ class _GpuEncoder {
   void glyphs(_GpuBuffer vertices, _GpuGlyphAtlas atlas) {
     _defaultStencil();
     pass.setColorBlendEquation(_paintBlend);
-    if (identical(_boundGlyphAtlas, atlas)) {
+    if (_retainedBindingKind == _GpuRetainedBindingKind.glyph &&
+        identical(_boundGlyphAtlas, atlas)) {
       stats.glyphBindingReuses++;
     } else {
+      _replaceRetainedBindings(_GpuRetainedBindingKind.glyph);
       pass
-        ..clearBindings()
         ..bindPipeline(pipelines.glyph)
         ..bindUniform(pipelines.glyphTransform, transform)
         ..bindUniform(pipelines.glyphInfo, atlas.info)
@@ -8775,7 +8790,7 @@ class _GpuEncoder {
 
   void softMask(_GpuBuffer vertices, gpu.Texture contentTexture,
       gpu.Texture maskTexture, gpu.BufferView info) {
-    _dropRetainedGlyphBindings();
+    _dropRetainedBindings();
     _defaultStencil();
     final sampler = gpu.SamplerOptions(
       minFilter: gpu.MinMagFilter.linear,
@@ -8833,10 +8848,19 @@ class _GpuEncoder {
     _clearStencil(_pathMask);
   }
 
-  void _dropRetainedGlyphBindings() {
-    if (_boundGlyphAtlas == null) return;
+  void _replaceRetainedBindings(_GpuRetainedBindingKind kind) {
     pass.clearBindings();
+    _retainedBindingKind = kind;
     _boundGlyphAtlas = null;
+    _boundImageTexture = null;
+  }
+
+  void _dropRetainedBindings() {
+    if (_retainedBindingKind == null) return;
+    pass.clearBindings();
+    _retainedBindingKind = null;
+    _boundGlyphAtlas = null;
+    _boundImageTexture = null;
   }
 
   // flutter_gpu is experimental. Flutter 3.47 split vertex count out of

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -40,6 +40,7 @@ class FlutterGpuTileBackendStats {
   int analyticSparseAtlasSkips = 0;
   int analyticTextFallbackRuns = 0;
   int glyphBindingReuses = 0;
+  int imageBindingReuses = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
@@ -127,6 +128,7 @@ class FlutterGpuTileBackendStats {
         'analyticSparseAtlasSkips': analyticSparseAtlasSkips,
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
         'glyphBindingReuses': glyphBindingReuses,
+        'imageBindingReuses': imageBindingReuses,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
@@ -213,6 +215,7 @@ class FlutterGpuTileBackendStats {
     analyticSparseAtlasSkips = 0;
     analyticTextFallbackRuns = 0;
     glyphBindingReuses = 0;
+    imageBindingReuses = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
@@ -279,6 +282,7 @@ class FlutterGpuTileBackendStats {
       'analyticSparseSkips=$analyticSparseAtlasSkips '
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'glyphBindingReuses=$glyphBindingReuses '
+      'imageBindingReuses=$imageBindingReuses '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1609,6 +1609,94 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('retains image bindings only across adjacent draws',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(2),
+          'Height': const CosInteger(2),
+        }),
+        Uint8List(0),
+      );
+      final alternateStream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(2),
+          'Height': const CosInteger(2),
+        }),
+        Uint8List(0),
+      );
+      final pixels = PdfDecodedPixels(
+        Uint8List.fromList([
+          235,
+          55,
+          45,
+          255,
+          45,
+          120,
+          235,
+          255,
+          55,
+          205,
+          95,
+          255,
+          240,
+          190,
+          40,
+          255,
+        ]),
+        2,
+        2,
+      );
+      PdfDrawImageCommand image(CosStream source, double x) =>
+          PdfDrawImageCommand(
+            PdfImageRequest(
+              stream: source,
+              transform: PdfMatrix(70, 0, 0, 70, x, 650),
+              decoded: pixels,
+            ),
+          );
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        image(stream, 40),
+        image(stream, 130),
+        image(alternateStream, 220),
+        PdfFillPathCommand(
+          _rect(310, 650, 380, 720),
+          const PdfColor(0.2, 0.7, 0.35),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        image(stream, 400),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final expectedPixels = await _pixels(expected);
+      final actualPixels = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < expectedPixels.length; index++) {
+        difference += (expectedPixels[index] - actualPixels[index]).abs();
+      }
+      expect(difference / expectedPixels.length, lessThan(8));
+      expect(backend.stats.imageBindingReuses, 2,
+          reason: 'an adjacent texture change keeps static image state, while '
+              'the solid draw must invalidate it');
+    });
+  });
+
   testWidgets('local portable pixels upload without an image readback',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -6,6 +6,7 @@ import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart' show PdfRect;
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -185,6 +186,87 @@ void main() {
       }
       // ignore: avoid_print
       print('flutter_gpu analytic text benchmark: runs=${commands.length} '
+          'settledMedian=${_median(settled).toStringAsFixed(0)}us '
+          'issueMean=${(backend.stats.issueMicros / settled.length).toStringAsFixed(0)}us '
+          '${backend.stats}');
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
+  testWidgets('reports dense texture submission cost', (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(2),
+          'Height': const CosInteger(2),
+        }),
+        Uint8List(0),
+      );
+      final pixels = PdfDecodedPixels(
+        Uint8List.fromList([
+          235,
+          55,
+          45,
+          255,
+          45,
+          120,
+          235,
+          255,
+          55,
+          205,
+          95,
+          255,
+          240,
+          190,
+          40,
+          255,
+        ]),
+        2,
+        2,
+      );
+      final commands = <PdfRenderCommand>[
+        for (var row = 0; row < 16; row++)
+          for (var column = 0; column < 16; column++)
+            PdfDrawImageCommand(PdfImageRequest(
+              stream: stream,
+              transform: PdfMatrix(
+                28,
+                0,
+                0,
+                28,
+                18 + column * 34,
+                748 - row * 44,
+              ),
+              decoded: pixels,
+            )),
+      ];
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final warm = await session.rasterizeRegion(region, pixelRatio: 0.5);
+      await warm.toByteData(format: ui.ImageByteFormat.rawRgba);
+      warm.dispose();
+      expect(backend.stats.texturesUploaded, 1);
+
+      backend.stats.reset();
+      final settled = <int>[];
+      for (var index = 0; index < 15; index++) {
+        settled.add(await _timeSettledImage(
+          () => session.rasterizeRegion(region, pixelRatio: 0.5),
+        ));
+      }
+      // ignore: avoid_print
+      print('flutter_gpu texture benchmark: draws=${commands.length} '
           'settledMedian=${_median(settled).toStringAsFixed(0)}us '
           'issueMean=${(backend.stats.issueMicros / settled.length).toStringAsFixed(0)}us '
           '${backend.stats}');


### PR DESCRIPTION
Compared with the stacked #824 base on the same host, the interleaved 256-image benchmark improves CPU issue mean from 1.916 ms to 1.725 ms (-9.9%). Settled median is effectively flat at 7.681 ms versus 7.795 ms (+1.5%, within run-to-run variance), and corpus routing is unchanged.

<details>
<summary>Implementation and validation</summary>

- Retains the image pipeline and page transform across adjacent image draws.
- Reuses an unchanged source texture and sampler while updating per-image metadata.
- Rebinds a changed adjacent texture without rebuilding static pipeline state.
- Clears retained image state before intervening solid, stencil, glyph, blend, texture-composite, or soft-mask work.
- Adds imageBindingReuses diagnostics plus focused same-texture, changed-texture, parity, and invalidation coverage.
- Adds a reproducible dense texture benchmark.
- Full native package suite: 317 passed, 4 expected environment skips.
- Non-GPU fallback package suite: 12 passed, 92 expected GPU/environment skips.
- Root analysis: clean.
- Ghent route: 49 accepted / 8 conservative fallbacks.
- PDF.js route: 111 accepted / 68 conservative fallbacks.

This PR is stacked on #824 and should be retargeted as the earlier GPU PRs land.

</details>