### PR TITLE
perf(gpu): reuse fenced transient attachments

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.2.0
 
+- Reuse final-pass multisample color and stencil attachments only after every
+  command buffer that references them reaches its completion fence. Final
+  resolve textures still remain one-shot because their `ui.Image` escapes to
+  Flutter; settled tiles avoid two native texture allocations where MSAA is
+  available without risking an in-use output surface. Retention is bounded by
+  the configurable `maxTransientAttachmentBytes` budget.
 - Reuse transient host-visible buffers only after every command buffer that
   references them reaches its completion fence. Settled tiles stop allocating
   one native `DeviceBuffer` apiece, while concurrent and multi-pass group

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -46,6 +46,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     this.overprintRetryMaxDimension = 512,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
+    this.maxTransientAttachmentBytes = 64 << 20,
     this.enableProactiveWarmUp,
     this.analyticText = true,
     FlutterGpuTextOutliner? textOutliner,
@@ -53,6 +54,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     FlutterGpuTileBackendStats? stats,
   })  : assert(overprintRetryMaxDimension == null ||
             overprintRetryMaxDimension > 0),
+        assert(maxTransientAttachmentBytes >= 0),
         stats = stats ?? FlutterGpuTileBackendStats(),
         textOutliner = textOutliner ??
             (systemTextOutlines
@@ -60,7 +62,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
                 : null),
         _imageCache = _GpuImageCache(maxTextureBytes),
         _geometryPool = _GpuGeometryPool(maxGeometryBytes),
-        _transientPool = _GpuTransientPool();
+        _transientPool = _GpuTransientPool(),
+        _attachmentPool = _GpuAttachmentPool(maxTransientAttachmentBytes);
 
   /// Enables 4x MSAA on the final tile target where Impeller supports it.
   /// Intermediate transparency-group targets stay single-sample and are
@@ -100,6 +103,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   /// cannot fit falls back to Canvas.
   final int maxGeometryBytes;
 
+  /// Maximum estimated bytes retained for reusable final-pass attachments.
+  ///
+  /// The estimate deliberately uses eight bytes per pixel sample so the
+  /// budget remains conservative across Flutter 3.44+ default attachment
+  /// formats. In-flight attachments may temporarily exceed this value because
+  /// budget misses remain one-shot instead of rejecting a valid render. Set
+  /// this to zero to disable attachment retention.
+  final int maxTransientAttachmentBytes;
+
   /// Whether the viewer should prepare GPU pipelines and live scenes at idle.
   ///
   /// Null (the default) enables proactive work on desktop and leaves mobile
@@ -133,6 +145,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   final _GpuImageCache _imageCache;
   final _GpuGeometryPool _geometryPool;
   final _GpuTransientPool _transientPool;
+  final _GpuAttachmentPool _attachmentPool;
   // Contexts belong to Flutter views and can disappear when a native window
   // closes. Keep only weak membership so diagnostics do not turn every view
   // ever opened into a process-lifetime root.
@@ -304,6 +317,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
         imageCache: _imageCache,
         geometryPool: _geometryPool,
         transientPool: _transientPool,
+        attachmentPool: _attachmentPool,
         analyticText: analyticText,
         analyticTextMinimumGlyphs:
             systemTextOutlines && usesHostOutlines ? 32 : 1,
@@ -4089,6 +4103,7 @@ class _FlutterGpuTileSession
     required this.imageCache,
     required this.geometryPool,
     required this.transientPool,
+    required this.attachmentPool,
     required this.analyticText,
     required this.analyticTextMinimumGlyphs,
   });
@@ -4117,6 +4132,7 @@ class _FlutterGpuTileSession
   final _GpuImageCache imageCache;
   final _GpuGeometryPool geometryPool;
   final _GpuTransientPool transientPool;
+  final _GpuAttachmentPool attachmentPool;
   final bool analyticText;
   final int analyticTextMinimumGlyphs;
 
@@ -4135,6 +4151,7 @@ class _FlutterGpuTileSession
         imageCache,
         geometryPool,
         transientPool,
+        attachmentPool,
         analyticText: analyticText,
         analyticTextMinimumGlyphs: analyticTextMinimumGlyphs,
         mipmapImages: mipmapImages,
