### PR TITLE
perf(gpu): bound overprint retry cost

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -365,6 +365,11 @@ full parity matrix on every change.
 Set `PDF_GPU_BENCHMARK_ANALYTIC_TEXT=0` or
 `GPU_CORPUS_ANALYTIC_TEXT=0` for a same-build comparison against the retained
 stencil-fan text path.
+The exact overprint rerecord keeps its 512-cell default but skips scenes above
+768 retained commands so a failed GPU retry cannot add seconds before Canvas
+fallback. Set `GPU_CORPUS_OVERPRINT_RETRY_MAX_COMMANDS` to override that corpus
+guard; `FlutterGpuTileRasterBackend.overprintRetryMaxCommands` is the runtime
+equivalent, and null removes the guard for exhaustive diagnostics.
 Set `PDF_GPU_BENCHMARK_OVERPRINT=0` to exercise the production-default exact
 fallback policy; the benchmark otherwise enables its documented source-over
 approximation so more of a corpus can be measured on the GPU.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -44,6 +44,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     this.msaa = true,
     this.allowOverprintApproximation = false,
     this.overprintRetryMaxDimension = 512,
+    this.overprintRetryMaxCommands = 768,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
     this.maxTransientAttachmentBytes = 64 << 20,
@@ -54,6 +55,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     FlutterGpuTileBackendStats? stats,
   })  : assert(overprintRetryMaxDimension == null ||
             overprintRetryMaxDimension > 0),
+        assert(
+            overprintRetryMaxCommands == null || overprintRetryMaxCommands > 0),
         assert(maxTransientAttachmentBytes >= 0),
         stats = stats ?? FlutterGpuTileBackendStats(),
         textOutliner = textOutliner ??
@@ -84,6 +87,13 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   /// every already-accepted scene are unchanged—and a retry that remains
   /// unsupported is handed back to the viewer's exact Canvas fallback.
   final int? overprintRetryMaxDimension;
+
+  /// Maximum retained commands eligible for the exact overprint retry.
+  ///
+  /// The default preserves small successful retries while declining complex
+  /// scenes before a denser colorant walk can add seconds to Canvas fallback.
+  /// Null removes the guard for exhaustive diagnostics.
+  final int? overprintRetryMaxCommands;
 
   /// Byte budget for decoded image textures shared by every scene/session
   /// created from this backend instance. Cached and active scene leases both
@@ -336,10 +346,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
     final maxDimension = overprintRetryMaxDimension;
     if (maxDimension == null ||
         _lastSessionRejection !=
-            'non-black overprint requires Canvas fallback' ||
-        !scene.canRerecordWithOverprint) {
+            'non-black overprint requires Canvas fallback') {
       return null;
     }
