### PR TITLE
feat(gpu): add live render route devtool

### DIFF
--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -694,6 +694,18 @@ class _ViewerScreenState extends State<ViewerScreen> {
           ),
         ),
         PopupMenuItem(
+          key: const ValueKey('dartpdf-gpu-route-devtool'),
+          value: () => pdfDebugShowGpuRasterRoutes.value =
+              !pdfDebugShowGpuRasterRoutes.value,
+          enabled: tab?.session != null,
+          child: _appMenuTile(
+            icon: Icons.developer_mode,
+            title: pdfDebugShowGpuRasterRoutes.value
+                ? 'Hide GPU rendering overlay'
+                : 'Show GPU rendering overlay',
+          ),
+        ),
+        PopupMenuItem(
           value: () => unawaited(_exportImage()),
           enabled: tab?.session != null,
           child: _appMenuTile(

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -89,6 +89,26 @@ void main() {
     expect(find.text('Compare with another PDF…'), findsOneWidget);
   });
 
+  testWidgets('the app menu toggles the GPU rendering devtool', (tester) async {
+    pdfDebugShowGpuRasterRoutes.value = false;
+    addTearDown(() => pdfDebugShowGpuRasterRoutes.value = false);
+    await openDemo(tester);
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    final devtool = find.byKey(
+      const ValueKey('dartpdf-gpu-route-devtool'),
+    );
+    await tester.ensureVisible(devtool);
+    await tester.pumpAndSettle();
+    await tester.tap(devtool);
+    await tester.pump();
+
+    expect(pdfDebugShowGpuRasterRoutes.value, isTrue);
+    expect(find.byKey(const ValueKey('pdf-gpu-route-overlay')), findsWidgets);
+    expect(find.text('Detail tiles: not active'), findsWidgets);
+  });
+
   testWidgets('performance menu switches between Auto and fixed workers',
       (tester) async {
     await openDemo(tester);

--- a/packages/dart_pdf_editor/lib/src/debug_overlays.dart
+++ b/packages/dart_pdf_editor/lib/src/debug_overlays.dart
@@ -5,9 +5,10 @@
 library;
 
 import 'dart:async';
-import 'dart:ui' show Rect;
-
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'tile_raster_backend.dart';
 
 /// Paints diagnostic borders on the deep-zoom detail surfaces: every tile
 /// placement in a [PdfTileLayer] (green for exact-bucket tiles, orange for
@@ -19,6 +20,179 @@ final ValueNotifier<bool> pdfDebugPaintDetailBounds = ValueNotifier(false);
 /// live page-view state ([PdfLivePageRegistry]) - the lazy-list "render
 /// window" whose retained scenes and rasters dominate per-page memory.
 final ValueNotifier<bool> pdfDebugShowRenderWindow = ValueNotifier(false);
+
+/// Shows each page's exact deep-zoom tile route.
+///
+/// Green means the requested accelerated backend owns the tile session;
+/// amber means it declined or failed and Canvas took over; blue is an
+/// explicitly requested Canvas backend; grey means detail tiles have not been
+/// requested yet and the fitted Canvas base raster is still carrying the
+/// page. The overlay reports detail tiles specifically because the initial
+/// fitted page raster is Canvas even when later zoom detail is accelerated.
+final ValueNotifier<bool> pdfDebugShowGpuRasterRoutes = ValueNotifier(false);
+
+/// A non-interactive page overlay for [pdfDebugShowGpuRasterRoutes].
+///
+/// [cacheNamespace] must be the same stable token supplied to the page's tile
+/// store. [transformScale] is optional for standalone pages; viewers pass
+/// their live zoom notifier so the border and badge stay screen-sized.
+class PdfGpuRasterRouteOverlay extends StatelessWidget {
+  const PdfGpuRasterRouteOverlay({
+    super.key,
+    required this.cacheNamespace,
+    required this.pageIndex,
+    this.transformScale,
+    this.diagnostics,
+  });
+
+  final Object cacheNamespace;
+  final int pageIndex;
+  final ValueListenable<double>? transformScale;
+  final PdfTileRasterDiagnostics? diagnostics;
+
+  @override
+  Widget build(BuildContext context) => ValueListenableBuilder<bool>(
+        valueListenable: pdfDebugShowGpuRasterRoutes,
+        builder: (context, visible, _) {
+          if (!visible) return const SizedBox.shrink();
+          final registry = diagnostics ?? PdfTileRasterDiagnostics.instance;
+          return ListenableBuilder(
+            listenable: registry,
+            builder: (context, _) {
+              final diagnostic = registry.page(cacheNamespace, pageIndex);
+              final scale = transformScale;
+              if (scale == null) {
+                return _PdfGpuRasterRouteChrome(
+                  diagnostic: diagnostic,
+                  zoom: 1,
+                );
+              }
+              return ValueListenableBuilder<double>(
+                valueListenable: scale,
+                builder: (context, zoom, _) => _PdfGpuRasterRouteChrome(
+                  diagnostic: diagnostic,
+                  zoom: zoom,
+                ),
+              );
+            },
+          );
+        },
+      );
+}
+
+class _PdfGpuRasterRouteChrome extends StatelessWidget {
+  const _PdfGpuRasterRouteChrome({
+    required this.diagnostic,
+    required this.zoom,
+  });
+
+  final PdfTileRasterDiagnostic? diagnostic;
+  final double zoom;
+
+  @override
+  Widget build(BuildContext context) {
+    final safeZoom = zoom.isFinite && zoom > 0 ? zoom : 1.0;
+    final chromeScale = 1 / safeZoom;
+    final route = diagnostic?.route ?? PdfTileRasterRoute.unrouted;
+    final tileCount = diagnostic?.tileRasters ?? 0;
+    final tileLabel = '$tileCount ${tileCount == 1 ? 'tile' : 'tiles'}';
+    final (color, title, detail) = switch (route) {
+      PdfTileRasterRoute.accelerated => (
+          const Color(0xFF1B5E20),
+          'Detail tiles: GPU · ${diagnostic!.effectiveBackend}',
+          '$tileLabel · ${diagnostic!.commandCount} commands',
+        ),
+      PdfTileRasterRoute.canvasFallback => (
+          const Color(0xFF9A6700),
+          'Detail tiles: Canvas fallback',
+          '${diagnostic!.requestedBackend}: '
+              '${diagnostic!.fallbackReason ?? diagnostic!.lastTileError ?? 'backend declined'}',
+        ),
+      PdfTileRasterRoute.canvas => (
+          const Color(0xFF1565C0),
+          'Detail tiles: Canvas',
+          '$tileLabel · ${diagnostic!.commandCount} commands',
+        ),
+      PdfTileRasterRoute.unrouted => (
+          const Color(0xFF455A64),
+          'Detail tiles: not active',
+          'Fitted page: Canvas',
+        ),
+    };
+
+    return IgnorePointer(
+      child: Stack(
+        key: const ValueKey('pdf-gpu-route-overlay'),
+        fit: StackFit.expand,
+        children: [
+          DecoratedBox(
+            position: DecorationPosition.foreground,
+            decoration: BoxDecoration(
+              border: Border.all(color: color, width: 2 * chromeScale),
+            ),
+          ),
+          Positioned(
+            left: 8 * chromeScale,
+            top: 8 * chromeScale,
+            child: Transform.scale(
+              alignment: Alignment.topLeft,
+              scale: chromeScale,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: DecoratedBox(
+                  key: const ValueKey('pdf-gpu-route-badge'),
+                  decoration: BoxDecoration(
+                    color: color.withValues(alpha: 0.94),
+                    borderRadius: BorderRadius.circular(6),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Color(0x55000000),
+                        blurRadius: 4,
+                        offset: Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            height: 1.15,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          detail,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: Color(0xEFFFFFFF),
+                            fontSize: 10,
+                            height: 1.2,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 /// Sink for the viewer's touch/gesture diagnostics. Null (the default) means
 /// the viewer emits nothing and pays only a single null-check at each gesture

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -6095,6 +6095,13 @@ class _PdfPageViewState extends State<PdfPageView>
                       ),
                     ),
                   if (tileLayer != null && sharpTilesInFront) tileLayer,
+                  Positioned.fill(
+                    child: PdfGpuRasterRouteOverlay(
+                      cacheNamespace: _effectiveTileCacheNamespace,
+                      pageIndex: widget.previewIndex,
+                      transformScale: widget.transformScale,
+                    ),
+                  ),
                 ],
               );
             },

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
@@ -165,7 +167,7 @@ abstract interface class PdfTileRasterWarmUp {
 /// whether that page had already fallen back to Canvas. This registry records
 /// the latest route and raster for up to [maxEntries] page namespaces without
 /// retaining documents, scenes, or viewer objects.
-class PdfTileRasterDiagnostics {
+class PdfTileRasterDiagnostics extends ChangeNotifier {
   PdfTileRasterDiagnostics._();
 
   static final PdfTileRasterDiagnostics instance = PdfTileRasterDiagnostics._();
@@ -207,6 +209,7 @@ class PdfTileRasterDiagnostics {
     while (_entries.length > maxEntries) {
       _entries.remove(_entries.keys.first);
     }
+    _scheduleNotify();
   }
 
   void reportFallback({
@@ -222,6 +225,7 @@ class PdfTileRasterDiagnostics {
       ..fallbackReason = error.toString()
       ..updatedAt = DateTime.now();
     _entries[(entry.namespaceIdentity, pageIndex)] = entry;
+    _scheduleNotify();
   }
 
   void reportTile({
@@ -254,7 +258,28 @@ class PdfTileRasterDiagnostics {
       }
       ..updatedAt = DateTime.now();
     _entries[(entry.namespaceIdentity, pageIndex)] = entry;
+    _scheduleNotify();
   }
+
+  /// The latest typed diagnostics for [pageIndex] in [cacheNamespace].
+  ///
+  /// The returned value is an immutable snapshot. It remains safe to retain
+  /// while later tile submissions update this process-wide registry.
+  PdfTileRasterDiagnostic? page(
+    Object cacheNamespace,
+    int pageIndex,
+  ) =>
+      _entries[(identityHashCode(cacheNamespace), pageIndex)]?.snapshot();
+
+  /// Typed diagnostics for one viewer namespace, oldest update first.
+  ///
+  /// [namespaceIdentity] is exposed by
+  /// [PdfViewerController.tileCacheNamespaceIdentity].
+  List<PdfTileRasterDiagnostic> forNamespace(int namespaceIdentity) =>
+      <PdfTileRasterDiagnostic>[
+        for (final entry in _entries.values)
+          if (entry.namespaceIdentity == namespaceIdentity) entry.snapshot(),
+      ];
 
   /// A JSON-safe, least-recently-updated-first snapshot.
   List<Map<String, Object?>> snapshot() => <Map<String, Object?>>[
@@ -262,7 +287,92 @@ class PdfTileRasterDiagnostics {
       ];
 
   /// Clears support history without changing any renderer or cache state.
-  void clear() => _entries.clear();
+  void clear() {
+    if (_entries.isEmpty) return;
+    _entries.clear();
+    _scheduleNotify();
+  }
+
+  bool _notifyScheduled = false;
+
+  // Sessions can be created from a lazy page's build/layout path. Coalesce a
+  // burst and notify after the current stack so a listening devtool never
+  // triggers a build-during-build exception.
+  void _scheduleNotify() {
+    // The support registry remains always-on, but the extra UI work is truly
+    // opt-in: without a visible devtool there is no listener and no queued
+    // microtask on each tile completion.
+    if (!hasListeners || _notifyScheduled) return;
+    _notifyScheduled = true;
+    scheduleMicrotask(() {
+      _notifyScheduled = false;
+      notifyListeners();
+    });
+  }
+}
+
+/// How a page's deep-zoom detail tiles are currently rasterized.
+enum PdfTileRasterRoute {
+  /// No tile session has been requested yet; the fitted base raster is Canvas.
+  unrouted,
+
+  /// Canvas was explicitly requested as the tile backend.
+  canvas,
+
+  /// An accelerated backend declined or failed and Canvas took over.
+  canvasFallback,
+
+  /// The requested non-Canvas backend owns the tile session.
+  accelerated,
+}
+
+/// Immutable, typed view of one page's latest tile-routing diagnostics.
+@immutable
+class PdfTileRasterDiagnostic {
+  const PdfTileRasterDiagnostic({
+    required this.namespaceIdentity,
+    required this.documentIdentity,
+    required this.sceneIdentity,
+    required this.pageIndex,
+    required this.requestedBackend,
+    required this.effectiveBackend,
+    required this.fallbackReason,
+    required this.commandCount,
+    required this.pageColor,
+    required this.annotations,
+    required this.rotation,
+    required this.updatedAt,
+    required this.tileRasters,
+    required this.tileFailures,
+    required this.lastTileError,
+    required this.lastTile,
+  });
+
+  final int namespaceIdentity;
+  final int documentIdentity;
+  final int sceneIdentity;
+  final int pageIndex;
+  int get pageNumber => pageIndex + 1;
+  final String requestedBackend;
+  final String effectiveBackend;
+  final String? fallbackReason;
+  final int commandCount;
+  final int pageColor;
+  final bool annotations;
+  final int? rotation;
+  final DateTime updatedAt;
+  final int tileRasters;
+  final int tileFailures;
+  final String? lastTileError;
+  final Map<String, Object?>? lastTile;
+
+  PdfTileRasterRoute get route {
+    if (effectiveBackend != 'canvas') return PdfTileRasterRoute.accelerated;
+    if (requestedBackend == 'canvas' && fallbackReason == null) {
+      return PdfTileRasterRoute.canvas;
+    }
+    return PdfTileRasterRoute.canvasFallback;
+  }
 }
 
 class _PdfTileRasterDiagnosticEntry {
@@ -318,6 +428,27 @@ class _PdfTileRasterDiagnosticEntry {
         'lastTileError': lastTileError,
         'lastTile': lastTile,
       };
+
+  PdfTileRasterDiagnostic snapshot() => PdfTileRasterDiagnostic(
+        namespaceIdentity: namespaceIdentity,
+        documentIdentity: documentIdentity,
+        sceneIdentity: sceneIdentity,
+        pageIndex: pageIndex,
+        requestedBackend: requestedBackend,
+        effectiveBackend: effectiveBackend,
+        fallbackReason: fallbackReason,
+        commandCount: commandCount,
+        pageColor: pageColor,
+        annotations: annotations,
+        rotation: rotation,
+        updatedAt: updatedAt,
+        tileRasters: tileRasters,
+        tileFailures: tileFailures,
+        lastTileError: lastTileError,
+        lastTile: lastTile == null
+            ? null
+            : Map<String, Object?>.unmodifiable(lastTile!),
+      );
 }
 
 /// The universal retained-scene renderer used today and as a fallback for

--- a/packages/dart_pdf_editor/test/debug_overlays_test.dart
+++ b/packages/dart_pdf_editor/test/debug_overlays_test.dart
@@ -10,6 +10,97 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('PdfTileRasterDiagnostics', () {
+    final diagnostics = PdfTileRasterDiagnostics.instance;
+
+    setUp(() async {
+      diagnostics.clear();
+      await pumpEventQueue();
+    });
+
+    tearDown(() async {
+      diagnostics.clear();
+      await pumpEventQueue();
+    });
+
+    test('publishes immutable typed routes and coalesces notifications',
+        () async {
+      final namespace = Object();
+      var ticks = 0;
+      void listener() => ticks++;
+      diagnostics.addListener(listener);
+      addTearDown(() => diagnostics.removeListener(listener));
+
+      diagnostics.reportSession(
+        cacheNamespace: namespace,
+        document: Object(),
+        scene: Object(),
+        pageIndex: 2,
+        requestedBackend: 'flutter_gpu',
+        effectiveBackend: 'flutter_gpu',
+        commandCount: 41,
+        pageColor: 0xFFFFFFFF,
+        annotations: true,
+        rotation: 90,
+      );
+      diagnostics.reportTile(
+        cacheNamespace: namespace,
+        pageIndex: 2,
+        region: const Rect.fromLTWH(0, 0, 10, 20),
+        pixelRatio: 2,
+        width: 20,
+        height: 40,
+      );
+
+      expect(ticks, 0, reason: 'reports may arrive during lazy-page build');
+      await pumpEventQueue();
+      expect(ticks, 1);
+
+      final accelerated = diagnostics.page(namespace, 2)!;
+      expect(accelerated.pageNumber, 3);
+      expect(accelerated.route, PdfTileRasterRoute.accelerated);
+      expect(accelerated.tileRasters, 1);
+      expect(accelerated.commandCount, 41);
+      final namespaceEntries =
+          diagnostics.forNamespace(identityHashCode(namespace));
+      expect(namespaceEntries, hasLength(1));
+      expect(namespaceEntries.single.pageIndex, accelerated.pageIndex);
+      expect(namespaceEntries.single.route, accelerated.route);
+
+      diagnostics.reportFallback(
+        cacheNamespace: namespace,
+        pageIndex: 2,
+        error: StateError('device lost'),
+      );
+      await pumpEventQueue();
+      final fallback = diagnostics.page(namespace, 2)!;
+      expect(fallback.route, PdfTileRasterRoute.canvasFallback);
+      expect(fallback.fallbackReason, contains('device lost'));
+      expect(accelerated.route, PdfTileRasterRoute.accelerated,
+          reason: 'previous snapshots stay immutable');
+    });
+
+    test('distinguishes an explicitly requested Canvas backend', () {
+      final namespace = Object();
+      diagnostics.reportSession(
+        cacheNamespace: namespace,
+        document: Object(),
+        scene: Object(),
+        pageIndex: 0,
+        requestedBackend: 'canvas',
+        effectiveBackend: 'canvas',
+        commandCount: 3,
+        pageColor: 0xFFFFFFFF,
+        annotations: false,
+        rotation: null,
+      );
+      expect(
+        diagnostics.page(namespace, 0)!.route,
+        PdfTileRasterRoute.canvas,
+      );
+    });
+  });
+
   group('PdfLivePageRegistry', () {
     final registry = PdfLivePageRegistry.instance;
 
@@ -145,6 +236,7 @@ void main() {
     test('default off', () {
       expect(pdfDebugPaintDetailBounds.value, isFalse);
       expect(pdfDebugShowRenderWindow.value, isFalse);
+      expect(pdfDebugShowGpuRasterRoutes.value, isFalse);
     });
 
     test('are ValueNotifiers that notify on change', () {
@@ -154,6 +246,7 @@ void main() {
       addTearDown(() {
         pdfDebugPaintDetailBounds.removeListener(listener);
         pdfDebugPaintDetailBounds.value = false;
+        pdfDebugShowGpuRasterRoutes.value = false;
       });
       pdfDebugPaintDetailBounds.value = true;
       expect(ticks, 1);

--- a/packages/dart_pdf_editor/test/gpu_route_devtool_test.dart
+++ b/packages/dart_pdf_editor/test/gpu_route_devtool_test.dart
@@ -1,0 +1,120 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final diagnostics = PdfTileRasterDiagnostics.instance;
+
+  setUp(() async {
+    pdfDebugShowGpuRasterRoutes.value = false;
+    diagnostics.clear();
+    await pumpEventQueue();
+  });
+
+  tearDown(() async {
+    pdfDebugShowGpuRasterRoutes.value = false;
+    diagnostics.clear();
+    await pumpEventQueue();
+  });
+
+  testWidgets('GPU route devtool follows the live page route', (tester) async {
+    final namespace = Object();
+    pdfDebugShowGpuRasterRoutes.value = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 612,
+          height: 792,
+          child: PdfGpuRasterRouteOverlay(
+            cacheNamespace: namespace,
+            pageIndex: 0,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('pdf-gpu-route-overlay')), findsOneWidget);
+    expect(find.text('Detail tiles: not active'), findsOneWidget);
+    expect(find.text('Fitted page: Canvas'), findsOneWidget);
+
+    diagnostics.reportSession(
+      cacheNamespace: namespace,
+      document: Object(),
+      scene: Object(),
+      pageIndex: 0,
+      requestedBackend: 'flutter_gpu',
+      effectiveBackend: 'flutter_gpu',
+      commandCount: 28,
+      pageColor: 0xFFFFFFFF,
+      annotations: true,
+      rotation: null,
+    );
+    diagnostics.reportTile(
+      cacheNamespace: namespace,
+      pageIndex: 0,
+      region: const Rect.fromLTWH(0, 0, 100, 100),
+      pixelRatio: 2,
+      width: 200,
+      height: 200,
+    );
+    await tester.pump();
+
+    expect(find.text('Detail tiles: GPU · flutter_gpu'), findsOneWidget);
+    expect(find.text('1 tile · 28 commands'), findsOneWidget);
+
+    diagnostics.reportFallback(
+      cacheNamespace: namespace,
+      pageIndex: 0,
+      error: StateError('device lost'),
+    );
+    await tester.idle();
+    await tester.pump();
+
+    expect(find.text('Detail tiles: Canvas fallback'), findsOneWidget);
+    expect(find.textContaining('device lost'), findsOneWidget);
+
+    pdfDebugShowGpuRasterRoutes.value = false;
+    await tester.pump();
+    expect(find.byKey(const ValueKey('pdf-gpu-route-overlay')), findsNothing);
+  });
+
+  testWidgets('GPU route badge stays screen-sized under viewer zoom',
+      (tester) async {
+    final zoom = ValueNotifier<double>(4);
+    addTearDown(zoom.dispose);
+    pdfDebugShowGpuRasterRoutes.value = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox(
+          width: 612,
+          height: 792,
+          child: PdfGpuRasterRouteOverlay(
+            cacheNamespace: Object(),
+            pageIndex: 0,
+            transformScale: zoom,
+          ),
+        ),
+      ),
+    );
+
+    final transform = tester.widget<Transform>(
+      find.descendant(
+        of: find.byKey(const ValueKey('pdf-gpu-route-overlay')),
+        matching: find.byType(Transform),
+      ),
+    );
+    expect(transform.transform.storage[0], closeTo(0.25, 0.0001));
+
+    zoom.value = 2;
+    await tester.pump();
+    final updated = tester.widget<Transform>(
+      find.descendant(
+        of: find.byKey(const ValueKey('pdf-gpu-route-overlay')),
+        matching: find.byType(Transform),
+      ),
+    );
+    expect(updated.transform.storage[0], closeTo(0.5, 0.0001));
+  });
+}

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -270,6 +270,27 @@ budget fallbacks.
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
+### Live GPU route devtool
+
+Turn on the viewer overlay while investigating a document:
+
+```dart
+pdfDebugShowGpuRasterRoutes.value = true;
+```
+
+Every page gets a screen-sized route badge and border. Green is an accelerated
+detail-tile session, amber is an exact Canvas fallback (with its rejection or
+runtime-failure reason), blue is an explicitly requested Canvas session, and
+grey means detail tiles have not been requested yet. The badge says *detail
+tiles* deliberately: the fitted base page raster remains Canvas even when deep
+zoom detail uses `flutter_gpu`.
+
+For spatial tile/LoD boundaries, also enable
+`pdfDebugPaintDetailBounds.value`. Hosts can build their own diagnostics panel
+from `PdfTileRasterDiagnostics.instance`, which is a `Listenable` and exposes
+typed `page(...)` / `forNamespace(...)` snapshots as well as the existing
+JSON-safe support export.
+
 Pages with other transparency groups or soft masks, non-nested radial
 gradients, gradient overprint, unsafe overprint, complex
 clips around a non-zero soft-mask backdrop, unresolved


### PR DESCRIPTION
## Result

The example app can now overlay the renderer's exact route on every visible page: **green GPU**, **amber Canvas fallback with the reason**, **blue intentional Canvas**, and **grey detail tiles not active yet**.

The badge explicitly distinguishes the fitted Canvas base raster from deep-zoom detail tiles, so it does not overstate how much of the page is accelerated.

<details>
<summary>Implementation and validation</summary>

- Add `pdfDebugShowGpuRasterRoutes` and wire a screen-sized, non-interactive badge/border into every `PdfPageView`.
- Make `PdfTileRasterDiagnostics` listenable only while a devtool is observing it; default rendering queues no extra notification work.
- Expose immutable typed page/namespace snapshots and route classification alongside the existing JSON support export.
- Update the badge on both initialization rejection and a later runtime GPU failure.
- Add a toggle to the example app menu and document the public devtool API.

Validation:

- `fvm dart analyze`
- complete `dart_pdf_editor` suite: 2,474 passed, 27 skipped
- focused diagnostics/tile fallback suite: 33 passed
- example app menu suite: 8 passed
- complete companion package suite
- Chrome companion web stub
- release web example build

CI's native GPU lanes remain authoritative for the platform-backed route.
</details>
