### PR TITLE
perf(gpu): reuse fenced transient buffers

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+- Reuse transient host-visible buffers only after every command buffer that
+  references them reaches its completion fence. Settled tiles stop allocating
+  one native `DeviceBuffer` apiece, while concurrent and multi-pass group
+  submissions retain independent leases until all of their GPU work finishes.
 - Start per-submission transient GPU arenas at 4 KiB instead of 64 KiB, then
   grow geometrically through 1 MiB for dense dynamic geometry. Common tiles
   keep their single transform upload without reserving sixteen times as much

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -59,7 +59,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
                 ? FlutterGpuSystemTextOutliner.tryCreate()
                 : null),
         _imageCache = _GpuImageCache(maxTextureBytes),
-        _geometryPool = _GpuGeometryPool(maxGeometryBytes);
+        _geometryPool = _GpuGeometryPool(maxGeometryBytes),
+        _transientPool = _GpuTransientPool();
 
   /// Enables 4x MSAA on the final tile target where Impeller supports it.
   /// Intermediate transparency-group targets stay single-sample and are
@@ -131,6 +132,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache _imageCache;
   final _GpuGeometryPool _geometryPool;
+  final _GpuTransientPool _transientPool;
   // Contexts belong to Flutter views and can disappear when a native window
   // closes. Keep only weak membership so diagnostics do not turn every view
   // ever opened into a process-lifetime root.
@@ -301,6 +303,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
         stats: stats,
         imageCache: _imageCache,
         geometryPool: _geometryPool,
+        transientPool: _transientPool,
         analyticText: analyticText,
         analyticTextMinimumGlyphs:
             systemTextOutlines && usesHostOutlines ? 32 : 1,
@@ -4085,6 +4088,7 @@ class _FlutterGpuTileSession
     required this.stats,
     required this.imageCache,
     required this.geometryPool,
+    required this.transientPool,
     required this.analyticText,
     required this.analyticTextMinimumGlyphs,
   });
@@ -4112,6 +4116,7 @@ class _FlutterGpuTileSession
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache imageCache;
   final _GpuGeometryPool geometryPool;
+  final _GpuTransientPool transientPool;
   final bool analyticText;
   final int analyticTextMinimumGlyphs;
 
@@ -4129,6 +4134,7 @@ class _FlutterGpuTileSession
         stats,
         imageCache,
         geometryPool,
+        transientPool,
         analyticText: analyticText,
         analyticTextMinimumGlyphs: analyticTextMinimumGlyphs,
         mipmapImages: mipmapImages,
