### PR TITLE
perf(gpu): draw rectangular fills directly

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8013,7 +8013,7 @@ _GradientDraw? _compileRadialGradientSubpaths(
   );
 }
 
-_StencilDraw? _stencilDraw(
+_GpuDraw? _stencilDraw(
   _GpuGeometryArena geometry,
   List<FlatSubpath> subpaths,
   PdfColor color,
@@ -8022,6 +8022,14 @@ _StencilDraw? _stencilDraw(
   bool union,
 ) {
   if (alpha <= 0) return null;
+  final rectangle = _axisAlignedRectangle(subpaths);
+  if (rectangle != null) {
+    geometry.stats.directRectangleDraws++;
+    final a = alpha.clamp(0.0, 1.0);
+    return _SolidDraw(
+      _coverGeometry(geometry, rectangle, _premul(color, a)),
+    );
+  }
   final parts = _stencilGeometry(geometry, subpaths);
   if (parts == null) return null;
   final fanBuffer = parts.$1;
@@ -8034,6 +8042,29 @@ _StencilDraw? _stencilDraw(
     union,
     opaquePaint: a == 1 ? (bounds: parts.$2, color: color) : null,
   );
+}
+
+/// Returns the bounds when [subpaths] describes one non-degenerate,
+/// axis-aligned rectangle. Both PDF fill rules agree for this shape, so it can
+/// go straight to two triangles instead of a stencil fan plus cover.
+FlatBounds? _axisAlignedRectangle(List<FlatSubpath> subpaths) {
+  if (subpaths.length != 1) return null;
+  final subpath = subpaths.single;
+  final points = subpath.points;
+  if (!subpath.closed || points.length != 10) return null;
+  if (points[0] != points[8] || points[1] != points[9]) return null;
+  for (var i = 0; i < 4; i++) {
+    final j = (i + 1) & 3;
+    final horizontal = points[2 * i + 1] == points[2 * j + 1];
+    final vertical = points[2 * i] == points[2 * j];
+    if (horizontal == vertical) return null;
+  }
+  final bounds = FlatBounds(points[0], points[1], points[0], points[1]);
+  for (var i = 1; i < 4; i++) {
+    bounds.include(points[2 * i], points[2 * i + 1]);
+  }
+  if (bounds.left == bounds.right || bounds.top == bounds.bottom) return null;
+  return bounds;
 }
 
 /// Compiles the shared fan + bounds cover used by both painted paths and clip
@@ -9757,6 +9788,7 @@ class _GpuEncoder {
   }
 
   void _drawView(gpu.BufferView view, int vertices) {
+    stats.drawCalls++;
     final dynamic dynamicPass = pass;
     if (_separateVertexCountApi == true) {
       dynamicPass.bindVertexBuffer(view);

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -43,6 +43,8 @@ class FlutterGpuTileBackendStats {
   int imageBindingReuses = 0;
   int coalescedDrawBatches = 0;
   int drawCallsSaved = 0;
+  int drawCalls = 0;
+  int directRectangleDraws = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
@@ -143,6 +145,8 @@ class FlutterGpuTileBackendStats {
         'imageBindingReuses': imageBindingReuses,
         'coalescedDrawBatches': coalescedDrawBatches,
         'drawCallsSaved': drawCallsSaved,
+        'drawCalls': drawCalls,
+        'directRectangleDraws': directRectangleDraws,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
@@ -243,6 +247,8 @@ class FlutterGpuTileBackendStats {
     imageBindingReuses = 0;
     coalescedDrawBatches = 0;
     drawCallsSaved = 0;
+    drawCalls = 0;
+    directRectangleDraws = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
@@ -320,6 +326,8 @@ class FlutterGpuTileBackendStats {
       'imageBindingReuses=$imageBindingReuses '
       'coalescedDrawBatches=$coalescedDrawBatches '
       'drawCallsSaved=$drawCallsSaved '
+      'drawCalls=$drawCalls '
+      'directRectangleDraws=$directRectangleDraws '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -97,6 +97,8 @@ void main() {
       ..analyticTextFallbackRuns = 2
       ..coalescedDrawBatches = 8
       ..drawCallsSaved = 120
+      ..drawCalls = 64
+      ..directRectangleDraws = 96
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
       ..subpixelStrokeFallbacks = 2
@@ -162,6 +164,8 @@ void main() {
     expect(stats.toJson(), containsPair('analyticTextFallbackRuns', 2));
     expect(stats.toJson(), containsPair('coalescedDrawBatches', 8));
     expect(stats.toJson(), containsPair('drawCallsSaved', 120));
+    expect(stats.toJson(), containsPair('drawCalls', 64));
+    expect(stats.toJson(), containsPair('directRectangleDraws', 96));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
     expect(stats.toJson(), containsPair('subpixelStrokeFallbacks', 2));
@@ -227,6 +231,8 @@ void main() {
     expect(stats.analyticTextFallbackRuns, 0);
     expect(stats.coalescedDrawBatches, 0);
     expect(stats.drawCallsSaved, 0);
+    expect(stats.drawCalls, 0);
+    expect(stats.directRectangleDraws, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);
     expect(stats.subpixelStrokeFallbacks, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -605,7 +605,7 @@ void main() {
   });
 
   testWidgets(
-      'coalesces disjoint opaque fills without merging overlap alpha or blend',
+      'emits axis-aligned fills directly and preserves overlap alpha and blend',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -684,10 +684,12 @@ void main() {
       }
       expect(difference / a.length, lessThan(3));
       expect(backend.stats.coalescedDrawBatches, 2);
-      expect(backend.stats.drawCallsSaved, 2,
-          reason: 'the mixed-color disjoint nonzero and even-odd pairs share '
-              'covers; '
-              'overlap, translucency, and Multiply retain painter order');
+      expect(backend.stats.drawCallsSaved, 6,
+          reason: 'rectangle color and alpha live in the vertex stream, so '
+              'each same-blend run becomes one ordered triangle draw');
+      expect(backend.stats.drawCalls, 3,
+          reason: 'one paper draw plus the two blend-state runs');
+      expect(backend.stats.directRectangleDraws, 8);
     });
   });
 


### PR DESCRIPTION
## Result

Compared with `main` on PDF.js `pattern_text_embedded_font.pdf` using the same host and 512 px MSAA tiles:

- warm tile median: **12.30 ms → 5.33 ms (-56.7%)**
- native GPU draws: **1,685 → 41 (-97.6%)**
- tile issue median: **27.06 ms → 19.08 ms (-29.5%)**
- retained vertices: **10,932 → 6,984 (-36.1%)**
- geometry pool: **256 KiB → 128 KiB (-50%)**
- rendered GPU PNG: **byte-for-byte identical** (`50a66f49…`)

Single-sample control also kept the same Canvas delta while warm replay improved **10.46 ms → 2.78 ms**.

Axis-aligned, closed, non-degenerate rectangular fills now use their existing bounds cover as two ordered solid triangles. Everything else remains on the exact stencil fan + cover path. Contiguous rectangles then benefit from the existing solid-draw coalescer, with color and alpha retained per vertex.

The backend diagnostics now report native `drawCalls` and compiled `directRectangleDraws`, so future performance PRs can compare commands selected, calls saved, and calls actually submitted.

<details>
<summary>Validation details</summary>

- `fvm dart analyze`
- full `dart_pdf_editor_flutter_gpu` test suite with Impeller + flutter_gpu
- focused exact GPU suite, including overlap, translucency, even-odd and Multiply cases
- default Ghent + PDF.js GPU corpus: all tests pass
- system-font corpus: **226 accelerated / 10 intentional fallbacks**, unchanged
- representative MSAA output compared directly against `main` with `cmp` and SHA-256
- single-sample benchmark preserves the same Canvas mean difference (`1.696`)
- dense analytic-text representative has zero direct rectangles and is behaviorally unchanged

Balanced MSAA samples (main warm ms: 11.536, 12.302, 12.340; candidate: 5.329, 5.059, 5.454) were run in separate worktrees on the same host.

</details>