### PR TITLE
perf(gpu): coalesce opaque hairlines

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5822,6 +5822,35 @@ class _CompiledScene {
             ..drawCallsSaved += nextUnitIndex - unitIndex - 1;
           draw = _coalescedGpuDraw(draw, lastDraw, vertices);
         }
+      } else if (draw is _HairlineDraw &&
+          unit.blendMode == PdfBlendMode.normal &&
+          draw.alpha == 1) {
+        final subpaths = <FlatSubpath>[...draw.subpaths];
+        while (nextUnitIndex < selected.length) {
+          final nextUnit = selected[nextUnitIndex];
+          if (!identical(unit.clip, nextUnit.clip) ||
+              nextUnit.blendMode != PdfBlendMode.normal) {
+            break;
+          }
+          final nextDraw = draws[nextUnit.commandIndex];
+          if (nextDraw is! _HairlineDraw ||
+              !_sameOpaqueHairline(draw, nextDraw)) {
+            break;
+          }
+          subpaths.addAll(nextDraw.subpaths);
+          nextUnitIndex++;
+        }
+        if (nextUnitIndex > unitIndex + 1) {
+          stats
+            ..coalescedDrawBatches += 1
+            ..drawCallsSaved += 2 * (nextUnitIndex - unitIndex - 1);
+          draw = _HairlineDraw(
+            List.unmodifiable(subpaths),
+            draw.color,
+            draw.stroke,
+            draw.alpha,
+          );
+        }
       }
       encoder
         ..setClip(unit.clip)
@@ -8696,6 +8725,24 @@ _GpuDraw _coalescedGpuDraw(_GpuDraw first, _GpuDraw last, int vertices) {
   };
 }
 
+/// Fully opaque source-over is idempotent at each raster sample, so adjacent
+/// matching hairlines can share one stencil union even when their contours
+/// overlap. Other blend equations and translucent sources deliberately keep
+/// their individual stencil/cover pairs because repeated coverage changes the
+/// result there.
+bool _sameOpaqueHairline(_HairlineDraw first, _HairlineDraw next) {
+  final a = first.color, b = next.color;
+  final firstStroke = first.stroke, nextStroke = next.stroke;
+  return next.alpha == 1 &&
+      a.red == b.red &&
+      a.green == b.green &&
+      a.blue == b.blue &&
+      firstStroke.width == nextStroke.width &&
+      firstStroke.cap == nextStroke.cap &&
+      firstStroke.join == nextStroke.join &&
+      firstStroke.miterLimit == nextStroke.miterLimit;
+}
+
 class _SoftMaskDraw implements _GpuDraw {
   const _SoftMaskDraw(
       this.vertices, this.contentTexture, this.maskTexture, this.info);
@@ -9088,15 +9135,28 @@ class _GpuEncoder {
         );
     _setBlendEquation(_noWrite);
     pass
-      ..setStencilReference(requiredClipBit)
       ..bindPipeline(pipelines.stencil)
       ..bindUniform(pipelines.stencilTransform, transform);
     if (union) {
-      pass.setStencilConfig(config(gpu.StencilOperation.incrementWrap));
+      // A union only needs one path bit. Setting it is idempotent, so any
+      // number of overlapping contours stays non-zero; incrementing the
+      // six-bit scratch field would wrap after 64 overlapping fragments.
+      pass
+        ..setStencilReference(requiredClipBit | 1)
+        ..setStencilConfig(gpu.StencilConfig(
+          compareFunction: compare,
+          depthStencilPassOperation: gpu.StencilOperation.setToReferenceValue,
+          stencilFailureOperation: gpu.StencilOperation.keep,
+          readMask: requiredClipBit == 0 ? 0 : requiredClipBit,
+          writeMask: 1,
+        ));
     } else if (rule == PdfFillRule.evenOdd) {
-      pass.setStencilConfig(config(gpu.StencilOperation.invert));
+      pass
+        ..setStencilReference(requiredClipBit)
+        ..setStencilConfig(config(gpu.StencilOperation.invert));
     } else {
       pass
+        ..setStencilReference(requiredClipBit)
         ..setStencilConfig(
           config(gpu.StencilOperation.incrementWrap),
           targetFace: gpu.StencilFace.front,

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -604,6 +604,124 @@ void main() {
     });
   });
 
