### PR TITLE
test: preserve already armed Patrol tool

### DIFF
--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -493,6 +493,11 @@ class _DemoHarness {
     required String group,
     required PdfEditTool tool,
   }) async {
+    // Some one-shot tools return to Select after they commit. Opening the
+    // Select group in that state toggles Select off, so preserve the already
+    // satisfied state instead of driving the toolbar again.
+    if (editing.tool == tool) return;
+
     final toolButton = find.byKey(ValueKey('pdf-tool-${tool.name}'));
     final mobileHandle = find.byKey(const ValueKey('pdf-tools-handle'));
     if (mobileHandle.evaluate().isNotEmpty) {


### PR DESCRIPTION
Fix the Android Patrol failure currently blocking the GPU PR stack.

The text-note flow returns the editor to Select after committing the note. The test helper was then opening the mobile tools sheet and tapping Select again, which toggled it off before looking for the single-option Select tile.

This adds an idempotence guard: when the requested tool is already armed, the driver leaves the toolbar untouched.

Validation:
- `fvm dart analyze`
- failure confirmed in Android Patrol job 98290523400 at `pdf-tool-select`

No product rendering code changes.