### PR TITLE
perf(gpu): coalesce opaque stroke unions

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5822,6 +5822,34 @@ class _CompiledScene {
             ..drawCallsSaved += nextUnitIndex - unitIndex - 1;
           draw = _coalescedGpuDraw(draw, lastDraw, vertices);
         }
+      } else if (draw is _StencilDraw &&
+          unit.blendMode == PdfBlendMode.normal &&
+          draw.opaqueUnion != null) {
+        final batch = <_StencilDraw>[draw];
+        while (nextUnitIndex < selected.length &&
+            batch.length < _maxOpaqueStencilBatchDraws) {
+          final nextUnit = selected[nextUnitIndex];
+          if (!identical(unit.clip, nextUnit.clip) ||
+              nextUnit.blendMode != PdfBlendMode.normal) {
+            break;
+          }
+          final nextDraw = draws[nextUnit.commandIndex];
+          if (nextDraw is! _StencilDraw ||
+              !_sameOpaqueStencilUnion(draw, nextDraw)) {
+            break;
+          }
+          batch.add(nextDraw);
+          nextUnitIndex++;
+        }
+        if (batch.length > 1) {
+          stats
+            ..coalescedDrawBatches += 1
+            ..drawCallsSaved += batch.length - 1;
+          draw = _OpaqueStencilBatchDraw(
+            batch,
+            draw.opaqueUnion!.color,
+          );
+        }
       } else if (draw is _HairlineDraw &&
           unit.blendMode == PdfBlendMode.normal &&
           draw.alpha == 1) {
@@ -7886,6 +7914,7 @@ _StencilDraw? _stencilDraw(
     _coverGeometry(geometry, parts.$2, rgba),
     rule,
     union,
+    opaqueUnion: union && a == 1 ? (bounds: parts.$2, color: color) : null,
   );
 }
 
