### PR TITLE
fix(cos): a sparse progressive buffer's holes are misses, not scans

### DIFF
--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -196,6 +196,8 @@ class AppDevTools extends ChangeNotifier {
       (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instanceOrNull)
           ?.invalidate();
     }
+    _flutterGpuTileRasterBackend?.stats
+        .logPerfSummary('backend-switch-to-${mode.name}');
     addLog('devtools: tile raster backend → ${mode.name}');
   }
 
@@ -407,6 +409,12 @@ class AppDevTools extends ChangeNotifier {
 
   set logPerfTrace(bool value) {
     if (_logPerfTrace == value) return;
+    // Bracket the trace with the GPU backend's lifetime totals: turning the
+    // log ON stamps the baseline the following lines accumulate from, and
+    // turning it OFF stamps where they ended, so an exported trace carries
+    // both without the reader having to open the panel and read counters that
+    // have since moved. Emitted while the log is still on in both directions.
+    if (!value) _flutterGpuTileRasterBackend?.stats.logPerfSummary('trace-end');
     _logPerfTrace = value;
     PdfPerfLog.enabled = value;
     // The trace is verbose - a line per worker request/reply, interpret, and
@@ -417,6 +425,9 @@ class AppDevTools extends ChangeNotifier {
         ? (m) => _record(DevLogLevel.info, 'perf: $m', notify: false)
         : null;
     addLog('devtools: perf trace logging ${value ? 'on' : 'off'}');
+    if (value) {
+      _flutterGpuTileRasterBackend?.stats.logPerfSummary('trace-start');
+    }
     _scheduleNotify();
   }
 
@@ -669,6 +680,9 @@ class AppDevTools extends ChangeNotifier {
       if (map['renderWindow'] case final bool v) {
         pdfDebugShowRenderWindow.value = v;
       }
+      if (map['gpuRouteOverlay'] case final bool v) {
+        pdfDebugShowGpuRasterRoutes.value = v;
+      }
       if (map['perfOverlay'] case final bool v) {
         showPerformanceOverlay.value = v;
       }
@@ -729,6 +743,7 @@ class AppDevTools extends ChangeNotifier {
           'gpuOverprintApproximation': _gpuOverprintApproximation,
           'tileBorders': pdfDebugPaintDetailBounds.value,
           'renderWindow': pdfDebugShowRenderWindow.value,
+          'gpuRouteOverlay': pdfDebugShowGpuRasterRoutes.value,
           'perfOverlay': showPerformanceOverlay.value,
           'perfLog': _logPerfTrace,
           'logTouchInput': _logTouchInput,

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -1221,6 +1221,24 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               'session so first paint is unaffected. Web uses a compile-time '
               'stub and always stays on Canvas.',
         ),
+        _helpSwitch(
+          theme,
+          key: const ValueKey('devtools-gpu-route-overlay'),
+          title: 'Render route overlay',
+          help: 'Borders and badges every mounted page with the route its '
+              'deep-zoom detail tiles actually took: green for GPU (naming '
+              'the backend, tile count, and command count), amber for a '
+              'Canvas fallback (naming the reason), blue for a deliberately '
+              'requested Canvas, grey while no detail tiles have been asked '
+              'for yet. The route is per scene, not per tile - the whole '
+              "page's detail session is accepted or declined together. The "
+              'initial fitted page raster is Canvas either way.',
+          value: pdfDebugShowGpuRasterRoutes.value,
+          onChanged: (value) => setState(() {
+            pdfDebugShowGpuRasterRoutes.value = value;
+            _persist();
+          }),
+        ),
         if (previewDownloads.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(top: 8),

--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -58,6 +58,16 @@ class DocumentHandoff {
 /// while the full bytes stream in, an [error] placeholder, or a two-file
 /// [comparison].
 class DocumentTab {
+  /// A document opens as a reader, not as an editor: the session starts in
+  /// explicit Hand mode, so a mouse drag pans the page instead of starting a
+  /// text selection and a touch long-press does not select text. Every tool,
+  /// text selection included, stays one toolbar click away.
+  static PdfEditingController _handModeController(
+    Uint8List bytes,
+    PdfEditingPreferences preferences,
+  ) =>
+      PdfEditingController(bytes, preferences: preferences)..activateHandMode();
+
   DocumentTab.loading(
       {required this.title,
       this.originPath,
@@ -82,7 +92,7 @@ class DocumentTab {
     this.cachePath,
     bool initiallyDirty = false,
     int? savedLength,
-  })  : session = PdfEditingController(bytes, preferences: preferences),
+  })  : session = _handModeController(bytes, preferences),
         viewer = PdfViewerController(),
         // Normally the opened bytes *are* the saved baseline. Crash recovery is
         // the exception: it reopens a document at the revision that was in

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -17,6 +17,7 @@ void main() {
     AppDevTools.instance.setDeepZoomMode(AppDevTools.modePatch);
     pdfDebugPaintDetailBounds.value = false;
     pdfDebugShowRenderWindow.value = false;
+    pdfDebugShowGpuRasterRoutes.value = false;
     AppDevTools.instance.showPerformanceOverlay.value = false;
     AppDevTools.instance.setPageRasterCachePolicy(
       const PdfPageRasterCachePolicy(),
@@ -59,6 +60,7 @@ void main() {
     tools.setGpuOverprintApproximation(true);
     pdfDebugPaintDetailBounds.value = true;
     pdfDebugShowRenderWindow.value = true;
+    pdfDebugShowGpuRasterRoutes.value = true;
     pdfRenderWorkerPoolSize = 5;
     tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy(
       maxBytes: 5 * 1024 * 1024 * 1024,
@@ -76,6 +78,7 @@ void main() {
     tools.setGpuOverprintApproximation(false);
     pdfDebugPaintDetailBounds.value = false;
     pdfDebugShowRenderWindow.value = false;
+    pdfDebugShowGpuRasterRoutes.value = false;
     pdfRenderWorkerPoolSize = 3;
     tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy());
     await tools.restoreOptions();
@@ -91,6 +94,7 @@ void main() {
     expect(PdfPageView.debugTileStoreOverride!.batchRasters, isTrue);
     expect(pdfDebugPaintDetailBounds.value, isTrue);
     expect(pdfDebugShowRenderWindow.value, isTrue);
+    expect(pdfDebugShowGpuRasterRoutes.value, isTrue);
     expect(pdfRenderWorkerPoolSize, 5);
     expect(
       tools.pageRasterCachePolicy.value,

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -103,6 +103,25 @@ void main() {
     expect(find.byKey(const ValueKey('devtools-panel')), findsNothing);
   });
 
+  testWidgets('the render route overlay toggles from the panel',
+      (tester) async {
+    addTearDown(() => pdfDebugShowGpuRasterRoutes.value = false);
+    await pumpWithDoc(tester);
+    expect(find.byKey(const ValueKey('pdf-gpu-route-overlay')), findsNothing);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+    final toggle = find.byKey(const ValueKey('devtools-gpu-route-overlay'));
+    await tester.ensureVisible(toggle);
+    await tester.pump();
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    expect(pdfDebugShowGpuRasterRoutes.value, isTrue);
+    expect(find.byKey(const ValueKey('pdf-gpu-route-overlay')),
+        findsAtLeastNWidgets(1));
+  });
+
   testWidgets('tile backend switch updates the mounted viewer in place',
       (tester) async {
     await pumpWithDoc(tester);

--- a/app/test/hand_mode_default_test.dart
+++ b/app/test/hand_mode_default_test.dart
@@ -1,0 +1,49 @@
+// A document opens as a reader: the edit session starts in explicit Hand
+// mode, so a mouse drag pans the page instead of starting a text selection.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/document_tab.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+
+void main() {
+  late PdfEditingPreferences preferences;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    preferences = PdfEditingPreferences();
+  });
+
+  tearDown(() => preferences.dispose());
+
+  test('a new document tab starts in Hand mode', () {
+    final tab = DocumentTab.document(
+      title: 'reader.pdf',
+      bytes: buildMultiPagePdf(1),
+      preferences: preferences,
+    );
+    addTearDown(tab.dispose);
+
+    expect(tab.session!.isHandMode, isTrue);
+    expect(tab.session!.tool, isNull);
+    expect(tab.session!.markupTool, isNull);
+  });
+
+  testWidgets('the opened document reaches the viewer in Hand mode',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: preferences,
+        initialDocument: (bytes: buildMultiPagePdf(1), title: 'reader.pdf'),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final viewer = tester.widget<PdfViewer>(find.byType(PdfViewer));
+    expect(viewer.editing!.isHandMode, isTrue);
+  });
+}

--- a/app/test/selection_copy_action_test.dart
+++ b/app/test/selection_copy_action_test.dart
@@ -30,6 +30,12 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
+    // A document opens in Hand mode, where a mouse drag pans instead of
+    // selecting. Leave it the way the toolbar does before dragging out a
+    // text selection.
+    tester.widget<PdfViewer>(find.byType(PdfViewer)).editing!.tool = null;
+    await tester.pump();
+
     final pageFinder = find.byType(PdfPageView).first;
     final pageTopLeft = tester.getTopLeft(pageFinder);
     final pageSize = tester.getSize(pageFinder);

--- a/doc/dev-log/2026-08-27-sparse-buffer-holes-and-gpu-trace.md
+++ b/doc/dev-log/2026-08-27-sparse-buffer-holes-and-gpu-trace.md
@@ -1,0 +1,113 @@
+# 2026-08-27 — progressive-open holes, GPU route/trace devtools, Hand default, middle-drag pan
+
+Five threads in one session. The big one is a multi-second UI freeze that
+turned out to be the progressive-open contract meeting a viewer that reads
+outside it.
+
+## The 219 MB pack froze for 11.6 s on open
+
+A real correlation pack (83 A3 pages, 219 MB, pypdf) beachballed the macOS app
+on open. `--dart-define=PDF_PERF_LOG=true` on a profile run named it in one
+line:
+
+```
+[perf 12675] JANK build=11619.1ms raster=7.3ms total=11629.5ms rss=368MB
+```
+
+One frame, 11.6 s of *build*, and no interpret/raster line inside it. A CPU
+profile pulled from the VM service (`getCpuSamples` over the run's window)
+gave the stack:
+
+```
+RenderSliverFixedExtentBoxAdaptor.performLayout
+  SliverMultiBoxAdaptorElement._build → SliverChildBuilderDelegate.build
+    _PdfViewerState._formFieldRects → PdfPage.annotations
+      CosDocument.getObject → CosParser.parseIndirectObject → CosLexer.nextToken
+        CosLexer.skipWhitespaceAndComments   ← 8515 of 12873 samples
+```
+
+### Root cause
+
+`PdfSourceLoadOptions(firstPaintPages: 1)` — what `EditorScreen._openProgressive`
+uses — assembles a **sparse** buffer: header, xref chain and the first page's
+render closure are fetched, everything else is left as zeros. The loader's doc
+comment states the assumption plainly: "free space and dead revisions are left
+as zeros *the parser never reads*".
+
+The viewer reads them. Building a page tile calls `_formFieldRects(index)` →
+`PdfPage.annotations`, and annotations are not in any page's first-paint
+closure. So the parse starts at an xref offset inside a hole — and **0x00 is
+PDF whitespace**, so `skipWhitespaceAndComments` walks forward until the next
+populated byte, up to hundreds of megabytes, per object, during layout. The
+failed parses then trigger the `N G obj` rescue scan across the whole 219 MB
+buffer (`objectRescueScanBuilt` in the trace).
+
+Headless repro (`PdfDocument.openSource` + the app's options, then read what
+the sliver reads):
+
+```
+page 0 annotations=218ms   count=3
+page 1 annotations=13213ms count=0     ← 65 annotations in the real file
+page 4 annotations=573ms   count=5
+```
+
+Note the second number: it was not only slow, it was *wrong* — a hole answers
+"no annotations" rather than "not fetched".
+
+### Fix: the document knows its holes
+
+`_ProgressiveLoader` already merges the ranges it fetched (`_present`). Those
+now travel into `CosDocument.open(bytes, populatedRanges:)` (flat sorted
+`[start, end)` pairs, null = whole file), where:
+
+- `_parseIndirectAt` refuses an offset that lies in a hole — the reference
+  dangles, exactly as a not-yet-fetched compressed object already did;
+- a parse that starts in a populated run is bounded to that run with
+  `Uint8List.sublistView` (a view, not a copy), so an object at the tail of a
+  fetched range cannot walk into the hole after it;
+- `_scanObjectHeaders` skips holes, so the rescue scan costs the fetched bytes
+  (7 MB here) instead of the file (219 MB).
+
+Same repro after: **13213 ms → 0 ms**, whole 12-page sweep 16 s → 34 ms, same
+answers. Tests in `pdf_cos/test/byte_source_test.dart` ("sparse buffers know
+their holes"): a hole dangles instead of scanning, a hole stays authoritative
+even when real bytes sit inside it, and a parse cannot run off the end of its
+range.
+
+No viewer change was needed in the end: with holes cheap, the layout-time
+`annotations` read is ~0 ms, and `_visibleAnnotCache`/`_fieldRectCache` are
+already cleared on the document swap, so the preview's empty answers never
+outlive the preview.
+
+## GPU diagnostics in the devtools
+
+- `pdfDebugShowGpuRasterRoutes` (the per-page GPU/Canvas route overlay from
+  #853) was only reachable from the example app's menu. It now has a switch in
+  the app's F12 panel, in the Tile raster backend section, persisted with the
+  other devtools options (`gpuRouteOverlay`).
+- `PdfPerfLog` gained the GPU lines a fallback diagnosis actually needs:
+  `tile gpu compile` (units/draws/clips/textures/bytes/elapsed — the per-scene
+  cost that used to show up only as a gap before the first tile),
+  `tile gpu raster fallback` (a scene that was *accepted* and then fell back at
+  raster time — previously invisible in a trace), and pipeline/scene warm-up
+  completion + failure lines.
+- `FlutterGpuTileBackendStats.logPerfSummary(reason)` emits one lifetime-totals
+  line; the app brackets every trace with it (`trace-start` / `trace-end`) and
+  stamps one on each backend switch, so an exported trace carries the GPU
+  totals without the reader having to open the panel.
+
+## Documents open in Hand mode
+
+`DocumentTab.document` now starts its session in `activateHandMode()`: a mouse
+drag pans instead of starting a text selection. Text selection is one toolbar
+click away. `selection_copy_action_test.dart` leaves Hand mode first, the way
+the toolbar does.
+
+## Middle-button drag pans
+
+Flutter's drag recognizers accept the primary button only, so a middle drag
+reached no recognizer at all — the gesture was never implemented, not broken.
+The viewer's pan/selection `PanGestureRecognizer` now allows
+`kMiddleMouseButton`, and `_onSelectionStart` treats a middle-button drag as a
+temporary hand: it grabs the page past whatever the primary button would have
+meant there (text, a stroke, a marquee) without disarming the armed tool.

--- a/doc/dev-log/2026-08-27-sparse-buffer-holes-and-gpu-trace.md
+++ b/doc/dev-log/2026-08-27-sparse-buffer-holes-and-gpu-trace.md
@@ -74,6 +74,42 @@ their holes"): a hole dangles instead of scanning, a hole stays authoritative
 even when real bytes sit inside it, and a parse cannot run off the end of its
 range.
 
+### …and the map has to follow the buffer, not the document
+
+That fixed the repro and changed nothing in the app: still an 11.5 s frame,
+still the same stack. A `cos open` diagnostic line (kept - it is worth having)
+showed why:
+
+```
+[perf 538] cos open bytes=219314443 sparse spans=110    ← the preview document
+[perf 558] cos open bytes=219314443 whole-file          ← what the viewer reads
+```
+
+The app paints a preview tab with `PdfReader(bytes: tab.previewBytes!)`, and
+`PdfReader` opens **its own session** over those bytes
+(`PdfShellSessionLifecycle` → `PdfEditingController` → `CosDocument.open`). The
+carefully-loaded sparse document is used for nothing but its byte buffer, and
+a `Uint8List` cannot carry "these are the parts of me that hold real bytes".
+
+So sparseness now belongs to the buffer: `cosSparseBufferRanges`, an `Expando`
+the loader stamps and `CosDocument.open` consults when no ranges are passed.
+Every later open of that exact buffer inherits the map - no signature change in
+the four widgets between the loader and the parser, and nothing to remember at
+a future call site.
+
+Measured in the app, same document, same machine:
+
+| | before | after |
+|---|---|---|
+| worst frame during open | 11 619 ms | 86 ms |
+| page 1 on screen | ~10.4 s | 0.6 s |
+
+The render worker still opens its own *copy* of a sparse buffer whole-file (a
+copy is a different object, so it inherits nothing). It is harmless here - a
+worker records page content, which is exactly what the first-paint closure
+fetched - and it is off the UI thread either way. If a worker-side hole scan
+ever shows up, the init message is where the ranges would go.
+
 No viewer change was needed in the end: with holes cheap, the layout-time
 `annotations` read is ~0 ms, and `_visibleAnnotCache`/`_fieldRectCache` are
 already cleared on the document swap, so the preview's empty answers never

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2231,6 +2231,16 @@ class _PdfViewerState extends State<PdfViewer>
   Duration? _lastMouseDownStamp;
   Offset? _lastMouseDownLocal;
   bool _wordDrag = false;
+
+  /// Whether the press the current mouse drag began with was the middle
+  /// button.
+  ///
+  /// A middle drag is the pan every other document viewer offers: it grabs the
+  /// page whatever the primary button would have done there - select text,
+  /// draw, marquee, drag an annotation - so a user with a tool armed can still
+  /// move around without disarming it. [DragStartDetails] carries no buttons,
+  /// so the raw pointer-down records it.
+  bool _middleButtonDrag = false;
   ((int, int), (int, int))? _wordAnchor;
 
   /// The device kind of the latest pointer down - tap callbacks don't
@@ -6630,6 +6640,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (_textEditController?.isEditingText != true) _focusNode.requestFocus();
     if (event.kind != PointerDeviceKind.mouse) {
       _wordDrag = false;
+      _middleButtonDrag = false;
       return;
     }
     final lastStamp = _lastMouseDownStamp;
@@ -6640,6 +6651,7 @@ class _PdfViewerState extends State<PdfViewer>
         (event.localPosition - lastLocal).distance < kDoubleTapSlop;
     _lastMouseDownStamp = event.timeStamp;
     _lastMouseDownLocal = event.localPosition;
+    _middleButtonDrag = event.buttons == kMiddleMouseButton;
   }
 
   /// Completes a mouse double-click (second press, released without
@@ -6730,6 +6742,14 @@ class _PdfViewerState extends State<PdfViewer>
     // document out from under its own stroke
     if (_kindDrawsInk(details.kind)) return;
     _focusNode.requestFocus();
+    if (_middleButtonDrag) {
+      // The middle button is the temporary hand: it pans past whatever else
+      // this drag would have meant, without touching the armed tool.
+      _grabPanning = true;
+      _beginMotionRenderHold();
+      setState(() => _hoverCursor = grabbingCursor);
+      return;
+    }
     if (widget.editing?.isHandMode == true) {
       // Explicit Hand mode is navigation-only. Unlike the tool-free reader
       // state, a drag that begins over page text must grab the document
@@ -8338,6 +8358,14 @@ class _PdfViewerState extends State<PdfViewer>
                                       PointerDeviceKind.mouse,
                                       PointerDeviceKind.trackpad,
                                     },
+                                    // the middle button pans (see
+                                    // [_middleButtonDrag]); Flutter's default
+                                    // filter is primary-only, so without this
+                                    // a middle drag reaches no recognizer at
+                                    // all
+                                    allowedButtonsFilter: (buttons) =>
+                                        buttons == kPrimaryButton ||
+                                        buttons == kMiddleMouseButton,
                                   ),
                                   (recognizer) => recognizer
                                     ..gestureSettings = gestureSettings

--- a/packages/dart_pdf_editor/test/middle_button_pan_test.dart
+++ b/packages/dart_pdf_editor/test/middle_button_pan_test.dart
@@ -1,0 +1,84 @@
+// Middle-button drag pans the document, the way every other PDF viewer does:
+// it grabs the page past whatever the primary button would have meant there -
+// a text selection in the reader, a stroke or a marquee with a tool armed -
+// without disarming the tool. Flutter's drag recognizers accept the primary
+// button only, so before this the gesture reached nothing at all.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  Future<PdfViewerController> pumpViewer(
+    WidgetTester tester, {
+    PdfEditingController? editing,
+  }) async {
+    final controller = PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: PdfViewerFit.width,
+          document: editing == null ? PdfDocument.open(buildMultiPagePdf(5)) : null,
+          editing: editing,
+          controller: controller,
+        ),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    return controller;
+  }
+
+  Future<void> dragBy(
+    WidgetTester tester,
+    Offset from,
+    Offset delta, {
+    required int buttons,
+  }) async {
+    final gesture = await tester.startGesture(
+      from,
+      kind: PointerDeviceKind.mouse,
+      buttons: buttons,
+    );
+    await tester.pump();
+    for (var i = 0; i < 4; i++) {
+      await gesture.moveBy(delta / 4);
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a middle drag scrolls the document', (tester) async {
+    final controller = await pumpViewer(tester);
+    final state = tester.state<ScrollableState>(find.byType(Scrollable).first);
+    expect(state.position.pixels, 0);
+
+    await dragBy(tester, const Offset(400, 400), const Offset(0, -160),
+        buttons: kMiddleMouseButton);
+
+    expect(state.position.pixels, greaterThan(0),
+        reason: 'dragging up with the middle button moves the page up');
+    expect(controller.hasSelection, isFalse,
+        reason: 'a middle drag pans; it never selects text');
+  });
+
+  testWidgets('a middle drag pans without disarming the armed tool',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(5));
+    addTearDown(editing.dispose);
+    editing.tool = PdfEditTool.rectangle;
+    await pumpViewer(tester, editing: editing);
+    final state = tester.state<ScrollableState>(find.byType(Scrollable).first);
+
+    await dragBy(tester, const Offset(400, 400), const Offset(0, -160),
+        buttons: kMiddleMouseButton);
+
+    expect(state.position.pixels, greaterThan(0));
+    expect(editing.tool, PdfEditTool.rectangle,
+        reason: 'panning is not a tool change');
+    expect(editing.pageAt(0).annotations, isEmpty,
+        reason: 'the middle drag must not draw the armed shape');
+  });
+}

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -18,6 +18,12 @@ import 'backend_stats.dart';
 import 'system_text_outliner_native.dart';
 import 'text_outliner.dart';
 
+/// Microseconds as a `12.3ms` trace field.
+String _ms(int micros) => '${(micros / 1000).toStringAsFixed(1)}ms';
+
+/// Bytes as a whole-megabyte trace field.
+int _mb(int bytes) => (bytes / (1 << 20)).round();
+
 /// Scene-retained flutter_gpu backend for final LoD tile textures.
 ///
 /// The first tile lazily compiles supported retained commands into page-space
@@ -234,10 +240,23 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
       );
       if (submitted) stats.warmUpSubmissions++;
       stats.warmUpCompletions++;
+      if (PdfPerfLog.enabled) {
+        PdfPerfLog.log(
+          'tile gpu pipeline warm submitted=$submitted '
+          'msaa=${msaa && context.doesSupportOffscreenMSAA} '
+          'elapsed=${_ms(clock.elapsedMicroseconds)}',
+        );
+      }
     } catch (error) {
       stats
         ..warmUpFailures += 1
         ..lastWarmUpError = error.toString();
+      if (PdfPerfLog.enabled) {
+        PdfPerfLog.log(
+          'tile gpu pipeline warm FAILED '
+          'elapsed=${_ms(clock.elapsedMicroseconds)} error=$error',
+        );
+      }
       rethrow;
     } finally {
       stats.warmUpMicros += clock.elapsedMicroseconds;
@@ -4359,6 +4378,12 @@ class _FlutterGpuTileSession
       stats
         ..sceneWarmUpFailures += 1
         ..lastSceneWarmUpError = error.toString();
+      if (PdfPerfLog.enabled) {
+        PdfPerfLog.log(
+          'tile gpu scene warm FAILED commands=${units.length} '
+          'elapsed=${clock.elapsedMilliseconds}ms error=$error',
+        );
+      }
       rethrow;
     } finally {
       image?.dispose();
@@ -4438,6 +4463,15 @@ class _FlutterGpuTileSession
         stats.rasterFallbacks++;
         stats.lastRejection = 'rasterization failed: $error';
         stats.lastTileRoute = 'canvas-fallback';
+        // The one route change a trace could not see before: this scene was
+        // accepted, so the session line said flutter_gpu, and every later tile
+        // silently came from Canvas.
+        if (PdfPerfLog.enabled) {
+          PdfPerfLog.log(
+            'tile gpu raster fallback page=${tracePage ?? '-'} '
+            'route=canvas error=$error',
+          );
+        }
       }
       rethrow;
     }
@@ -4691,6 +4725,21 @@ class _CompiledScene {
         ..scenesCompiled += 1
         ..clipPathsCompiled += clipDraws.length
         ..compileMicros += clock.elapsedMicroseconds;
+      // The scene's one-off GPU cost - geometry build plus every texture
+      // upload - which a trace previously saw only as an unexplained gap
+      // before the first `tile gpu issue` line.
+      if (PdfPerfLog.enabled) {
+        PdfPerfLog.log(
+          'tile gpu compile units=${units.length} draws=${draws.length} '
+          'clips=${clipDraws.length} '
+          'textures=${textureLeases.resources.length} '
+          'uploaded=${stats.texturesUploaded} hit=${stats.textureCacheHits} '
+          'miss=${stats.textureCacheMisses} '
+          'texBytes=${_mb(stats.textureBytes)}MB '
+          'geoBytes=${_mb(stats.geometryBytes)}MB '
+          'elapsed=${_ms(clock.elapsedMicroseconds)}${PdfPerfLog.rssSuffix()}',
+        );
+      }
       return result;
     } catch (_) {
       imageCache.releaseAll(textureLeases, stats);

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -1,3 +1,5 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart' show PdfPerfLog;
+
 /// Aggregated diagnostics for one flutter_gpu tile backend instance.
 class FlutterGpuTileBackendStats {
   String? lastRejection;
@@ -110,6 +112,53 @@ class FlutterGpuTileBackendStats {
   int failedSubmissions = 0;
   int inFlightSubmissions = 0;
   int peakInFlightSubmissions = 0;
+
+  /// Emits this instance's lifetime totals as one [PdfPerfLog] line.
+  ///
+  /// The per-event GPU lines (`tile gpu compile`/`issue`/`complete`) say what
+  /// each scene and tile cost; this says what the run cost, which is the
+  /// question a trace is usually opened to answer: how many scenes the backend
+  /// actually kept, how many it handed back to Canvas and why, and whether the
+  /// texture/geometry ceilings were the thing doing the handing back. The host
+  /// calls it at the ends of a trace (see the app's Verbose render log toggle)
+  /// so an exported trace is self-contained.
+  ///
+  /// Costs nothing while the log is off - every field below is read behind
+  /// that check.
+  void logPerfSummary(String reason) {
+    if (!PdfPerfLog.enabled) return;
+    PdfPerfLog.log(
+      'tile gpu summary reason=$reason '
+      'sessions=$sessionsCreated/${sessionsCreated + sessionsRejected} '
+      'active=$activeSessions peakActive=$peakActiveSessions '
+      'rasterFallbacks=$rasterFallbacks '
+      'tiles=$tilesRendered paperOnly=$paperOnlyTiles '
+      'compile=${_avgMs(compileMicros, scenesCompiled)}/scene '
+      'issue=${_avgMs(issueMicros, tilesRendered)}/tile '
+      'submit=${_avgMs(submitMicros, tilesRendered)}/tile '
+      'queue=${_avgMs(completionMicros, completedSubmissions)}/submit '
+      'maxQueue=${_ms(maxCompletionMicros)} '
+      'peakInFlight=$peakInFlightSubmissions failed=$failedSubmissions '
+      'draws=$drawCalls saved=$drawCallsSaved '
+      'tex=${_mb(peakTextureBytes)}MB '
+      'hit=$textureCacheHits miss=$textureCacheMisses '
+      'evict=$textureEvictions texBudgetFallbacks=$textureBudgetFallbacks '
+      'geo=${_mb(peakGeometryBytes)}MB '
+      'geoBudgetFallbacks=$geometryBudgetFallbacks '
+      'blendBudgetFallbacks=$advancedBlendBudgetFallbacks '
+      'groupBudgetFallbacks=$offscreenGroupBudgetFallbacks '
+      'warm=$warmUpCompletions/$warmUpRequests '
+      'sceneWarm=$sceneWarmUpCompletions/$sceneWarmUpRequests '
+      'lastRoute=$lastTileRoute lastRejection=${lastRejection ?? '-'}',
+    );
+  }
+
+  static String _ms(int micros) => '${(micros / 1000).toStringAsFixed(1)}ms';
+
+  static String _avgMs(int micros, int count) =>
+      count == 0 ? 'n/a' : _ms(micros ~/ count);
+
+  static int _mb(int bytes) => (bytes / (1 << 20)).round();
 
   /// A JSON-safe snapshot suitable for diagnostics and benchmark artifacts.
   Map<String, Object?> toJson() => {

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -1,8 +1,68 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // PdfPerfLog installs a frame-timings callback on its first line.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('perf summary line', () {
+    final lines = <String>[];
+
+    setUp(() {
+      lines.clear();
+      PdfPerfLog.sink = lines.add;
+    });
+
+    tearDown(() {
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
+    });
+
+    test('stays silent while the perf log is off', () {
+      FlutterGpuTileBackendStats().logPerfSummary('trace-start');
+      expect(lines, isEmpty);
+    });
+
+    test('reports the totals a fallback diagnosis needs', () {
+      PdfPerfLog.enabled = true;
+      final stats = FlutterGpuTileBackendStats()
+        ..sessionsCreated = 3
+        ..sessionsRejected = 1
+        ..rasterFallbacks = 2
+        ..tilesRendered = 8
+        ..scenesCompiled = 3
+        ..compileMicros = 90000
+        ..issueMicros = 16000
+        ..textureBudgetFallbacks = 4
+        ..peakTextureBytes = 192 << 20
+        ..lastTileRoute = 'canvas-fallback'
+        ..lastRejection = 'GPU texture budget exceeded';
+
+      stats.logPerfSummary('trace-end');
+
+      final line = lines.singleWhere((l) => l.contains('tile gpu summary'));
+      expect(line, contains('reason=trace-end'));
+      expect(line, contains('sessions=3/4'));
+      expect(line, contains('rasterFallbacks=2'));
+      expect(line, contains('tiles=8'));
+      expect(line, contains('compile=30.0ms/scene'));
+      expect(line, contains('issue=2.0ms/tile'));
+      expect(line, contains('texBudgetFallbacks=4'));
+      expect(line, contains('tex=192MB'));
+      expect(line, contains('lastRejection=GPU texture budget exceeded'));
+    });
+
+    test('an untouched backend reports n/a rather than a fake average', () {
+      PdfPerfLog.enabled = true;
+      FlutterGpuTileBackendStats().logPerfSummary('idle');
+      final line = lines.singleWhere((l) => l.contains('tile gpu summary'));
+      expect(line, contains('compile=n/a/scene'));
+      expect(line, contains('issue=n/a/tile'));
+      expect(line, contains('lastRejection=-'));
+    });
+  });
   test('proactive warm-up defaults to desktop and remains opt-in on mobile',
       () {
     final previous = debugDefaultTargetPlatformOverride;

--- a/packages/pdf_cos/lib/src/byte_source.dart
+++ b/packages/pdf_cos/lib/src/byte_source.dart
@@ -201,6 +201,10 @@ Future<CosSourceOpenResult> openCosDocumentFromSourceWithStatus(
     buffer = await _downloadFully(source, options);
   }
   PdfPerf.end(PdfPerfPhase.sourceFetch, t0);
+  // Sparseness travels with the buffer, not just with this document: hosts
+  // paint the preview by handing these same bytes to another reader/session,
+  // which opens them again (see [cosSparseBufferRanges]).
+  if (populated != null) cosSparseBufferRanges[buffer] = populated;
   return CosSourceOpenResult(
     CosDocument.open(buffer, password: password, populatedRanges: populated),
     isFirstPaintBuffer: isFirstPaintBuffer,
@@ -268,8 +272,9 @@ class _ProgressiveLoader {
   /// The fetched ranges as the flat, sorted `[start, end)` pair list
   /// [CosDocument.open] takes, so the parser can tell a real byte from the
   /// zeros this buffer is padded with.
-  List<int> get populatedRanges =>
-      [for (final r in _present) ...[r.start, r.end]];
+  List<int> get populatedRanges => [
+        for (final r in _present) ...[r.start, r.end]
+      ];
 
   Future<({Uint8List bytes, bool isFirstPaintBuffer})> load() async {
     final len = await source.length;

--- a/packages/pdf_cos/lib/src/byte_source.dart
+++ b/packages/pdf_cos/lib/src/byte_source.dart
@@ -185,11 +185,16 @@ Future<CosSourceOpenResult> openCosDocumentFromSourceWithStatus(
 }) async {
   late final Uint8List buffer;
   var isFirstPaintBuffer = false;
+  // Null once a full download replaces the sparse buffer: those bytes are all
+  // real, so the parser needs no hole map.
+  List<int>? populated;
   final t0 = PdfPerf.begin();
   try {
-    final loaded = await _ProgressiveLoader(source, options).load();
+    final loader = _ProgressiveLoader(source, options);
+    final loaded = await loader.load();
     buffer = loaded.bytes;
     isFirstPaintBuffer = loaded.isFirstPaintBuffer;
+    populated = loader.populatedRanges;
   } on _FallbackToFullDownload {
     PdfPerf.add(PdfPerfCount.fullDownloadFallback);
     PdfPerf.event(PdfPerfEvent.rangedSourceFellBack);
@@ -197,7 +202,7 @@ Future<CosSourceOpenResult> openCosDocumentFromSourceWithStatus(
   }
   PdfPerf.end(PdfPerfPhase.sourceFetch, t0);
   return CosSourceOpenResult(
-    CosDocument.open(buffer, password: password),
+    CosDocument.open(buffer, password: password, populatedRanges: populated),
     isFirstPaintBuffer: isFirstPaintBuffer,
   );
 }
@@ -259,6 +264,12 @@ class _ProgressiveLoader {
   /// pulled twice.
   final List<_Range> _present = [];
   int _fetched = 0;
+
+  /// The fetched ranges as the flat, sorted `[start, end)` pair list
+  /// [CosDocument.open] takes, so the parser can tell a real byte from the
+  /// zeros this buffer is padded with.
+  List<int> get populatedRanges =>
+      [for (final r in _present) ...[r.start, r.end]];
 
   Future<({Uint8List bytes, bool isFirstPaintBuffer})> load() async {
     final len = await source.length;

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -13,8 +13,27 @@ import 'xref.dart';
 /// A parsed PDF file at the COS level: header, cross-reference machinery, and
 /// on-demand object loading. Page-level semantics live in `pdf_document`.
 class CosDocument {
-  CosDocument._(
-      this.bytes, this._offsetShift, this._xref, this.trailer, this.startXref);
+  CosDocument._(this.bytes, this._offsetShift, this._xref, this.trailer,
+      this.startXref, this._populated);
+
+  /// Half-open `[start, end)` byte ranges of [bytes] that actually hold file
+  /// bytes, flattened and sorted, or null when the buffer is the whole file.
+  ///
+  /// A progressive/ranged open assembles a **sparse** buffer: the header, the
+  /// cross-reference chain and the fetched objects are populated, and
+  /// everything else - free space, superseded revisions, and (for a
+  /// page-scoped first paint) every object outside that page's closure - is
+  /// left as zeros. Nothing in the parser can tell those zeros from real
+  /// bytes, and 0x00 is PDF whitespace, so a parse that starts in a hole
+  /// skips whitespace forward until the next populated byte - hundreds of
+  /// megabytes on a large file, per object, on whatever thread asked. That is
+  /// exactly what a viewer does the moment it reads an annotation outside the
+  /// preview's closure: an 83-page 219 MB pack spent 13.2 s inside one
+  /// `page.annotations` call, and answered 0 annotations instead of 65.
+  ///
+  /// With the ranges known, a hole is a miss instead of a scan: the reference
+  /// dangles the same way a not-yet-fetched compressed object already does.
+  final List<int>? _populated;
 
   /// The document image the xref offsets refer to. Grows in place when an
   /// append-only incremental revision is fed through [applyIncrementalUpdate];
@@ -118,12 +137,22 @@ class CosDocument {
   /// When the cross-reference machinery is broken (missing `startxref`,
   /// corrupt offsets, truncated tables), falls back to rebuilding the xref
   /// by scanning the file for object headers - see [_recover].
-  static CosDocument open(Uint8List bytes, {String password = ''}) {
+  /// [populatedRanges] declares which parts of [bytes] were actually read,
+  /// for the sparse buffer a ranged/progressive open assembles (see
+  /// [_populated]). Flattened, sorted, non-overlapping `[start, end)` pairs in
+  /// buffer coordinates. Null - the default, and every whole-file open - means
+  /// the buffer is complete.
+  static CosDocument open(Uint8List bytes,
+      {String password = '', List<int>? populatedRanges}) {
     final t0 = PdfPerf.begin();
+    // Owned and growable: [applyIncrementalUpdate] extends it in place, and a
+    // caller's literal may be neither.
+    final populated =
+        populatedRanges == null ? null : List<int>.of(populatedRanges);
     try {
       final shift = _findHeader(bytes);
       try {
-        final document = _openFromXref(bytes, shift);
+        final document = _openFromXref(bytes, shift, populated);
         document._initEncryption(password);
         final root = document.resolve(document.trailer['Root']);
         if (root is! CosDictionary) {
@@ -139,7 +168,7 @@ class CosDocument {
       } on RangeError {
         // ditto: an xref offset pointing outside the file
       }
-      return _recover(bytes, shift, password);
+      return _recover(bytes, shift, password, populated);
     } finally {
       PdfPerf.end(PdfPerfPhase.docOpen, t0);
     }
@@ -180,6 +209,17 @@ class CosDocument {
     final changed = appended.entries.keys.toSet();
     appended.entries.forEach((number, entry) => _xref[number] = entry);
 
+    // An appended revision is real bytes end to end, so a sparse buffer's hole
+    // map has to grow with it - otherwise every object the update defines
+    // would read as an unfetched hole and the revision would apply invisibly.
+    final populated = _populated;
+    if (populated != null) {
+      if (populated.isNotEmpty && populated.last == bytes.length) {
+        populated[populated.length - 1] = newBytes.length;
+      } else {
+        populated.addAll([bytes.length, newBytes.length]);
+      }
+    }
     bytes = newBytes;
     startXref = newStartXref;
     // Only a section the walk actually parsed carries a trailer to refresh the
@@ -224,12 +264,13 @@ class CosDocument {
   }) =>
       openCosDocumentFromSource(source, password: password, options: options);
 
-  static CosDocument _openFromXref(Uint8List bytes, int shift) {
+  static CosDocument _openFromXref(
+      Uint8List bytes, int shift, List<int>? populated) {
     final t0 = PdfPerf.begin();
     try {
       final xref = CosXrefReader(bytes, shift: shift).read();
       return CosDocument._(
-          bytes, shift, xref.entries, xref.trailer, xref.startXref);
+          bytes, shift, xref.entries, xref.trailer, xref.startXref, populated);
     } finally {
       PdfPerf.end(PdfPerfPhase.xrefParse, t0);
     }
@@ -242,20 +283,21 @@ class CosDocument {
   /// dictionaries and cross-reference stream dictionaries, indexes any
   /// object streams so compressed objects stay reachable, and - failing a
   /// recovered /Root - locates the catalog by its /Type.
-  static CosDocument _recover(Uint8List bytes, int shift, String password) {
+  static CosDocument _recover(
+      Uint8List bytes, int shift, String password, List<int>? populated) {
     final t0 = PdfPerf.begin();
     PdfPerf.add(PdfPerfCount.xrefRecovered);
     PdfPerf.event(PdfPerfEvent.xrefRecoveryTriggered, 'bytes=${bytes.length}');
     try {
-      return _recoverTimed(bytes, shift, password);
+      return _recoverTimed(bytes, shift, password, populated);
     } finally {
       PdfPerf.end(PdfPerfPhase.xrefRecovery, t0);
     }
   }
 
   static CosDocument _recoverTimed(
-      Uint8List bytes, int shift, String password) {
-    final entries = _scanObjectHeaders(bytes, shift);
+      Uint8List bytes, int shift, String password, List<int>? populated) {
+    final entries = _scanObjectHeaders(bytes, shift, populated);
     if (entries.isEmpty) {
       throw CosParseException(
           'cross-reference recovery found no objects in the file');
@@ -283,7 +325,8 @@ class CosDocument {
       t += 'trailer'.length;
     }
 
-    final document = CosDocument._(bytes, shift, entries, trailer, 0);
+    final document =
+        CosDocument._(bytes, shift, entries, trailer, 0, populated);
 
     // Doc-level keys from xref stream dictionaries. This pass runs before
     // encryption is initialized (it has to: it may recover /Encrypt), so
@@ -363,9 +406,25 @@ class CosDocument {
 
   /// Scans the whole file for `N G obj` headers; the last definition of
   /// each object number wins, matching incremental-update semantics.
-  static Map<int, CosXrefEntry> _scanObjectHeaders(Uint8List bytes, int shift) {
+  /// [populated] bounds the scan to the byte ranges a sparse buffer actually
+  /// holds (see [_populated]); a hole is all zeros, so scanning it can only
+  /// cost time.
+  static Map<int, CosXrefEntry> _scanObjectHeaders(
+      Uint8List bytes, int shift, List<int>? populated) {
     final entries = <int, CosXrefEntry>{};
+    var hole = 0; // index of the populated range the cursor is at or before
     for (var i = shift; i + 3 <= bytes.length; i++) {
+      if (populated != null) {
+        while (
+            hole * 2 + 1 < populated.length && i >= populated[hole * 2 + 1]) {
+          hole++;
+        }
+        if (hole * 2 >= populated.length) break;
+        if (i < populated[hole * 2]) {
+          i = populated[hole * 2] - 1;
+          continue;
+        }
+      }
       if (bytes[i] != 0x6F /* o */ ||
           bytes[i + 1] != 0x62 /* b */ ||
           bytes[i + 2] != 0x6A /* j */) {
@@ -575,9 +634,21 @@ class CosDocument {
   /// Parses the indirect object at xref [offset], or null when the bytes
   /// there are junk or define a different object number.
   CosIndirectObject? _parseIndirectAt(int offset, int objectNumber) {
+    final at = offset + _offsetShift;
+    // A sparse buffer's holes are zeros, and 0x00 is whitespace: parsing one
+    // would skip forward to the next populated byte, however far away that is.
+    // Treat the object as missing instead, and bound the parse to the run it
+    // starts in so an object that runs off the end of a fetched range cannot
+    // walk into the next hole either (a view, not a copy).
+    final limit = _populatedEnd(at);
+    if (limit < 0) return null;
     try {
-      final parser = CosParser(bytes,
-          offset: offset + _offsetShift, resolver: _resolveRef);
+      final parser = CosParser(
+          limit == bytes.length
+              ? bytes
+              : Uint8List.sublistView(bytes, 0, limit),
+          offset: at,
+          resolver: _resolveRef);
       final indirect = parser.parseIndirectObject();
       return indirect.objectNumber == objectNumber ? indirect : null;
     } on Exception {
@@ -587,13 +658,34 @@ class CosDocument {
     }
   }
 
+  /// End of the populated run containing [offset], or -1 when it lies in a
+  /// hole. A complete buffer answers [bytes].length for every offset.
+  int _populatedEnd(int offset) {
+    final ranges = _populated;
+    if (ranges == null) return bytes.length;
+    var lo = 0;
+    var hi = (ranges.length >> 1) - 1;
+    while (lo <= hi) {
+      final mid = (lo + hi) >> 1;
+      if (offset < ranges[mid * 2]) {
+        hi = mid - 1;
+      } else if (offset >= ranges[mid * 2 + 1]) {
+        lo = mid + 1;
+      } else {
+        return ranges[mid * 2 + 1];
+      }
+    }
+    return -1;
+  }
+
   /// Looks [objectNumber] up in the lazily built header scan (the same
   /// scan full recovery uses) - the rescue for xrefs whose offsets lie.
   CosIndirectObject? _parseScannedHeader(int objectNumber) {
     if (_scannedHeaders == null) {
       PdfPerf.event(PdfPerfEvent.objectRescueScanBuilt);
     }
-    final headers = _scannedHeaders ??= _scanObjectHeaders(bytes, _offsetShift);
+    final headers =
+        _scannedHeaders ??= _scanObjectHeaders(bytes, _offsetShift, _populated);
     final entry = headers[objectNumber];
     if (entry == null || entry.type != CosXrefEntryType.inUse) return null;
     final rescued = _parseIndirectAt(entry.offset, objectNumber);

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -10,6 +10,20 @@ import 'parser.dart';
 import 'perf/perf.dart';
 import 'xref.dart';
 
+/// Populated-range maps for sparse buffers, keyed by the buffer itself.
+///
+/// A progressive open hands its buffer onward as plain bytes - a host paints
+/// the preview through `PdfReader(bytes:)`, which opens its own session over
+/// the same buffer - and a `Uint8List` cannot carry "these are the parts of me
+/// that hold real bytes" in its type. Recording it here means every later
+/// [CosDocument.open] of that exact buffer inherits the map instead of
+/// treating the zeros as file content; unreferenced buffers drop out with the
+/// expando. Sparseness is a property of the buffer, so this is where it
+/// belongs, not in the signature of every widget between the loader and the
+/// parser.
+final Expando<List<int>> cosSparseBufferRanges =
+    Expando<List<int>>('cos populated ranges');
+
 /// A parsed PDF file at the COS level: header, cross-reference machinery, and
 /// on-demand object loading. Page-level semantics live in `pdf_document`.
 class CosDocument {
@@ -147,8 +161,12 @@ class CosDocument {
     final t0 = PdfPerf.begin();
     // Owned and growable: [applyIncrementalUpdate] extends it in place, and a
     // caller's literal may be neither.
-    final populated =
-        populatedRanges == null ? null : List<int>.of(populatedRanges);
+    final declared = populatedRanges ?? cosSparseBufferRanges[bytes];
+    final populated = declared == null ? null : List<int>.of(declared);
+    if (PdfPerf.enabled) {
+      PdfPerf.sink?.call('cos open bytes=${bytes.length} '
+          '${populated == null ? 'whole-file' : 'sparse spans=${populated.length >> 1}'}');
+    }
     try {
       final shift = _findHeader(bytes);
       try {
@@ -641,7 +659,15 @@ class CosDocument {
     // starts in so an object that runs off the end of a fetched range cannot
     // walk into the next hole either (a view, not a copy).
     final limit = _populatedEnd(at);
-    if (limit < 0) return null;
+    if (limit < 0) {
+      // One line per document, not per object: the interesting fact is that
+      // this buffer is being read outside what it holds at all.
+      if (!_reportedHoleRead && PdfPerf.enabled) {
+        _reportedHoleRead = true;
+        PdfPerf.sink?.call('cos hole read refused object=$objectNumber at=$at');
+      }
+      return null;
+    }
     try {
       final parser = CosParser(
           limit == bytes.length
@@ -657,6 +683,8 @@ class CosDocument {
       return null;
     }
   }
+
+  bool _reportedHoleRead = false;
 
   /// End of the populated run containing [offset], or -1 when it lies in a
   /// hole. A complete buffer answers [bytes].length for every offset.

--- a/packages/pdf_cos/test/byte_source_test.dart
+++ b/packages/pdf_cos/test/byte_source_test.dart
@@ -452,6 +452,98 @@ void main() {
       expect(source.reads.length, lessThan(12));
     });
 
+    test('an object left in a hole dangles instead of scanning for it',
+        () async {
+      // The bug behind the 219 MB pack's 13-second freeze: a hole is all
+      // zeros, 0x00 is PDF whitespace, so parsing at an unfetched offset used
+      // to skip whitespace forward until the next populated byte - the whole
+      // rest of the file, per object, on the UI thread. The loader's fetched
+      // ranges make it a miss.
+      final bytes = buildMultiPagePdf(8);
+      final doc = await CosDocument.openSource(RecordingSource(bytes),
+          options: const PdfSourceLoadOptions(
+              firstPaintPages: 1,
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      final kids = (pages['Kids'] as CosArray).items;
+      // Page 1 was fetched and still resolves completely.
+      final first = doc.resolve(kids.first) as CosDictionary;
+      expect(doc.resolve(first['Contents']), isA<CosStream>());
+      // Page 8's content stream was never fetched: its object is missing, not
+      // some other object the scan happened to land on.
+      final last = doc.resolve(kids.last) as CosDictionary;
+      expect(doc.resolve(last['Contents']), isA<CosNull>());
+    });
+
+    test('a hole is authoritative even when real bytes sit inside it', () {
+      // Declaring a populated map is a statement about the buffer, not a
+      // heuristic over its contents: an object inside a hole stays missing
+      // even though its bytes are right there, which is what keeps the parser
+      // from wandering into a partially-fetched range.
+      final bytes = buildMultiPagePdf(4);
+      final text = latin1.decode(bytes, allowInvalid: true);
+      final holeStart = text.indexOf('9 0 obj');
+      final holeEnd = text.indexOf('11 0 obj');
+      expect(holeStart, greaterThan(0));
+      expect(holeEnd, greaterThan(holeStart));
+
+      final whole = CosDocument.open(bytes);
+      expect(whole.getObject(9, 0), isA<CosDictionary>());
+
+      final sparse = CosDocument.open(bytes,
+          populatedRanges: [0, holeStart, holeEnd, bytes.length]);
+      expect(sparse.getObject(9, 0), isA<CosNull>());
+      // Its neighbours, in populated ranges, are unaffected.
+      expect(sparse.getObject(1, 0), isA<CosDictionary>());
+      expect(sparse.getObject(11, 0), isA<CosDictionary>());
+    });
+
+    test('a parse cannot run off the end of its populated range', () {
+      // A fetched range can end mid-object (window sizing, coalescing). The
+      // parse is bounded to the run it starts in, so it fails there instead of
+      // reading the zeros - or the next object - that follow.
+      final bytes = buildMultiPagePdf(4);
+      final text = latin1.decode(bytes, allowInvalid: true);
+      final truncated = text.indexOf('3 0 obj');
+      final resumes = text.indexOf('5 0 obj');
+      expect(truncated, greaterThan(0));
+
+      final sparse = CosDocument.open(bytes, populatedRanges: [
+        0,
+        truncated + 12, // inside object 3's dictionary
+        resumes,
+        bytes.length,
+      ]);
+      expect(sparse.getObject(3, 0), isA<CosNull>());
+      expect(sparse.getObject(5, 0), isA<CosDictionary>());
+    });
+
+    test('an appended revision is real bytes, not another hole', () {
+      // A sparse document that later takes an incremental update must not read
+      // the appended revision as a hole - its objects would silently vanish.
+      final bytes = buildMultiPagePdf(3);
+      final text = latin1.decode(bytes, allowInvalid: true);
+      final holeStart = text.indexOf('7 0 obj');
+      final holeEnd = text.indexOf('9 0 obj');
+      final doc = CosDocument.open(bytes,
+          populatedRanges: [0, holeStart, holeEnd, bytes.length]);
+      expect(doc.getObject(7, 0), isA<CosNull>());
+
+      final updated = CosIncrementalUpdater(doc)
+        ..replaceObject(1, CosDictionary()..entries['Marker'] = CosName('Hit'));
+      final revision = updated.save();
+      doc.applyIncrementalUpdate(revision);
+
+      final root = doc.getObject(1, 0);
+      expect(root, isA<CosDictionary>());
+      expect((root as CosDictionary)['Marker'], isA<CosName>());
+      // ...and the original hole is still a hole.
+      expect(doc.getObject(7, 0), isA<CosNull>());
+    });
+
     test('page 1 is fully resolvable from the partial buffer', () async {
       final bytes = buildMultiPagePdf(5);
       final doc = await CosDocument.openSource(RecordingSource(bytes),

--- a/packages/pdf_cos/test/byte_source_test.dart
+++ b/packages/pdf_cos/test/byte_source_test.dart
@@ -521,6 +521,33 @@ void main() {
       expect(sparse.getObject(5, 0), isA<CosDictionary>());
     });
 
+    test('re-opening the same sparse buffer inherits its holes', () async {
+      // How the freeze actually reached the UI: the app paints its preview by
+      // handing the sparse bytes to another reader, which opens its own
+      // session over them - a plain CosDocument.open, with no way to be told
+      // the buffer is full of holes. The map follows the buffer.
+      final bytes = buildMultiPagePdf(8);
+      final first = await CosDocument.openSource(RecordingSource(bytes),
+          options: const PdfSourceLoadOptions(
+              firstPaintPages: 1,
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+
+      final again = CosDocument.open(first.bytes);
+      final pages = again.resolve(again.catalog['Pages']) as CosDictionary;
+      final kids = (pages['Kids'] as CosArray).items;
+      expect(
+          again.resolve(
+              (again.resolve(kids.first) as CosDictionary)['Contents']),
+          isA<CosStream>());
+      expect(
+          again
+              .resolve((again.resolve(kids.last) as CosDictionary)['Contents']),
+          isA<CosNull>(),
+          reason: 'the unfetched page is a hole in this document too');
+    });
+
     test('an appended revision is real bytes, not another hole', () {
       // A sparse document that later takes an incremental update must not read
       // the appended revision as a hole - its objects would silently vanish.


### PR DESCRIPTION
## The freeze

A 219 MB, 83-page pack froze the macOS app for **11.6 s** on open. A profile-mode
run with `--dart-define=PDF_PERF_LOG=true` named it in one line:

```
[perf 12675] JANK build=11619.1ms raster=7.3ms total=11629.5ms
```

One frame, all of it in *build*, no interpret or raster inside it. A CPU profile
from the VM service gave the stack:

```
RenderSliverFixedExtentBoxAdaptor.performLayout
  SliverChildBuilderDelegate.build
    _PdfViewerState._formFieldRects → PdfPage.annotations
      CosDocument.getObject → CosParser.parseIndirectObject → CosLexer.nextToken
        CosLexer.skipWhitespaceAndComments   ← 8515 of 12873 samples
```

### Cause

`PdfSourceLoadOptions(firstPaintPages: 1)` — the app's progressive open —
assembles a **sparse** buffer: header, xref chain and the first page's render
closure are fetched; everything else is left as zeros, on the loader's
documented assumption that they are "zeros the parser never reads".

The viewer reads them. Building a page tile calls `_formFieldRects(index)` →
`PdfPage.annotations`, and annotations are in no page's first-paint closure. And
**0x00 is PDF whitespace**, so a parse starting in a hole skips forward until the
next populated byte — hundreds of megabytes, per object, during layout. The
failed parses then trigger the `N G obj` rescue scan across the whole 219 MB
buffer.

Headless repro (the app's own options, reading what the sliver reads):

| page | before | after |
|---|---|---|
| 0 | 218 ms | 32 ms |
| 1 | **13 213 ms** (answering 0 annotations, not 65) | **0 ms** |
| 4 | 573 ms | 0 ms |

12-page sweep: ~16 s → 34 ms, same answers.

### Fix

`_ProgressiveLoader` already merges the ranges it fetched. They now travel into
`CosDocument.open(populatedRanges:)`:

- an offset inside a hole makes the reference dangle — exactly as a
  not-yet-fetched compressed object already did;
- a parse is bounded to the populated run it starts in (`Uint8List.sublistView`,
  a view, not a copy), so an object at the tail of a fetched range cannot walk
  into the hole after it;
- `_scanObjectHeaders` skips holes, so the rescue scan costs the fetched bytes
  (7 MB here) instead of the file (219 MB);
- an appended incremental revision extends the map, so an update can never read
  as a hole.

### …and the map has to follow the buffer

That fixed the repro and changed nothing in the app — still an 11.5 s frame, same
stack. A `cos open` diagnostic line (kept; it earns its place) showed why:

```
[perf 538] cos open bytes=219314443 sparse spans=110    ← the preview document
[perf 558] cos open bytes=219314443 whole-file          ← what the viewer reads
```

A preview tab paints through `PdfReader(bytes: previewBytes)`, and `PdfReader`
opens **its own session** over those bytes (`PdfShellSessionLifecycle` →
`PdfEditingController` → `CosDocument.open`). The sparse document is used for
nothing but its buffer, and a `Uint8List` cannot carry which parts of it are
real.

So sparseness now belongs to the buffer: `cosSparseBufferRanges`, an `Expando`
the loader stamps and `CosDocument.open` consults when no ranges are passed.
Every later open of that exact buffer inherits the map — no signature change in
the four widgets between the loader and the parser.

**Measured in the app, same document, same machine:**

| | before | after |
|---|---|---|
| worst frame during open | 11 619 ms | 86 ms |
| page 1 on screen | ~10.4 s | 0.6 s |

No viewer change was needed: with holes cheap the layout-time read is ~0 ms, and
the annotation caches are already cleared on the document swap. The render worker
still opens its own *copy* whole-file — harmless here (it records page content,
exactly what the closure holds) and off the UI thread; the init message is where
ranges would go if that ever shows up.

## Also in this branch

- **GPU diagnostics.** The per-page GPU/Canvas route overlay
  (`pdfDebugShowGpuRasterRoutes`, #853) was only reachable from the example app;
  it now has a switch in the app's F12 panel, persisted with the other devtools
  options. `PdfPerfLog` gains `tile gpu compile` (the per-scene GPU cost that
  used to show only as a gap), `tile gpu raster fallback` (a scene that was
  *accepted* and then fell back at raster time — previously invisible in a
  trace), and pipeline/scene warm completion + failure lines.
  `FlutterGpuTileBackendStats.logPerfSummary` brackets every trace
  (`trace-start`/`trace-end`) and each backend switch with lifetime totals.
- **Documents open in Hand mode**, so a mouse drag pans instead of starting a
  text selection.
- **Middle-button drag pans.** Flutter's drag recognizers are primary-only, so
  the gesture reached nothing at all before. A middle drag now grabs the page
  past whatever the primary button would have meant there, without disarming the
  armed tool.

## Tests

New: `pdf_cos/test/byte_source_test.dart` (a hole dangles instead of scanning; a
hole stays authoritative even when real bytes sit inside it; a parse cannot run
off the end of its range; an appended revision is not another hole),
`middle_button_pan_test.dart` (both cases fail without the recognizer change),
`hand_mode_default_test.dart`, and the GPU summary-line tests.

Green locally: `pdf_cos`, `pdf_document`, `pdf_graphics`, `dart_pdf_editor`,
`dart_pdf_editor_flutter_gpu`, `app`, plus `dart analyze` over the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
