### PR TITLE
perf(gpu): coalesce adjacent draw calls

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5788,9 +5788,41 @@ class _CompiledScene {
         ..setClip(_rootGpuClip)
         ..solid(paper.vertices);
     }
-    for (final unit in selected) {
-      final draw = draws[unit.commandIndex];
-      if (draw == null) continue;
+    var unitIndex = 0;
+    while (unitIndex < selected.length) {
+      final unit = selected[unitIndex];
+      var draw = draws[unit.commandIndex];
+      if (draw == null) {
+        unitIndex++;
+        continue;
+      }
+      var nextUnitIndex = unitIndex + 1;
+      final firstBuffer = _batchableDrawBuffer(draw);
+      if (firstBuffer != null) {
+        var lastDraw = draw;
+        var vertices = firstBuffer.vertices;
+        while (nextUnitIndex < selected.length) {
+          final nextUnit = selected[nextUnitIndex];
+          if (!identical(unit.clip, nextUnit.clip) ||
+              unit.blendMode != nextUnit.blendMode) {
+            break;
+          }
+          final nextDraw = draws[nextUnit.commandIndex];
+          if (nextDraw == null ||
+              !_canCoalesceGpuDraws(draw, lastDraw, nextDraw)) {
+            break;
+          }
+          vertices += _batchableDrawBuffer(nextDraw)!.vertices;
+          lastDraw = nextDraw;
+          nextUnitIndex++;
+        }
+        if (!identical(lastDraw, draw)) {
+          stats
+            ..coalescedDrawBatches += 1
+            ..drawCallsSaved += nextUnitIndex - unitIndex - 1;
+          draw = _coalescedGpuDraw(draw, lastDraw, vertices);
+        }
+      }
       encoder
         ..setClip(unit.clip)
         ..setBlendMode(unit.blendMode);
@@ -5800,6 +5832,7 @@ class _CompiledScene {
       } else {
         draw.encode(encoder);
       }
+      unitIndex = nextUnitIndex;
     }
     stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
     transient.flush();
@@ -8602,6 +8635,65 @@ class _AnalyticTextDraw implements _GpuDraw {
 
   @override
   void encode(_GpuEncoder encoder) => encoder.glyphs(vertices, atlas);
+}
+
+/// Returns the retained triangle-list range for draws whose complete varying
+/// state lives in their vertices and one immutable texture or glyph atlas.
+/// Stencil, gradient, mask, sequence, and group draws keep their pass boundary.
+_GpuBuffer? _batchableDrawBuffer(_GpuDraw draw) => switch (draw) {
+      _SolidDraw(:final vertices) when draw.runtimeType == _SolidDraw =>
+        vertices,
+      _TextureDraw(:final vertices) => vertices,
+      _AnalyticTextDraw(:final vertices) => vertices,
+      _ => null,
+    };
+
+/// Proves that [next] immediately extends the same ordered vertex stream as
+/// [last]. The shared clip and blend equation are checked by the caller.
+bool _canCoalesceGpuDraws(
+  _GpuDraw first,
+  _GpuDraw last,
+  _GpuDraw next,
+) {
+  final compatible = switch ((first, next)) {
+    (_SolidDraw(), _SolidDraw()) =>
+      first.runtimeType == _SolidDraw && next.runtimeType == _SolidDraw,
+    (
+      _TextureDraw(texture: final texture),
+      _TextureDraw(texture: final nextTexture),
+    ) =>
+      identical(texture, nextTexture),
+    (
+      _AnalyticTextDraw(atlas: final atlas),
+      _AnalyticTextDraw(atlas: final nextAtlas),
+    ) =>
+      identical(atlas, nextAtlas),
+    _ => false,
+  };
+  if (!compatible) return false;
+  final lastView = _batchableDrawBuffer(last)!.view;
+  final nextView = _batchableDrawBuffer(next)!.view;
+  return identical(lastView.buffer, nextView.buffer) &&
+      lastView.offsetInBytes + lastView.lengthInBytes == nextView.offsetInBytes;
+}
+
+_GpuDraw _coalescedGpuDraw(_GpuDraw first, _GpuDraw last, int vertices) {
+  final firstView = _batchableDrawBuffer(first)!.view;
+  final lastView = _batchableDrawBuffer(last)!.view;
+  final buffer = _GpuBuffer(vertices)
+    .._view = gpu.BufferView(
+      firstView.buffer,
+      offsetInBytes: firstView.offsetInBytes,
+      lengthInBytes: lastView.offsetInBytes +
+          lastView.lengthInBytes -
+          firstView.offsetInBytes,
+    );
+  return switch (first) {
+    _SolidDraw() when first.runtimeType == _SolidDraw => _SolidDraw(buffer),
+    _TextureDraw(:final texture) => _TextureDraw(buffer, texture),
+    _AnalyticTextDraw(:final atlas) => _AnalyticTextDraw(buffer, atlas),
+    _ => throw StateError('unsupported coalesced GPU draw'),
+  };
 }
 
 class _SoftMaskDraw implements _GpuDraw {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -41,6 +41,8 @@ class FlutterGpuTileBackendStats {
   int analyticTextFallbackRuns = 0;
   int glyphBindingReuses = 0;
   int imageBindingReuses = 0;
+  int coalescedDrawBatches = 0;
+  int drawCallsSaved = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
@@ -139,6 +141,8 @@ class FlutterGpuTileBackendStats {
         'analyticTextFallbackRuns': analyticTextFallbackRuns,
         'glyphBindingReuses': glyphBindingReuses,
         'imageBindingReuses': imageBindingReuses,
+        'coalescedDrawBatches': coalescedDrawBatches,
+        'drawCallsSaved': drawCallsSaved,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
@@ -237,6 +241,8 @@ class FlutterGpuTileBackendStats {
     analyticTextFallbackRuns = 0;
     glyphBindingReuses = 0;
     imageBindingReuses = 0;
+    coalescedDrawBatches = 0;
+    drawCallsSaved = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
@@ -312,6 +318,8 @@ class FlutterGpuTileBackendStats {
       'analyticFallbackRuns=$analyticTextFallbackRuns '
       'glyphBindingReuses=$glyphBindingReuses '
       'imageBindingReuses=$imageBindingReuses '
+      'coalescedDrawBatches=$coalescedDrawBatches '
+      'drawCallsSaved=$drawCallsSaved '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -95,6 +95,8 @@ void main() {
       ..analyticAtlasFallbacks = 1
       ..analyticSparseAtlasSkips = 3
       ..analyticTextFallbackRuns = 2
+      ..coalescedDrawBatches = 8
+      ..drawCallsSaved = 120
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
       ..subpixelStrokeFallbacks = 2
@@ -158,6 +160,8 @@ void main() {
     expect(stats.toJson(), containsPair('analyticAtlasFallbacks', 1));
     expect(stats.toJson(), containsPair('analyticSparseAtlasSkips', 3));
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
+    expect(stats.toJson(), containsPair('coalescedDrawBatches', 8));
+    expect(stats.toJson(), containsPair('drawCallsSaved', 120));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
     expect(stats.toJson(), containsPair('subpixelStrokeFallbacks', 2));
@@ -221,6 +225,8 @@ void main() {
     expect(stats.analyticAtlasFallbacks, 0);
     expect(stats.analyticSparseAtlasSkips, 0);
     expect(stats.analyticTextFallbackRuns, 0);
+    expect(stats.coalescedDrawBatches, 0);
+    expect(stats.drawCallsSaved, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);
     expect(stats.subpixelStrokeFallbacks, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1814,9 +1814,12 @@ void main() {
         difference += (expectedPixels[index] - actualPixels[index]).abs();
       }
       expect(difference / expectedPixels.length, lessThan(8));
-      expect(backend.stats.imageBindingReuses, 2,
-          reason: 'an adjacent texture change keeps static image state, while '
-              'the solid draw must invalidate it');
+      expect(backend.stats.imageBindingReuses, 1,
+          reason: 'the first adjacent pair emits one coalesced draw; the '
+              'alternate texture keeps static image state, while the solid '
+              'draw invalidates it');
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 1);
       expect(backend.stats.texturesUploaded, 2);
       expect(backend.stats.textureCacheMisses, 2);
       expect(backend.stats.textureCacheHits, 0,
@@ -1843,6 +1846,65 @@ void main() {
       expect(backend.stats.activeTextureLeases, 2);
       secondSession.dispose();
       expect(backend.stats.activeTextureLeases, 0);
+    });
+  });
+
+  testWidgets('coalesces solid draws only while paint state is identical',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      PdfFillMeshCommand triangle(
+        double left,
+        double bottom,
+        double right,
+        double top,
+        PdfColor color,
+        double alpha,
+      ) =>
+          PdfFillMeshCommand(
+            PdfMesh(
+              [
+                PdfMeshVertex(left, bottom, color),
+                PdfMeshVertex(right, bottom, color),
+                PdfMeshVertex((left + right) / 2, top, color),
+              ],
+              const [0, 1, 2],
+            ),
+            alpha,
+          );
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        triangle(60, 540, 250, 720, const PdfColor(0.85, 0.15, 0.25), 0.75),
+        triangle(150, 500, 340, 680, const PdfColor(0.15, 0.35, 0.9), 0.65),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        triangle(100, 460, 290, 640, const PdfColor(0.95, 0.75, 0.1), 0.7),
+        triangle(200, 420, 390, 600, const PdfColor(0.1, 0.8, 0.4), 0.6),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.5);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.5);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final expectedPixels = await _pixels(expected);
+      final actualPixels = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < expectedPixels.length; index++) {
+        difference += (expectedPixels[index] - actualPixels[index]).abs();
+      }
+      expect(difference / expectedPixels.length, lessThan(4));
+      expect(backend.stats.coalescedDrawBatches, 2,
+          reason: 'normal and Multiply draws form separate batches');
+      expect(backend.stats.drawCallsSaved, 2);
     });
   });
 
@@ -5783,8 +5845,11 @@ void main() {
       }
       expect(difference / expectedPixels.length, lessThan(8));
       expect(backend.stats.analyticTextRuns, 3);
-      expect(backend.stats.glyphBindingReuses, 1,
-          reason: 'the solid draw must invalidate the retained atlas state');
+      expect(backend.stats.glyphBindingReuses, 0,
+          reason: 'the adjacent runs emit one coalesced draw, then the solid '
+              'draw invalidates the retained atlas state');
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 1);
     });
   });
 


