### PR TITLE
perf(gpu): reuse default stencil state

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8722,6 +8722,27 @@ class _GpuEncoder {
     magFilter: gpu.MinMagFilter.linear,
     mipFilter: gpu.MipFilter.linear,
   );
+  // setStencilConfig reads these value fields synchronously. Keep the private
+  // descriptors immutable so every ordinary path, glyph, and texture draw can
+  // reuse the same state instead of allocating one Dart object per draw.
+  static final _stencilDefaultNoClip = gpu.StencilConfig(
+    compareFunction: gpu.CompareFunction.always,
+    depthStencilPassOperation: gpu.StencilOperation.keep,
+    readMask: 0,
+    writeMask: 0,
+  );
+  static final _stencilDefaultClipA = gpu.StencilConfig(
+    compareFunction: gpu.CompareFunction.equal,
+    depthStencilPassOperation: gpu.StencilOperation.keep,
+    readMask: _clipBitA,
+    writeMask: 0,
+  );
+  static final _stencilDefaultClipB = gpu.StencilConfig(
+    compareFunction: gpu.CompareFunction.equal,
+    depthStencilPassOperation: gpu.StencilOperation.keep,
+    readMask: _clipBitB,
+    writeMask: 0,
+  );
 
   void setBlendMode(PdfBlendMode mode) {
     _paintBlend = switch (mode) {
@@ -9293,14 +9314,12 @@ class _GpuEncoder {
   void _defaultStencil() {
     pass
       ..setStencilReference(_activeClipBit)
-      ..setStencilConfig(gpu.StencilConfig(
-        compareFunction: _activeClipBit == 0
-            ? gpu.CompareFunction.always
-            : gpu.CompareFunction.equal,
-        depthStencilPassOperation: gpu.StencilOperation.keep,
-        readMask: _activeClipBit == 0 ? 0 : _activeClipBit,
-        writeMask: 0,
-      ));
+      ..setStencilConfig(switch (_activeClipBit) {
+        0 => _stencilDefaultNoClip,
+        _clipBitA => _stencilDefaultClipA,
+        _clipBitB => _stencilDefaultClipB,
+        _ => throw StateError('unsupported active clip bit: $_activeClipBit'),
+      });
   }
 }
 


### PR DESCRIPTION
## Headline comparison with parent/main

- Dense analytic-text issue time: **1500.5 us -> 1433.5 us (-4.5%)** across four balanced Metal pairs.
- Dense analytic-text settle time: **6988.5 us -> 6937.5 us (-0.7%)**.
- Internal advanced-group issue time: **effectively flat**; settle time improved **3.8%**.
- Dense-texture issue time was **+1.2% within run spread**; settle time was flat.

This reuses the three immutable default stencil-state descriptors selected by ordinary unclipped and clipped drawing. `RenderPass.setStencilConfig` reads their scalar fields synchronously, so the submitted state and rendered output are unchanged. The dense analytic benchmark avoids 3,840 short-lived `StencilConfig` allocations across its 15 x 256 draws.

<details>
<summary>Validation and measurement details</summary>

- `fvm flutter analyze`: pass after rebasing onto `main`.
- Full native package suite with Impeller/Flutter GPU: **319 passed, 4 expected skips**.
- System-font GPU corpus: **218 passed**.
  - Ghent: 49 accepted, 8 expected rejections.
  - PDF.js: 177 accepted, 2 expected rejections.
- Pixel-heavy nested-clip, advanced-blend, and soft-mask tests remain exact.
- Earlier broad stencil-descriptor reuse was deliberately narrowed to these three hot default states; no dynamic lookup or mutable shared state remains.

The benchmark figures are medians from balanced same-host Metal pairs against PR #837's head. Lower is better.
</details>
