### PR TITLE
perf(gpu): coalesce disjoint opaque fills

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5823,11 +5823,12 @@ class _CompiledScene {
           draw = _coalescedGpuDraw(draw, lastDraw, vertices);
         }
       } else if (draw is _StencilDraw &&
+          draw.union &&
           unit.blendMode == PdfBlendMode.normal &&
-          draw.opaqueUnion != null) {
+          draw.opaquePaint != null) {
         final batch = <_StencilDraw>[draw];
         while (nextUnitIndex < selected.length &&
-            batch.length < _maxOpaqueStencilBatchDraws) {
+            batch.length < _maxOpaqueStencilBatchPaints) {
           final nextUnit = selected[nextUnitIndex];
           if (!identical(unit.clip, nextUnit.clip) ||
               nextUnit.blendMode != PdfBlendMode.normal) {
@@ -5847,7 +5848,36 @@ class _CompiledScene {
             ..drawCallsSaved += batch.length - 1;
           draw = _OpaqueStencilBatchDraw(
             batch,
-            draw.opaqueUnion!.color,
+            draw.opaquePaint!.color,
+          );
+        }
+      } else if (draw is _StencilDraw &&
+          !draw.union &&
+          unit.blendMode == PdfBlendMode.normal &&
+          draw.opaquePaint != null) {
+        final batch = <_StencilDraw>[draw];
+        while (nextUnitIndex < selected.length &&
+            batch.length < _maxOpaqueStencilBatchPaints) {
+          final nextUnit = selected[nextUnitIndex];
+          if (!identical(unit.clip, nextUnit.clip) ||
+              nextUnit.blendMode != PdfBlendMode.normal) {
+            break;
+          }
+          final nextDraw = draws[nextUnit.commandIndex];
+          if (nextDraw is! _StencilDraw ||
+              !_sameDisjointOpaqueFill(draw, batch, nextDraw)) {
+            break;
+          }
+          batch.add(nextDraw);
+          nextUnitIndex++;
+        }
+        if (batch.length > 1) {
+          stats
+            ..coalescedDrawBatches += 1
+            ..drawCallsSaved += batch.length - 1;
+          draw = _OpaqueStencilFillBatchDraw(
+            batch,
+            draw.rule,
           );
         }
       } else if (draw is _HairlineDraw &&
@@ -7914,7 +7944,7 @@ _StencilDraw? _stencilDraw(
     _coverGeometry(geometry, parts.$2, rgba),
     rule,
     union,
-    opaqueUnion: union && a == 1 ? (bounds: parts.$2, color: color) : null,
+    opaquePaint: a == 1 ? (bounds: parts.$2, color: color) : null,
   );
 }
 
@@ -8636,12 +8666,12 @@ class _PaperDraw extends _SolidDraw {
 
 class _StencilDraw implements _GpuDraw {
   const _StencilDraw(this.fan, this.cover, this.rule, this.union,
-      {this.opaqueUnion});
+      {this.opaquePaint});
   final _GpuBuffer fan;
   final _GpuBuffer cover;
   final PdfFillRule rule;
   final bool union;
-  final ({FlatBounds bounds, PdfColor color})? opaqueUnion;
+  final ({FlatBounds bounds, PdfColor color})? opaquePaint;
 
   @override
   void encode(_GpuEncoder encoder) =>
@@ -8656,6 +8686,17 @@ class _OpaqueStencilBatchDraw implements _GpuDraw {
 
   @override
   void encode(_GpuEncoder encoder) => encoder.opaqueStencilBatch(draws, color);
+}
+
+class _OpaqueStencilFillBatchDraw implements _GpuDraw {
+  const _OpaqueStencilFillBatchDraw(this.draws, this.rule);
+
+  final List<_StencilDraw> draws;
+  final PdfFillRule rule;
+
+  @override
+  void encode(_GpuEncoder encoder) =>
+      encoder.opaqueStencilFillBatch(draws, rule);
 }
 
 /// A PDF zero-width stroke. Its source polyline is retained with the scene,
@@ -8723,10 +8764,10 @@ _GpuBuffer? _batchableDrawBuffer(_GpuDraw draw) => switch (draw) {
       _ => null,
     };
 
-// One cover quad is rebuilt per selected stroke at tile time. Bound that
-// transient upload on adversarial streams while still collapsing dense CAD
-// runs into a small number of batches.
-const _maxOpaqueStencilBatchDraws = 256;
+// One cover quad is rebuilt per selected paint at tile time. Bound that
+// transient upload on adversarial streams while still collapsing dense runs
+// into a small number of batches.
+const _maxOpaqueStencilBatchPaints = 256;
 
 /// Proves that [next] immediately extends the same ordered vertex stream as
 /// [last]. The shared clip and blend equation are checked by the caller.
@@ -8795,13 +8836,34 @@ bool _sameOpaqueHairline(_HairlineDraw first, _HairlineDraw next) {
 }
 
 bool _sameOpaqueStencilUnion(_StencilDraw first, _StencilDraw next) {
-  final a = first.opaqueUnion, b = next.opaqueUnion;
+  final a = first.opaquePaint, b = next.opaquePaint;
   return a != null &&
       b != null &&
+      next.union &&
       a.color.red == b.color.red &&
       a.color.green == b.color.green &&
       a.color.blue == b.color.blue;
 }
+
+bool _sameDisjointOpaqueFill(
+  _StencilDraw first,
+  List<_StencilDraw> batch,
+  _StencilDraw next,
+) {
+  final a = first.opaquePaint, b = next.opaquePaint;
+  return a != null &&
+      b != null &&
+      !next.union &&
+      first.rule == next.rule &&
+      batch.every(
+          (draw) => _strictlyDisjoint(draw.opaquePaint!.bounds, b.bounds));
+}
+
+bool _strictlyDisjoint(FlatBounds a, FlatBounds b) =>
+    a.right < b.left ||
+    b.right < a.left ||
+    a.bottom < b.top ||
+    b.bottom < a.top;
 
 class _SoftMaskDraw implements _GpuDraw {
   const _SoftMaskDraw(
@@ -9078,10 +9140,67 @@ class _GpuEncoder {
     for (final draw in draws) {
       _drawBuffer(draw.fan);
     }
+    _paintOpaqueStencilBatchCover(draws, color);
+  }
+
+  void opaqueStencilFillBatch(
+    List<_StencilDraw> draws,
+    PdfFillRule rule,
+  ) {
+    _dropRetainedBindings();
+    _appliedDefaultStencilBit = null;
+    final compare = _activeClipBit == 0
+        ? gpu.CompareFunction.always
+        : gpu.CompareFunction.equal;
+    gpu.StencilConfig config(gpu.StencilOperation operation) =>
+        gpu.StencilConfig(
+          compareFunction: compare,
+          depthStencilPassOperation: operation,
+          stencilFailureOperation: gpu.StencilOperation.keep,
+          readMask: _activeClipBit == 0 ? 0 : _activeClipBit,
+          writeMask: _pathMask,
+        );
+    _setBlendEquation(_noWrite);
+    pass
+      ..bindPipeline(pipelines.stencil)
+      ..bindUniform(pipelines.stencilTransform, transform)
+      ..setStencilReference(_activeClipBit);
+    if (rule == PdfFillRule.evenOdd) {
+      pass.setStencilConfig(config(gpu.StencilOperation.invert));
+    } else {
+      pass
+        ..setStencilConfig(
+          config(gpu.StencilOperation.incrementWrap),
+          targetFace: gpu.StencilFace.front,
+        )
+        ..setStencilConfig(
+          config(gpu.StencilOperation.decrementWrap),
+          targetFace: gpu.StencilFace.back,
+        );
+    }
+    for (final draw in draws) {
+      _drawBuffer(draw.fan);
+    }
+    _paintOpaqueStencilFillBatchCover(draws);
+  }
+
+  void _paintOpaqueStencilFillBatchCover(List<_StencilDraw> draws) {
+    final cover = FloatBuilder(draws.length * 36);
+    for (final draw in draws) {
+      final paint = draw.opaquePaint!;
+      _appendCoverVertices(cover, paint.bounds, _premul(paint.color, 1));
+    }
+    _paintStencilCover(
+      emplaceTransient(cover.bytes),
+      cover.length ~/ 6,
+    );
+  }
+
+  void _paintOpaqueStencilBatchCover(List<_StencilDraw> draws, PdfColor color) {
     final rgba = _premul(color, 1);
     final cover = FloatBuilder(draws.length * 36);
     for (final draw in draws) {
-      _appendCoverVertices(cover, draw.opaqueUnion!.bounds, rgba);
+      _appendCoverVertices(cover, draw.opaquePaint!.bounds, rgba);
     }
     _paintStencilCover(
       emplaceTransient(cover.bytes),

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -605,6 +605,93 @@ void main() {
   });
 
   testWidgets(
+      'coalesces disjoint opaque fills without merging overlap alpha or blend',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const color = PdfColor(0.08, 0.24, 0.82);
+      const otherColor = PdfColor(0.82, 0.18, 0.12);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(
+          _rect(60, 100, 150, 190),
+          color,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(190, 100, 280, 190),
+          otherColor,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(240, 140, 330, 230),
+          color,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(370, 100, 460, 190),
+          color,
+          PdfFillRule.nonzero,
+          0.5,
+        ),
+        PdfFillPathCommand(
+          _rect(60, 270, 150, 360),
+          color,
+          PdfFillRule.evenOdd,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(190, 270, 280, 360),
+          otherColor,
+          PdfFillRule.evenOdd,
+          1,
+        ),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        PdfFillPathCommand(
+          _rect(60, 420, 150, 510),
+          color,
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(190, 420, 280, 510),
+          color,
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(backend.stats.coalescedDrawBatches, 2);
+      expect(backend.stats.drawCallsSaved, 2,
+          reason: 'the mixed-color disjoint nonzero and even-odd pairs share '
+              'covers; '
+              'overlap, translucency, and Multiply retain painter order');
+    });
+  });
+
+  testWidgets(
       'coalesces matching opaque stroke unions without merging alpha or blend',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Performance versus `main`

Ghent `GWG080_DeviceN-Support_6c_x3.pdf` page 0, four balanced alternating pairs on the same host with the production pipeline + scene warm-up path:

- first measured tile: **17.34 -> 14.71 ms (-15.1%)**
- warm LoD replay: **20.37 -> 17.96 ms (-11.8%)**
- candidate won all four first-tile and all four replay pairs
- Canvas mean difference stayed identical at `4.497`

The system-font corpus removes **1,160 additional draw calls across 51 accepted pages** versus `main` (8,714 -> 9,874 total calls saved). `quadpoints.pdf` independently confirms an **11.7% warm replay improvement** (11.08 -> 9.78 ms), winning all four pairs; its first-tile median is flat within noise (31.53 -> 31.36 ms).

<details>
<summary>Implementation and measurement details</summary>

Adjacent fully opaque fills can share one stencil accumulation and cover draw when they have the same clip and fill rule and their conservative flattened bounds are pairwise strictly disjoint. Disjoint regions cannot affect one another's winding or parity counters, and the combined cover retains each fill's own vertex color.

The batcher remains conservative:

- overlapping or merely touching bounds stop the batch
- translucent and non-normal-blend fills stay ordered
- nonzero and even-odd fills never share a batch
- batches are capped at 256 paints to bound the transient cover upload

The benchmark protocol uses separate processes in balanced `main/candidate/candidate/main` order, registers the same system fonts, performs pipeline and scene warm-up, forces image completion with RGBA readback, and reports medians. The `quadpoints.pdf` first-tile result is intentionally reported as flat rather than using the earlier noisier apparent gain.

</details>

## Validation

- `fvm flutter analyze`
- focused native backend suite: 90 passed, 2 expected skips
- full native package suite: 324 passed, 4 expected skips
- system-font GPU corpus: all 218 cases passed with unchanged routes
  - Ghent: 49 GPU / 8 exact Canvas fallbacks
  - PDF.js: 177 GPU / 2 exact Canvas fallbacks
- exact mixed-color regression verifies disjoint nonzero/even-odd fills batch while overlap, translucency, and Multiply do not
