### PR TITLE
perf(gpu): reuse sampler descriptors

### DIFF
--- a/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/native_perf_e2e_test.dart
@@ -129,6 +129,7 @@ Future<void> runNativeGpuPerfScenario() async {
         ),
       ),
     );
+    await _waitForGpuIdle(backend);
 
     expect(backend.stats.contextsSeen, 1);
     expect(backend.stats.sessionsCreated, 1);
@@ -156,6 +157,19 @@ Future<void> runNativeGpuPerfScenario() async {
     backend.clearImageCache();
     scene.dispose();
   }
+}
+
+Future<void> _waitForGpuIdle(FlutterGpuTileRasterBackend backend) async {
+  for (var attempt = 0;
+      attempt < 100 && backend.stats.inFlightSubmissions != 0;
+      attempt++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  expect(
+    backend.stats.inFlightSubmissions,
+    0,
+    reason: 'readback may complete before the GPU completion callback runs',
+  );
 }
 
 Future<_NativeGpuRaster?> _measureNativeGpuScenario(

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8713,6 +8713,15 @@ class _GpuEncoder {
     sourceAlphaBlendFactor: gpu.BlendFactor.zero,
     destinationAlphaBlendFactor: gpu.BlendFactor.one,
   );
+  // bindTexture reads these value fields synchronously. Keep the private
+  // descriptors immutable so dense image and blend runs do not allocate the
+  // same short-lived Dart object for every binding.
+  static final _nearestSampler = gpu.SamplerOptions();
+  static final _linearSampler = gpu.SamplerOptions(
+    minFilter: gpu.MinMagFilter.linear,
+    magFilter: gpu.MinMagFilter.linear,
+    mipFilter: gpu.MipFilter.linear,
+  );
 
   void setBlendMode(PdfBlendMode mode) {
     _paintBlend = switch (mode) {
@@ -9015,11 +9024,7 @@ class _GpuEncoder {
       pass.bindTexture(
         pipelines.textureSampler,
         texture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.linear,
-          magFilter: gpu.MinMagFilter.linear,
-          mipFilter: gpu.MipFilter.linear,
-        ),
+        sampler: _linearSampler,
       );
       _boundImageTexture = texture;
     }
@@ -9044,10 +9049,7 @@ class _GpuEncoder {
       ..bindTexture(
         pipelines.textureSampler,
         texture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-        ),
+        sampler: _nearestSampler,
       );
     _drawView(emplaceTransient(vertices.bytes), 6);
     pass.clearBindings();
@@ -9066,10 +9068,7 @@ class _GpuEncoder {
       ..bindTexture(
         pipelines.textureSampler,
         texture,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-        ),
+        sampler: _nearestSampler,
       );
     _drawView(emplaceTransient(vertices.bytes), 6);
     pass.clearBindings();
@@ -9101,18 +9100,12 @@ class _GpuEncoder {
       ..bindTexture(
         pipelines.blendBackdropSampler,
         backdrop,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-        ),
+        sampler: _nearestSampler,
       )
       ..bindTexture(
         pipelines.blendSourceSampler,
         source,
-        sampler: gpu.SamplerOptions(
-          minFilter: gpu.MinMagFilter.nearest,
-          magFilter: gpu.MinMagFilter.nearest,
-        ),
+        sampler: _nearestSampler,
       );
     _drawView(emplaceTransient(vertices.bytes), 6);
     pass.clearBindings();
@@ -9194,11 +9187,7 @@ class _GpuEncoder {
         ..bindTexture(
           pipelines.glyphSampler,
           atlas.texture,
-          sampler: gpu.SamplerOptions(
-            minFilter: gpu.MinMagFilter.nearest,
-            magFilter: gpu.MinMagFilter.nearest,
-            mipFilter: gpu.MipFilter.nearest,
-          ),
+          sampler: _nearestSampler,
         );
       _boundGlyphAtlas = atlas;
     }
@@ -9209,20 +9198,15 @@ class _GpuEncoder {
       gpu.Texture maskTexture, gpu.BufferView info) {
     _dropRetainedBindings();
     _defaultStencil();
-    final sampler = gpu.SamplerOptions(
-      minFilter: gpu.MinMagFilter.linear,
-      magFilter: gpu.MinMagFilter.linear,
-      mipFilter: gpu.MipFilter.linear,
-    );
     pass
       ..setColorBlendEquation(_paintBlend)
       ..bindPipeline(pipelines.softMask)
       ..bindUniform(pipelines.softMaskTransform, transform)
       ..bindUniform(pipelines.softMaskInfo, info)
       ..bindTexture(pipelines.softMaskContentSampler, contentTexture,
-          sampler: sampler)
+          sampler: _linearSampler)
       ..bindTexture(pipelines.softMaskMaskSampler, maskTexture,
-          sampler: sampler);
+          sampler: _linearSampler);
     _drawBuffer(vertices);
     pass.clearBindings();
   }
@@ -9234,11 +9218,6 @@ class _GpuEncoder {
       rule: rule,
       union: false,
       requiredClipBit: _activeClipBit,
-    );
-    final sampler = gpu.SamplerOptions(
-      minFilter: gpu.MinMagFilter.linear,
-      magFilter: gpu.MinMagFilter.linear,
-      mipFilter: gpu.MipFilter.linear,
     );
     pass
       ..setStencilReference(0)
@@ -9257,9 +9236,9 @@ class _GpuEncoder {
       // content sample too lets contentStencil supply the solid fill color,
       // while the second lookup still evaluates the PDF mask luminance/alpha.
       ..bindTexture(pipelines.softMaskContentSampler, maskTexture,
-          sampler: sampler)
+          sampler: _linearSampler)
       ..bindTexture(pipelines.softMaskMaskSampler, maskTexture,
-          sampler: sampler);
+          sampler: _linearSampler);
     _drawBuffer(cover);
     pass.clearBindings();
     _clearStencil(_pathMask);


