### PR TITLE
perf(gpu): retain corpus runtime stats

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -136,7 +136,7 @@ void _corpus(
         );
         final limit = math.min(document.pageCount, maxPages);
         for (var pageIndex = 0; pageIndex < limit; pageIndex++) {
-          final PdfTileRasterBackend backend = FlutterGpuTileRasterBackend(
+          final backend = FlutterGpuTileRasterBackend(
             analyticText:
                 Platform.environment['GPU_CORPUS_ANALYTIC_TEXT'] != '0',
             systemTextOutlines:
@@ -155,9 +155,8 @@ void _corpus(
           );
           try {
             var session = backend.createSession(scene);
-            if (session == null && backend is PdfTileRasterRetryBackend) {
-              final retry =
-                  (backend as PdfTileRasterRetryBackend).retrySession(scene);
+            if (session == null) {
+              final retry = backend.retrySession(scene);
               if (retry != null) session = await retry;
             }
             if (session == null) {
@@ -167,6 +166,7 @@ void _corpus(
                 'id': '$suite/$relativeName page $pageIndex',
                 'route': 'canvas-fallback',
                 'reason': reason,
+                'stats': backend.stats.toJson(),
               });
               rejectionReasons.update(reason, (count) => count + 1,
                   ifAbsent: () => 1);
@@ -183,10 +183,11 @@ void _corpus(
               continue;
             }
             accepted++;
-            pages.add({
+            final pageReport = <String, Object?>{
               'id': '$suite/$relativeName page $pageIndex',
               'route': 'flutter-gpu',
-            });
+            };
+            pages.add(pageReport);
             try {
               final region = Offset.zero & scene.pageSize;
               final ratio = math.min(
@@ -207,6 +208,9 @@ void _corpus(
                   await _writeFailure(
                       suite, name, pageIndex, canvas, accelerated, mean);
                 }
+                pageReport
+                  ..['meanDifference'] = mean
+                  ..['stats'] = backend.stats.toJson();
                 expect(mean, lessThan(16),
                     reason: '$suite/$name page $pageIndex: GPU accepted the '
                         'scene, so it must agree with Canvas (mean=$mean)');

--- a/tool/gpu_corpus_summary.dart
+++ b/tool/gpu_corpus_summary.dart
@@ -123,6 +123,8 @@ class GpuCorpusPage {
     required this.id,
     required this.route,
     this.reason,
+    this.meanDifference,
+    this.stats = const {},
   });
 
   factory GpuCorpusPage.parse(Object? value) {
@@ -137,14 +139,20 @@ class GpuCorpusPage {
       id: value['id'] as String,
       route: route,
       reason: value['reason'] as String?,
+      meanDifference: (value['meanDifference'] as num?)?.toDouble(),
+      stats: _stringKeyedMap(value['stats']),
     );
   }
 
   final String id;
   final String route;
   final String? reason;
+  final double? meanDifference;
+  final Map<String, Object?> stats;
 
   bool get accepted => route == 'flutter-gpu';
+
+  num? stat(String name) => stats[name] as num?;
 }
 
 class GpuCorpusComparison {
@@ -198,6 +206,8 @@ class GpuCorpusComparison {
 
   String toMarkdown() {
     final buffer = StringBuffer(toHeadlineMarkdown());
+    _writeStructuralComparison(buffer);
+    _writeHotspots(buffer);
     _writeChanges(buffer, 'New GPU coverage', improvements);
     _writeChanges(buffer, 'New Canvas fallbacks', regressions);
 
@@ -224,6 +234,92 @@ class GpuCorpusComparison {
       }
     }
     return buffer.toString().trimRight();
+  }
+
+  void _writeStructuralComparison(StringBuffer buffer) {
+    final samples = <(GpuCorpusPage, GpuCorpusPage)>[];
+    for (final suiteName in _suiteNames) {
+      final mainPages = baseline.suites[suiteName]?.pages;
+      final currentPages = current.suites[suiteName]?.pages;
+      if (mainPages == null || currentPages == null) continue;
+      for (final entry in mainPages.entries) {
+        final pullRequest = currentPages[entry.key];
+        if (entry.value.accepted &&
+            pullRequest?.accepted == true &&
+            entry.value.stats.isNotEmpty &&
+            pullRequest!.stats.isNotEmpty) {
+          samples.add((entry.value, pullRequest));
+        }
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln()
+      ..writeln('#### GPU corpus structural comparison')
+      ..writeln();
+    if (samples.isEmpty) {
+      buffer.writeln(
+        'Per-page backend statistics are unavailable for one side of this '
+        'comparison.',
+      );
+      return;
+    }
+    buffer
+      ..writeln('Common accelerated pages: ${samples.length}.')
+      ..writeln()
+      ..writeln('| Metric | Main | PR | Change |')
+      ..writeln('| --- | ---: | ---: | ---: |');
+    for (final metric in const [
+      ('Native draw calls', 'drawCalls'),
+      ('Selected commands', 'selectedCommands'),
+      ('Draw calls saved', 'drawCallsSaved'),
+      ('Direct rectangle draws', 'directRectangleDraws'),
+      ('Geometry vertices', 'geometryVertices'),
+    ]) {
+      final main = _sumStats(samples.map((sample) => sample.$1), metric.$2);
+      final pullRequest =
+          _sumStats(samples.map((sample) => sample.$2), metric.$2);
+      buffer.writeln(
+        '| ${metric.$1} | $main | $pullRequest | '
+        '${_deltaPercent(main, pullRequest)} |',
+      );
+    }
+  }
+
+  void _writeHotspots(StringBuffer buffer) {
+    final pages = <GpuCorpusPage>[
+      for (final suite in current.suites.values)
+        for (final page in suite.pages.values)
+          if (page.accepted && page.stat('drawCalls') != null) page,
+    ]..sort((a, b) {
+        final draws =
+            (b.stat('drawCalls') ?? 0).compareTo(a.stat('drawCalls') ?? 0);
+        return draws != 0 ? draws : a.id.compareTo(b.id);
+      });
+    buffer
+      ..writeln()
+      ..writeln()
+      ..writeln('#### Current GPU corpus draw hotspots')
+      ..writeln();
+    if (pages.isEmpty) {
+      buffer.writeln('Per-page backend statistics were not recorded.');
+      return;
+    }
+    buffer
+      ..writeln('| Page | Draws | Commands | Saved | Direct rectangles | '
+          'Issue | Compile | Canvas mean delta |')
+      ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+    for (final page in pages.take(15)) {
+      buffer.writeln(
+        '| `${_escape(page.id)}` | ${_integerStat(page, 'drawCalls')} | '
+        '${_integerStat(page, 'selectedCommands')} | '
+        '${_integerStat(page, 'drawCallsSaved')} | '
+        '${_integerStat(page, 'directRectangleDraws')} | '
+        '${_millisecondsStat(page, 'issueMicros')} | '
+        '${_millisecondsStat(page, 'compileMicros')} | '
+        '${page.meanDifference?.toStringAsFixed(3) ?? '—'} |',
+      );
+    }
   }
 
   List<String> get _suiteNames => {
@@ -290,3 +386,30 @@ String _inlinePages(
 String _signed(int value) => value > 0 ? '+$value' : '$value';
 
 String _escape(String value) => value.replaceAll('|', r'\|');
+
+Map<String, Object?> _stringKeyedMap(Object? value) {
+  if (value == null) return const {};
+  if (value is! Map || value.keys.any((key) => key is! String)) {
+    throw const FormatException('Invalid Flutter GPU page statistics');
+  }
+  return {for (final entry in value.entries) entry.key as String: entry.value};
+}
+
+int _sumStats(Iterable<GpuCorpusPage> pages, String name) => pages.fold(
+      0,
+      (total, page) => total + (page.stat(name)?.toInt() ?? 0),
+    );
+
+String _deltaPercent(int baseline, int current) {
+  if (baseline == 0) return current == 0 ? '0.0%' : 'new';
+  final percent = (current - baseline) * 100 / baseline;
+  return '${percent >= 0 ? '+' : ''}${percent.toStringAsFixed(1)}%';
+}
+
+String _integerStat(GpuCorpusPage page, String name) =>
+    page.stat(name)?.toInt().toString() ?? '—';
+
+String _millisecondsStat(GpuCorpusPage page, String name) {
+  final micros = page.stat(name);
+  return micros == null ? '—' : '${(micros / 1000).toStringAsFixed(3)} ms';
+}

--- a/tool/gpu_corpus_summary_test.dart
+++ b/tool/gpu_corpus_summary_test.dart
@@ -20,7 +20,20 @@ void main() {
         'accepted': 1,
         'rejected': 0,
         'pages': [
-          {'id': 'PDF.js/stable.pdf page 0', 'route': 'flutter-gpu'},
+          {
+            'id': 'PDF.js/stable.pdf page 0',
+            'route': 'flutter-gpu',
+            'meanDifference': 0.5,
+            'stats': {
+              'drawCalls': 10,
+              'selectedCommands': 5,
+              'drawCallsSaved': 2,
+              'directRectangleDraws': 0,
+              'geometryVertices': 100,
+              'issueMicros': 4000,
+              'compileMicros': 2000,
+            },
+          },
         ],
       },
     },
@@ -37,14 +50,40 @@ void main() {
             'route': 'canvas-fallback',
             'reason': 'new rejection',
           },
-          {'id': 'Ghent/fallback.pdf page 0', 'route': 'flutter-gpu'},
+          {
+            'id': 'Ghent/fallback.pdf page 0',
+            'route': 'flutter-gpu',
+            'meanDifference': 0.25,
+            'stats': {
+              'drawCalls': 20,
+              'selectedCommands': 12,
+              'drawCallsSaved': 4,
+              'directRectangleDraws': 3,
+              'geometryVertices': 240,
+              'issueMicros': 6000,
+              'compileMicros': 3000,
+            },
+          },
         ],
       },
       'PDF.js': {
         'accepted': 1,
         'rejected': 0,
         'pages': [
-          {'id': 'PDF.js/stable.pdf page 0', 'route': 'flutter-gpu'},
+          {
+            'id': 'PDF.js/stable.pdf page 0',
+            'route': 'flutter-gpu',
+            'meanDifference': 0.4,
+            'stats': {
+              'drawCalls': 8,
+              'selectedCommands': 5,
+              'drawCallsSaved': 4,
+              'directRectangleDraws': 2,
+              'geometryVertices': 90,
+              'issueMicros': 3500,
+              'compileMicros': 1800,
+            },
+          },
         ],
       },
     },
@@ -85,6 +124,17 @@ void main() {
     comparison.toMarkdown(),
     '| `Ghent/accepted.pdf page 0` | new rejection |',
     'fallback detail',
+  );
+  _expectContains(
+    comparison.toMarkdown(),
+    '| Native draw calls | 10 | 8 | -20.0% |',
+    'structural draw comparison',
+  );
+  _expectContains(
+    comparison.toMarkdown(),
+    '| `Ghent/fallback.pdf page 0` | 20 | 12 | 4 | 3 | 6.000 ms | '
+        '3.000 ms | 0.250 |',
+    'ranked draw hotspot',
   );
 
   final safe = summary.GpuCorpusComparison(


### PR DESCRIPTION
## Outcome

Future Flutter GPU PR reports retain the per-page backend counters and exact Canvas mean delta that CI already computes. The hidden validation details now compare structural totals with main and rank the top 15 native-draw hotspots, so the next optimization can be selected from the same-host corpus evidence.

## Validation

- fvm dart analyze
- fvm dart tool/gpu_corpus_summary_test.dart
- Expanded system-font GPU corpus: 177 PDF.js pages accelerated / 2 fallbacks; 49 Ghent pages accelerated / 8 fallbacks; all exact parity checks passed
- Generated report ranks standard_fonts.pdf, quadpoints.pdf, and the DeviceN pages as the current native-draw hotspots

This changes reporting only; rendering and route selection are unchanged.