### PR TITLE
perf(gpu): classify native corpus draws

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -9013,6 +9013,17 @@ class _SoftMaskFillDraw implements _GpuDraw {
 
 enum _GpuRetainedBindingKind { glyph, image }
 
+enum _GpuDrawKind {
+  directSolid,
+  stencilFan,
+  stencilCover,
+  stencilClear,
+  texture,
+  glyph,
+  blend,
+  softMask,
+}
+
 class _GpuEncoder {
   _GpuEncoder({
     required this.pass,
@@ -9212,7 +9223,7 @@ class _GpuEncoder {
         ))
         ..bindPipeline(pipelines.solid)
         ..bindUniform(pipelines.solidTransform, transform);
-      _drawBuffer(draw.cover);
+      _drawBuffer(draw.cover, _GpuDrawKind.stencilCover);
       // The lower bits are scratch. Clearing them here leaves the final clip
       // bit intact and makes the following PDF fill independent of how many
       // contours built this mask.
@@ -9228,7 +9239,7 @@ class _GpuEncoder {
     pass
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
-    _drawBuffer(vertices);
+    _drawBuffer(vertices, _GpuDrawKind.directSolid);
   }
 
   void stencil(_GpuBuffer fan, _GpuBuffer cover,
@@ -9257,7 +9268,7 @@ class _GpuEncoder {
         writeMask: 1,
       ));
     for (final draw in draws) {
-      _drawBuffer(draw.fan);
+      _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
     }
     _paintOpaqueStencilBatchCover(draws, color);
   }
@@ -9298,7 +9309,7 @@ class _GpuEncoder {
         );
     }
     for (final draw in draws) {
-      _drawBuffer(draw.fan);
+      _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
     }
     _paintOpaqueStencilFillBatchCover(draws);
   }
@@ -9399,7 +9410,7 @@ class _GpuEncoder {
       ))
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
-    _drawView(cover, vertices);
+    _drawView(cover, vertices, _GpuDrawKind.stencilCover);
   }
 
   void gradient(_GpuBuffer fan, _GpuBuffer mesh, PdfFillRule rule) {
@@ -9422,7 +9433,7 @@ class _GpuEncoder {
       ))
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
-    _drawBuffer(mesh);
+    _drawBuffer(mesh, _GpuDrawKind.stencilCover);
     // The gradient mesh conservatively covers the path bounds, but clearing
     // the scratch bits explicitly keeps a malformed transform or degenerate
     // interval from leaking winding state into the next draw.
@@ -9496,7 +9507,7 @@ class _GpuEncoder {
           targetFace: gpu.StencilFace.back,
         );
     }
-    _drawView(fan, vertices);
+    _drawView(fan, vertices, _GpuDrawKind.stencilFan);
   }
 
   void _clearStencil(int mask) {
@@ -9514,7 +9525,7 @@ class _GpuEncoder {
       ))
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform);
-    _drawBuffer(stencilClear);
+    _drawBuffer(stencilClear, _GpuDrawKind.stencilClear);
   }
 
   void texture(_GpuBuffer vertices, gpu.Texture texture) {
@@ -9541,7 +9552,7 @@ class _GpuEncoder {
       );
       _boundImageTexture = texture;
     }
-    _drawBuffer(vertices);
+    _drawBuffer(vertices, _GpuDrawKind.texture);
   }
 
   /// Samples a tile-sized offscreen group back into the same raster region.
@@ -9564,7 +9575,7 @@ class _GpuEncoder {
         texture,
         sampler: _nearestSampler,
       );
-    _drawView(emplaceTransient(vertices.bytes), 6);
+    _drawView(emplaceTransient(vertices.bytes), 6, _GpuDrawKind.texture);
     pass.clearBindings();
   }
 
@@ -9583,7 +9594,7 @@ class _GpuEncoder {
         texture,
         sampler: _nearestSampler,
       );
-    _drawView(emplaceTransient(vertices.bytes), 6);
+    _drawView(emplaceTransient(vertices.bytes), 6, _GpuDrawKind.texture);
     pass.clearBindings();
   }
 
@@ -9620,7 +9631,7 @@ class _GpuEncoder {
         source,
         sampler: _nearestSampler,
       );
