### PR TITLE
perf(gpu): right-size transient tile arenas

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+- Start per-submission transient GPU arenas at 4 KiB instead of 64 KiB, then
+  grow geometrically through 1 MiB for dense dynamic geometry. Common tiles
+  keep their single transform upload without reserving sixteen times as much
+  host-visible device memory.
 - Carry ordinary image tint, alpha, and stencil mode in retained vertex data
   instead of binding a separately aligned fragment uniform for every draw.
   Dense image scenes halve their pooled arena size and avoid one native bind

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -7898,14 +7898,15 @@ class _GpuGeometryArena {
 /// though the tile renderer creates a fresh allocator for every submission.
 /// Its rollover check also ignores the incoming emplacement length, so a
 /// dense sequence of individually small CAD hairlines can cross the active
-/// block boundary and fail the upload. This arena owns only the buffers used
-/// by one tile, tests the complete aligned range before every write, and is
-/// retained until the command-buffer completion fence fires.
+/// block boundary and fail the upload. This arena starts at 4 KiB for the
+/// common one-transform submission, grows geometrically through 1 MiB for
+/// dense dynamic geometry, tests the complete aligned range before every
+/// write, and is retained until the command-buffer completion fence fires.
 class _GpuTransientArena {
   _GpuTransientArena(this.context, [this.stats]);
 
-  static const _firstBlockBytes = 64 << 10;
-  static const _secondBlockBytes = 256 << 10;
+  static const _firstBlockBytes = 4 << 10;
+  static const _secondBlockBytes = 16 << 10;
   static const _maximumBlockBytes = 1 << 20;
 
   final gpu.GpuContext context;

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -184,6 +184,8 @@ void main() {
           () => session.rasterizeRegion(region, pixelRatio: 0.5),
         ));
       }
+      expect(backend.stats.transientAllocatedBytes, 15 * (4 << 10),
+          reason: 'one-transform tiles should use the 4 KiB first block');
       // ignore: avoid_print
       print('flutter_gpu analytic text benchmark: runs=${commands.length} '
           'settledMedian=${_median(settled).toStringAsFixed(0)}us '


### PR DESCRIPTION
## Headline

Compared with #828 on the same host, this cuts transient GPU buffer reservation for the 15-tile dense-image benchmark from **983,040 bytes to 61,440 bytes (-93.8%)** while leaving settled time flat.

- cold compile median: **22.455 ms -> 21.987 ms (-2.1%)**
- CPU issue median: **1.585 ms -> 1.629 ms (+2.8%, within run noise)**
- settled median: **7.269 ms -> 7.283 ms (+0.2%, flat)**
- transient buffers: **15 -> 15**
- common per-tile reservation: **64 KiB -> 4 KiB**

The completion-fenced transient arena now starts at 4 KiB and grows from 16 KiB instead of starting at 64 KiB and growing from 256 KiB. Dense geometry still grows geometrically through 1 MiB, oversized writes still allocate their exact aligned minimum, and the complete aligned range is checked before every upload.

<details>
<summary>Benchmark samples and validation</summary>

Five controlled same-host runs per revision, comparing this PR with its direct parent #828:

| Metric | #828 samples (us) | This PR samples (us) | Median change |
| --- | --- | --- | --- |
| compile | 22455, 22360, 22567, 23280, 21580 | 23473, 21987, 21025, 23016, 20723 | 22455 -> 21987 (-2.1%) |
| issue | 1552, 1636, 1585, 1682, 1557 | 1659, 1645, 1629, 1558, 1607 | 1585 -> 1629 (+2.8%) |
| settled | 6978, 7492, 7269, 7693, 7167 | 7131, 7395, 7312, 7242, 7283 | 7269 -> 7283 (+0.2%) |

The benchmark uploads only 960 bytes across 15 submissions, so the old 64 KiB first block was almost entirely reservation overhead. The focused assertion pins the new 61,440-byte total.

Validation:

- `fvm flutter test --enable-impeller --enable-flutter-gpu`: **317 passed, 4 expected skips**
- Ghent GPU corpus: **49 accepted, 8 exact Canvas fallbacks**
- PDF.js GPU corpus: **111 accepted, 68 exact Canvas fallbacks**
- dense CAD hairline rollover regression: passes with transient uploads crossing 1 MiB
- `fvm flutter test` without GPU flags: **12 passed, 92 expected GPU-only skips**
- `fvm dart analyze`: clean

The stack was rebased after #824 merged; the post-rebase tree is identical to the validated tree.

</details>