### PR DESCRIPTION
## Summary

Compared with #836 on the same host, reusing immutable sampler descriptors reduces issue time by **8.8%** and aggregate issue time by **7.3%** in a sampler-heavy advanced-blend stress case. Ordinary image, group, and blend routes stay within **±2%**, with dense-texture settle improving **2.0%**. Canvas parity and all 218 corpus expectations are unchanged.

The native encoder was constructing short-lived `SamplerOptions` objects for every texture binding. Dense image and advanced-blend tiles repeat identical nearest/linear descriptors hundreds of times. This change keeps one private immutable nearest descriptor and one private immutable linear descriptor and reuses them across image, copy, blend, glyph, and soft-mask bindings.

It also fixes the native Patrol assertion race exposed on #836: image readback can finish just before Flutter GPU delivers the submission-completion callback, so the scenario now waits for `inFlightSubmissions == 0` before asserting completion counters. The assertions remain unchanged.

<details>
<summary>Performance details</summary>

Balanced five-pair runs, candidate versus #836's head on the same macOS host:

| Route | Metric | #836 | This PR | Change |
|---|---:|---:|---:|---:|
| 24-binding advanced-blend stress | issue median | 1,155 µs | 1,053 µs | **-8.8%** |
| 24-binding advanced-blend stress | aggregate issue median | 34,577 µs | 32,057 µs | **-7.3%** |
| Dense texture | issue median | 1,510 µs | 1,519 µs | +0.6% |
| Dense texture | settle median | 6,937 µs | 6,801 µs | **-2.0%** |
| Mixed group + page blend | issue median | 885 µs | 882 µs | -0.3% |
| Mixed group + page blend | settle median | 18,740 µs | 18,691 µs | -0.3% |
| Advanced blends inside group | issue median | 386 µs | 393 µs | +1.8% |
| Advanced blends inside group | settle median | 12,301 µs | 12,206 µs | -0.8% |

The focused stress fixture represents 24 different advanced blends, which previously created 48 identical sampler descriptors per tile. The ordinary routes show no material issue-time regression.

</details>

## Affected packages

- [x] `dart_pdf_editor_flutter_gpu`

## Change type

- [x] Performance change
- [x] Tests / fixtures only

## Validation

- [x] Targeted `fvm dart analyze`
- [x] Full native `flutter_gpu_tile_backend_test.dart`: 84 passed, 2 expected skips
- [x] Full system-font GPU corpus: 218 passed
  - Ghent: 49 accepted, 8 expected rejections
  - PDF.js: 177 accepted, 2 expected rejections
- [x] Same-host balanced stress and ordinary-route benchmarks against #836's head
- [x] Native Patrol GPU scenario through a temporary Metal widget-test wrapper

No rendering baselines changed. The corpus rejection set and reasons are identical to #836.

## Compatibility checklist

- [x] Flutter-only code remains inside the experimental Flutter GPU package.
- [x] No public API changes.
- [x] Sampler descriptors are private and never mutated.
- [x] `bindTexture` consumes descriptor fields synchronously; GPU resource ownership is unchanged.

## Notes for reviewers

This changes Dart allocation behavior only. Sampler values, texture bindings, pipeline order, render-pass structure, and shader inputs are unchanged.