@@ -7916,6 +7945,12 @@ _StencilDraw? _stencilDraw(
 _GpuBuffer _coverGeometry(
     _GpuGeometryArena geometry, FlatBounds bounds, List<double> rgba) {
   final cover = FloatBuilder(36);
+  _appendCoverVertices(cover, bounds, rgba);
+  return geometry.add(cover.bytes, 6);
+}
+
+void _appendCoverVertices(
+    FloatBuilder cover, FlatBounds bounds, List<double> rgba) {
   for (final (x, y) in <(double, double)>[
     (bounds.left, bounds.bottom),
     (bounds.right, bounds.bottom),
@@ -7926,7 +7961,6 @@ _GpuBuffer _coverGeometry(
   ]) {
     cover.add6(x, y, rgba[0], rgba[1], rgba[2], rgba[3]);
   }
-  return geometry.add(cover.bytes, 6);
 }
 
 List<double> _premul(PdfColor color, double alpha) => [
@@ -8601,15 +8635,27 @@ class _PaperDraw extends _SolidDraw {
 }
 
 class _StencilDraw implements _GpuDraw {
-  const _StencilDraw(this.fan, this.cover, this.rule, this.union);
+  const _StencilDraw(this.fan, this.cover, this.rule, this.union,
+      {this.opaqueUnion});
   final _GpuBuffer fan;
   final _GpuBuffer cover;
   final PdfFillRule rule;
   final bool union;
+  final ({FlatBounds bounds, PdfColor color})? opaqueUnion;
 
   @override
   void encode(_GpuEncoder encoder) =>
       encoder.stencil(fan, cover, rule: rule, union: union);
+}
+
+class _OpaqueStencilBatchDraw implements _GpuDraw {
+  const _OpaqueStencilBatchDraw(this.draws, this.color);
+
+  final List<_StencilDraw> draws;
+  final PdfColor color;
+
+  @override
+  void encode(_GpuEncoder encoder) => encoder.opaqueStencilBatch(draws, color);
 }
 
 /// A PDF zero-width stroke. Its source polyline is retained with the scene,
@@ -8677,6 +8723,11 @@ _GpuBuffer? _batchableDrawBuffer(_GpuDraw draw) => switch (draw) {
       _ => null,
     };
 
+// One cover quad is rebuilt per selected stroke at tile time. Bound that
+// transient upload on adversarial streams while still collapsing dense CAD
+// runs into a small number of batches.
+const _maxOpaqueStencilBatchDraws = 256;
+
 /// Proves that [next] immediately extends the same ordered vertex stream as
 /// [last]. The shared clip and blend equation are checked by the caller.
 bool _canCoalesceGpuDraws(
@@ -8741,6 +8792,15 @@ bool _sameOpaqueHairline(_HairlineDraw first, _HairlineDraw next) {
       firstStroke.cap == nextStroke.cap &&
       firstStroke.join == nextStroke.join &&
       firstStroke.miterLimit == nextStroke.miterLimit;
+}
+
+bool _sameOpaqueStencilUnion(_StencilDraw first, _StencilDraw next) {
+  final a = first.opaqueUnion, b = next.opaqueUnion;
+  return a != null &&
+      b != null &&
+      a.color.red == b.color.red &&
+      a.color.green == b.color.green &&
+      a.color.blue == b.color.blue;
 }
 
 class _SoftMaskDraw implements _GpuDraw {
@@ -8995,6 +9055,38 @@ class _GpuEncoder {
     _accumulateStencil(fan,
         rule: rule, union: union, requiredClipBit: _activeClipBit);
     _paintStencilCover(cover.view, cover.vertices);
+  }
+
+  void opaqueStencilBatch(List<_StencilDraw> draws, PdfColor color) {
+    _dropRetainedBindings();
+    _appliedDefaultStencilBit = null;
+    final compare = _activeClipBit == 0
+        ? gpu.CompareFunction.always
+        : gpu.CompareFunction.equal;
+    _setBlendEquation(_noWrite);
+    pass
+      ..bindPipeline(pipelines.stencil)
+      ..bindUniform(pipelines.stencilTransform, transform)
+      ..setStencilReference(_activeClipBit | 1)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: compare,
+        depthStencilPassOperation: gpu.StencilOperation.setToReferenceValue,
+        stencilFailureOperation: gpu.StencilOperation.keep,
+        readMask: _activeClipBit == 0 ? 0 : _activeClipBit,
+        writeMask: 1,
+      ));
+    for (final draw in draws) {
+      _drawBuffer(draw.fan);
+    }
+    final rgba = _premul(color, 1);
+    final cover = FloatBuilder(draws.length * 36);
+    for (final draw in draws) {
+      _appendCoverVertices(cover, draw.opaqueUnion!.bounds, rgba);
+    }
+    _paintStencilCover(
+      emplaceTransient(cover.bytes),
+      cover.length ~/ 6,
+    );
   }
 
   void hairline(List<FlatSubpath> subpaths, PdfColor color, PdfStroke stroke,

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -605,6 +605,97 @@ void main() {
   });
 
   testWidgets(
+      'coalesces matching opaque stroke unions without merging alpha or blend',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const stroke = PdfStroke(width: 8, cap: 1, join: 1);
+      const color = PdfColor(0.08, 0.24, 0.82);
+      const first = PdfPath([
+        PdfMoveTo(80, 180),
+        PdfLineTo(500, 500),
+      ]);
+      const second = PdfPath([
+        PdfMoveTo(80, 500),
+        PdfLineTo(500, 180),
+      ]);
+      const translucent = PdfPath([
+        PdfMoveTo(80, 340),
+        PdfLineTo(500, 340),
+      ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, const [
+        PdfStrokePathCommand(first, color, stroke, 1),
+        PdfStrokePathCommand(second, color, stroke, 1),
+        PdfStrokePathCommand(translucent, color, stroke, 0.5),
+        PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        PdfStrokePathCommand(first, color, stroke, 1),
+        PdfStrokePathCommand(second, color, stroke, 1),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 1,
+          reason: 'two opaque strokes keep their two stencil fans and share '
+              'one cover; the translucent and Multiply strokes stay split');
+    });
+  });
+
+  testWidgets('bounds opaque stroke batches to one 256-cover upload',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const path = PdfPath([
+        PdfMoveTo(80, 300),
+        PdfLineTo(500, 300),
+      ]);
+      const stroke = PdfStroke(width: 8, cap: 1, join: 1);
+      const color = PdfColor(0.08, 0.24, 0.82);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        for (var index = 0; index < 257; index++)
+          const PdfStrokePathCommand(path, color, stroke, 1),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend(msaa: false);
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final image = await session.rasterizeRegion(
+        Offset.zero & scene.pageSize,
+        pixelRatio: 0.25,
+      );
+      await _pixels(image);
+      image.dispose();
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 255,
+          reason: 'the 257th stroke begins a new bounded batch');
+    });
+  });
+
+  testWidgets(
       'coalesces matching opaque hairlines without merging alpha or blend',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Performance versus current `main`

Balanced same-host Apple GPU benchmark on PDF.js `standard_fonts.pdf` page 0, alternating base/candidate order across four pairs:

- **Cold tile median: 31.82 → 26.41 ms (-17.0%)**
- **Warm tile median: 15.49 → 12.71 ms (-17.9%)**
- The candidate won every cold and warm paired sample; Canvas difference was identical in all runs.

The 256-stroke submission stress case also reduced issue time **1,773 → 951 µs (-46.4%)** in every pair. Its GPU-bound settled median was effectively flat at 50.39 → 50.16 ms (-0.5%).

## What changed

- Coalesce only consecutive positive-width stroke unions with the same clip, normal blend mode, full opacity, and RGB color.
- Accumulate their retained stencil fans under one idempotent union state, then paint all original bounds with one combined cover draw.
- Keep per-stroke cover quads, so batching does not inflate sparse strokes into one large bounding rectangle.
- Cap each batch at 256 strokes, bounding the transient cover upload on adversarial content.
- Leave translucent strokes, non-normal blends, differing colors, fills, masks, and interrupted painter order unchanged.

<details>
<summary>Validation, corpus applicability, and raw benchmark data</summary>

- `fvm flutter analyze`: clean on the rebased PR head.
- Focused native backend suite: 89 passed, 2 expected environment skips.
- Full native package suite: 324 passed, 4 expected environment skips.
- System-font GPU corpus: all 218 tests passed; routes remained Ghent 49 GPU / 8 exact fallbacks and PDF.js 177 GPU / 2 exact fallbacks.
- Corpus instrumentation found 661 additional saved draw calls across 17 accepted pages; 596 were on the two `standard_fonts.pdf` pages.
- Parity regression covers overlapping opaque strokes and proves translucent and Multiply strokes remain separate.
- A 257-stroke regression proves the cover upload stops at 256 and the final stroke starts a bounded new batch.

`standard_fonts.pdf` page 0 raw cold/warm µs:

- Base: 30089/15239, 33034/15737, 30601/13261, 34068/16752
- Candidate: 28680/12405, 25621/11388, 26190/13022, 26633/13054

256-stroke stress issue µs:

- Base: 1800.5, 1731.0, 1803.2, 1745.8
- Candidate: 958.7, 915.1, 948.5, 952.8

</details>
