### PR TITLE
perf(gpu): pack retained scene uniforms

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0
 
+- Pack immutable image, soft-mask, and glyph-atlas uniforms into the
+  lifetime-fenced scene arena with device-required alignment. Image-dense
+  scenes avoid one standalone native `DeviceBuffer` allocation per draw.
 - Pin each unique image texture once per compiled scene instead of once per
   draw. Repeated image commands bypass the shared cache's lease bookkeeping,
   while distinct scenes still acquire independent lifetime-safe leases.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -88,14 +88,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   /// A non-positive value disables cross-scene texture reuse.
   final int maxTextureBytes;
 
-  /// Hard ceiling for reusable scene geometry buffers.
+  /// Hard ceiling for reusable retained-scene buffers.
   ///
   /// Stable flutter_gpu does not expose explicit DeviceBuffer disposal, so
   /// relying on native finalizers lets fast CAD navigation outrun collection.
-  /// Buffers are therefore pooled in power-of-two size classes from 64 KiB to
-  /// the arena's 16 MiB chunk size, leased by compiled scenes, and reused only
-  /// after the scene is disposed and every submitted command buffer has
-  /// completed. A scene that cannot fit falls back to Canvas.
+  /// Geometry and aligned immutable uniform metadata are therefore packed
+  /// together in power-of-two size classes from 64 KiB to the arena's 16 MiB
+  /// chunk size, leased by compiled scenes, and reused only after the scene is
+  /// disposed and every submitted command buffer has completed. A scene that
+  /// cannot fit falls back to Canvas.
   final int maxGeometryBytes;
 
   /// Whether the viewer should prepare GPU pipelines and live scenes at idle.
