### PR TITLE
perf(gpu): draw triangle fills directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,7 @@ jobs:
               prime_index=$((prime_index + 1))
             done <<'SCENARIOS'
           tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          type3-triangles pdf ../../test_corpora/pdfjs/Type3WordSpacing.pdf
           radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
           deferred-mask fixture deferred-mask
           vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
@@ -391,6 +392,7 @@ jobs:
               fi
             done <<'SCENARIOS'
           tiling pdf ../../test_corpora/pdfjs/tiling-pattern-box.pdf
+          type3-triangles pdf ../../test_corpora/pdfjs/Type3WordSpacing.pdf
           radial pdf ../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf
           deferred-mask fixture deferred-mask
           vector-mask pdf ../../test_corpora/pdfjs/smask_luminosity_oob_transfer.pdf
@@ -429,6 +431,10 @@ jobs:
             --require-scenario-runs gpu-tiling-page-0-scene-warm=6
             --require-scenario-runs gpu-tiling-page-0-first-tile=6
             --require-scenario-runs gpu-tiling-page-0-canvas-tile=6
+            --require-scenario-runs gpu-type3-triangles-pipeline-warm=6
+            --require-scenario-runs gpu-type3-triangles-page-0-scene-warm=6
+            --require-scenario-runs gpu-type3-triangles-page-0-first-tile=6
+            --require-scenario-runs gpu-type3-triangles-page-0-canvas-tile=6
             --require-scenario-runs gpu-radial-pipeline-warm=6
             --require-scenario-runs gpu-radial-page-0-scene-warm=6
             --require-scenario-runs gpu-radial-page-0-first-tile=6

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -191,6 +191,9 @@ The route rejects before allocating when its temporary attachments would
 exceed 256 MiB.
 Rectangles use hardware scissors; other clip stacks compile once into retained
 stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
+solid-fill path sends axis-aligned rectangles and non-degenerate closed
+triangles straight to the color pipeline. Longer polygons retain the stencil
+cover so internal triangulation edges cannot change multisample coverage. The
 mask case keeps the base and mask as two GPU textures and combines them during
 tile replay; it never builds an eager full-size RGBA composite or reads pixels
 back to the CPU. Worker-retained RGBA uploads directly; compatible locally
@@ -249,6 +252,7 @@ tile route, runtime fallback reasons, context and scene warm-up outcomes,
 scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
