### PR TITLE
perf(gpu): trim redundant clip clears

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -9137,6 +9137,7 @@ class _GpuEncoder {
 
   _GpuClipState? _clipState;
   int _activeClipBit = 0;
+  bool _clipBitsDirty = false;
   int clipMaskRebuilds = 0;
   bool? _separateVertexCountApi;
   gpu.ColorBlendEquation _paintBlend = _srcOver;
@@ -9268,15 +9269,26 @@ class _GpuEncoder {
 
     // A restored clip can be broader than the state used by the preceding
     // draw. Rebuild from the persistent root rather than trying to preserve an
-    // ancestor bit whose alternating slot may since have been reused.
-    _clearStencil(_allStencilBits);
+    // ancestor bit whose alternating slot may since have been reused. A new
+    // render pass starts with stencilClearValue=0, so its first clip needs no
+    // draw just to reproduce that clear.
+    if (_clipBitsDirty) {
+      _clearStencil(_allStencilBits);
+      _clipBitsDirty = false;
+    }
     final chain = <_GpuClipNode>[];
     for (_GpuClipNode? node = leaf; node != null; node = node.previous) {
       chain.add(node);
     }
+    var usedClipBits = 0;
     for (final node in chain.reversed) {
       final nextBit = _activeClipBit == _clipBitA ? _clipBitB : _clipBitA;
-      _clearStencil(_pathMask | nextBit);
+      // The full clear above already zeroed both clip bits, and the previous
+      // iteration zeroed the scratch path bits after resolving its mask. Only
+      // clear [nextBit] once this rebuild is deep enough to reuse it.
+      if ((usedClipBits & nextBit) != 0) {
+        _clearStencil(nextBit);
+      }
       final draw = clipDraws[node]!;
       _accumulateStencil(
         draw.fan,
@@ -9292,16 +9304,16 @@ class _GpuEncoder {
           depthStencilPassOperation: gpu.StencilOperation.setToReferenceValue,
           stencilFailureOperation: gpu.StencilOperation.keep,
           readMask: _pathMask,
-          writeMask: nextBit,
+          writeMask: _pathMask | nextBit,
         ))
         ..bindPipeline(pipelines.solid)
         ..bindUniform(pipelines.solidTransform, transform);
       _drawBuffer(draw.cover, _GpuDrawKind.stencilCover);
-      // The lower bits are scratch. Clearing them here leaves the final clip
-      // bit intact and makes the following PDF fill independent of how many
-      // contours built this mask.
-      _clearStencil(_pathMask);
+      // setToReferenceValue writes zero into the scratch bits while setting
+      // [nextBit], so the following path starts from an empty winding field.
       _activeClipBit = nextBit;
+      _clipBitsDirty = true;
+      usedClipBits |= nextBit;
     }
   }
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2092,6 +2092,9 @@ void main() {
       expect(backend.stats.clipPathsCompiled, 2);
       expect(backend.stats.clipMaskRebuilds, greaterThanOrEqualTo(3),
           reason: 'nested state and restored ancestor are rebuilt exactly');
+      expect(backend.stats.stencilClearDrawCalls, 2,
+          reason: 'the first clip uses the render-pass clear; later rebuilds '
+              'clear once while each cover also clears its scratch field');
     });
   });
 


### PR DESCRIPTION
## Headline

- Native GPU draw calls across 226 accelerated corpus pages: 7,595 -> 7,187 (-5.4%)
- Stencil-clear draws: 609 -> 201 (-67.0%)
- GPU routes unchanged: Ghent 49/8 accepted/fallback; PDF.js 177/2
- Pixel parity means unchanged on every accelerated page

## Change

An arbitrary-clip rebuild starts in a render pass whose stencil attachment is already cleared to zero. Reuse that initial clear, avoid immediately clearing still-zero bits, and make each clip-cover stencil operation clear its scratch winding bits while writing the resolved clip bit. A clip bit is still cleared before actual reuse at deeper nesting. Paint order, clip coverage, and the clear-before-reuse invariant remain unchanged.

<details>
<summary>Validation details</summary>

- fvm dart analyze packages/dart_pdf_editor_flutter_gpu
- Full native package suite: 327 passed, 4 skipped
- Full expanded native GPU corpus with system fonts: all parity checks passed
- Chrome web-stub test passed
- Focused nested/restored arbitrary-clip regression now asserts 2 stencil clears; the previous path issued 11
- Timing is intentionally left to the balanced same-host CI report; the retained draw counters are deterministic

</details>