### PR TITLE
Fix blank page from an inverted clip range in the colorant buffer

### DIFF
--- a/doc/dev-log/2026-08-28-colorant-clip-inverted-range.md
+++ b/doc/dev-log/2026-08-28-colorant-clip-inverted-range.md
@@ -1,0 +1,61 @@
+# Blank page from an inverted clip range in the colorant buffer
+
+A real-world A3 engineering drawing (an ARTC level-crossing GA sheet, one
+page, ~38k strokes) rendered as a completely blank page. The page declares
+`/OP` in its ExtGStates, so the overprint colorant buffer
+(`PdfOverprintCompositor` + `PdfColorantRaster`) is built for it, and part
+way through the content stream a stroke threw:
+
+```
+RangeError (end): Invalid value: Not in inclusive range 79992..104448: 79988
+  PdfColorantRaster.paintFlat (raster/colorant_raster.dart:260)
+  PdfOverprintCompositor._resolve / .strokeShape
+  PdfInterpreter._paint -> drawPage
+```
+
+The exception escapes `drawPage`, so nothing that had been recorded up to
+that point reached the device - hence blank, not partial.
+
+## The bug
+
+Every span loop in `PdfColorantRaster` clips a run to the active clip box
+the same way:
+
+```dart
+if (from < _clipX0) from = _clipX0;
+if (to > _clipX1) to = _clipX1;
+```
+
+A scanline can be inside the clip's *rows* while its run lies entirely
+outside the clip's *columns* - any slanted or off-to-the-side shape crossing
+a narrow clip. Both clamps then fire and leave `to < from`: an inverted
+range. The `for (var x = from; x < to; x++)` loops that most of the class
+uses no-op on that, which is why this went unnoticed. The two `fillRange`
+fast paths - `paintFlat` when there is no clip mask, and `markCovered` when
+there is no clip - do not: `fillRange(start, end)` with `end < start` throws.
+
+The fast paths were the later addition, so the crash needed a page that both
+builds a colorant buffer (declares overprint) and paints an unmasked
+rectangular-clipped shape that misses the clip's columns on some row. This
+drawing is full of them.
+
+## The fix
+
+`if (to <= from) continue;` after the clamp in `paintFlat` and
+`markCovered`. Behaviour-neutral everywhere else: an empty run wrote nothing
+before (it threw or it no-op'd), and writes nothing now.
+
+`test/colorant_raster_clip_test.dart` pins it directly on the raster - a
+draw wholly left of a right-hand clip must be a no-op rather than a throw,
+and a draw that straddles the clip edge must still fill exactly the part
+inside. Both no-op tests fail without the change.
+
+## Worth noting
+
+The blast radius here was out of all proportion to the defect: one bad
+`fillRange` in an accelerator for a *colour-accuracy* feature took out the
+entire page. The overprint compositor already has a kill switch
+(`PdfInterpreter.debugResolveOverprint`); nothing currently catches a
+failure inside it and falls back to the unresolved paint. That is a
+separate change, but if a third crash of this shape turns up it is probably
+the right answer.

--- a/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
+++ b/packages/pdf_graphics/lib/src/raster/colorant_raster.dart
@@ -256,6 +256,11 @@ class PdfColorantRaster {
       var from = spans.startAt(i), to = spans.endAt(i);
       if (from < _clipX0) from = _clipX0;
       if (to > _clipX1) to = _clipX1;
+      // A scanline can lie inside the clip's rows while its run sits entirely
+      // outside its columns (any slanted shape crossing a narrow clip), which
+      // leaves an inverted range the span loops no-op on but fillRange throws
+      // on.
+      if (to <= from) continue;
       if (mask == null) {
         cells.fillRange(row + from, row + to, value);
         continue;
@@ -284,6 +289,7 @@ class PdfColorantRaster {
       var from = spans.startAt(i), to = spans.endAt(i);
       if (from < _clipX0) from = _clipX0;
       if (to > _clipX1) to = _clipX1;
+      if (to <= from) continue;
       if (clip == null) {
         mask.fillRange(row + from, row + to, 1);
         continue;

--- a/packages/pdf_graphics/test/colorant_raster_clip_test.dart
+++ b/packages/pdf_graphics/test/colorant_raster_clip_test.dart
@@ -1,0 +1,54 @@
+// A draw whose scanlines fall inside the clip's rows but whose runs fall
+// outside its columns - any slanted or off-to-the-side shape crossing a
+// narrow clip. Clamping start up to the clip's left edge and end down to its
+// right edge then leaves `to < from`, an inverted range. The span loops
+// no-op on it, but the two `fillRange` fast paths threw a RangeError, which
+// escaped `drawPage` and rendered the whole page blank.
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_graphics/src/raster/colorant_raster.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const width = 20, height = 10;
+
+  PdfColorantRaster raster() => PdfColorantRaster(
+        width: width,
+        height: height,
+        mapping: const ColorantPageMapping(PdfMatrix.identity, 1),
+      );
+
+  /// Clips to the right-hand columns over every row.
+  void clipRight(PdfColorantRaster r) =>
+      r.clipTo(r.boxSpans(12, 0, 20, height.toDouble()));
+
+  test('paintFlat leaves a draw entirely left of the clip alone', () {
+    final r = raster();
+    clipRight(r);
+    expect(() => r.paintFlat(r.boxSpans(2, 0, 6, height.toDouble()), 3),
+        returnsNormally);
+    expect(r.cells.every((cell) => cell == 0), isTrue);
+  });
+
+  test('paintFlat still fills the part of a draw inside the clip', () {
+    final r = raster();
+    clipRight(r);
+    r.paintFlat(r.boxSpans(2, 0, 16, height.toDouble()), 3);
+    for (var y = 0; y < height; y++) {
+      for (var x = 0; x < width; x++) {
+        expect(r.cells[y * width + x], x >= 12 && x < 16 ? 3 : 0,
+            reason: 'cell ($x,$y)');
+      }
+    }
+  });
+
+  test('markCovered leaves a draw entirely left of the clip alone', () {
+    final r = raster();
+    clipRight(r);
+    final mask = Uint8List(width * height);
+    expect(() => r.markCovered(r.boxSpans(2, 0, 6, height.toDouble()), mask),
+        returnsNormally);
+    expect(mask.every((cell) => cell == 0), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

A real-world A3 engineering drawing (single page, ~3.8k fills / ~38.6k strokes) rendered as a completely blank page. The page declares `/OP` in its ExtGStates, so the overprint colorant buffer is built for it, and part way through the content stream a stroke threw:

```
RangeError (end): Invalid value: Not in inclusive range 79992..104448: 79988
  PdfColorantRaster.paintFlat (raster/colorant_raster.dart:260)
  PdfOverprintCompositor._resolve / .strokeShape
  PdfInterpreter._paint -> drawPage
```

The exception escapes `drawPage`, so nothing recorded up to that point reached the device — hence blank rather than partial.

**The bug.** Every span loop in `PdfColorantRaster` clips a run to the active clip box the same way (`if (from < _clipX0) from = _clipX0; if (to > _clipX1) to = _clipX1;`). A scanline can be inside the clip's *rows* while its run lies entirely outside the clip's *columns* — any slanted or off-to-the-side shape crossing a narrow clip. Both clamps then fire and leave `to < from`. The `for (var x = from; x < to; x++)` loops that most of the class uses no-op on that inverted range, which is why it went unnoticed; the two `fillRange` fast paths (`paintFlat` with no clip mask, `markCovered` with no clip) throw, because `fillRange(start, end)` with `end < start` is a `RangeError`.

**The fix.** `if (to <= from) continue;` after the clamp in `paintFlat` and `markCovered`. Behaviour-neutral: an empty run wrote nothing before either (it threw on one path and no-op'd on the other), and writes nothing now. No API change.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (pdf_graphics — no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test` (1059 passing)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`overprint_render_test.dart` + `ghent_render_test.dart`, 60 passing)
- [x] Ghent corpus test or baseline update (all pass unchanged — no baseline update needed)
- [x] Real PDF corpus parse/render smoke test (`render_smoke_test.dart` on the reported PDF: blank before, full 2382x1684 render after)

If any relevant check was not run, explain why: `pdf_cos` and `pdf_document` were not run — the change is confined to one `pdf_graphics` raster file and neither package depends on it (layering runs the other way).

## User experience

- [x] The affected user journey and expected outcome are described above: a page that previously opened blank now renders its content.
- [ ] Completion, cancellation, disabled, loading, and error states were considered. *(No UI surface; the change is a bounds guard inside the interpreter.)*
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked. *(Not applicable.)*
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable. *(Not applicable — rendering only, no document mutation.)*
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out: ruled out by inspection. The added guard is one comparison on a path that previously either threw or fell through to a zero-iteration loop; it removes work rather than adding it, and no other path changes.

## PDF fixtures and screenshots

The reproducing document is a third-party engineering drawing and is not attached. The regression is pinned programmatically instead, directly on the raster (`packages/pdf_graphics/test/colorant_raster_clip_test.dart`):

- a draw wholly left of a right-hand clip is a no-op rather than a throw (`paintFlat`, and the same for `markCovered`);
- a draw straddling the clip edge still fills exactly the part inside.

Both no-op tests fail on `main` and pass with this change.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The new test imports `package:pdf_graphics/src/raster/colorant_raster.dart` directly, since `PdfColorantRaster` is not exported from the public library. There is precedent (`cff_test.dart`, `cjk_cmap_test.dart`).

Worth flagging as follow-up, deliberately out of scope here: the blast radius was out of proportion to the defect — one bad `fillRange` in an accelerator for a *colour-accuracy* feature took out an entire page. The overprint compositor already has a kill switch (`PdfInterpreter.debugResolveOverprint`), but nothing catches a failure inside it and falls back to the unresolved paint. If a third crash of this shape turns up, that is probably the right answer.

Background note: `doc/dev-log/2026-08-28-colorant-clip-inverted-range.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyQNv9euK8VEpd2azxWnFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyQNv9euK8VEpd2azxWnFn)_