@@ -4300,6 +4317,7 @@ class _CompiledScene {
     required this.geometryPool,
     required this.geometryLeases,
     required this.transientPool,
+    required this.attachmentPool,
   });
 
   static Future<_CompiledScene> build(
@@ -4311,6 +4329,7 @@ class _CompiledScene {
       _GpuImageCache imageCache,
       _GpuGeometryPool geometryPool,
       _GpuTransientPool transientPool,
+      _GpuAttachmentPool attachmentPool,
       {required bool analyticText,
       required int analyticTextMinimumGlyphs,
       required bool mipmapImages}) async {
@@ -4513,6 +4532,7 @@ class _CompiledScene {
         geometryPool: geometryPool,
         geometryLeases: geometry.leases,
         transientPool: transientPool,
+        attachmentPool: attachmentPool,
       );
       stats
         ..scenesCompiled += 1
@@ -4538,6 +4558,7 @@ class _CompiledScene {
   final _GpuGeometryPool geometryPool;
   final List<_GpuGeometryResource> geometryLeases;
   final _GpuTransientPool transientPool;
+  final _GpuAttachmentPool attachmentPool;
   bool _disposed = false;
   bool _texturesReleased = false;
   bool _geometryReleased = false;
@@ -4612,7 +4633,12 @@ class _CompiledScene {
         tracePage: tracePage,
       );
     }
-    final transient = _GpuTransientArena(context, stats, transientPool);
+    final transient = _GpuTransientArena(
+      context,
+      stats,
+      transientPool,
+      attachmentPool,
+    );
     try {
       if (selected.any((unit) =>
           !FlutterGpuTileRasterBackend._isFixedFunctionBlendMode(
@@ -5641,18 +5667,16 @@ class _CompiledScene {
       format: context.defaultColorFormat,
     );
     final color = multisampled
-        ? context.createTexture(
-            gpu.StorageMode.deviceTransient,
-            width,
-            height,
+        ? transient.attachment(
+            width: width,
+            height: height,
             format: context.defaultColorFormat,
             sampleCount: 4,
           )
         : resolve;
-    final stencil = context.createTexture(
-      gpu.StorageMode.deviceTransient,
-      width,
-      height,
+    final stencil = transient.attachment(
+      width: width,
+      height: height,
       format: context.defaultStencilFormat,
       sampleCount: multisampled ? 4 : 1,
     );
@@ -7920,7 +7944,12 @@ class _GpuGeometryArena {
 /// dense dynamic geometry, tests the complete aligned range before every
 /// write, and is retained until the command-buffer completion fence fires.
 class _GpuTransientArena {
-  _GpuTransientArena(this.context, [this.stats, this.pool]);
+  _GpuTransientArena(
+    this.context, [
+    this.stats,
+    this.pool,
+    this.attachmentPool,
+  ]);
 
   static const _firstBlockBytes = 4 << 10;
   static const _secondBlockBytes = 16 << 10;
@@ -7929,9 +7958,12 @@ class _GpuTransientArena {
   final gpu.GpuContext context;
   final FlutterGpuTileBackendStats? stats;
   final _GpuTransientPool? pool;
+  final _GpuAttachmentPool? attachmentPool;
   final List<_GpuTransientBlock> _blocks = [];
+  final List<_GpuAttachmentResource> _attachments = [];
   _GpuTransientBlock? _active;
   var _allocatedBytes = 0;
+  var _attachmentBytes = 0;
   var _nextBlockBytes = _secondBlockBytes;
   var _pendingSubmissions = 0;
   var _sealed = false;
@@ -7993,6 +8025,60 @@ class _GpuTransientArena {
     );
   }
 
+  /// Leases a render-pass attachment until every submission using this arena
+  /// reaches its completion callback.
+  ///
+  /// These textures must never escape as a [ui.Image]. Final resolve textures
+  /// remain caller-owned because Flutter may sample them after GPU completion.
+  gpu.Texture attachment({
+    required int width,
+    required int height,
+    required gpu.PixelFormat format,
+    int sampleCount = 1,
+  }) {
+    if (_sealed) throw StateError('GPU transient arena is sealed');
+    // Conservatively budget eight logical bytes per sample without depending
+    // on PixelFormat sizing helpers added after the package's Flutter 3.44
+    // minimum. deviceTransient heaps may alias or use less physical memory.
+    final estimatedBytes = width * height * sampleCount * 8;
+    final resource = attachmentPool?.acquire(
+          context,
+          width: width,
+          height: height,
+          format: format,
+          sampleCount: sampleCount,
+          estimatedBytes: estimatedBytes,
+          stats: stats,
+        ) ??
+        _GpuAttachmentResource(
+          context,
+          context.createTexture(
+            gpu.StorageMode.deviceTransient,
+            width,
+            height,
+            format: format,
+            sampleCount: sampleCount,
+          ),
+          width,
+          height,
+          format,
+          sampleCount,
+          estimatedBytes,
+        );
+    _attachments.add(resource);
+    _attachmentBytes += resource.estimatedBytes;
+    if (attachmentPool == null) {
+      stats
+        ?..transientAttachmentTextures += 1
+        ..transientAttachmentAllocatedBytes += resource.estimatedBytes;
+    }
+    stats?.peakTransientAttachmentTileBytes = math.max(
+      stats!.peakTransientAttachmentTileBytes,
+      _attachmentBytes,
+    );
+    return resource.texture;
+  }
+
   void flush() {
     for (final block in _blocks) {
       if (block.flushedBytes == block.usedBytes) continue;
@@ -8046,7 +8132,9 @@ class _GpuTransientArena {
       [for (final block in _blocks) block.resource],
       stats,
     );
+    attachmentPool?.releaseAll(_attachments, stats);
     _blocks.clear();
+    _attachments.clear();
     _active = null;
   }
 
@@ -8138,6 +8226,107 @@ class _GpuTransientResource {
   final gpu.GpuContext context;
   final gpu.DeviceBuffer buffer;
   final int capacity;
+  bool leased = false;
+}
+
+/// Exact-shape pool for render-pass attachments that never escape to Flutter.
+///
+/// A texture remains leased until the owning [_GpuTransientArena] is sealed
+/// and all of its command buffers complete. Oversized or budget-exceeding
+/// attachments stay one-shot, so valid rendering never depends on a pool hit.
+class _GpuAttachmentPool {
+  _GpuAttachmentPool(this.maxBytes);
+
+  final int maxBytes;
+  final List<_GpuAttachmentResource> _resources = [];
+  var _bytes = 0;
+
+  _GpuAttachmentResource acquire(
+    gpu.GpuContext context, {
+    required int width,
+    required int height,
+    required gpu.PixelFormat format,
+    required int sampleCount,
+    required int estimatedBytes,
+    required FlutterGpuTileBackendStats? stats,
+  }) {
+    for (final resource in _resources) {
+      if (!resource.leased &&
+          identical(resource.context, context) &&
+          resource.width == width &&
+          resource.height == height &&
+          resource.format == format &&
+          resource.sampleCount == sampleCount) {
+        resource.leased = true;
+        stats?.transientAttachmentReuses++;
+        return resource;
+      }
+    }
+
+    final pooled =
+        estimatedBytes <= maxBytes && _bytes + estimatedBytes <= maxBytes;
+    final resource = _GpuAttachmentResource(
+      context,
+      context.createTexture(
+        gpu.StorageMode.deviceTransient,
+        width,
+        height,
+        format: format,
+        sampleCount: sampleCount,
+      ),
+      width,
+      height,
+      format,
+      sampleCount,
+      estimatedBytes,
+    )..leased = true;
+    if (pooled) {
+      _resources.add(resource);
+      _bytes += estimatedBytes;
+    }
+    stats
+      ?..transientAttachmentTextures += 1
+      ..transientAttachmentAllocatedBytes += estimatedBytes;
+    if (stats != null) {
+      stats
+        ..transientAttachmentResidentBytes = _bytes
+        ..peakTransientAttachmentResidentBytes = math.max(
+          stats.peakTransientAttachmentResidentBytes,
+          _bytes,
+        );
+    }
+    return resource;
+  }
+
+  void releaseAll(
+    Iterable<_GpuAttachmentResource> resources,
+    FlutterGpuTileBackendStats? stats,
+  ) {
+    for (final resource in resources) {
+      resource.leased = false;
+    }
+    if (stats != null) stats.transientAttachmentResidentBytes = _bytes;
+  }
+}
+
+class _GpuAttachmentResource {
+  _GpuAttachmentResource(
+    this.context,
+    this.texture,
+    this.width,
+    this.height,
+    this.format,
+    this.sampleCount,
+    this.estimatedBytes,
+  );
+
+  final gpu.GpuContext context;
+  final gpu.Texture texture;
+  final int width;
+  final int height;
+  final gpu.PixelFormat format;
+  final int sampleCount;
+  final int estimatedBytes;
   bool leased = false;
 }
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -68,6 +68,12 @@ class FlutterGpuTileBackendStats {
   int transientResidentBytes = 0;
   int peakTransientResidentBytes = 0;
   int peakTransientTileBytes = 0;
+  int transientAttachmentTextures = 0;
+  int transientAttachmentReuses = 0;
+  int transientAttachmentAllocatedBytes = 0;
+  int transientAttachmentResidentBytes = 0;
+  int peakTransientAttachmentResidentBytes = 0;
+  int peakTransientAttachmentTileBytes = 0;
   int texturesUploaded = 0;
   int textureImports = 0;
   int textureDirectUploads = 0;
@@ -160,6 +166,13 @@ class FlutterGpuTileBackendStats {
         'transientResidentBytes': transientResidentBytes,
         'peakTransientResidentBytes': peakTransientResidentBytes,
         'peakTransientTileBytes': peakTransientTileBytes,
+        'transientAttachmentTextures': transientAttachmentTextures,
+        'transientAttachmentReuses': transientAttachmentReuses,
+        'transientAttachmentAllocatedBytes': transientAttachmentAllocatedBytes,
+        'transientAttachmentResidentBytes': transientAttachmentResidentBytes,
+        'peakTransientAttachmentResidentBytes':
+            peakTransientAttachmentResidentBytes,
+        'peakTransientAttachmentTileBytes': peakTransientAttachmentTileBytes,
         'texturesUploaded': texturesUploaded,
         'textureImports': textureImports,
         'textureDirectUploads': textureDirectUploads,
@@ -248,6 +261,11 @@ class FlutterGpuTileBackendStats {
     transientAllocatedBytes = 0;
     peakTransientResidentBytes = transientResidentBytes;
     peakTransientTileBytes = 0;
+    transientAttachmentTextures = 0;
+    transientAttachmentReuses = 0;
+    transientAttachmentAllocatedBytes = 0;
+    peakTransientAttachmentResidentBytes = transientAttachmentResidentBytes;
+    peakTransientAttachmentTileBytes = 0;
     texturesUploaded = 0;
     textureImports = 0;
     textureDirectUploads = 0;
@@ -319,6 +337,13 @@ class FlutterGpuTileBackendStats {
       'transientResidentBytes=$transientResidentBytes '
       'peakTransientResidentBytes=$peakTransientResidentBytes '
       'peakTransientTileBytes=$peakTransientTileBytes '
+      'transientAttachmentTextures=$transientAttachmentTextures '
+      'transientAttachmentReuses=$transientAttachmentReuses '
+      'transientAttachmentAllocatedBytes=$transientAttachmentAllocatedBytes '
+      'transientAttachmentResidentBytes=$transientAttachmentResidentBytes '
+      'peakTransientAttachmentResidentBytes='
+      '$peakTransientAttachmentResidentBytes '
+      'peakTransientAttachmentTileBytes=$peakTransientAttachmentTileBytes '
       'uploads=$texturesUploaded imports=$textureImports '
       'directUploads=$textureDirectUploads '
       'readbacks=$textureReadbacks textureHits=$textureCacheHits '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -17,10 +17,16 @@ void main() {
       expect(desktop.supportsWarmUp, isTrue);
       expect(desktop.supportsSessionWarmUp, isTrue);
       expect(desktop.overprintRetryMaxDimension, 512);
+      expect(desktop.maxTransientAttachmentBytes, 64 << 20);
       expect(
         FlutterGpuTileRasterBackend(overprintRetryMaxDimension: null)
             .overprintRetryMaxDimension,
         isNull,
+      );
+      expect(
+        FlutterGpuTileRasterBackend(maxTransientAttachmentBytes: 0)
+            .maxTransientAttachmentBytes,
+        0,
       );
 
       final optedIn = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
@@ -75,6 +81,12 @@ void main() {
       ..transientResidentBytes = 2 << 20
       ..peakTransientResidentBytes = 3 << 20
       ..peakTransientTileBytes = 896 << 10
+      ..transientAttachmentTextures = 4
+      ..transientAttachmentReuses = 12
+      ..transientAttachmentAllocatedBytes = 20 << 20
+      ..transientAttachmentResidentBytes = 24 << 20
+      ..peakTransientAttachmentResidentBytes = 32 << 20
+      ..peakTransientAttachmentTileBytes = 16 << 20
       ..textureImports = 6
       ..analyticTextRuns = 7
       ..analyticGlyphQuads = 18
@@ -129,6 +141,16 @@ void main() {
     expect(stats.toJson(), containsPair('transientResidentBytes', 2 << 20));
     expect(stats.toJson(), containsPair('peakTransientResidentBytes', 3 << 20));
     expect(stats.toJson(), containsPair('peakTransientTileBytes', 896 << 10));
+    expect(stats.toJson(), containsPair('transientAttachmentTextures', 4));
+    expect(stats.toJson(), containsPair('transientAttachmentReuses', 12));
+    expect(stats.toJson(),
+        containsPair('transientAttachmentAllocatedBytes', 20 << 20));
+    expect(stats.toJson(),
+        containsPair('transientAttachmentResidentBytes', 24 << 20));
+    expect(stats.toJson(),
+        containsPair('peakTransientAttachmentResidentBytes', 32 << 20));
+    expect(stats.toJson(),
+        containsPair('peakTransientAttachmentTileBytes', 16 << 20));
     expect(stats.toJson(), containsPair('textureImports', 6));
     expect(stats.toJson(), containsPair('analyticGlyphQuads', 18));
     expect(stats.toJson(), containsPair('analyticGlyphSlots', 4));
@@ -185,6 +207,12 @@ void main() {
     expect(stats.transientResidentBytes, 2 << 20);
     expect(stats.peakTransientResidentBytes, 2 << 20);
     expect(stats.peakTransientTileBytes, 0);
+    expect(stats.transientAttachmentTextures, 0);
+    expect(stats.transientAttachmentReuses, 0);
+    expect(stats.transientAttachmentAllocatedBytes, 0);
+    expect(stats.transientAttachmentResidentBytes, 24 << 20);
+    expect(stats.peakTransientAttachmentResidentBytes, 24 << 20);
+    expect(stats.peakTransientAttachmentTileBytes, 0);
     expect(stats.textureImports, 0);
     expect(stats.analyticTextRuns, 0);
     expect(stats.analyticGlyphQuads, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -267,6 +267,68 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('completion-fenced attachments respect the retention budget',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final attachmentsPerTile =
+          gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+      for (final budget in [0, 64 << 20]) {
+        final page = PdfDocument.open(buildClassicPdf()).page(0);
+        final scene = await PdfRetainedScene.fromCommands(page, [
+          PdfFillPathCommand(
+            _rect(40, 40, 572, 752),
+            const PdfColor(0.2, 0.45, 0.8),
+            PdfFillRule.nonzero,
+            0.8,
+          ),
+        ]);
+        final backend = FlutterGpuTileRasterBackend(
+          maxTransientAttachmentBytes: budget,
+        );
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        final active = session!;
+        try {
+          const region = Rect.fromLTWH(30, 50, 300, 220);
+          final warm = await active.rasterizeRegion(region, pixelRatio: 1);
+          await _pixels(warm);
+          warm.dispose();
+
+          backend.stats.reset();
+          final replay = await active.rasterizeRegion(region, pixelRatio: 1);
+          await _pixels(replay);
+          replay.dispose();
+          expect(backend.stats.failedSubmissions, 0);
+          if (budget == 0) {
+            expect(
+              backend.stats.transientAttachmentTextures,
+              attachmentsPerTile,
+            );
+            expect(backend.stats.transientAttachmentReuses, 0);
+            expect(backend.stats.transientAttachmentResidentBytes, 0);
+          } else {
+            expect(backend.stats.transientAttachmentTextures, 0);
+            expect(
+              backend.stats.transientAttachmentReuses,
+              attachmentsPerTile,
+            );
+            expect(
+              backend.stats.transientAttachmentResidentBytes,
+              greaterThan(0),
+            );
+          }
+        } finally {
+          active.dispose();
+          scene.dispose();
+        }
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
   testWidgets('rotation and rectangular clips match Canvas', (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -189,6 +189,16 @@ void main() {
       expect(backend.stats.transientBufferReuses, settled.length);
       expect(backend.stats.transientAllocatedBytes, 0);
       expect(backend.stats.transientResidentBytes, 4 << 10);
+      final attachmentsPerTile =
+          gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+      expect(backend.stats.transientAttachmentTextures, 0,
+          reason: 'settled tiles should reuse warmed final-pass attachments');
+      expect(
+        backend.stats.transientAttachmentReuses,
+        settled.length * attachmentsPerTile,
+      );
+      expect(backend.stats.transientAttachmentAllocatedBytes, 0);
+      expect(backend.stats.transientAttachmentResidentBytes, greaterThan(0));
       // ignore: avoid_print
       print('flutter_gpu analytic text benchmark: runs=${commands.length} '
           'settledMedian=${_median(settled).toStringAsFixed(0)}us '
@@ -287,6 +297,16 @@ void main() {
       expect(backend.stats.transientBufferReuses, settled.length);
       expect(backend.stats.transientAllocatedBytes, 0);
       expect(backend.stats.transientResidentBytes, 4 << 10);
+      final attachmentsPerTile =
+          gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+      expect(backend.stats.transientAttachmentTextures, 0,
+          reason: 'settled tiles should reuse warmed final-pass attachments');
+      expect(
+        backend.stats.transientAttachmentReuses,
+        settled.length * attachmentsPerTile,
+      );
+      expect(backend.stats.transientAttachmentAllocatedBytes, 0);
+      expect(backend.stats.transientAttachmentResidentBytes, greaterThan(0));
       // ignore: avoid_print
       print('flutter_gpu texture benchmark: draws=${commands.length} '
           'compile=${compileMicros}us compileCacheHits=$compileCacheHits '
@@ -461,6 +481,21 @@ void main() {
       expect(backend.stats.transientBufferReuses,
           backend.stats.tilesRendered - backend.stats.transientBuffers,
           reason: 'completed submissions should return buffers to the pool');
+      final attachmentsPerTile =
+          gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+      expect(
+        backend.stats.transientAttachmentTextures,
+        greaterThanOrEqualTo(
+          backend.stats.peakInFlightSubmissions * attachmentsPerTile,
+        ),
+        reason: 'in-flight tiles must receive distinct attachment leases',
+      );
+      expect(
+        backend.stats.transientAttachmentTextures +
+            backend.stats.transientAttachmentReuses,
+        backend.stats.tilesRendered * attachmentsPerTile,
+        reason: 'every final-pass attachment should be allocated or reused',
+      );
       // ignore: avoid_print
       print('flutter_gpu isolated group benchmark: cold=${coldGpu}us '
           'issueMedian=${issueMedian.toStringAsFixed(0)}us '


### PR DESCRIPTION
## Performance

**Same-host comparison with parent #830:**

- Dense image settled median: **6.81 ms vs 7.12 ms parent (-4.3%)**
- Dense image issue mean: **1.54 ms vs 1.63 ms parent (-5.7%)**
- Dense analytic-text settled median: **7.19 ms vs 7.32 ms parent (-1.8%)**
- Dense analytic-text issue mean: **1.51 ms vs 1.66 ms parent (-9.2%)**
- Settled loops: **0 attachment allocations, 30 completion-fenced reuses per 15 MSAA tiles**

<details>
<summary>Implementation and validation</summary>

The final simple pass now leases exact-shape deviceTransient MSAA color and stencil attachments from a backend-wide pool. The owning transient arena returns them only after it is sealed and every command buffer registered with it has completed. The final resolve texture remains one-shot because its ui.Image escapes to Flutter.

Retention uses a conservative eight-byte-per-sample estimate and is capped by the configurable maxTransientAttachmentBytes budget (64 MiB by default, zero disables retention). Budget misses remain one-shot rather than rejecting valid rendering.

Concurrency evidence: eight overlapping tiles received sixteen distinct attachments; later submissions reused sixteen completed leases; failed submissions remained zero.

Validation:

- GPU package analyzer: clean
- Complete package test suite: green
- Native Flutter GPU backend parity: 83 passed
- Ghent corpus: 49 GPU, 8 exact Canvas fallbacks
- PDF.js corpus: 177 GPU, 2 exact Canvas fallbacks
- All 218 corpus tests passed the existing Canvas parity bound

The timing figures are medians across interleaved parent/candidate process cohorts on the same Apple Silicon host. Individual GPU settle samples remain noisy; the allocation counters and issue-time reductions are the primary signal.

</details>