### PR TITLE
test: wait for mobile Patrol tool sheet

### DIFF
--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -505,7 +505,9 @@ class _DemoHarness {
       await $.pump(const Duration(milliseconds: 250));
       final groupTab = find.byKey(ValueKey('pdf-group-tab-$group'));
       await tester.ensureVisible(groupTab);
-      await tester.tap(groupTab);
+      final visibleGroupTab = groupTab.hitTestable();
+      await waitForFinder(visibleGroupTab, attempts: 30);
+      await tester.tap(visibleGroupTab);
       await $.pump(const Duration(milliseconds: 250));
       // Select is the mobile sheet's only single-option group, so tapping its
       // group tab now arms it directly and closes the sheet. Multi-tool groups
@@ -514,7 +516,9 @@ class _DemoHarness {
       expect(toolButton, findsOneWidget,
           reason: '$tool should be available in the $group tool group');
       await tester.ensureVisible(toolButton);
-      await tester.tap(toolButton);
+      final visibleToolButton = toolButton.hitTestable();
+      await waitForFinder(visibleToolButton, attempts: 30);
+      await tester.tap(visibleToolButton);
       await $.pump();
       // Mobile keeps the tools sheet open to expose the active settings.
       // Tap its modal barrier so the armed tool can reach the page.


### PR DESCRIPTION
Android Patrol on PRs #829 and #830 attempted to tap the Select group while the mobile tool sheet was still below the viewport: the tab center was y=982 on a 914 px render view. The missed tap then produced a misleading missing pdf-tool-select failure.

Wait for the requested group tab, and subsequently a multi-tool tile, to become hit-testable before tapping. This keeps the journey on the real UI path and adapts to slow route transitions instead of adding a fixed delay.

Validation:

- example analysis: clean
- complete example widget suite: 55 passed
- authoritative Android validation: this PR Patrol job