### PR DESCRIPTION
## Result

Against current main (#840) on the same Metal host, adjacent draw coalescing reduced dense analytic submission CPU from **1,256 us to 238 us (-81.0%)** and dense texture submission from **1,296 us to 313 us (-75.9%)**. Settle time improved **55.0%** and **74.5%**, respectively.

<details>
<summary>Implementation and validation</summary>

The simple retained route now combines adjacent solid, texture, and analytic-text draws only when their complete native state matches and their retained buffer views are exactly contiguous. Solid-paper draws are excluded, clips and blend state must be identical, and texture/atlas identity must match. Advanced destination-sampling and offscreen-group routes are unchanged.

Four balanced same-host Metal pairs, alternating base and candidate order:

- Analytic issue: 1,255.5 -> 238 us (-81.0%)
- Analytic settle: 6,742.5 -> 3,037.5 us (-55.0%)
- Texture issue: 1,295.5 -> 312.5 us (-75.9%)
- Texture settle: 6,966 -> 1,773.5 us (-74.5%)

Every candidate pair improved. The 256-draw fixtures report 15 coalesced batches and 3,825 saved native draw calls. Real Ghent page GWG090 records 22 batches and 206 saved calls across cold and warm tiles with unchanged Canvas parity; its wall time is intentionally not used as performance evidence because the individual run was noisy.

Validation:

- fvm flutter analyze
- Full native Flutter GPU suite: 320 passed, 4 expected skips
- Rebased focused native suite: 87 passed, 2 expected environment skips
- System-font GPU corpus: 218 passed
  - Ghent: 49 accepted, 8 expected rejections
  - PDF.js: 177 accepted, 2 expected rejections
- Exact regression coverage for matching and intervening clip/blend/texture/buffer state

No rendering baseline or corpus route changed.

</details>
