### PR TITLE
perf(gpu): elide redundant tiled-cell clips

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -1227,6 +1227,7 @@ PdfTextRun? _tryOutlineGpuText(
 _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
   const maxExpandedCommands = 1000000;
   source = _dropInvisibleGroups(source);
+  source = _dropRedundantTiledCellClips(source);
   var hasTiledCell = false;
   final mipmapImages = _requiresMipmappedImages(source);
 
@@ -1309,6 +1310,93 @@ _GpuCommandBuild _buildGpuCommands(List<PdfRenderCommand> source) {
     null,
     mipmapImages: mipmapImages,
   );
+}
+
+/// Drops a tiled cell's leading rectangular clip when every paint is already
+/// contained by it.
+///
+/// Pattern cells routinely spell their `/BBox` as `q`, a rectangular clip,
+/// several fills, then `Q`. Repeating that cell hundreds of times otherwise
+/// rebuilds the same translated stencil mask even though the clip cannot
+/// remove a sample. The proof deliberately recognizes only this balanced,
+/// fill-only shape; strokes, images, nested state, and non-rectangular clips
+/// retain the ordinary exact clip path.
+List<PdfRenderCommand> _dropRedundantTiledCellClips(
+  List<PdfRenderCommand> source,
+) {
+  List<PdfRenderCommand>? rewritten;
+  for (var index = 0; index < source.length; index++) {
+    final command = source[index];
+    final PdfRenderCommand replacement;
+    switch (command) {
+      case PdfEndSoftMaskedCommand():
+        final mask = _dropRedundantTiledCellClips(command.maskCommands);
+        replacement = identical(mask, command.maskCommands)
+            ? command
+            : PdfEndSoftMaskedCommand(
+                luminosity: command.luminosity,
+                backdrop: command.backdrop,
+                maskCommands: mask,
+                backdropLuminance: command.backdropLuminance,
+                transferScale: command.transferScale,
+                transferOffset: command.transferOffset,
+              );
+      case PdfDrawTiledCellCommand():
+        final nested = _dropRedundantTiledCellClips(command.cellCommands);
+        final cell = _dropRedundantCellClip(nested);
+        replacement = identical(cell, command.cellCommands)
+            ? command
+            : PdfDrawTiledCellCommand(
+                cell,
+                command.originsX,
+                command.originsY,
+              );
+      default:
+        replacement = command;
+    }
+    if (!identical(replacement, command)) {
+      rewritten ??= List<PdfRenderCommand>.of(source);
+      rewritten[index] = replacement;
+    }
+  }
+  return rewritten == null ? source : List.unmodifiable(rewritten);
+}
+
+List<PdfRenderCommand> _dropRedundantCellClip(
+  List<PdfRenderCommand> commands,
+) {
+  if (commands.length < 4 ||
+      commands.first is! PdfSaveCommand ||
+      commands[1] is! PdfClipPathCommand ||
+      commands.last is! PdfRestoreCommand) {
+    return commands;
+  }
+  final clip = commands[1] as PdfClipPathCommand;
+  if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(clip.path)) {
+    return commands;
+  }
+  final clipBounds = pdfRenderPathBounds(clip.path);
+  if (clipBounds == null ||
+      clipBounds.right <= clipBounds.left ||
+      clipBounds.top <= clipBounds.bottom) {
+    return commands;
+  }
+  for (var index = 2; index < commands.length - 1; index++) {
+    final command = commands[index];
+    if (command is! PdfFillPathCommand) return commands;
+    final bounds = pdfRenderPathBounds(command.path);
+    if (bounds != null &&
+        (bounds.left < clipBounds.left ||
+            bounds.bottom < clipBounds.bottom ||
+            bounds.right > clipBounds.right ||
+            bounds.top > clipBounds.top)) {
+      return commands;
+    }
+  }
+  return List.unmodifiable([
+    commands.first,
+    ...commands.sublist(2),
+  ]);
 }
 
 /// Whether Canvas parity requires the scene-wide hand-built mip chain.

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1720,6 +1720,101 @@ void main() {
     });
   });
 