-    _drawView(emplaceTransient(vertices.bytes), 6);
+    _drawView(emplaceTransient(vertices.bytes), 6, _GpuDrawKind.blend);
     pass.clearBindings();
   }
 
@@ -9704,7 +9715,7 @@ class _GpuEncoder {
         );
       _boundGlyphAtlas = atlas;
     }
-    _drawBuffer(vertices);
+    _drawBuffer(vertices, _GpuDrawKind.glyph);
   }
 
   void softMask(_GpuBuffer vertices, gpu.Texture contentTexture,
@@ -9720,7 +9731,7 @@ class _GpuEncoder {
           sampler: _linearSampler)
       ..bindTexture(pipelines.softMaskMaskSampler, maskTexture,
           sampler: _linearSampler);
-    _drawBuffer(vertices);
+    _drawBuffer(vertices, _GpuDrawKind.softMask);
     pass.clearBindings();
   }
 
@@ -9753,7 +9764,7 @@ class _GpuEncoder {
           sampler: _linearSampler)
       ..bindTexture(pipelines.softMaskMaskSampler, maskTexture,
           sampler: _linearSampler);
-    _drawBuffer(cover);
+    _drawBuffer(cover, _GpuDrawKind.softMask);
     pass.clearBindings();
     _clearStencil(_pathMask);
   }