@@ -4323,7 +4324,7 @@ class _CompiledScene {
       if (analyticText) {
         try {
           glyphAtlas = _GpuGlyphAtlas.build(
-            context,
+            geometry,
             commands,
             units,
             stats,
@@ -5924,8 +5925,7 @@ Future<_GpuDraw> _compileSoftMaskImage(
       ? _premul(spec.mask.stencilColor, spec.mask.alpha)
       : <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)];
   final info = _softMaskInfo(
-    context,
-    stats,
+    geometry,
     maskTransform: spec.mask.transform,
     contentTint: contentTint,
     maskTint: maskTint,
@@ -6328,8 +6328,7 @@ Future<_GpuDraw> _compileSoftMaskFill(
     spec.content.rule,
     maskResource.texture,
     _softMaskInfo(
-      context,
-      stats,
+      geometry,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.color, spec.content.alpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6388,8 +6387,7 @@ Future<_GpuDraw> _compileSoftMaskStroke(
     PdfFillRule.nonzero,
     maskResource.texture,
     _softMaskInfo(
-      context,
-      stats,
+      geometry,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.color, spec.content.alpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6440,8 +6438,7 @@ Future<_GpuDraw> _compileSoftMaskText(
     PdfFillRule.nonzero,
     maskResource.texture,
     _softMaskInfo(
-      context,
-      stats,
+      geometry,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.run.color, spec.content.run.fillAlpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6638,9 +6635,8 @@ double _vectorMaskValue(_SoftMaskVectorFillSpec spec, double x, double y) {
   return (value * spec.transferScale + spec.transferOffset).clamp(0.0, 1.0);
 }
 
-gpu.BufferView _softMaskInfo(
-  gpu.GpuContext context,
-  FlutterGpuTileBackendStats stats, {
+_GpuBuffer _softMaskInfo(
+  _GpuGeometryArena geometry, {
   required PdfMatrix maskTransform,
   required List<double> contentTint,
   required List<double> maskTint,
@@ -6695,24 +6691,20 @@ gpu.BufferView _softMaskInfo(
       clip.right,
       clip.top,
     ]);
-  stats.standaloneUniformBuffers++;
-  return gpu.BufferView(
-    context.createDeviceBufferWithCopy(ByteData.sublistView(values)),
-    offsetInBytes: 0,
-    lengthInBytes: values.lengthInBytes,
-  );
+  return geometry.addUniform(ByteData.sublistView(values));
 }
 
 class _GpuGlyphAtlas {
   _GpuGlyphAtlas(this.texture, this.info, this.slots);
 
   static _GpuGlyphAtlas? build(
-    gpu.GpuContext context,
+    _GpuGeometryArena geometry,
     List<PdfRenderCommand> commands,
     List<_GpuUnit> units,
     FlutterGpuTileBackendStats stats, {
     required int minimumGlyphs,
   }) {
+    final context = geometry.context;
     var candidateGlyphs = 0;
     for (final unit in units) {
       if (unit.composite != null) continue;
@@ -6796,12 +6788,7 @@ class _GpuGlyphAtlas {
     final dimensions = Float32List.fromList(
       <double>[slugAtlasWidth.toDouble(), height.toDouble()],
     );
-    stats.standaloneUniformBuffers++;
-    final info = gpu.BufferView(
-      context.createDeviceBufferWithCopy(ByteData.sublistView(dimensions)),
-      offsetInBytes: 0,
-      lengthInBytes: dimensions.lengthInBytes,
-    );
+    final info = geometry.addUniform(ByteData.sublistView(dimensions));
     stats
       ..analyticGlyphSlots += data.length
       ..analyticAtlasBytes += pixels.length;
@@ -6809,7 +6796,7 @@ class _GpuGlyphAtlas {
   }
 
   final gpu.Texture texture;
-  final gpu.BufferView info;
+  final _GpuBuffer info;
   final Map<PdfPath, int> slots;
 }
 
@@ -7436,8 +7423,7 @@ Future<_GpuDraw?> _compileImageCommand(
       resource.texture,
       maskResource.texture,
       _softMaskInfo(
-        context,
-        stats,
+        geometry,
         maskTransform: request.transform,
         contentTint: tint,
         maskTint: const [0, 0, 0, 1],
@@ -7453,15 +7439,10 @@ Future<_GpuDraw?> _compileImageCommand(
   final info = Float32List(8)
     ..setRange(0, 4, tint)
     ..[4] = request.isStencil ? 1 : 0;
-  stats.standaloneUniformBuffers++;
   return _TextureDraw(
     geometry.add(vertices.bytes, 6),
     resource.texture,
-    gpu.BufferView(
-      context.createDeviceBufferWithCopy(ByteData.sublistView(info)),
-      offsetInBytes: 0,
-      lengthInBytes: info.lengthInBytes,
-    ),
+    geometry.addUniform(ByteData.sublistView(info)),
   );
 }
 
@@ -7821,15 +7802,26 @@ class _GpuGeometryArena {
 
   List<_GpuGeometryResource> get leases => List.unmodifiable(_leases);
 
-  _GpuBuffer add(ByteData bytes, int vertices) {
+  _GpuBuffer add(ByteData bytes, int vertices) =>
+      _add(bytes, vertices, alignment: 1);
+
+  _GpuBuffer addUniform(ByteData bytes) => _add(
+        bytes,
+        0,
+        alignment: math.max(1, context.minimumUniformByteAlignment),
+      );
+
+  _GpuBuffer _add(ByteData bytes, int vertices, {required int alignment}) {
     if (_finalized) throw StateError('GPU geometry arena already finalized');
+    var offset = _align(_pendingBytes, alignment);
     if (_slices.isNotEmpty &&
-        _pendingBytes + bytes.lengthInBytes > _GpuGeometryPool.chunkBytes) {
+        offset + bytes.lengthInBytes > _GpuGeometryPool.chunkBytes) {
       _flush();
+      offset = 0;
     }
-    final result = _GpuBuffer(vertices);
+    final result = _GpuBuffer(vertices).._offsetInBytes = offset;
     _slices.add(_GpuGeometrySlice(bytes, result));
-    _pendingBytes += bytes.lengthInBytes;
+    _pendingBytes = offset + bytes.lengthInBytes;
     stats.geometryVertices += vertices;
     return result;
   }
@@ -7848,15 +7840,13 @@ class _GpuGeometryArena {
   void _flush() {
     if (_slices.isEmpty) return;
     final packed = Uint8List(_pendingBytes);
-    var offset = 0;
     for (final slice in _slices) {
       final source = slice.bytes.buffer.asUint8List(
         slice.bytes.offsetInBytes,
         slice.bytes.lengthInBytes,
       );
+      final offset = slice.buffer._offsetInBytes;
       packed.setRange(offset, offset + source.length, source);
-      slice.buffer._offsetInBytes = offset;
-      offset += source.length;
     }
     final resource = pool.acquire(context, ByteData.sublistView(packed), stats);
     _leases.add(resource);
@@ -7870,6 +7860,9 @@ class _GpuGeometryArena {
     _slices.clear();
     _pendingBytes = 0;
   }
+
+  static int _align(int value, int alignment) =>
+      ((value + alignment - 1) ~/ alignment) * alignment;
 }
 
 /// Single-submission bump arena for transient uniforms and dynamic vertices.
@@ -8211,10 +8204,11 @@ class _TextureDraw implements _GpuDraw {
   const _TextureDraw(this.vertices, this.texture, this.info);
   final _GpuBuffer vertices;
   final gpu.Texture texture;
-  final gpu.BufferView info;
+  final _GpuBuffer info;
 
   @override
-  void encode(_GpuEncoder encoder) => encoder.texture(vertices, texture, info);
+  void encode(_GpuEncoder encoder) =>
+      encoder.texture(vertices, texture, info.view);
 }
 
 class _AnalyticTextDraw implements _GpuDraw {
@@ -8233,11 +8227,11 @@ class _SoftMaskDraw implements _GpuDraw {
   final _GpuBuffer vertices;
   final gpu.Texture contentTexture;
   final gpu.Texture maskTexture;
-  final gpu.BufferView info;
+  final _GpuBuffer info;
 
   @override
   void encode(_GpuEncoder encoder) =>
-      encoder.softMask(vertices, contentTexture, maskTexture, info);
+      encoder.softMask(vertices, contentTexture, maskTexture, info.view);
 }
 
 class _SoftMaskFillDraw implements _GpuDraw {
@@ -8247,11 +8241,11 @@ class _SoftMaskFillDraw implements _GpuDraw {
   final _GpuBuffer cover;
   final PdfFillRule rule;
   final gpu.Texture maskTexture;
-  final gpu.BufferView info;
+  final _GpuBuffer info;
 
   @override
   void encode(_GpuEncoder encoder) =>
-      encoder.softMaskFill(fan, cover, rule, maskTexture, info);
+      encoder.softMaskFill(fan, cover, rule, maskTexture, info.view);
 }
 
 enum _GpuRetainedBindingKind { glyph, image }
@@ -8809,7 +8803,7 @@ class _GpuEncoder {
       pass
         ..bindPipeline(pipelines.glyph)
         ..bindUniform(pipelines.glyphTransform, transform)
-        ..bindUniform(pipelines.glyphInfo, atlas.info)
+        ..bindUniform(pipelines.glyphInfo, atlas.info.view)
         ..bindTexture(
           pipelines.glyphSampler,
           atlas.texture,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5925,6 +5925,7 @@ Future<_GpuDraw> _compileSoftMaskImage(
       : <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)];
   final info = _softMaskInfo(
     context,
+    stats,
     maskTransform: spec.mask.transform,
     contentTint: contentTint,
     maskTint: maskTint,
@@ -6328,6 +6329,7 @@ Future<_GpuDraw> _compileSoftMaskFill(
     maskResource.texture,
     _softMaskInfo(
       context,
+      stats,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.color, spec.content.alpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6387,6 +6389,7 @@ Future<_GpuDraw> _compileSoftMaskStroke(
     maskResource.texture,
     _softMaskInfo(
       context,
+      stats,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.color, spec.content.alpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6438,6 +6441,7 @@ Future<_GpuDraw> _compileSoftMaskText(
     maskResource.texture,
     _softMaskInfo(
       context,
+      stats,
       maskTransform: spec.mask.transform,
       contentTint: _premul(spec.content.run.color, spec.content.run.fillAlpha),
       maskTint: <double>[0, 0, 0, spec.mask.alpha.clamp(0.0, 1.0)],
@@ -6635,7 +6639,8 @@ double _vectorMaskValue(_SoftMaskVectorFillSpec spec, double x, double y) {
 }
 
 gpu.BufferView _softMaskInfo(
-  gpu.GpuContext context, {
+  gpu.GpuContext context,
+  FlutterGpuTileBackendStats stats, {
   required PdfMatrix maskTransform,
   required List<double> contentTint,
   required List<double> maskTint,
@@ -6690,6 +6695,7 @@ gpu.BufferView _softMaskInfo(
       clip.right,
       clip.top,
     ]);
+  stats.standaloneUniformBuffers++;
   return gpu.BufferView(
     context.createDeviceBufferWithCopy(ByteData.sublistView(values)),
     offsetInBytes: 0,
@@ -6790,6 +6796,7 @@ class _GpuGlyphAtlas {
     final dimensions = Float32List.fromList(
       <double>[slugAtlasWidth.toDouble(), height.toDouble()],
     );
+    stats.standaloneUniformBuffers++;
     final info = gpu.BufferView(
       context.createDeviceBufferWithCopy(ByteData.sublistView(dimensions)),
       offsetInBytes: 0,
@@ -7430,6 +7437,7 @@ Future<_GpuDraw?> _compileImageCommand(
       maskResource.texture,
       _softMaskInfo(
         context,
+        stats,
         maskTransform: request.transform,
         contentTint: tint,
         maskTint: const [0, 0, 0, 1],
@@ -7445,6 +7453,7 @@ Future<_GpuDraw?> _compileImageCommand(
   final info = Float32List(8)
     ..setRange(0, 4, tint)
     ..[4] = request.isStencil ? 1 : 0;
+  stats.standaloneUniformBuffers++;
   return _TextureDraw(
     geometry.add(vertices.bytes, 6),
     resource.texture,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -60,6 +60,7 @@ class FlutterGpuTileBackendStats {
   int activeGeometryLeases = 0;
   int geometryBytes = 0;
   int peakGeometryBytes = 0;
+  int standaloneUniformBuffers = 0;
   int transientBuffers = 0;
   int transientEmplacedBytes = 0;
   int transientAllocatedBytes = 0;
@@ -148,6 +149,7 @@ class FlutterGpuTileBackendStats {
         'activeGeometryLeases': activeGeometryLeases,
         'geometryBytes': geometryBytes,
         'peakGeometryBytes': peakGeometryBytes,
+        'standaloneUniformBuffers': standaloneUniformBuffers,
         'transientBuffers': transientBuffers,
         'transientEmplacedBytes': transientEmplacedBytes,
         'transientAllocatedBytes': transientAllocatedBytes,
@@ -233,6 +235,7 @@ class FlutterGpuTileBackendStats {
     offscreenGroupBudgetFallbacks = 0;
     geometryBudgetFallbacks = 0;
     peakGeometryBytes = geometryBytes;
+    standaloneUniformBuffers = 0;
     transientBuffers = 0;
     transientEmplacedBytes = 0;
     transientAllocatedBytes = 0;
@@ -300,6 +303,7 @@ class FlutterGpuTileBackendStats {
       'geometryBudgetFallbacks=$geometryBudgetFallbacks '
       'activeGeometryLeases=$activeGeometryLeases '
       'geometryBytes=$geometryBytes peakGeometryBytes=$peakGeometryBytes '
+      'standaloneUniformBuffers=$standaloneUniformBuffers '
       'transientBuffers=$transientBuffers '
       'transientEmplacedBytes=$transientEmplacedBytes '
       'transientAllocatedBytes=$transientAllocatedBytes '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -67,6 +67,7 @@ void main() {
       ..geometryBuffers = 3
       ..geometryBytes = 32 << 20
       ..peakGeometryBytes = 48 << 20
+      ..standaloneUniformBuffers = 9
       ..transientBuffers = 5
       ..transientEmplacedBytes = 768 << 10
       ..transientAllocatedBytes = 1 << 20
@@ -117,6 +118,7 @@ void main() {
     expect(stats.toJson(), containsPair('sceneWarmUpCancellations', 1));
     expect(stats.toJson(), containsPair('sceneWarmUpMicros', 18000));
     expect(stats.toJson(), containsPair('analyticTextRuns', 7));
+    expect(stats.toJson(), containsPair('standaloneUniformBuffers', 9));
     expect(stats.toJson(), containsPair('transientBuffers', 5));
     expect(stats.toJson(), containsPair('transientEmplacedBytes', 768 << 10));
     expect(stats.toJson(), containsPair('transientAllocatedBytes', 1 << 20));
@@ -169,6 +171,7 @@ void main() {
     expect(stats.geometryBuffers, 3);
     expect(stats.geometryBytes, 32 << 20);
     expect(stats.peakGeometryBytes, 32 << 20);
+    expect(stats.standaloneUniformBuffers, 0);
     expect(stats.transientBuffers, 0);
     expect(stats.transientEmplacedBytes, 0);
     expect(stats.transientAllocatedBytes, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1703,6 +1703,8 @@ void main() {
               'before touching the shared cache');
       expect(backend.stats.activeTextureLeases, 2,
           reason: 'one scene pins each unique texture once, not once per draw');
+      expect(backend.stats.standaloneUniformBuffers, 0,
+          reason: 'retained image metadata shares the aligned scene arena');
 
       final secondSession = backend.createSession(scene)!;
       addTearDown(secondSession.dispose);

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -262,6 +262,10 @@ void main() {
       final compileLeases = backend.stats.activeTextureLeases;
       final compileStandaloneUniformBuffers =
           backend.stats.standaloneUniformBuffers;
+      expect(compileStandaloneUniformBuffers, 0,
+          reason: 'immutable image metadata belongs in the retained arena');
+      expect(backend.stats.geometryBuffers, 1,
+          reason: 'all image vertices and aligned uniforms fit one arena');
 
       backend.stats.reset();
       final settled = <int>[];

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -260,6 +260,8 @@ void main() {
       final compileMicros = backend.stats.compileMicros;
       final compileCacheHits = backend.stats.textureCacheHits;
       final compileLeases = backend.stats.activeTextureLeases;
+      final compileStandaloneUniformBuffers =
+          backend.stats.standaloneUniformBuffers;
 
       backend.stats.reset();
       final settled = <int>[];
@@ -272,6 +274,7 @@ void main() {
       print('flutter_gpu texture benchmark: draws=${commands.length} '
           'compile=${compileMicros}us compileCacheHits=$compileCacheHits '
           'compileLeases=$compileLeases '
+          'compileStandaloneUniformBuffers=$compileStandaloneUniformBuffers '
           'settledMedian=${_median(settled).toStringAsFixed(0)}us '
           'issueMean=${(backend.stats.issueMicros / settled.length).toStringAsFixed(0)}us '
           '${backend.stats}');


### PR DESCRIPTION
Compared with stacked #826 on the same host, the interleaved 256-image benchmark improves scene compile median from 24.426 ms to 23.798 ms (-2.6%) and CPU issue median from 1.750 ms to 1.714 ms (-2.1%). Settled median is flat at 7.421 ms versus 7.434 ms (-0.2%), while standalone retained-scene uniform buffers fall from 256 to 0.

The dense scene's pooled arena grows from 64 KiB to 128 KiB because Metal requires 256-byte uniform offsets. That bounded padding replaces 256 separately finalized native `DeviceBuffer`s and keeps their lifetime behind the existing scene lease and command-completion fence.

<details>
<summary>Implementation and validation</summary>

- Adds aligned immutable-uniform slices to the retained geometry arena.
- Packs image metadata, soft-mask metadata, and glyph-atlas dimensions with retained scene geometry.
- Removes every standalone `createDeviceBufferWithCopy` call from the native backend.
- Adds `standaloneUniformBuffers` diagnostics and dense-scene assertions for zero standalone buffers and one pooled arena resource.
- Five interleaved fresh-process pairs on the same Mac/Metal host:
  - compile median: 24.426 -> 23.798 ms (-2.6%)
  - issue median: 1.750 -> 1.714 ms (-2.1%)
  - settled median: 7.434 -> 7.421 ms (-0.2%)
  - standalone uniform buffers: 256 -> 0
- Complete native package suite: 317 passed, 4 expected environment skips.
- Non-GPU fallback package suite: 12 passed, 92 expected GPU/environment skips.
- Root analysis: clean.
- Ghent route: 49 accepted / 8 conservative fallbacks.
- PDF.js route: 111 accepted / 68 conservative fallbacks.

This PR is stacked on #826 and contains only two commits above that PR. It should be retargeted as the earlier GPU PRs land.

</details>