+  testWidgets('tiled cells elide only proven redundant rectangular clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+
+      Future<(double, FlutterGpuTileBackendStats)> render(
+        List<PdfRenderCommand> cell,
+      ) async {
+        final page = PdfDocument.open(buildClassicPdf()).page(0);
+        final scene = await PdfRetainedScene.fromCommands(page, [
+          const PdfSaveCommand(),
+          PdfClipPathCommand(
+            const PdfPath([
+              PdfMoveTo(0, 0),
+              PdfLineTo(400, 0),
+              PdfLineTo(0, 400),
+              PdfClosePath(),
+            ]),
+            PdfFillRule.nonzero,
+          ),
+          PdfDrawTiledCellCommand(
+            cell,
+            Float64List.fromList([0, 40, 80]),
+            Float64List.fromList([0, 30, 60]),
+          ),
+          const PdfRestoreCommand(),
+        ]);
+        addTearDown(scene.dispose);
+        final backend = FlutterGpuTileRasterBackend();
+        final session = backend.createSession(scene);
+        expect(session, isNotNull, reason: backend.stats.lastRejection);
+        addTearDown(session!.dispose);
+        final region = Offset.zero & scene.pageSize;
+        final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+        final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+        addTearDown(expected.dispose);
+        addTearDown(actual.dispose);
+        final a = await _pixels(expected), b = await _pixels(actual);
+        var difference = 0;
+        for (var index = 0; index < a.length; index++) {
+          difference += (a[index] - b[index]).abs();
+        }
+        return (difference / a.length, backend.stats);
+      }
+
+      final redundant = await render([
+        const PdfSaveCommand(),
+        PdfClipPathCommand(
+          _rect(60, 100, 92, 132),
+          PdfFillRule.nonzero,
+        ),
+        PdfFillPathCommand(
+          _rect(60, 100, 92, 132),
+          const PdfColor(0.65, 0.65, 0.65),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rect(60, 100, 76, 116),
+          const PdfColor(0.15, 0.15, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfRestoreCommand(),
+      ]);
+      expect(redundant.$1, lessThan(3));
+      expect(redundant.$2.clipPathsCompiled, 1);
+      expect(redundant.$2.clipMaskRebuilds, 1);
+
+      final required = await render([
+        const PdfSaveCommand(),
+        PdfClipPathCommand(
+          _rect(60, 100, 92, 132),
+          PdfFillRule.nonzero,
+        ),
+        PdfFillPathCommand(
+          _rect(0, 0, 200, 200),
+          const PdfColor(0.15, 0.15, 0.15),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfRestoreCommand(),
+      ]);
+      expect(required.$1, lessThan(3));
+      expect(required.$2.clipPathsCompiled, 1);
+      expect(
+        required.$2.clipMaskRebuilds,
+        greaterThan(redundant.$2.clipMaskRebuilds),
+      );
+    });
+  });
+
   testWidgets('axial gradients use exact path stencil and stop geometry',
       (tester) async {
     await tester.runAsync(() async {


### PR DESCRIPTION
## Result versus merged `main` (#844)

On PDF.js `pattern_text_embedded_font.pdf` page 0, four balanced alternating same-host Metal pairs with the production pipeline and scene warm-up improved:

- **First measured tile: 108.08 -> 31.08 ms (-71.2%)**
- **Warm LoD replay: 33.79 -> 11.95 ms (-64.6%)**
- **Scene warm-up: 364.59 -> 271.48 ms (-25.5%)**
- **Session creation: 18.02 -> 14.86 ms (-17.5%)**
- **Submission CPU: 36.71 -> 22.77 ms (-38.0%)**

The candidate won all four pairs for every metric above. Across scene warm-up plus the two measured renders, clip-mask rebuilds fell **516 -> 3** and the existing exact fill coalescer saved 31 draw calls instead of zero. Canvas mean difference stayed identical at **0.302**.

<details>
<summary>Implementation, validation, and measurement details</summary>

Repeated pattern cells often contain `q`, a rectangular `/BBox` clip, several fills wholly inside that box, then `Q`. Expanding the cell changes the rectangular scissor for every repeat. When an outer non-rectangular clip is also active, that forces its stencil mask to be rebuilt for every translated cell and prevents adjacent fills from coalescing.

Before expansion, this change removes only that inner clip when all of the following are proven:

- it is the first command after a balanced save and the cell ends with restore;
- the clip is one non-degenerate axis-aligned rectangle;
- every intervening command is a fill;
- every fill's conservative path bounds are contained by the clip.

Strokes, images, nested state, non-rectangular clips, and any fill extending outside the rectangle retain the ordinary exact clip. Nested tiled cells and soft-mask tapes are checked recursively. The focused regression reproduces the outer-path-mask interaction and verifies both exact rendering and that an out-of-bounds fill keeps the clip.

Validation after rebasing directly onto the merged #844 squash:

- `fvm dart analyze`: clean
- Full native Flutter GPU package suite: **326 passed, 4 expected skips**
- System-font GPU corpus: **218 accepted pages**
  - Ghent: 49 GPU / 8 conservative Canvas fallbacks
  - PDF.js: 177 GPU / 2 conservative Canvas fallbacks
- Affected PDF.js page: accepted with exact Canvas/GPU parity

Benchmark configuration: 4 balanced pairs, alternating base/candidate order, `warmUp()` and scene `warmUp()` enabled, 512px page-0 tile at LoD 1 followed by LoD 2. The selected-unit count stayed 849. Transient host-buffer residency on this page increased from 4KB to 20KB because the newly enabled fill batches use combined cover geometry; attachment residency was unchanged.

</details>
