### PR TITLE
perf(gpu): coalesce opaque stencil fans

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -5931,12 +5931,16 @@ class _CompiledScene {
           nextUnitIndex++;
         }
         if (batch.length > 1) {
+          final fan = _coalescedGpuBuffers([
+            for (final draw in batch) draw.fan,
+          ]);
           stats
             ..coalescedDrawBatches += 1
-            ..drawCallsSaved += batch.length - 1;
+            ..drawCallsSaved += (batch.length - 1) * (fan == null ? 1 : 2);
           draw = _OpaqueStencilBatchDraw(
             batch,
             draw.opaquePaint!.color,
+            fan,
           );
         }
       } else if (draw is _StencilDraw &&
@@ -5960,12 +5964,16 @@ class _CompiledScene {
           nextUnitIndex++;
         }
         if (batch.length > 1) {
+          final fan = _coalescedGpuBuffers([
+            for (final draw in batch) draw.fan,
+          ]);
           stats
             ..coalescedDrawBatches += 1
-            ..drawCallsSaved += batch.length - 1;
+            ..drawCallsSaved += (batch.length - 1) * (fan == null ? 1 : 2);
           draw = _OpaqueStencilFillBatchDraw(
             batch,
             draw.rule,
+            fan,
           );
         }
       } else if (draw is _HairlineDraw &&
@@ -8088,7 +8096,7 @@ FlatBounds? _axisAlignedRectangle(List<FlatSubpath> subpaths) {
     }
   }
   if (fan.isEmpty) return null;
