### PR TITLE
perf(gpu): cull off-crop paint units

### DIFF
--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -66,6 +66,11 @@
 - Retry only non-black-overprint scene rejections with a lazily re-recorded
   512-cell colourant grid. Exact scenes such as Ghent GWG164 move to native
   Flutter GPU, while any remaining mismatch continues through Canvas.
+- Cull paint units wholly outside the page crop before compatibility checks
+  and scene compilation. Unreachable imposition or malformed-form content can
+  no longer force a Canvas fallback or consume retained geometry.
+- Keep the unsupported-platform/web constructor surface in sync with the
+  native transient-attachment budget option.
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
 - Keep sparse native system-font outlines on retained stencil geometry instead

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -166,6 +166,10 @@ When spatial selection finds no retained command for one of those interior
 tiles, the backend submits a color-only clear pass. It does not allocate a
 stencil or multisample attachment, create a transient host buffer, or bind a
 draw pipeline; tiles near the crop edge continue through the ordinary path.
+Paint units whose clipped bounds are wholly outside the page `/CropBox` are
+discarded even earlier, before route compatibility checks and scene
+compilation. Off-page imposition marks therefore cannot reject the visible
+page or consume retained geometry.
 Advanced blend paints use bounded ping-pong tile attachments. Paints whose
 bounds prove they cannot affect one another share one destination-sampling
 pass; overlapping paints replay sequentially inside their conservative command
@@ -252,6 +256,8 @@ tile route, runtime fallback reasons, context and scene warm-up outcomes,
 scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
+It also reports `offCropUnitsCulled` for unreachable paints removed before
+the route audit.
 Direct-primitive diagnostics count rectangle and triangle fills separately.
 Clip diagnostics separately report paths compiled and tile-mask rebuilds.
 Paper diagnostics report how many tiles used the exact interior clear path and

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -298,8 +298,15 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
         stats.sessionsRejected++;
         return null;
       }
+      final visibleUnits = _visibleGpuUnits(scene, units);
+      stats.offCropUnitsCulled += units.length - visibleUnits.length;
       final rejection = _unsupportedReason(
-          scene, commands, units, allowOverprintApproximation);
+        scene,
+        commands,
+        units,
+        visibleUnits,
+        allowOverprintApproximation,
+      );
       if (rejection != null) {
         _lastSessionRejection = rejection;
         stats.lastRejection = rejection;
@@ -307,7 +314,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
         stats.sessionsRejected++;
         return null;
       }