@@ -4293,6 +4299,7 @@ class _CompiledScene {
     required this.textureLeases,
     required this.geometryPool,
     required this.geometryLeases,
+    required this.transientPool,
   });
 
   static Future<_CompiledScene> build(
@@ -4303,6 +4310,7 @@ class _CompiledScene {
       FlutterGpuTileBackendStats stats,
       _GpuImageCache imageCache,
       _GpuGeometryPool geometryPool,
+      _GpuTransientPool transientPool,
       {required bool analyticText,
       required int analyticTextMinimumGlyphs,
       required bool mipmapImages}) async {
@@ -4504,6 +4512,7 @@ class _CompiledScene {
         textureLeases: textureLeases,
         geometryPool: geometryPool,
         geometryLeases: geometry.leases,
+        transientPool: transientPool,
       );
       stats
         ..scenesCompiled += 1
@@ -4528,6 +4537,7 @@ class _CompiledScene {
   final _GpuTextureLeases textureLeases;
   final _GpuGeometryPool geometryPool;
   final List<_GpuGeometryResource> geometryLeases;
+  final _GpuTransientPool transientPool;
   bool _disposed = false;
   bool _texturesReleased = false;
   bool _geometryReleased = false;
@@ -4602,10 +4612,24 @@ class _CompiledScene {
         tracePage: tracePage,
       );
     }
-    if (selected.any((unit) =>
-        !FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(
-            unit.blendMode))) {
-      return _renderAdvanced(
+    final transient = _GpuTransientArena(context, stats, transientPool);
+    try {
+      if (selected.any((unit) =>
+          !FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(
+              unit.blendMode))) {
+        return _renderAdvanced(
+          selected,
+          region: region,
+          pixelRatio: pixelRatio,
+          pipelines: pipelines,
+          useMsaa: useMsaa,
+          width: width,
+          height: height,
+          transient: transient,
+          tracePage: tracePage,
+        );
+      }
+      return _renderSimple(
         selected,
         region: region,
         pixelRatio: pixelRatio,
@@ -4613,19 +4637,12 @@ class _CompiledScene {
         useMsaa: useMsaa,
         width: width,
         height: height,
+        transient: transient,
         tracePage: tracePage,
       );
+    } finally {
+      transient.seal();
     }
-    return _renderSimple(
-      selected,
-      region: region,
-      pixelRatio: pixelRatio,
-      pipelines: pipelines,
-      useMsaa: useMsaa,
-      width: width,
-      height: height,
-      tracePage: tracePage,
-    );
   }
 
   ui.Image _renderPaperOnly({
@@ -4876,7 +4893,7 @@ class _CompiledScene {
         transient,
       ];
       transient.flush();
-      groupCommandBuffer.submit(completionCallback: (_) {
+      transient.submit(groupCommandBuffer, completionCallback: (_) {
         // The page completion owns the textures on the success path. This
         // independent capture also fences every submitted group resource if a
         // later allocation or the final page submission throws.
@@ -5106,7 +5123,7 @@ class _CompiledScene {
       transient,
     ];
     for (final commandBuffer in commandBuffers) {
-      commandBuffer.submit(completionCallback: (_) {
+      transient.submit(commandBuffer, completionCallback: (_) {
         // A later page submission owns the completed texture on the success
         // path. This independent capture fences every intermediate if a
         // subsequent allocation or submission throws.
@@ -5124,6 +5141,7 @@ class _CompiledScene {
     required bool useMsaa,
     required int width,
     required int height,
+    required _GpuTransientArena transient,
     int? tracePage,
   }) {
     final issue = Stopwatch()..start();
@@ -5228,7 +5246,6 @@ class _CompiledScene {
             sampleCount: multisampled ? 4 : 1,
           )
         : stencil;
-    final transient = _GpuTransientArena(context, stats);
     final groups = _renderOffscreenGroups(
       selected,
       region: region,
@@ -5576,7 +5593,7 @@ class _CompiledScene {
     try {
       for (var i = 0; i < commandBuffers.length; i++) {
         final last = i == commandBuffers.length - 1;
-        commandBuffers[i].submit(completionCallback: (success) {
+        transient.submit(commandBuffers[i], completionCallback: (success) {
           retained.length;
           if (last) {
             _completeSubmission(
@@ -5612,6 +5629,7 @@ class _CompiledScene {
     required bool useMsaa,
     required int width,
     required int height,
+    required _GpuTransientArena transient,
     int? tracePage,
   }) {
     final issue = Stopwatch()..start();
@@ -5638,8 +5656,6 @@ class _CompiledScene {
       format: context.defaultStencilFormat,
       sampleCount: multisampled ? 4 : 1,
     );
-    final transient = _GpuTransientArena(context, stats);
-
     gpu.RenderPass createPass(
       gpu.CommandBuffer commandBuffer,
       gpu.Texture target,
@@ -5765,7 +5781,8 @@ class _CompiledScene {
         stats.inFlightSubmissions,
       );
     try {
-      commandBuffer.submit(
+      transient.submit(
+        commandBuffer,
         completionCallback: (success) {
           // Keep every intermediate attachment alive until the command buffer
           // has finished sampling it into the page target.
@@ -7903,7 +7920,7 @@ class _GpuGeometryArena {
 /// dense dynamic geometry, tests the complete aligned range before every
 /// write, and is retained until the command-buffer completion fence fires.
 class _GpuTransientArena {
-  _GpuTransientArena(this.context, [this.stats]);
+  _GpuTransientArena(this.context, [this.stats, this.pool]);
 
   static const _firstBlockBytes = 4 << 10;
   static const _secondBlockBytes = 16 << 10;
@@ -7911,12 +7928,17 @@ class _GpuTransientArena {
 
   final gpu.GpuContext context;
   final FlutterGpuTileBackendStats? stats;
+  final _GpuTransientPool? pool;
   final List<_GpuTransientBlock> _blocks = [];
   _GpuTransientBlock? _active;
   var _allocatedBytes = 0;
   var _nextBlockBytes = _secondBlockBytes;
+  var _pendingSubmissions = 0;
+  var _sealed = false;
+  var _released = false;
 
   gpu.BufferView emplace(ByteData bytes) {
+    if (_sealed) throw StateError('GPU transient arena is sealed');
     final length = bytes.lengthInBytes;
     if (length <= 0) {
       throw ArgumentError.value(length, 'bytes.lengthInBytes');
@@ -7929,26 +7951,31 @@ class _GpuTransientArena {
       final first = _blocks.isEmpty;
       final base = first ? _firstBlockBytes : _nextBlockBytes;
       final capacity = math.max(base, minimum);
-      block = _GpuTransientBlock(
-        context.createDeviceBuffer(gpu.StorageMode.hostVisible, capacity),
-        capacity,
-      );
+      final resource = pool?.acquire(context, capacity, stats) ??
+          _GpuTransientResource(
+            context,
+            context.createDeviceBuffer(gpu.StorageMode.hostVisible, capacity),
+            capacity,
+          );
+      block = _GpuTransientBlock(resource);
       _blocks.add(block);
       _active = block;
-      _allocatedBytes += capacity;
+      _allocatedBytes += resource.capacity;
+      if (pool == null) {
+        stats
+          ?..transientBuffers += 1
+          ..transientAllocatedBytes += resource.capacity;
+      }
       if (!first) {
         _nextBlockBytes = math.min(
           _maximumBlockBytes,
-          math.max(_nextBlockBytes * 2, capacity),
+          math.max(_nextBlockBytes * 2, resource.capacity),
         );
       }
-      stats
-        ?..transientBuffers += 1
-        ..transientAllocatedBytes += capacity
-        ..peakTransientTileBytes = math.max(
-          stats!.peakTransientTileBytes,
-          _allocatedBytes,
-        );
+      stats?.peakTransientTileBytes = math.max(
+        stats!.peakTransientTileBytes,
+        _allocatedBytes,
+      );
       offset = 0;
     }
     if (!block.buffer.overwrite(bytes, destinationOffsetInBytes: offset)) {
@@ -7977,17 +8004,141 @@ class _GpuTransientArena {
     }
   }
 
+  /// Submits one command buffer that references this arena.
+  ///
+  /// The pool lease is released only after [seal] has been called and every
+  /// command buffer registered here has reached its completion callback.
+  void submit(
+    gpu.CommandBuffer commandBuffer, {
+    required void Function(bool success) completionCallback,
+  }) {
+    if (_sealed) throw StateError('GPU transient arena is sealed');
+    _pendingSubmissions++;
+    var completed = false;
+    try {
+      commandBuffer.submit(completionCallback: (success) {
+        if (completed) return;
+        completed = true;
+        try {
+          completionCallback(success);
+        } finally {
+          _pendingSubmissions--;
+          _releaseIfReady();
+        }
+      });
+    } catch (_) {
+      if (!completed) _pendingSubmissions--;
+      rethrow;
+    }
+  }
+
+  /// Prevents further writes and returns pooled blocks after GPU completion.
+  void seal() {
+    if (_sealed) return;
+    _sealed = true;
+    _releaseIfReady();
+  }
+
+  void _releaseIfReady() {
+    if (_released || !_sealed || _pendingSubmissions != 0) return;
+    _released = true;
+    pool?.releaseAll(
+      [for (final block in _blocks) block.resource],
+      stats,
+    );
+    _blocks.clear();
+    _active = null;
+  }
+
   static int _align(int value, int alignment) =>
       ((value + alignment - 1) ~/ alignment) * alignment;
 }
 
 class _GpuTransientBlock {
-  _GpuTransientBlock(this.buffer, this.capacity);
+  _GpuTransientBlock(this.resource);
 
-  final gpu.DeviceBuffer buffer;
-  final int capacity;
+  final _GpuTransientResource resource;
+  gpu.DeviceBuffer get buffer => resource.buffer;
+  int get capacity => resource.capacity;
   var usedBytes = 0;
   var flushedBytes = 0;
+}
+
+/// Small exact-size-class pool for completion-fenced transient uploads.
+///
+/// Stable flutter_gpu has no explicit DeviceBuffer disposal. Reusing the
+/// common blocks therefore both removes one native allocation per tile and
+/// bounds how quickly rapid scrolling can outrun native finalizers. Buffers
+/// that would exceed the retained budget stay one-shot; correctness never
+/// depends on a pool hit.
+class _GpuTransientPool {
+  _GpuTransientPool();
+
+  static const maxBytes = 8 << 20;
+  final List<_GpuTransientResource> _resources = [];
+  var _bytes = 0;
+
+  _GpuTransientResource acquire(
+    gpu.GpuContext context,
+    int capacity,
+    FlutterGpuTileBackendStats? stats,
+  ) {
+    for (final resource in _resources) {
+      if (!resource.leased &&
+          identical(resource.context, context) &&
+          resource.capacity == capacity) {
+        resource.leased = true;
+        stats?.transientBufferReuses++;
+        return resource;
+      }
+    }
+
+    final pooled = capacity <= maxBytes && _bytes + capacity <= maxBytes;
+    final resource = _GpuTransientResource(
+      context,
+      context.createDeviceBuffer(gpu.StorageMode.hostVisible, capacity),
+      capacity,
+    )..leased = true;
+    if (pooled) {
+      _resources.add(resource);
+      _bytes += capacity;
+    }
+    stats
+      ?..transientBuffers += 1
+      ..transientAllocatedBytes += capacity;
+    if (stats != null) {
+      stats
+        ..transientResidentBytes = _bytes
+        ..peakTransientResidentBytes = math.max(
+          stats.peakTransientResidentBytes,
+          _bytes,
+        );
+    }
+    return resource;
+  }
+
+  void releaseAll(
+    Iterable<_GpuTransientResource> resources,
+    FlutterGpuTileBackendStats? stats,
+  ) {
+    for (final resource in resources) {
+      resource.leased = false;
+    }
+    if (stats != null) stats.transientResidentBytes = _bytes;
+  }
+}
+
+class _GpuTransientResource {
+  _GpuTransientResource(
+    this.context,
+    this.buffer,
+    this.capacity,
+  );
+
+  final gpu.GpuContext context;
+  final gpu.DeviceBuffer buffer;
+  final int capacity;
+  bool leased = false;
 }
 
 class _GpuGeometryPool {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -62,8 +62,11 @@ class FlutterGpuTileBackendStats {
   int peakGeometryBytes = 0;
   int standaloneUniformBuffers = 0;
   int transientBuffers = 0;
+  int transientBufferReuses = 0;
   int transientEmplacedBytes = 0;
   int transientAllocatedBytes = 0;
+  int transientResidentBytes = 0;
+  int peakTransientResidentBytes = 0;
   int peakTransientTileBytes = 0;
   int texturesUploaded = 0;
   int textureImports = 0;
@@ -151,8 +154,11 @@ class FlutterGpuTileBackendStats {
         'peakGeometryBytes': peakGeometryBytes,
         'standaloneUniformBuffers': standaloneUniformBuffers,
         'transientBuffers': transientBuffers,
+        'transientBufferReuses': transientBufferReuses,
         'transientEmplacedBytes': transientEmplacedBytes,
         'transientAllocatedBytes': transientAllocatedBytes,
+        'transientResidentBytes': transientResidentBytes,
+        'peakTransientResidentBytes': peakTransientResidentBytes,
         'peakTransientTileBytes': peakTransientTileBytes,
         'texturesUploaded': texturesUploaded,
         'textureImports': textureImports,
@@ -237,8 +243,10 @@ class FlutterGpuTileBackendStats {
     peakGeometryBytes = geometryBytes;
     standaloneUniformBuffers = 0;
     transientBuffers = 0;
+    transientBufferReuses = 0;
     transientEmplacedBytes = 0;
     transientAllocatedBytes = 0;
+    peakTransientResidentBytes = transientResidentBytes;
     peakTransientTileBytes = 0;
     texturesUploaded = 0;
     textureImports = 0;
@@ -305,8 +313,11 @@ class FlutterGpuTileBackendStats {
       'geometryBytes=$geometryBytes peakGeometryBytes=$peakGeometryBytes '
       'standaloneUniformBuffers=$standaloneUniformBuffers '
       'transientBuffers=$transientBuffers '
+      'transientBufferReuses=$transientBufferReuses '
       'transientEmplacedBytes=$transientEmplacedBytes '
       'transientAllocatedBytes=$transientAllocatedBytes '
+      'transientResidentBytes=$transientResidentBytes '
+      'peakTransientResidentBytes=$peakTransientResidentBytes '
       'peakTransientTileBytes=$peakTransientTileBytes '
       'uploads=$texturesUploaded imports=$textureImports '
       'directUploads=$textureDirectUploads '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -69,8 +69,11 @@ void main() {
       ..peakGeometryBytes = 48 << 20
       ..standaloneUniformBuffers = 9
       ..transientBuffers = 5
+      ..transientBufferReuses = 11
       ..transientEmplacedBytes = 768 << 10
       ..transientAllocatedBytes = 1 << 20
+      ..transientResidentBytes = 2 << 20
+      ..peakTransientResidentBytes = 3 << 20
       ..peakTransientTileBytes = 896 << 10
       ..textureImports = 6
       ..analyticTextRuns = 7
@@ -120,8 +123,11 @@ void main() {
     expect(stats.toJson(), containsPair('analyticTextRuns', 7));
     expect(stats.toJson(), containsPair('standaloneUniformBuffers', 9));
     expect(stats.toJson(), containsPair('transientBuffers', 5));
+    expect(stats.toJson(), containsPair('transientBufferReuses', 11));
     expect(stats.toJson(), containsPair('transientEmplacedBytes', 768 << 10));
     expect(stats.toJson(), containsPair('transientAllocatedBytes', 1 << 20));
+    expect(stats.toJson(), containsPair('transientResidentBytes', 2 << 20));
+    expect(stats.toJson(), containsPair('peakTransientResidentBytes', 3 << 20));
     expect(stats.toJson(), containsPair('peakTransientTileBytes', 896 << 10));
     expect(stats.toJson(), containsPair('textureImports', 6));
     expect(stats.toJson(), containsPair('analyticGlyphQuads', 18));
@@ -173,8 +179,11 @@ void main() {
     expect(stats.peakGeometryBytes, 32 << 20);
     expect(stats.standaloneUniformBuffers, 0);
     expect(stats.transientBuffers, 0);
+    expect(stats.transientBufferReuses, 0);
     expect(stats.transientEmplacedBytes, 0);
     expect(stats.transientAllocatedBytes, 0);
+    expect(stats.transientResidentBytes, 2 << 20);
+    expect(stats.peakTransientResidentBytes, 2 << 20);
     expect(stats.peakTransientTileBytes, 0);
     expect(stats.textureImports, 0);
     expect(stats.analyticTextRuns, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -184,8 +184,11 @@ void main() {
           () => session.rasterizeRegion(region, pixelRatio: 0.5),
         ));
       }
-      expect(backend.stats.transientAllocatedBytes, 15 * (4 << 10),
-          reason: 'one-transform tiles should use the 4 KiB first block');
+      expect(backend.stats.transientBuffers, 0,
+          reason: 'the settled loop should reuse the warmed 4 KiB block');
+      expect(backend.stats.transientBufferReuses, settled.length);
+      expect(backend.stats.transientAllocatedBytes, 0);
+      expect(backend.stats.transientResidentBytes, 4 << 10);
       // ignore: avoid_print
       print('flutter_gpu analytic text benchmark: runs=${commands.length} '
           'settledMedian=${_median(settled).toStringAsFixed(0)}us '
@@ -279,6 +282,11 @@ void main() {
           () => session.rasterizeRegion(region, pixelRatio: 0.5),
         ));
       }
+      expect(backend.stats.transientBuffers, 0,
+          reason: 'the settled loop should reuse the warmed 4 KiB block');
+      expect(backend.stats.transientBufferReuses, settled.length);
+      expect(backend.stats.transientAllocatedBytes, 0);
+      expect(backend.stats.transientResidentBytes, 4 << 10);
       // ignore: avoid_print
       print('flutter_gpu texture benchmark: draws=${commands.length} '
           'compile=${compileMicros}us compileCacheHits=$compileCacheHits '
@@ -446,6 +454,13 @@ void main() {
       final canvasMedian = _median(warmCanvas);
       expect(backend.stats.offscreenGroupPasses, 16);
       expect(backend.stats.offscreenGroupAllocatedBytes, greaterThan(0));
+      expect(backend.stats.peakInFlightSubmissions, greaterThan(1));
+      expect(
+          backend.stats.transientBuffers, backend.stats.peakInFlightSubmissions,
+          reason: 'concurrent submissions must receive distinct buffers');
+      expect(backend.stats.transientBufferReuses,
+          backend.stats.tilesRendered - backend.stats.transientBuffers,
+          reason: 'completed submissions should return buffers to the pool');
       // ignore: avoid_print
       print('flutter_gpu isolated group benchmark: cold=${coldGpu}us '
           'issueMedian=${issueMedian.toStringAsFixed(0)}us '


### PR DESCRIPTION
## Headline vs #829

- Settled 15-tile dense texture replay: **15 → 0 native `DeviceBuffer` allocations** and **61,440 → 0 transient allocation bytes after warm-up** (-100%).
- The steady-state pool retains one exact-size **4 KiB** block; concurrent tiles never share an in-flight buffer.
- Same-host five-pair medians are effectively flat: compile **23.091 → 21.610 ms** (-6.4%, noisy), issue **1.594 → 1.636 ms** (+2.6%), settled **7.241 → 7.379 ms** (+1.9%). This PR is an allocation/lifetime improvement, not a claimed speedup.

<details>
<summary>Implementation and validation</summary>

### What changed

- Add an exact-size transient `DeviceBuffer` pool with an 8 MiB retained budget.
- Fence each arena across every command buffer it submits; blocks return to the pool only after the arena is sealed and all completion callbacks have fired.
- Keep over-budget buffers one-shot, so pool pressure cannot reject an otherwise valid render.
- Report physical allocations, pool hits, resident bytes, and peak resident bytes in backend stats.
- Preserve the warm-up path as an unpooled one-shot arena.

The isolated-group benchmark exercises multiple command buffers per tile. On this host it reached eight concurrent submissions, allocated eight distinct blocks, then reused those eight blocks for the remaining tiles. The test asserts the invariant dynamically against observed peak concurrency so it is not tied to one GPU's scheduling speed.

### Validation

- `fvm dart analyze` — clean.
- Native package suite — 317 passed, 4 expected environment skips.
- No-GPU fallback suite — 12 passed, 92 expected GPU skips.
- Tile backend pixel/correctness suite — 82 passed, 2 expected environment skips.
- Ghent GPU corpus — 49 accepted / 8 exact Canvas fallbacks, unchanged.
- PDF.js GPU corpus — 111 accepted / 68 exact Canvas fallbacks, unchanged.
- Dense >1 MiB hairline rollover test — passed.
- Completion-fence benchmark/stat tests — passed for simple, isolated-group, mixed group+advanced, and advanced-inside-group routes.

</details>