+  testWidgets(
+      'coalesces matching opaque hairlines without merging alpha or blend',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const stroke = PdfStroke(width: 0, cap: 1, join: 1);
+      const color = PdfColor(0.08, 0.24, 0.82);
+      const first = PdfPath([
+        PdfMoveTo(80, 180),
+        PdfLineTo(500, 500),
+      ]);
+      const second = PdfPath([
+        PdfMoveTo(80, 500),
+        PdfLineTo(500, 180),
+      ]);
+      const translucent = PdfPath([
+        PdfMoveTo(80, 340),
+        PdfLineTo(500, 340),
+      ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, const [
+        PdfStrokePathCommand(first, color, stroke, 1),
+        PdfStrokePathCommand(second, color, stroke, 1),
+        PdfStrokePathCommand(translucent, color, stroke, 0.5),
+        PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        PdfStrokePathCommand(first, color, stroke, 1),
+        PdfStrokePathCommand(second, color, stroke, 1),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 2,
+          reason: 'two opaque hairlines share one stencil and one cover; '
+              'the translucent and Multiply lines keep their own pairs');
+    });
+  });
+
+  testWidgets('opaque hairline unions stay set past the stencil counter range',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const path = PdfPath([
+        PdfMoveTo(80, 300),
+        PdfLineTo(500, 300),
+      ]);
+      const stroke = PdfStroke(width: 0, cap: 1, join: 1);
+      const color = PdfColor(0.08, 0.24, 0.82);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        for (var index = 0; index < 64; index++)
+          const PdfStrokePathCommand(path, color, stroke, 1),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend(msaa: false);
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      (int, int) darkest(Uint8List pixels) {
+        var best = -1, value = 4 * 255;
+        for (var y = 489; y <= 495; y++) {
+          final offset = 4 * (y * expected.width + 300);
+          final sum = pixels[offset] +
+              pixels[offset + 1] +
+              pixels[offset + 2] +
+              pixels[offset + 3];
+          if (sum < value) {
+            value = sum;
+            best = offset;
+          }
+        }
+        return (best, value);
+      }
+
+      final expectedDarkest = darkest(a), actualDarkest = darkest(b);
+      expect(expectedDarkest.$1, isNonNegative);
+      expect(actualDarkest.$1, isNonNegative);
+      expect(actualDarkest.$2, lessThan(900));
+      expect(
+        (a[expectedDarkest.$1] - b[actualDarkest.$1]).abs() +
+            (a[expectedDarkest.$1 + 1] - b[actualDarkest.$1 + 1]).abs() +
+            (a[expectedDarkest.$1 + 2] - b[actualDarkest.$1 + 2]).abs(),
+        lessThan(40),
+        reason: '64 overlapping contours must set rather than wrap the '
+            'six-bit path stencil back to zero',
+      );
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 126);
+    });
+  });
+
   testWidgets('sub-MSAA positive strokes request exact Canvas fallback',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Performance versus current `main`

Balanced same-host benchmark on Apple GPU, alternating base/candidate order across four pairs with 256 heavily overlapping opaque hairlines and 15 settled tiles:

- **Issue median: 3,087 → 1,024 µs (-66.8%)**
- **Settle median: 32,035 → 4,981 µs (-84.5%)**
- The candidate won every paired sample and reported 15 coalesced batches / 7,650 saved draw calls (510 per tile).

## What changed

- Coalesce only consecutive zero-width strokes with the same clip, normal blend mode, full opacity, RGB color, cap, join, and miter limit.
- Submit the combined contours through one stencil union and one cover draw.
- Make stencil unions idempotently set a scratch bit instead of incrementing a six-bit counter. This prevents 64 overlapping contours from wrapping the stencil back to zero.
- Keep translucent strokes, non-normal blends, differing styles, and interrupted painter order as separate draw pairs.

The idempotent union change is the correctness basis for batching an unbounded number of overlapping hairlines, so it is included with the optimization and covered by a regression that fails with the old incrementing implementation.

<details>
<summary>Validation and benchmark details</summary>

- `fvm flutter analyze`: clean after rebase.
- Focused native backend suite after rebase: 87 passed, 2 expected environment skips.
- Full native package suite on the final change: 322 passed, 4 expected environment skips.
- System-font GPU corpus: all 218 fixtures passed; routes unchanged (Ghent 49 GPU / 8 exact fallbacks, PDF.js 177 GPU / 2 exact fallbacks).
- Canvas parity regression covers crossing opaque hairlines and proves translucent and Multiply strokes do not merge.
- A 64-identical-hairline regression proves the union remains painted past the old stencil counter range and reports 126 saved draw calls.
- Benchmark medians use four balanced base/candidate pairs on the same host, alternating execution order. Base issue samples: 3086.7, 3044.1, 3124.8, 3086.5 µs. Candidate: 1018.0, 1017.3, 1030.3, 1074.2 µs. Base settle: 33126, 31672, 32397, 31225 µs. Candidate: 4752, 5436, 5135, 4827 µs.

</details>
