### PR TITLE
perf(gpu): share tile transforms across passes

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -4984,6 +4984,16 @@ class _CompiledScene {
     ];
     final commandBuffers = <gpu.CommandBuffer>[];
     final passes = <gpu.RenderPass>[];
+    // Every pass targets the same group tile. Keep one immutable uniform view
+    // alive in the route-wide arena instead of re-emplacing identical bytes
+    // for each paint, source, and blend encoder.
+    final groupTransform = transient.emplace(_tileTransform(
+      pageToRaster,
+      groupRegion,
+      pixelRatio,
+      width,
+      height,
+    ));
 
     gpu.RenderPass createPaintPass(
       gpu.CommandBuffer commandBuffer,
@@ -5016,13 +5026,7 @@ class _CompiledScene {
           pass: pass,
           pipelines: pipelines,
           stats: stats,
-          transform: transient.emplace(_tileTransform(
-            pageToRaster,
-            groupRegion,
-            pixelRatio,
-            width,
-            height,
-          )),
+          transform: groupTransform,
           pageToRaster: pageToRaster,
           region: groupRegion,
           pixelRatio: pixelRatio,
@@ -5294,6 +5298,25 @@ class _CompiledScene {
       ...groups.retained,
       commandBuffers,
     ];
+    // The encoders below share target geometry. Their immutable BufferViews
+    // remain valid until every route command buffer completes because the
+    // transient arena is retained by each submission.
+    final pageTransform = transient.emplace(_tileTransform(
+      pageToRaster,
+      region,
+      pixelRatio,
+      width,
+      height,
+    ));
+    final sourceTransform = cropSource
+        ? transient.emplace(_tileTransform(
+            pageToRaster,
+            sourceRegion,
+            pixelRatio,
+            sourceWidth,
+            sourceHeight,
+          ))
+        : pageTransform;
 
     gpu.RenderPass createPaintPass(
       gpu.CommandBuffer commandBuffer,
@@ -5329,6 +5352,7 @@ class _CompiledScene {
 
     _GpuEncoder encoderFor(
       gpu.RenderPass pass, {
+      required gpu.BufferView transform,
       required Rect targetRegion,
       required int targetWidth,
       required int targetHeight,
@@ -5337,13 +5361,7 @@ class _CompiledScene {
           pass: pass,
           pipelines: pipelines,
           stats: stats,
-          transform: transient.emplace(_tileTransform(
-            pageToRaster,
-            targetRegion,
-            pixelRatio,
-            targetWidth,
-            targetHeight,
-          )),
+          transform: transform,
           pageToRaster: pageToRaster,
           region: targetRegion,
           pixelRatio: pixelRatio,
@@ -5370,6 +5388,7 @@ class _CompiledScene {
           stencil,
           clearValue: clearPaper ? paper.clearColor : null,
         ),
+        transform: pageTransform,
         targetRegion: region,
         targetWidth: width,
         targetHeight: height,
@@ -5418,6 +5437,7 @@ class _CompiledScene {
           sourceColor,
           sourceStencil,
         ),
+        transform: sourceTransform,
         targetRegion: sourceRegion,
         targetWidth: sourceWidth,
         targetHeight: sourceHeight,
@@ -5467,6 +5487,7 @@ class _CompiledScene {
         ..setColorBlendEnable(false);
       final blendEncoder = encoderFor(
         blendPass,
+        transform: pageTransform,
         targetRegion: region,
         targetWidth: width,
         targetHeight: height,

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -45,6 +45,19 @@ Future<int> _timeSettledImage(Future<ui.Image> Function() render) async {
   return clock.elapsedMicroseconds;
 }
 
+Future<void> _waitForGpuIdle(FlutterGpuTileRasterBackend backend) async {
+  for (var attempt = 0;
+      attempt < 100 && backend.stats.inFlightSubmissions != 0;
+      attempt++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  expect(
+    backend.stats.inFlightSubmissions,
+    0,
+    reason: 'the warm submission must retire before reuse accounting resets',
+  );
+}
+
 Future<(int, Uint8List)> _timePixels(Future<ui.Image> Function() render) async {
   final clock = Stopwatch()..start();
   final image = await render();
@@ -175,6 +188,7 @@ void main() {
       final warm = await session.rasterizeRegion(region, pixelRatio: 0.5);
       await warm.toByteData(format: ui.ImageByteFormat.rawRgba);
       warm.dispose();
+      await _waitForGpuIdle(backend);
       expect(backend.stats.analyticTextRuns, commands.length);
 
       backend.stats.reset();
@@ -271,6 +285,7 @@ void main() {
       final warm = await session.rasterizeRegion(region, pixelRatio: 0.5);
       await warm.toByteData(format: ui.ImageByteFormat.rawRgba);
       warm.dispose();
+      await _waitForGpuIdle(backend);
       expect(backend.stats.texturesUploaded, 1);
       final compileMicros = backend.stats.compileMicros;
       final compileCacheHits = backend.stats.textureCacheHits;
@@ -612,6 +627,11 @@ void main() {
       expect(backend.stats.offscreenGroupPasses, 16);
       expect(backend.stats.advancedBlendPasses, 32);
       expect(backend.stats.advancedBlendBlits, 32);
+      expect(
+        backend.stats.transientEmplacedBytes,
+        lessThanOrEqualTo(13440),
+        reason: 'identical tile transforms should be shared across passes',
+      );
       final attachmentsPerTile =
           gpu.gpuContext.doesSupportOffscreenMSAA ? 2 : 1;
       expect(
@@ -730,6 +750,11 @@ void main() {
       expect(backend.stats.offscreenGroupPasses, 16);
       expect(backend.stats.advancedBlendPasses, 32);
       expect(backend.stats.advancedBlendBlits, 32);
+      expect(
+        backend.stats.transientEmplacedBytes,
+        lessThanOrEqualTo(13440),
+        reason: 'identical group transforms should be shared across passes',
+      );
       // ignore: avoid_print
       print('flutter_gpu internal group blend benchmark: '
           'cold=${coldGpu}us '


### PR DESCRIPTION
## Summary

Compared with merged #833 on the same host, this reduces warm GPU issue time by **17.9%** for advanced blends inside an offscreen group and **4.0%** for the mixed group + page-blend route. Visual settle improves **5.7%** and **3.2%**, respectively. Transient uniform payload falls **23.4%** on both routes, with unchanged Canvas parity and corpus acceptance.

The GPU backend was rebuilding and emplacing the same immutable tile-transform uniform for every paint, source, and blend render pass. This change creates one route-lifetime `BufferView` for each distinct target geometry and shares it across encoders. Cropped advanced-blend sources retain their separate transform.

Benchmark tests now cap transient payload for both affected routes so duplicate transform uploads cannot silently return. They also explicitly wait for the warmed GPU submission to retire before resetting reuse counters; image readback and the completion callback are not ordered consistently on Linux.

<details>
<summary>Performance details</summary>

Balanced five-pair runs, candidate versus merged #833 on the same macOS host:

| Route | Metric | #833 | This PR | Change |
|---|---:|---:|---:|---:|
| Advanced blends inside group | issue median | 546 µs | 448 µs | **-17.9%** |
| Advanced blends inside group | settle median | 12,876 µs | 12,136 µs | **-5.7%** |
| Advanced blends inside group | transient payload / 16 tiles | 17,536 B | 13,440 B | **-23.4%** |
| Mixed group + page blend | issue median | 1,097 µs | 1,053 µs | **-4.0%** |
| Mixed group + page blend | settle median | 19,670 µs | 19,040 µs | **-3.2%** |
| Mixed group + page blend | transient payload / 16 tiles | 17,536 B | 13,440 B | **-23.4%** |

A deterministic two-tile advanced-blend stress fixture improved warm render by **4.9%** and aggregate issue time by **4.0%**, while transient payload fell from 880 B to 624 B (**-29.1%**). Mean Canvas difference remained 0.058.

Cold timing moved -2.5% for the internal-group fixture, -1.6% for the mixed fixture, and -0.4% for the stress fixture; compilation dominates those samples.

</details>

## Affected packages

- [x] `dart_pdf_editor_flutter_gpu`

## Change type

- [x] Performance change
- [x] Tests / fixtures only

## Validation

- [x] Targeted `fvm dart analyze`
- [x] Full native `flutter_gpu_tile_backend_test.dart`: 84 passed, 2 expected skips
- [x] Full native `gpu_benchmark_test.dart`
- [x] Native affected-route benchmarks with new allocation guards
- [x] Full system-font GPU corpus: 218 passed
  - Ghent: 49 accepted, 8 expected rejections
  - PDF.js: 177 accepted, 2 expected rejections
- [x] Same-host balanced benchmarks against merged #833

No rendering baselines changed. The corpus rejection set and reasons are identical to #833.

## Compatibility checklist

- [x] Flutter-only code remains inside the experimental Flutter GPU package.
- [x] No public API changes.
- [x] Cropped source targets keep their distinct geometry transform.
- [x] Buffer views remain owned by the transient arena until every submitted command buffer completes.

## Notes for reviewers

The optimization changes only uniform construction and lifetime. Render-pass ordering, pipelines, attachment ownership, clipping, and blend math are unchanged.

Replaces #835 because GitHub did not schedule check suites for that PR after its head was amended, force-pushed twice by Ben, and closed/reopened. This PR points at the same validated branch/head.