+Direct-primitive diagnostics count rectangle and triangle fills separately.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
 Paper diagnostics report how many tiles used the exact interior clear path and
 how many of those were content-free color-only submissions.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8045,18 +8045,34 @@ _GpuDraw? _stencilDraw(
   bool union,
 ) {
   if (alpha <= 0) return null;
+  final a = alpha.clamp(0.0, 1.0);
   final rectangle = _axisAlignedRectangle(subpaths);
   if (rectangle != null) {
     geometry.stats.directRectangleDraws++;
-    final a = alpha.clamp(0.0, 1.0);
     return _SolidDraw(
       _coverGeometry(geometry, rectangle, _premul(color, a)),
     );
   }
+  final triangle = _closedTriangle(subpaths);
+  if (triangle != null) {
+    geometry.stats.directTriangleDraws++;
+    final rgba = _premul(color, a);
+    final vertices = FloatBuilder(18);
+    for (var index = 0; index < 3; index++) {
+      vertices.add6(
+        triangle[2 * index],
+        triangle[2 * index + 1],
+        rgba[0],
+        rgba[1],
+        rgba[2],
+        rgba[3],
+      );
+    }
+    return _SolidDraw(geometry.add(vertices.bytes, 3));
+  }
   final parts = _stencilGeometry(geometry, subpaths);
   if (parts == null) return null;
   final fanBuffer = parts.$1;
-  final a = alpha.clamp(0.0, 1.0);
   final rgba = _premul(color, a);
   return _StencilDraw(
     fanBuffer,
@@ -8065,6 +8081,26 @@ _GpuDraw? _stencilDraw(
     union,
     opaquePaint: a == 1 ? (bounds: parts.$2, color: color) : null,
   );
+}
+
+/// Returns the three vertices when [subpaths] is one non-degenerate triangle.
+///
+/// A triangle has no internal triangulation edge, so painting it directly has
+/// exactly the same per-sample coverage as the stencil fan. Longer convex
+/// paths deliberately stay on the stencil route: a triangle fan introduces
+/// internal MSAA edges whose coverage can differ slightly from the resolved
+/// path union.
+Float64List? _closedTriangle(List<FlatSubpath> subpaths) {
+  if (subpaths.length != 1) return null;
+  final subpath = subpaths.single;
+  final points = subpath.points;
+  if (!subpath.closed || points.length != 8) return null;
+  if (points[0] != points[6] || points[1] != points[7]) return null;
+  if (!points.every((coordinate) => coordinate.isFinite)) return null;
+  final area2 = (points[2] - points[0]) * (points[5] - points[1]) -
+      (points[3] - points[1]) * (points[4] - points[0]);
+  if (!area2.isFinite || area2 == 0) return null;
+  return points;
 }
 
 /// Returns the bounds when [subpaths] describes one non-degenerate,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -54,6 +54,7 @@ class FlutterGpuTileBackendStats {
   int blendDrawCalls = 0;
   int softMaskDrawCalls = 0;
   int directRectangleDraws = 0;
+  int directTriangleDraws = 0;
   int clipPathsCompiled = 0;
   int clipMaskRebuilds = 0;
   int paperClearTiles = 0;
@@ -165,6 +166,7 @@ class FlutterGpuTileBackendStats {
         'blendDrawCalls': blendDrawCalls,
         'softMaskDrawCalls': softMaskDrawCalls,
         'directRectangleDraws': directRectangleDraws,
+        'directTriangleDraws': directTriangleDraws,
         'clipPathsCompiled': clipPathsCompiled,
         'clipMaskRebuilds': clipMaskRebuilds,
         'paperClearTiles': paperClearTiles,
@@ -276,6 +278,7 @@ class FlutterGpuTileBackendStats {
     blendDrawCalls = 0;
     softMaskDrawCalls = 0;
     directRectangleDraws = 0;
+    directTriangleDraws = 0;
     clipPathsCompiled = 0;
     clipMaskRebuilds = 0;
     paperClearTiles = 0;
@@ -359,6 +362,7 @@ class FlutterGpuTileBackendStats {
       '$stencilCoverDrawCalls/$stencilClearDrawCalls/$textureDrawCalls/'
       '$glyphDrawCalls/$blendDrawCalls/$softMaskDrawCalls '
       'directRectangleDraws=$directRectangleDraws '
+      'directTriangleDraws=$directTriangleDraws '
       'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'paperClearTiles=$paperClearTiles '
       'paperOnlyTiles=$paperOnlyTiles '

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -114,6 +114,7 @@ void main() {
       ..blendDrawCalls = 2
       ..softMaskDrawCalls = 2
       ..directRectangleDraws = 96
+      ..directTriangleDraws = 24
       ..paperClearTiles = 6
       ..paperOnlyTiles = 3
       ..subpixelStrokeFallbacks = 2
@@ -190,6 +191,7 @@ void main() {
     expect(stats.toJson(), containsPair('blendDrawCalls', 2));
     expect(stats.toJson(), containsPair('softMaskDrawCalls', 2));
     expect(stats.toJson(), containsPair('directRectangleDraws', 96));
+    expect(stats.toJson(), containsPair('directTriangleDraws', 24));
     expect(stats.toJson(), containsPair('paperClearTiles', 6));
     expect(stats.toJson(), containsPair('paperOnlyTiles', 3));
     expect(stats.toJson(), containsPair('subpixelStrokeFallbacks', 2));
@@ -266,6 +268,7 @@ void main() {
     expect(stats.blendDrawCalls, 0);
     expect(stats.softMaskDrawCalls, 0);
     expect(stats.directRectangleDraws, 0);
+    expect(stats.directTriangleDraws, 0);
     expect(stats.paperClearTiles, 0);
     expect(stats.paperOnlyTiles, 0);
     expect(stats.subpixelStrokeFallbacks, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -697,6 +697,94 @@ void main() {
     });
   });
 
+  testWidgets('draws a closed triangle without a stencil cover',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const triangle = PdfPath([
+        PdfMoveTo(80, 120),
+        PdfLineTo(500, 180),
+        PdfLineTo(210, 620),
+        PdfClosePath(),
+      ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, const [
+        PdfFillPathCommand(
+          triangle,
+          PdfColor(0.08, 0.24, 0.82),
+          PdfFillRule.evenOdd,
+          0.65,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var index = 0; index < a.length; index++) {
+        difference += (a[index] - b[index]).abs();
+      }
+      expect(difference / a.length, lessThan(3));
+      expect(backend.stats.directTriangleDraws, 1);
+      expect(backend.stats.directSolidDrawCalls, 2,
+          reason: 'one paper draw plus the triangle');
+      expect(backend.stats.stencilFanDrawCalls, 0);
+      expect(backend.stats.stencilCoverDrawCalls, 0);
+    });
+  });
+
+  testWidgets('keeps longer convex polygons on the stencil path',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      const quadrilateral = PdfPath([
+        PdfMoveTo(80, 120),
+        PdfLineTo(500, 180),
+        PdfLineTo(450, 620),
+        PdfLineTo(140, 560),
+        PdfClosePath(),
+      ]);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, const [
+        PdfFillPathCommand(
+          quadrilateral,
+          PdfColor(0.08, 0.24, 0.82),
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+
+      final image = await session.rasterizeRegion(
+        Offset.zero & scene.pageSize,
+        pixelRatio: 1,
+      );
+      await _pixels(image);
+      image.dispose();
+      expect(backend.stats.directTriangleDraws, 0);
+      expect(backend.stats.stencilFanDrawCalls, 1);
+      expect(backend.stats.stencilCoverDrawCalls, 1);
+    });
+  });
+
   testWidgets('coalesces disjoint opaque stencil fans and covers',
       (tester) async {
     await tester.runAsync(() async {
@@ -707,13 +795,19 @@ void main() {
       const first = PdfPath([
         PdfMoveTo(60, 100),
         PdfLineTo(150, 100),
-        PdfLineTo(105, 190),
+        PdfLineTo(120, 145),
+        PdfLineTo(150, 190),
+        PdfLineTo(60, 190),
+        PdfLineTo(90, 145),
         PdfClosePath(),
       ]);
       const second = PdfPath([
         PdfMoveTo(240, 100),
         PdfLineTo(330, 100),
-        PdfLineTo(285, 190),
+        PdfLineTo(300, 145),
+        PdfLineTo(330, 190),
+        PdfLineTo(240, 190),
+        PdfLineTo(270, 145),
         PdfClosePath(),
       ]);
       final page = PdfDocument.open(buildClassicPdf()).page(0);

--- a/tool/gpu_corpus_summary.dart
+++ b/tool/gpu_corpus_summary.dart
@@ -270,23 +270,29 @@ class GpuCorpusComparison {
       ..writeln('| Metric | Main | PR | Change |')
       ..writeln('| --- | ---: | ---: | ---: |');
     for (final metric in const [
-      ('Native draw calls', 'drawCalls'),
-      ('Direct solid draws', 'directSolidDrawCalls'),
-      ('Stencil fan draws', 'stencilFanDrawCalls'),
-      ('Stencil cover draws', 'stencilCoverDrawCalls'),
-      ('Stencil clear draws', 'stencilClearDrawCalls'),
-      ('Texture draws', 'textureDrawCalls'),
-      ('Glyph draws', 'glyphDrawCalls'),
-      ('Advanced blend draws', 'blendDrawCalls'),
-      ('Soft-mask draws', 'softMaskDrawCalls'),
-      ('Selected commands', 'selectedCommands'),
-      ('Draw calls saved', 'drawCallsSaved'),
-      ('Direct rectangle draws', 'directRectangleDraws'),
-      ('Geometry vertices', 'geometryVertices'),
+      ('Native draw calls', 'drawCalls', false),
+      ('Direct solid draws', 'directSolidDrawCalls', false),
+      ('Stencil fan draws', 'stencilFanDrawCalls', false),
+      ('Stencil cover draws', 'stencilCoverDrawCalls', false),
+      ('Stencil clear draws', 'stencilClearDrawCalls', false),
+      ('Texture draws', 'textureDrawCalls', false),
+      ('Glyph draws', 'glyphDrawCalls', false),
+      ('Advanced blend draws', 'blendDrawCalls', false),
+      ('Soft-mask draws', 'softMaskDrawCalls', false),
+      ('Selected commands', 'selectedCommands', false),
+      ('Draw calls saved', 'drawCallsSaved', false),
+      ('Direct rectangle draws', 'directRectangleDraws', false),
+      // This counter is introduced by the current report. Older base
+      // revisions omitted it, which is equivalent to observing zero direct
+      // triangles rather than having no comparable page statistics.
+      ('Direct triangle draws', 'directTriangleDraws', true),
+      ('Geometry vertices', 'geometryVertices', false),
     ]) {
-      if (!samples.every((sample) =>
-          sample.$1.stat(metric.$2) != null &&
-          sample.$2.stat(metric.$2) != null)) {
+      final hasCurrent =
+          samples.every((sample) => sample.$2.stat(metric.$2) != null);
+      final hasBaseline =
+          samples.every((sample) => sample.$1.stat(metric.$2) != null);
+      if (!hasCurrent || !hasBaseline && !metric.$3) {
         continue;
       }
       final main = _sumStats(samples.map((sample) => sample.$1), metric.$2);
@@ -323,15 +329,17 @@ class GpuCorpusComparison {
           'stencil clear / texture / glyph / advanced blend / soft mask.')
       ..writeln()
       ..writeln('| Page | Draws | Commands | Saved | Direct rectangles | '
-          'Draw mix | Issue | Compile | Canvas mean delta |')
-      ..writeln(
-          '| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |');
+          'Direct triangles | Draw mix | Issue | Compile | '
+          'Canvas mean delta |')
+      ..writeln('| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | '
+          '---: | ---: |');
     for (final page in pages.take(15)) {
       buffer.writeln(
         '| `${_escape(page.id)}` | ${_integerStat(page, 'drawCalls')} | '
         '${_integerStat(page, 'selectedCommands')} | '
         '${_integerStat(page, 'drawCallsSaved')} | '
         '${_integerStat(page, 'directRectangleDraws')} | '
+        '${_integerStat(page, 'directTriangleDraws')} | '
         '${_drawMix(page)} | '
         '${_millisecondsStat(page, 'issueMicros')} | '
         '${_millisecondsStat(page, 'compileMicros')} | '

--- a/tool/gpu_corpus_summary_test.dart
+++ b/tool/gpu_corpus_summary_test.dart
@@ -75,6 +75,7 @@ void main() {
               'selectedCommands': 12,
               'drawCallsSaved': 4,
               'directRectangleDraws': 3,
+              'directTriangleDraws': 3,
               'geometryVertices': 240,
               'issueMicros': 6000,
               'compileMicros': 3000,
@@ -103,6 +104,7 @@ void main() {
               'selectedCommands': 5,
               'drawCallsSaved': 4,
               'directRectangleDraws': 2,
+              'directTriangleDraws': 2,
               'geometryVertices': 90,
               'issueMicros': 3500,
               'compileMicros': 1800,
@@ -161,8 +163,13 @@ void main() {
   );
   _expectContains(
     comparison.toMarkdown(),
+    '| Direct triangle draws | 0 | 2 | new |',
+    'direct-triangle comparison',
+  );
+  _expectContains(
+    comparison.toMarkdown(),
     '| `Ghent/fallback.pdf page 0` | 20 | 12 | 4 | 3 | '
-        '4/6/4/2/1/1/1/1 | 6.000 ms | 3.000 ms | 0.250 |',
+        '3 | 4/6/4/2/1/1/1/1 | 6.000 ms | 3.000 ms | 0.250 |',
     'ranked draw hotspot',
   );
 


### PR DESCRIPTION
## Result

On the new same-host `Type3WordSpacing` cohort, direct triangle fills reduce median first-tile settle from **5.25 ms to 4.43 ms (-15.6%)**, scene warm-up from **93.31 ms to 62.07 ms (-33.5%)**, and the second tile from **4.41 ms to 3.84 ms (-12.9%)**.

Across the expanded native corpus, routes and pixels are unchanged while native draws fall **7187 -> 7161 (-0.4%)**. `Type3WordSpacing.pdf` falls **99 -> 75 draws (-24.2%)**.

<details>
<summary>Implementation and validation</summary>

- Send one closed, finite, non-degenerate triangle straight through the solid pipeline.
- Keep quadrilaterals, flattened curves, multi-subpath fills, and all longer polygons on the exact stencil route; the broader convex prototype changed MSAA edge coverage on two pages.
- Add `directTriangleDraws` diagnostics and make the corpus reporter treat the missing old-base counter as zero.
- Add a permanent same-host `type3-triangles` CI benchmark cohort.

Validation:

- `fvm dart analyze`
- complete native GPU package suite: 329 passed, 4 skipped
- expanded system-font corpus: Ghent 49/8, PDF.js 177/2, zero route/parity changes
- Chrome web stub
- corpus summary regression test

Local alternating six-sample medians are above; CI's same-host comparison remains authoritative.
</details>