@@ -9783,12 +9794,30 @@ class _GpuEncoder {
   // bindVertexBuffer and into draw; 3.44 uses the original pair. Keep this
   // package usable across both stable SDKs without exposing that churn to
   // callers. The one-time dynamic probe is cached for every render pass.
-  void _drawBuffer(_GpuBuffer buffer) {
-    _drawView(buffer.view, buffer.vertices);
+  void _drawBuffer(_GpuBuffer buffer, _GpuDrawKind kind) {
+    _drawView(buffer.view, buffer.vertices, kind);
   }
 
-  void _drawView(gpu.BufferView view, int vertices) {
+  void _drawView(gpu.BufferView view, int vertices, _GpuDrawKind kind) {
     stats.drawCalls++;
+    switch (kind) {
+      case _GpuDrawKind.directSolid:
+        stats.directSolidDrawCalls++;
+      case _GpuDrawKind.stencilFan:
+        stats.stencilFanDrawCalls++;
+      case _GpuDrawKind.stencilCover:
+        stats.stencilCoverDrawCalls++;
+      case _GpuDrawKind.stencilClear:
+        stats.stencilClearDrawCalls++;
+      case _GpuDrawKind.texture:
+        stats.textureDrawCalls++;
+      case _GpuDrawKind.glyph:
+        stats.glyphDrawCalls++;
+      case _GpuDrawKind.blend:
+        stats.blendDrawCalls++;
+      case _GpuDrawKind.softMask:
+        stats.softMaskDrawCalls++;
+    }
     final dynamic dynamicPass = pass;
     if (_separateVertexCountApi == true) {
       dynamicPass.bindVertexBuffer(view);

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -44,6 +44,14 @@ class FlutterGpuTileBackendStats {
   int coalescedDrawBatches = 0;
   int drawCallsSaved = 0;
   int drawCalls = 0;
+  int directSolidDrawCalls = 0;
+  int stencilFanDrawCalls = 0;
+  int stencilCoverDrawCalls = 0;
+  int stencilClearDrawCalls = 0;
+  int textureDrawCalls = 0;
+  int glyphDrawCalls = 0;
+  int blendDrawCalls = 0;
+  int softMaskDrawCalls = 0;
   int directRectangleDraws = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
@@ -146,6 +154,14 @@ class FlutterGpuTileBackendStats {
         'coalescedDrawBatches': coalescedDrawBatches,
         'drawCallsSaved': drawCallsSaved,
         'drawCalls': drawCalls,
+        'directSolidDrawCalls': directSolidDrawCalls,
+        'stencilFanDrawCalls': stencilFanDrawCalls,
+        'stencilCoverDrawCalls': stencilCoverDrawCalls,
+        'stencilClearDrawCalls': stencilClearDrawCalls,
+        'textureDrawCalls': textureDrawCalls,
+        'glyphDrawCalls': glyphDrawCalls,
+        'blendDrawCalls': blendDrawCalls,
+        'softMaskDrawCalls': softMaskDrawCalls,
         'directRectangleDraws': directRectangleDraws,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
@@ -248,6 +264,14 @@ class FlutterGpuTileBackendStats {
     coalescedDrawBatches = 0;
     drawCallsSaved = 0;
     drawCalls = 0;
+    directSolidDrawCalls = 0;
+    stencilFanDrawCalls = 0;
+    stencilCoverDrawCalls = 0;
+    stencilClearDrawCalls = 0;
+    textureDrawCalls = 0;
+    glyphDrawCalls = 0;
+    blendDrawCalls = 0;
+    softMaskDrawCalls = 0;
     directRectangleDraws = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
@@ -327,6 +351,9 @@ class FlutterGpuTileBackendStats {
       'coalescedDrawBatches=$coalescedDrawBatches '
       'drawCallsSaved=$drawCallsSaved '
       'drawCalls=$drawCalls '
+      'drawMix=$directSolidDrawCalls/$stencilFanDrawCalls/'
+      '$stencilCoverDrawCalls/$stencilClearDrawCalls/$textureDrawCalls/'
+      '$glyphDrawCalls/$blendDrawCalls/$softMaskDrawCalls '
       'directRectangleDraws=$directRectangleDraws '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -98,6 +98,14 @@ void main() {
       ..coalescedDrawBatches = 8
       ..drawCallsSaved = 120
       ..drawCalls = 64
+      ..directSolidDrawCalls = 10
+      ..stencilFanDrawCalls = 20
+      ..stencilCoverDrawCalls = 15
+      ..stencilClearDrawCalls = 8
+      ..textureDrawCalls = 4
+      ..glyphDrawCalls = 3
+      ..blendDrawCalls = 2
+      ..softMaskDrawCalls = 2
       ..directRectangleDraws = 96
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
@@ -165,6 +173,14 @@ void main() {
     expect(stats.toJson(), containsPair('coalescedDrawBatches', 8));
     expect(stats.toJson(), containsPair('drawCallsSaved', 120));
     expect(stats.toJson(), containsPair('drawCalls', 64));
+    expect(stats.toJson(), containsPair('directSolidDrawCalls', 10));
+    expect(stats.toJson(), containsPair('stencilFanDrawCalls', 20));
+    expect(stats.toJson(), containsPair('stencilCoverDrawCalls', 15));
+    expect(stats.toJson(), containsPair('stencilClearDrawCalls', 8));
+    expect(stats.toJson(), containsPair('textureDrawCalls', 4));
+    expect(stats.toJson(), containsPair('glyphDrawCalls', 3));
+    expect(stats.toJson(), containsPair('blendDrawCalls', 2));
+    expect(stats.toJson(), containsPair('softMaskDrawCalls', 2));
     expect(stats.toJson(), containsPair('directRectangleDraws', 96));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
@@ -232,6 +248,14 @@ void main() {
     expect(stats.coalescedDrawBatches, 0);
     expect(stats.drawCallsSaved, 0);
     expect(stats.drawCalls, 0);
+    expect(stats.directSolidDrawCalls, 0);
+    expect(stats.stencilFanDrawCalls, 0);
+    expect(stats.stencilCoverDrawCalls, 0);
+    expect(stats.stencilClearDrawCalls, 0);
+    expect(stats.textureDrawCalls, 0);
+    expect(stats.glyphDrawCalls, 0);
+    expect(stats.blendDrawCalls, 0);
+    expect(stats.softMaskDrawCalls, 0);
     expect(stats.directRectangleDraws, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -689,6 +689,10 @@ void main() {
               'each same-blend run becomes one ordered triangle draw');
       expect(backend.stats.drawCalls, 3,
           reason: 'one paper draw plus the two blend-state runs');
+      expect(backend.stats.directSolidDrawCalls, 3);
+      expect(backend.stats.stencilFanDrawCalls, 0);
+      expect(backend.stats.stencilCoverDrawCalls, 0);
+      expect(backend.stats.stencilClearDrawCalls, 0);
       expect(backend.stats.directRectangleDraws, 8);
     });
   });

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -58,6 +58,16 @@ Future<double> _meanDifference(ui.Image expected, ui.Image actual) async {
   return difference / a.length;
 }
 
+int _classifiedDrawCalls(FlutterGpuTileBackendStats stats) =>
+    stats.directSolidDrawCalls +
+    stats.stencilFanDrawCalls +
+    stats.stencilCoverDrawCalls +
+    stats.stencilClearDrawCalls +
+    stats.textureDrawCalls +
+    stats.glyphDrawCalls +
+    stats.blendDrawCalls +
+    stats.softMaskDrawCalls;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   if (!_gpuAvailable()) {
@@ -204,6 +214,12 @@ void _corpus(
               );
               try {
                 final mean = await _meanDifference(canvas, accelerated);
+                expect(
+                  _classifiedDrawCalls(backend.stats),
+                  backend.stats.drawCalls,
+                  reason: '$suite/$name page $pageIndex: every issued GPU '
+                      'draw must have one diagnostic kind',
+                );
                 if (mean >= 16) {
                   await _writeFailure(
                       suite, name, pageIndex, canvas, accelerated, mean);

--- a/tool/gpu_corpus_summary.dart
+++ b/tool/gpu_corpus_summary.dart
@@ -271,11 +271,24 @@ class GpuCorpusComparison {
       ..writeln('| --- | ---: | ---: | ---: |');
     for (final metric in const [
       ('Native draw calls', 'drawCalls'),
+      ('Direct solid draws', 'directSolidDrawCalls'),
+      ('Stencil fan draws', 'stencilFanDrawCalls'),
+      ('Stencil cover draws', 'stencilCoverDrawCalls'),
+      ('Stencil clear draws', 'stencilClearDrawCalls'),
+      ('Texture draws', 'textureDrawCalls'),
+      ('Glyph draws', 'glyphDrawCalls'),
+      ('Advanced blend draws', 'blendDrawCalls'),
+      ('Soft-mask draws', 'softMaskDrawCalls'),
       ('Selected commands', 'selectedCommands'),
       ('Draw calls saved', 'drawCallsSaved'),
       ('Direct rectangle draws', 'directRectangleDraws'),
       ('Geometry vertices', 'geometryVertices'),
     ]) {
+      if (!samples.every((sample) =>
+          sample.$1.stat(metric.$2) != null &&
+          sample.$2.stat(metric.$2) != null)) {
+        continue;
+      }
       final main = _sumStats(samples.map((sample) => sample.$1), metric.$2);
       final pullRequest =
           _sumStats(samples.map((sample) => sample.$2), metric.$2);
@@ -306,15 +319,20 @@ class GpuCorpusComparison {
       return;
     }
     buffer
+      ..writeln('Draw mix is direct solid / stencil fan / stencil cover / '
+          'stencil clear / texture / glyph / advanced blend / soft mask.')
+      ..writeln()
       ..writeln('| Page | Draws | Commands | Saved | Direct rectangles | '
-          'Issue | Compile | Canvas mean delta |')
-      ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |');
+          'Draw mix | Issue | Compile | Canvas mean delta |')
+      ..writeln(
+          '| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |');
     for (final page in pages.take(15)) {
       buffer.writeln(
         '| `${_escape(page.id)}` | ${_integerStat(page, 'drawCalls')} | '
         '${_integerStat(page, 'selectedCommands')} | '
         '${_integerStat(page, 'drawCallsSaved')} | '
         '${_integerStat(page, 'directRectangleDraws')} | '
+        '${_drawMix(page)} | '
         '${_millisecondsStat(page, 'issueMicros')} | '
         '${_millisecondsStat(page, 'compileMicros')} | '
         '${page.meanDifference?.toStringAsFixed(3) ?? '—'} |',
@@ -408,6 +426,21 @@ String _deltaPercent(int baseline, int current) {
 
 String _integerStat(GpuCorpusPage page, String name) =>
     page.stat(name)?.toInt().toString() ?? '—';
+
+String _drawMix(GpuCorpusPage page) {
+  const names = [
+    'directSolidDrawCalls',
+    'stencilFanDrawCalls',
+    'stencilCoverDrawCalls',
+    'stencilClearDrawCalls',
+    'textureDrawCalls',
+    'glyphDrawCalls',
+    'blendDrawCalls',
+    'softMaskDrawCalls',
+  ];
+  if (names.any((name) => page.stat(name) == null)) return '—';
+  return names.map((name) => page.stat(name)!.toInt()).join('/');
+}
 
 String _millisecondsStat(GpuCorpusPage page, String name) {
   final micros = page.stat(name);

--- a/tool/gpu_corpus_summary_test.dart
+++ b/tool/gpu_corpus_summary_test.dart
@@ -26,6 +26,14 @@ void main() {
             'meanDifference': 0.5,
             'stats': {
               'drawCalls': 10,
+              'directSolidDrawCalls': 2,
+              'stencilFanDrawCalls': 3,
+              'stencilCoverDrawCalls': 2,
+              'stencilClearDrawCalls': 1,
+              'textureDrawCalls': 1,
+              'glyphDrawCalls': 1,
+              'blendDrawCalls': 0,
+              'softMaskDrawCalls': 0,
               'selectedCommands': 5,
               'drawCallsSaved': 2,
               'directRectangleDraws': 0,
@@ -56,6 +64,14 @@ void main() {
             'meanDifference': 0.25,
             'stats': {
               'drawCalls': 20,
+              'directSolidDrawCalls': 4,
+              'stencilFanDrawCalls': 6,
+              'stencilCoverDrawCalls': 4,
+              'stencilClearDrawCalls': 2,
+              'textureDrawCalls': 1,
+              'glyphDrawCalls': 1,
+              'blendDrawCalls': 1,
+              'softMaskDrawCalls': 1,
               'selectedCommands': 12,
               'drawCallsSaved': 4,
               'directRectangleDraws': 3,
@@ -76,6 +92,14 @@ void main() {
             'meanDifference': 0.4,
             'stats': {
               'drawCalls': 8,
+              'directSolidDrawCalls': 2,
+              'stencilFanDrawCalls': 2,
+              'stencilCoverDrawCalls': 1,
+              'stencilClearDrawCalls': 1,
+              'textureDrawCalls': 1,
+              'glyphDrawCalls': 1,
+              'blendDrawCalls': 0,
+              'softMaskDrawCalls': 0,
               'selectedCommands': 5,
               'drawCallsSaved': 4,
               'directRectangleDraws': 2,
@@ -132,8 +156,13 @@ void main() {
   );
   _expectContains(
     comparison.toMarkdown(),
-    '| `Ghent/fallback.pdf page 0` | 20 | 12 | 4 | 3 | 6.000 ms | '
-        '3.000 ms | 0.250 |',
+    '| Stencil fan draws | 3 | 2 | -33.3% |',
+    'structural draw-kind comparison',
+  );
+  _expectContains(
+    comparison.toMarkdown(),
+    '| `Ghent/fallback.pdf page 0` | 20 | 12 | 4 | 3 | '
+        '4/6/4/2/1/1/1/1 | 6.000 ms | 3.000 ms | 0.250 |',
     'ranked draw hotspot',
   );
 


### PR DESCRIPTION
## Summary
- classify every issued Flutter GPU draw as direct solid, stencil fan/cover/clear, texture, glyph, advanced blend, or soft mask
- retain the breakdown in corpus JSON and show it in structural comparisons and hotspot reports
- assert across the GPU corpus that draw-kind totals equal native draw calls

## Validation
- `fvm dart analyze`
- `fvm dart tool/gpu_corpus_summary_test.dart`
- `fvm flutter test test/backend_stats_test.dart`
- focused native GPU tile test with Impeller/flutter_gpu enabled
- full expanded GPU corpus with system font outlines: PDF.js 177 accelerated / 2 fallback; Ghent 49 accelerated / 8 fallback; all parity and draw-accounting checks pass

## Initial evidence
Across 226 accelerated corpus pages, 9,254 native draws classify as 518 direct solid, 4,246 stencil fan, 2,567 stencil cover, 609 stencil clear, 170 texture, 1,109 glyph, 13 advanced blend, and 22 soft-mask draws. This identifies stencil batching as the next measured target.