+    final maxCommands = overprintRetryMaxCommands;
+    if (maxCommands != null && scene.commands.length > maxCommands) {
+      stats.overprintRetryCostSkips++;
+      return null;
+    }
+    if (!scene.canRerecordWithOverprint) return null;
     stats
       ..overprintRetryRequests += 1
       ..lastTileRoute = 'flutter_gpu-overprint-retry';

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -23,6 +23,7 @@ class FlutterGpuTileBackendStats {
   int overprintRetryRequests = 0;
   int overprintRetrySuccesses = 0;
   int overprintRetryFallbacks = 0;
+  int overprintRetryCostSkips = 0;
   int overprintRetryMicros = 0;
   int rasterFallbacks = 0;
   int activeSessions = 0;
@@ -133,6 +134,7 @@ class FlutterGpuTileBackendStats {
         'overprintRetryRequests': overprintRetryRequests,
         'overprintRetrySuccesses': overprintRetrySuccesses,
         'overprintRetryFallbacks': overprintRetryFallbacks,
+        'overprintRetryCostSkips': overprintRetryCostSkips,
         'overprintRetryMicros': overprintRetryMicros,
         'rasterFallbacks': rasterFallbacks,
         'activeSessions': activeSessions,
@@ -232,6 +234,7 @@ class FlutterGpuTileBackendStats {
     overprintRetryRequests = 0;
     overprintRetrySuccesses = 0;
     overprintRetryFallbacks = 0;
+    overprintRetryCostSkips = 0;
     overprintRetryMicros = 0;
     rasterFallbacks = 0;
     contextSwitches = 0;
@@ -338,6 +341,7 @@ class FlutterGpuTileBackendStats {
       'sceneWarmUpUs=$sceneWarmUpMicros '
       'lastContext=$lastContextIdentity '
       'activeSessions=$activeSessions peakActiveSessions=$peakActiveSessions '
+      'overprintRetryCostSkips=$overprintRetryCostSkips '
       'overprintApprox=$overprintApproximationSessions '
       'compiled=$scenesCompiled compileUs=$compileMicros '
       'buffers=$geometryBuffers vertices=$geometryVertices '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -9,6 +9,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     this.msaa = true,
     this.allowOverprintApproximation = false,
     this.overprintRetryMaxDimension = 512,
+    this.overprintRetryMaxCommands = 768,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
     this.enableProactiveWarmUp,
@@ -18,11 +19,14 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     FlutterGpuTileBackendStats? stats,
   })  : assert(overprintRetryMaxDimension == null ||
             overprintRetryMaxDimension > 0),
+        assert(
+            overprintRetryMaxCommands == null || overprintRetryMaxCommands > 0),
         stats = stats ?? FlutterGpuTileBackendStats();
 
   final bool msaa;
   final bool allowOverprintApproximation;
   final int? overprintRetryMaxDimension;
+  final int? overprintRetryMaxCommands;
   final int maxTextureBytes;
   final int maxGeometryBytes;
   final bool? enableProactiveWarmUp;

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -17,10 +17,16 @@ void main() {
       expect(desktop.supportsWarmUp, isTrue);
       expect(desktop.supportsSessionWarmUp, isTrue);
       expect(desktop.overprintRetryMaxDimension, 512);
+      expect(desktop.overprintRetryMaxCommands, 768);
       expect(desktop.maxTransientAttachmentBytes, 64 << 20);
       expect(
         FlutterGpuTileRasterBackend(overprintRetryMaxDimension: null)
             .overprintRetryMaxDimension,
+        isNull,
+      );
+      expect(
+        FlutterGpuTileRasterBackend(overprintRetryMaxCommands: null)
+            .overprintRetryMaxCommands,
         isNull,
       );
       expect(
@@ -49,6 +55,7 @@ void main() {
       ..overprintRetryRequests = 3
       ..overprintRetrySuccesses = 2
       ..overprintRetryFallbacks = 1
+      ..overprintRetryCostSkips = 4
       ..overprintRetryMicros = 24000
       ..rasterFallbacks = 1
       ..lastContextIdentity = 1234
@@ -129,6 +136,7 @@ void main() {
     expect(stats.toJson(), containsPair('overprintRetryRequests', 3));
     expect(stats.toJson(), containsPair('overprintRetrySuccesses', 2));
     expect(stats.toJson(), containsPair('overprintRetryFallbacks', 1));
+    expect(stats.toJson(), containsPair('overprintRetryCostSkips', 4));
     expect(stats.toJson(), containsPair('overprintRetryMicros', 24000));
     expect(stats.toJson(), containsPair('lastRejection', 'test fallback'));
     expect(stats.toJson(), containsPair('lastTileRoute', 'canvas-fallback'));
@@ -198,6 +206,7 @@ void main() {
     expect(stats.overprintRetryRequests, 0);
     expect(stats.overprintRetrySuccesses, 0);
     expect(stats.overprintRetryFallbacks, 0);
+    expect(stats.overprintRetryCostSkips, 0);
     expect(stats.overprintRetryMicros, 0);
     expect(stats.rasterFallbacks, 0);
     expect(stats.lastContextIdentity, 1234);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2619,6 +2619,11 @@ void main() {
       expect(exact.stats.lastRejection, contains('overprint'));
       expect(exact.stats.lastTileRoute, 'canvas-fallback');
 
+      final guarded = FlutterGpuTileRasterBackend(overprintRetryMaxCommands: 1);
+      expect(guarded.createSession(scene), isNull);
+      expect(guarded.retrySession(scene), isNull);
+      expect(guarded.stats.overprintRetryCostSkips, 1);
+
       final benchmark =
           FlutterGpuTileRasterBackend(allowOverprintApproximation: true);
       final session = benchmark.createSession(scene);

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_corpus_test.dart
@@ -157,6 +157,12 @@ void _corpus(
                       '',
                 ) ??
                 512,
+            overprintRetryMaxCommands: int.tryParse(
+                  Platform.environment[
+                          'GPU_CORPUS_OVERPRINT_RETRY_MAX_COMMANDS'] ??
+                      '',
+                ) ??
+                768,
           );
           final scene = await PdfRetainedScene.record(
             document.page(pageIndex),

--- a/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
@@ -9,6 +9,7 @@ void main() {
     expect(backend.debugLabel, contains('flutter_gpu'));
     expect(backend.msaa, isFalse);
     expect(backend.overprintRetryMaxDimension, 512);
+    expect(backend.overprintRetryMaxCommands, 768);
     expect(backend.stats, same(stats));
   });
 }


### PR DESCRIPTION
## Performance vs main

- Exact-overprint retry work: **9.43s → 0.28s (-97.0%)** across the expanded Ghent + PDF.js system-font corpus.
- GPU coverage is unchanged: **Ghent 49 accelerated / 8 fallback; PDF.js 177 / 2**.
- The successful GWG164 retry is preserved (mean pixel difference **14.93**); six complex scenes skip only retries that previously failed.
- Routes, accepted-page parity, geometry, and draw counts are unchanged.

## Change

Keep the existing 512-cell exact overprint rerecord, but make scenes above 768 retained commands go directly to the exact Canvas fallback. The limit is configurable through `overprintRetryMaxCommands`; null removes it for exhaustive diagnostics. Diagnostics now expose `overprintRetryCostSkips`, and the corpus harness accepts `GPU_CORPUS_OVERPRINT_RETRY_MAX_COMMANDS`.

<details>
<summary>Validation details</summary>

- `fvm dart analyze packages/dart_pdf_editor_flutter_gpu`
- Full `dart_pdf_editor_flutter_gpu` suite with Impeller/flutter_gpu: 327 passed, 4 skipped
- Full expanded system-font Ghent + PDF.js GPU corpus
- Web stub regression under Chrome
- Focused native regression for the command-cost guard
- Rebased focused regression passed again on merged #849

The 768-command threshold was derived from the complete retry set: the only successful corpus retry has 643 commands and cost 0.13s in the guarded run; the skipped scenes range from 840 to 3,038 commands and previously consumed the multi-second tail.

</details>