-      if (allowOverprintApproximation && units.any((unit) => unit.darken)) {
+      if (allowOverprintApproximation &&
+          visibleUnits.any((unit) => unit.darken)) {
         stats.overprintApproximationSessions++;
       }
       stats.sessionsCreated++;
@@ -321,7 +329,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
         mipmapImages: commandBuild.mipmapImages,
         context: context,
         pipelines: _GpuPipelines.instance(context),
-        units: units,
+        units: visibleUnits,
         msaa: msaa,
         stats: stats,
         imageCache: _imageCache,
@@ -392,15 +400,17 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   static String? _unsupportedReason(
       PdfRetainedScene scene,
       List<PdfRenderCommand> commands,
-      List<_GpuUnit> units,
+      List<_GpuUnit> allUnits,
+      List<_GpuUnit> visibleUnits,
       bool allowOverprintApproximation) {
     final hasAdvancedBlend =
-        units.any((unit) => !_isFixedFunctionBlendMode(unit.blendMode));
+        visibleUnits.any((unit) => !_isFixedFunctionBlendMode(unit.blendMode));
     if (hasAdvancedBlend &&
-        units.any((unit) => unit.composite is _KnockoutSoftMaskFillSpec)) {
+        visibleUnits
+            .any((unit) => unit.composite is _KnockoutSoftMaskFillSpec)) {
       return 'advanced blend with knockout soft mask';
     }
-    for (final unit in units) {
+    for (final unit in visibleUnits) {
       if (!_isGpuBlendMode(unit.blendMode)) {
         return 'blend mode ${unit.blendMode.name}';
       }
@@ -509,7 +519,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
       }
     }
     final covered = <int>{
-      for (final unit in units)
+      for (final unit in allUnits)
         if (unit.endCommandIndex > unit.commandIndex)
           for (var i = unit.commandIndex; i <= unit.endCommandIndex; i++) i,
     };
@@ -616,6 +626,7 @@ class _GpuUnit {
   const _GpuUnit({
     required this.commandIndex,
     required this.endCommandIndex,
+    required this.contentBounds,
     required this.bounds,
     required this.clip,
     required this.blendMode,
@@ -629,6 +640,11 @@ class _GpuUnit {
 
   final int commandIndex;
   final int endCommandIndex;
+
+  /// Exact clipped paint bounds before the tile-selection antialiasing pad.
+  final PdfRect contentBounds;
+
+  /// Conservative spatial-index bounds, including the replay fringe.
   final PdfRect bounds;
   final _GpuClipState clip;
   final PdfBlendMode blendMode;
@@ -1571,6 +1587,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               units.add(_GpuUnit(
                 commandIndex: paint.commandIndex,
                 endCommandIndex: paint.endCommandIndex,
+                contentBounds: paint.bounds,
                 bounds: _inflatePdf(paint.bounds, 2),
                 clip: paintClip,
                 blendMode: paint.blendMode,
@@ -1593,6 +1610,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               units.add(_GpuUnit(
                 commandIndex: capture.start,
                 endCommandIndex: i,
+                contentBounds: bounds,
                 bounds: _inflatePdf(bounds, 2),
                 clip: capture.clip,
                 blendMode: PdfBlendMode.normal,
@@ -1623,6 +1641,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               units.add(_GpuUnit(
                 commandIndex: paint.commandIndex,
                 endCommandIndex: paint.commandIndex,
+                contentBounds: clipped,
                 bounds: _inflatePdf(clipped, 2),
                 clip: paintClip,
                 blendMode: capture.blendMode,
@@ -1647,6 +1666,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               units.add(_GpuUnit(
                 commandIndex: capture.start,
                 endCommandIndex: i,
+                contentBounds: groupBounds,
                 bounds: _inflatePdf(groupBounds, 2),
                 clip: capture.clip,
                 blendMode: PdfBlendMode.normal,
@@ -1680,6 +1700,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               units.add(_GpuUnit(
                 commandIndex: capture.start,
                 endCommandIndex: i,
+                contentBounds: bounds,
                 bounds: _inflatePdf(bounds, 2),
                 clip: compositeClip,
                 blendMode: capture.blendMode,
@@ -1712,6 +1733,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
           units.add(_GpuUnit(
             commandIndex: i,
             endCommandIndex: i,
+            contentBounds: clipped,
             bounds: _inflatePdf(clipped, 2),
             clip: clip,
             blendMode: blend,
@@ -3968,6 +3990,34 @@ bool _pdfIntersects(PdfRect a, PdfRect b) =>
     a.right > b.left &&
     a.bottom < b.top &&
     a.top > b.bottom;
+
+bool _pdfTouches(PdfRect a, PdfRect b) =>
+    a.left <= b.right &&
+    a.right >= b.left &&
+    a.bottom <= b.top &&
+    a.top >= b.bottom;
+
+/// Paint units wholly outside the page crop cannot affect any detail tile.
+///
+/// PDF content streams frequently retain imposition marks or malformed-form
+/// content far beyond a tiny `/CropBox`. Auditing those unreachable paints can
+/// reject an otherwise empty GPU scene (for example an off-crop overprint),
+/// and compiling them spends geometry memory that no tile can select. Unit
+/// `contentBounds` already include the active graphics-state clip but exclude
+/// the spatial index's two-point replay fringe. The crop is a mathematical
+/// clip boundary, so geometry outside it cannot contribute antialiasing even
+/// when its padded lookup bounds overlap the last tile.
+List<_GpuUnit> _visibleGpuUnits(
+  PdfRetainedScene scene,
+  List<_GpuUnit> units,
+) {
+  final crop = scene.page.cropBox;
+  final visible = [
+    for (final unit in units)
+      if (_pdfTouches(unit.contentBounds, crop)) unit,
+  ];
+  return visible.length == units.length ? units : List.unmodifiable(visible);
+}
 
 String? _compositeOverprintReason(
   PdfRenderCommand command,

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -29,6 +29,7 @@ class FlutterGpuTileBackendStats {
   int activeSessions = 0;
   int peakActiveSessions = 0;
   int overprintApproximationSessions = 0;
+  int offCropUnitsCulled = 0;
   int scenesCompiled = 0;
   int compileMicros = 0;
   int geometryBuffers = 0;
@@ -141,6 +142,7 @@ class FlutterGpuTileBackendStats {
         'activeSessions': activeSessions,
         'peakActiveSessions': peakActiveSessions,
         'overprintApproximationSessions': overprintApproximationSessions,
+        'offCropUnitsCulled': offCropUnitsCulled,
         'scenesCompiled': scenesCompiled,
         'compileMicros': compileMicros,
         'geometryBuffers': geometryBuffers,
@@ -254,6 +256,7 @@ class FlutterGpuTileBackendStats {
     lastSceneWarmUpError = null;
     peakActiveSessions = activeSessions;
     overprintApproximationSessions = 0;
+    offCropUnitsCulled = 0;
     scenesCompiled = 0;
     compileMicros = 0;
     geometryVertices = 0;
@@ -346,6 +349,7 @@ class FlutterGpuTileBackendStats {
       'activeSessions=$activeSessions peakActiveSessions=$peakActiveSessions '
       'overprintRetryCostSkips=$overprintRetryCostSkips '
       'overprintApprox=$overprintApproximationSessions '
+      'offCropUnitsCulled=$offCropUnitsCulled '
       'compiled=$scenesCompiled compileUs=$compileMicros '
       'buffers=$geometryBuffers vertices=$geometryVertices '
       'analyticRuns=$analyticTextRuns analyticQuads=$analyticGlyphQuads '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -12,6 +12,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
     this.overprintRetryMaxCommands = 768,
     this.maxTextureBytes = 256 << 20,
     this.maxGeometryBytes = 256 << 20,
+    this.maxTransientAttachmentBytes = 64 << 20,
     this.enableProactiveWarmUp,
     this.analyticText = true,
     this.textOutliner,
@@ -21,6 +22,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
             overprintRetryMaxDimension > 0),
         assert(
             overprintRetryMaxCommands == null || overprintRetryMaxCommands > 0),
+        assert(maxTransientAttachmentBytes >= 0),
         stats = stats ?? FlutterGpuTileBackendStats();
 
   final bool msaa;
@@ -29,6 +31,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   final int? overprintRetryMaxCommands;
   final int maxTextureBytes;
   final int maxGeometryBytes;
+  final int maxTransientAttachmentBytes;
   final bool? enableProactiveWarmUp;
   final bool analyticText;
   final FlutterGpuTextOutliner? textOutliner;

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -73,6 +73,7 @@ void main() {
       ..lastSceneWarmUpError = 'test scene warm-up failure'
       ..activeSessions = 3
       ..peakActiveSessions = 4
+      ..offCropUnitsCulled = 7
       ..activeTextureLeases = 5
       ..textureBytes = 12 << 20
       ..peakTextureBytes = 18 << 20
@@ -134,6 +135,7 @@ void main() {
       ..lastRejection = 'test fallback';
 
     expect(stats.toJson(), containsPair('rasterFallbacks', 1));
+    expect(stats.toJson(), containsPair('offCropUnitsCulled', 7));
     expect(stats.toJson(), containsPair('overprintRetryRequests', 3));
     expect(stats.toJson(), containsPair('overprintRetrySuccesses', 2));
     expect(stats.toJson(), containsPair('overprintRetryFallbacks', 1));
@@ -211,6 +213,7 @@ void main() {
     expect(stats.overprintRetryCostSkips, 0);
     expect(stats.overprintRetryMicros, 0);
     expect(stats.rasterFallbacks, 0);
+    expect(stats.offCropUnitsCulled, 0);
     expect(stats.lastContextIdentity, 1234);
     expect(stats.contextsSeen, 2);
     expect(stats.contextSwitches, 0);

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -2730,6 +2730,42 @@ void main() {
     });
   });
 
+  testWidgets('off-crop unsupported paints are culled before route audit',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        const PdfSetOverprintCommand(fill: true, stroke: false, mode: 1),
+        PdfFillPathCommand(
+          _rect(2000, 2000, 2100, 2100),
+          const PdfColor(0.2, 0.6, 0.8),
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      expect(backend.stats.offCropUnitsCulled, 1);
+
+      const region = Rect.fromLTWH(0, 0, 128, 128);
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 1);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      expect(await _pixels(actual), await _pixels(expected));
+      expect(backend.stats.geometryVertices, 6,
+          reason: 'only the page-paper quad should be compiled');
+      expect(backend.stats.lastTileRoute, 'flutter_gpu');
+    });
+  });
+
   testWidgets('solid black overprint remains exact inside groups',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/web_stub_test.dart
@@ -4,12 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('unsupported-platform backend keeps the public API available', () {
     final stats = FlutterGpuTileBackendStats();
-    final backend = FlutterGpuTileRasterBackend(msaa: false, stats: stats);
+    final backend = FlutterGpuTileRasterBackend(
+      msaa: false,
+      maxTransientAttachmentBytes: 0,
+      stats: stats,
+    );
 
     expect(backend.debugLabel, contains('flutter_gpu'));
     expect(backend.msaa, isFalse);
     expect(backend.overprintRetryMaxDimension, 512);
     expect(backend.overprintRetryMaxCommands, 768);
+    expect(backend.maxTransientAttachmentBytes, 0);
     expect(backend.stats, same(stats));
   });
 }


### PR DESCRIPTION
## Headline

- PDF.js GPU corpus: **177 accepted / 2 fallbacks → 178 / 1** (`endchar.pdf` is newly accelerated)
- Ghent GPU corpus: **49 / 8 unchanged**
- Visible non-black overprint remains on the exact Canvas fallback

## What changed

- Keep exact clipped content bounds separate from the two-point tile-selection fringe.
- Cull units wholly outside the mathematical page `/CropBox` before compatibility audit and scene compilation.
- Report `offCropUnitsCulled` in backend diagnostics.
- Restore `maxTransientAttachmentBytes` constructor parity in the web/unsupported stub.

The PDF.js `endchar.pdf` fixture has a 14.6 × 34 point crop over a much larger source page. Its three unsupported overprint runs are entirely beyond the crop, but the conservative spatial-index fringe previously kept them in the scene-wide audit and forced Canvas. The visible text remains retained and pixel-compared; only unreachable units are removed.

## Validation

- `fvm dart analyze`
- complete `dart_pdf_editor_flutter_gpu` suite with `--enable-impeller --enable-flutter-gpu`
- focused native Metal off-crop parity test
- filtered real `endchar.pdf` GPU corpus run: accepted, 3 units culled
- remaining fallback-document sweep: Ghent reasons unchanged
- Chrome web-stub test
- `git diff --check`