### PR TITLE
perf(gpu): reuse fenced advanced attachments

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0
 
+- Reuse page-level advanced-blend multisample and stencil attachments only
+  after every command buffer in the destination-sampling route completes.
+  Repeated tiles no longer allocate a fresh attachment pair, while the page
+  ping-pong and source textures keep their existing exact ownership.
 - Reuse final-pass multisample color and stencil attachments only after every
   command buffer that references them reaches its completion fence. Final
   resolve textures still remain one-shot because their `ui.Image` escapes to

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5239,35 +5239,31 @@ class _CompiledScene {
     final pageB = texture(width, height);
     final source = texture(sourceWidth, sourceHeight);
     final color = multisampled
-        ? context.createTexture(
-            gpu.StorageMode.deviceTransient,
-            width,
-            height,
+        ? transient.attachment(
+            width: width,
+            height: height,
             format: context.defaultColorFormat,
             sampleCount: 4,
           )
         : null;
-    final stencil = context.createTexture(
-      gpu.StorageMode.deviceTransient,
-      width,
-      height,
+    final stencil = transient.attachment(
+      width: width,
+      height: height,
       format: context.defaultStencilFormat,
       sampleCount: multisampled ? 4 : 1,
     );
     final sourceColor = cropSource && multisampled
-        ? context.createTexture(
-            gpu.StorageMode.deviceTransient,
-            sourceWidth,
-            sourceHeight,
+        ? transient.attachment(
+            width: sourceWidth,
+            height: sourceHeight,
             format: context.defaultColorFormat,
             sampleCount: 4,
           )
         : color;
     final sourceStencil = cropSource
-        ? context.createTexture(
-            gpu.StorageMode.deviceTransient,
-            sourceWidth,
-            sourceHeight,
+        ? transient.attachment(
+            width: sourceWidth,
+            height: sourceHeight,
             format: context.defaultStencilFormat,
             sampleCount: multisampled ? 4 : 1,
           )

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -329,6 +329,65 @@ void main() {
     });
   }, timeout: const Timeout(Duration(minutes: 2)));
 
+  testWidgets('advanced blend attachments return after route completion',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(0, 0, 612, 792),
+          const PdfColor(0.16, 0.52, 0.82),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.overlay),
+        PdfFillPathCommand(
+          _rect(0, 0, 612, 792),
+          const PdfColor(0.88, 0.26, 0.12),
+          PdfFillRule.nonzero,
+          0.63,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      final active = session!;
+      try {
+        const region = Rect.fromLTWH(40, 80, 320, 240);
+        final warm = await active.rasterizeRegion(region, pixelRatio: 1);
+        await _pixels(warm);
+        warm.dispose();
+
+        final attachmentsPerTile =
+            gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+        expect(
+          backend.stats.transientAttachmentTextures,
+          attachmentsPerTile,
+        );
+        expect(backend.stats.transientAttachmentReuses, 0);
+
+        backend.stats.reset();
+        final replay = await active.rasterizeRegion(region, pixelRatio: 1);
+        await _pixels(replay);
+        replay.dispose();
+        expect(backend.stats.failedSubmissions, 0);
+        expect(backend.stats.transientAttachmentTextures, 0);
+        expect(
+          backend.stats.transientAttachmentReuses,
+          attachmentsPerTile,
+        );
+      } finally {
+        active.dispose();
+        scene.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 2)));
+
   testWidgets('rotation and rectangular clips match Canvas', (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -612,6 +612,21 @@ void main() {
       expect(backend.stats.offscreenGroupPasses, 16);
       expect(backend.stats.advancedBlendPasses, 32);
       expect(backend.stats.advancedBlendBlits, 32);
+      final attachmentsPerTile =
+          gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
+      expect(
+        backend.stats.transientAttachmentTextures,
+        greaterThanOrEqualTo(
+          backend.stats.peakInFlightSubmissions * attachmentsPerTile,
+        ),
+        reason: 'in-flight advanced routes need distinct attachment leases',
+      );
+      expect(
+        backend.stats.transientAttachmentTextures +
+            backend.stats.transientAttachmentReuses,
+        backend.stats.tilesRendered * attachmentsPerTile,
+        reason: 'every advanced route attachment should allocate or reuse',
+      );
       // ignore: avoid_print
       print('flutter_gpu mixed group+blend benchmark: cold=${coldGpu}us '
           'issueMedian=${issueMedian.toStringAsFixed(0)}us '


### PR DESCRIPTION
## Result

Compared with parent PR #832 on the same host across five interleaved runs:

- settled mixed group plus advanced-blend median: 20.018 ms -> 19.399 ms (-3.1%)
- aggregate issue time median for the 16-tile run: 51.489 ms -> 48.111 ms (-6.6%)
- advanced attachment objects: 32 one-shot allocations -> 16 allocations plus 16 completion-fenced reuses

The page ping-pong resolves and source resolve keep their existing ownership. Only non-escaping page advanced-blend multisample color and stencil attachments enter the bounded pool from #832.

<details>
<summary>Implementation and validation</summary>

- Leases full-tile advanced color/stencil attachments through the route-wide transient arena.
- Leases cropped-source color/stencil attachments when source cropping is selected.
- Returns leases only after every command buffer registered by the advanced route has completed.
- Adds a serial completion/reuse regression test and allocation assertions to the targeted benchmark.
- Analyzer: clean.
- Full package test suite: passed.
- Native flutter_gpu backend: 84 passed, 2 environment skips.
- Full system-font GPU corpus: 218 passed.
  - Ghent: 49 accepted, 8 conservative fallbacks.
  - PDF.js: 177 accepted, 2 conservative fallbacks.
- Five-pair settled medians, parent: 18.843, 21.037, 20.018, 19.667, 21.745 ms.
- Five-pair settled medians, candidate: 22.538, 19.399, 18.713, 20.250, 18.978 ms.

</details>