-  return (geometry.add(fan.bytes, fan.length ~/ 2), bounds);
+  return (geometry.addStencilFan(fan.bytes, fan.length ~/ 2), bounds);
 }
 
 _GpuBuffer _coverGeometry(
@@ -8133,25 +8141,32 @@ class _GpuGeometryArena {
   List<_GpuGeometryResource> get leases => List.unmodifiable(_leases);
 
   _GpuBuffer add(ByteData bytes, int vertices) =>
-      _add(bytes, vertices, alignment: 1);
+      _add(bytes, vertices, alignment: 1, lane: _GpuGeometryLane.general);
+
+  _GpuBuffer addStencilFan(ByteData bytes, int vertices) =>
+      _add(bytes, vertices, alignment: 1, lane: _GpuGeometryLane.stencilFan);
 
   _GpuBuffer addUniform(ByteData bytes) => _add(
         bytes,
         0,
         alignment: math.max(1, context.minimumUniformByteAlignment),
+        lane: _GpuGeometryLane.general,
       );
 
-  _GpuBuffer _add(ByteData bytes, int vertices, {required int alignment}) {
+  _GpuBuffer _add(
+    ByteData bytes,
+    int vertices, {
+    required int alignment,
+    required _GpuGeometryLane lane,
+  }) {
     if (_finalized) throw StateError('GPU geometry arena already finalized');
-    var offset = _align(_pendingBytes, alignment);
-    if (_slices.isNotEmpty &&
-        offset + bytes.lengthInBytes > _GpuGeometryPool.chunkBytes) {
+    final projected = _pendingBytes + alignment - 1 + bytes.lengthInBytes;
+    if (_slices.isNotEmpty && projected > _GpuGeometryPool.chunkBytes) {
       _flush();
-      offset = 0;
     }
-    final result = _GpuBuffer(vertices).._offsetInBytes = offset;
-    _slices.add(_GpuGeometrySlice(bytes, result));
-    _pendingBytes = offset + bytes.lengthInBytes;
+    final result = _GpuBuffer(vertices);
+    _slices.add(_GpuGeometrySlice(bytes, result, alignment, lane));
+    _pendingBytes += alignment - 1 + bytes.lengthInBytes;
     stats.geometryVertices += vertices;
     return result;
   }
@@ -8169,8 +8184,23 @@ class _GpuGeometryArena {
 
   void _flush() {
     if (_slices.isEmpty) return;
-    final packed = Uint8List(_pendingBytes);
-    for (final slice in _slices) {
+    // Stencil fans all share one two-float vertex layout. Packing that lane
+    // contiguously lets an already-safe opaque paint batch issue all of its
+    // fans with one draw instead of rebinding non-contiguous ranges.
+    final ordered = <_GpuGeometrySlice>[
+      for (final slice in _slices)
+        if (slice.lane == _GpuGeometryLane.stencilFan) slice,
+      for (final slice in _slices)
+        if (slice.lane == _GpuGeometryLane.general) slice,
+    ];
+    var length = 0;
+    for (final slice in ordered) {
+      length = _align(length, slice.alignment);
+      slice.buffer._offsetInBytes = length;
+      length += slice.bytes.lengthInBytes;
+    }
+    final packed = Uint8List(length);
+    for (final slice in ordered) {
       final source = slice.bytes.buffer.asUint8List(
         slice.bytes.offsetInBytes,
         slice.bytes.lengthInBytes,
@@ -8688,10 +8718,14 @@ class _GpuBuffer {
 }
 
 class _GpuGeometrySlice {
-  const _GpuGeometrySlice(this.bytes, this.buffer);
+  const _GpuGeometrySlice(this.bytes, this.buffer, this.alignment, this.lane);
   final ByteData bytes;
   final _GpuBuffer buffer;
+  final int alignment;
+  final _GpuGeometryLane lane;
 }
+
+enum _GpuGeometryLane { stencilFan, general }
 
 sealed class _GpuDraw {
   void encode(_GpuEncoder encoder);
@@ -8798,24 +8832,27 @@ class _StencilDraw implements _GpuDraw {
 }
 
 class _OpaqueStencilBatchDraw implements _GpuDraw {
-  const _OpaqueStencilBatchDraw(this.draws, this.color);
+  const _OpaqueStencilBatchDraw(this.draws, this.color, this.fan);
 
   final List<_StencilDraw> draws;
   final PdfColor color;
-
-  @override
-  void encode(_GpuEncoder encoder) => encoder.opaqueStencilBatch(draws, color);
-}
-
-class _OpaqueStencilFillBatchDraw implements _GpuDraw {
-  const _OpaqueStencilFillBatchDraw(this.draws, this.rule);
-
-  final List<_StencilDraw> draws;
-  final PdfFillRule rule;
+  final _GpuBuffer? fan;
 
   @override
   void encode(_GpuEncoder encoder) =>
-      encoder.opaqueStencilFillBatch(draws, rule);
+      encoder.opaqueStencilBatch(draws, color, fan);
+}
+
+class _OpaqueStencilFillBatchDraw implements _GpuDraw {
+  const _OpaqueStencilFillBatchDraw(this.draws, this.rule, this.fan);
+
+  final List<_StencilDraw> draws;
+  final PdfFillRule rule;
+  final _GpuBuffer? fan;
+
+  @override
+  void encode(_GpuEncoder encoder) =>
+      encoder.opaqueStencilFillBatch(draws, rule, fan);
 }
 
 /// A PDF zero-width stroke. Its source polyline is retained with the scene,
@@ -8934,6 +8971,27 @@ _GpuDraw _coalescedGpuDraw(_GpuDraw first, _GpuDraw last, int vertices) {
     _AnalyticTextDraw(:final atlas) => _AnalyticTextDraw(buffer, atlas),
     _ => throw StateError('unsupported coalesced GPU draw'),
   };
+}
+
+_GpuBuffer? _coalescedGpuBuffers(List<_GpuBuffer> buffers) {
+  if (buffers.isEmpty) return null;
+  final first = buffers.first.view;
+  var end = first.offsetInBytes + first.lengthInBytes;
+  var vertices = buffers.first.vertices;
+  for (final buffer in buffers.skip(1)) {
+    final view = buffer.view;
+    if (!identical(first.buffer, view.buffer) || view.offsetInBytes != end) {
+      return null;
+    }
+    end += view.lengthInBytes;
+    vertices += buffer.vertices;
+  }
+  return _GpuBuffer(vertices)
+    .._view = gpu.BufferView(
+      first.buffer,
+      offsetInBytes: first.offsetInBytes,
+      lengthInBytes: end - first.offsetInBytes,
+    );
 }
 
 /// Fully opaque source-over is idempotent at each raster sample, so adjacent
@@ -9249,7 +9307,11 @@ class _GpuEncoder {
     _paintStencilCover(cover.view, cover.vertices);
   }
 
-  void opaqueStencilBatch(List<_StencilDraw> draws, PdfColor color) {
+  void opaqueStencilBatch(
+    List<_StencilDraw> draws,
+    PdfColor color,
+    _GpuBuffer? fan,
+  ) {
     _dropRetainedBindings();
     _appliedDefaultStencilBit = null;
     final compare = _activeClipBit == 0
@@ -9267,8 +9329,12 @@ class _GpuEncoder {
         readMask: _activeClipBit == 0 ? 0 : _activeClipBit,
         writeMask: 1,
       ));
-    for (final draw in draws) {
-      _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
+    if (fan != null) {
+      _drawBuffer(fan, _GpuDrawKind.stencilFan);
+    } else {
+      for (final draw in draws) {
+        _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
+      }
     }
     _paintOpaqueStencilBatchCover(draws, color);
   }
@@ -9276,6 +9342,7 @@ class _GpuEncoder {
   void opaqueStencilFillBatch(
     List<_StencilDraw> draws,
     PdfFillRule rule,
+    _GpuBuffer? fan,
   ) {
     _dropRetainedBindings();
     _appliedDefaultStencilBit = null;
@@ -9308,8 +9375,12 @@ class _GpuEncoder {
           targetFace: gpu.StencilFace.back,
         );
     }
-    for (final draw in draws) {
-      _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
+    if (fan != null) {
+      _drawBuffer(fan, _GpuDrawKind.stencilFan);
+    } else {
+      for (final draw in draws) {
+        _drawBuffer(draw.fan, _GpuDrawKind.stencilFan);
+      }
     }
     _paintOpaqueStencilFillBatchCover(draws);
   }

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -697,6 +697,64 @@ void main() {
     });
   });
 
+  testWidgets('coalesces disjoint opaque stencil fans and covers',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const first = PdfPath([
+        PdfMoveTo(60, 100),
+        PdfLineTo(150, 100),
+        PdfLineTo(105, 190),
+        PdfClosePath(),
+      ]);
+      const second = PdfPath([
+        PdfMoveTo(240, 100),
+        PdfLineTo(330, 100),
+        PdfLineTo(285, 190),
+        PdfClosePath(),
+      ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, const [
+        PdfFillPathCommand(
+          first,
+          PdfColor(0.08, 0.24, 0.82),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          second,
+          PdfColor(0.82, 0.18, 0.12),
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(backend.stats.coalescedDrawBatches, 1);
+      expect(backend.stats.drawCallsSaved, 2);
+      expect(backend.stats.stencilFanDrawCalls, 1);
+      expect(backend.stats.stencilCoverDrawCalls, 1);
+    });
+  });
+
   testWidgets(
       'coalesces matching opaque stroke unions without merging alpha or blend',
       (tester) async {
@@ -746,13 +804,13 @@ void main() {
       }
       expect(difference / a.length, lessThan(3));
       expect(backend.stats.coalescedDrawBatches, 1);
-      expect(backend.stats.drawCallsSaved, 1,
-          reason: 'two opaque strokes keep their two stencil fans and share '
+      expect(backend.stats.drawCallsSaved, 2,
+          reason: 'two opaque strokes share one stencil fan submission and '
               'one cover; the translucent and Multiply strokes stay split');
     });
   });
 
-  testWidgets('bounds opaque stroke batches to one 256-cover upload',
+  testWidgets('bounds opaque stroke batches to 256 fan-and-cover submissions',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -783,8 +841,9 @@ void main() {
       await _pixels(image);
       image.dispose();
       expect(backend.stats.coalescedDrawBatches, 1);
-      expect(backend.stats.drawCallsSaved, 255,
-          reason: 'the 257th stroke begins a new bounded batch');
+      expect(backend.stats.drawCallsSaved, 510,
+          reason: 'the first 256 fans and covers each collapse to one draw; '
+              'the 257th stroke begins a new bounded batch');
     });
   });
 


### PR DESCRIPTION
## Performance vs main

- Native draw calls: **9,254 → 7,595 (-17.9%)** across the 226 pages accelerated by both revisions.
- Stencil-fan draws: **4,246 → 2,587 (-39.1%)**.
- Draw calls saved by batching: **10,696 → 12,355 (+15.5%)**.
- Routes, geometry vertices, buffers, bytes, and pixel parity are unchanged.
- Standard-font benchmark draw calls: **1,327 → 1,005 (-24.3%)**; warm median **12,723 → 11,922 us (-6.3%)**.
- Quadpoints benchmark draw calls: **823 → 562 (-31.7%)**; compile median **65,206 → 58,592 us (-10.1%)**, issue median **39,811 → 35,222 us (-11.5%)**.

## Change

Pack stencil-fan slices into a dedicated lane inside the retained geometry allocation, then coalesce adjacent fan buffer views into one draw when they are exactly contiguous. The existing opaque-batch safety proof remains the gate, and non-contiguous geometry keeps the previous path.

<details>
<summary>Validation details</summary>

- `fvm dart analyze packages/dart_pdf_editor_flutter_gpu`
- Native backend suite with Impeller/flutter_gpu
- Entire `dart_pdf_editor_flutter_gpu` test suite
- Expanded system-font Ghent + PDF.js GPU corpus
- Ghent: 49 accelerated / 8 fallback
- PDF.js: 177 accelerated / 2 fallback
- Regression: disjoint opaque stencil fans coalesce while covers and pixels remain correct
- Rebased focused regression passed again on merged #848

No new fallbacks, route changes, geometry growth, or pixel regressions were observed.

</details>