### PR TITLE
fix(editor): unfreeze the eyedropper, reach every page, offer it in the colour dialog

### DIFF
--- a/doc/dev-log/2026-08-28-eyedropper-freeze-reach-dialog.md
+++ b/doc/dev-log/2026-08-28-eyedropper-freeze-reach-dialog.md
@@ -1,0 +1,117 @@
+# Eyedropper: the freeze, the one-page reach, the zoom, and the dialog
+
+Four complaints about the colour picker, which turned out to be four
+separate defects in the same tool. All of them are in
+`packages/dart_pdf_editor`.
+
+## 1. Arming the eyedropper froze the app
+
+`_EditingPageOverlayState.build` warmed the sampling raster:
+
+```dart
+if (_controller.isPickingColor) unawaited(_ensureSampler());
+```
+
+Every mounted page overlay ran that, and the overlay is mounted for every
+page in the lazy list's cache extent - so arming the tool kicked off one
+**full page render per mounted page, all at once**. Each of those went
+through `PdfPageColorSampler.of`, which called
+`renderPictureRecordedWithPlan` on the **UI isolate**: the content-stream
+parse and interpreter walk, then a rasterize and a `toByteData`, times
+however many pages happened to be mounted. On an ordinary report that is
+the whole freeze; on anything raster-heavy it was worse, because the
+sampler passed no `maxImagePixelRatio` at all, so every image decoded at
+its native resolution for a raster that is only ever read three pixels at
+a time.
+
+Three changes:
+
+- **Lazy, per-page.** The warm moved out of `build` and onto the pointer:
+  `MouseRegion.onEnter` and `_updatePickPreview`. Only the page the
+  pointer actually reaches builds a raster. `build` now does the opposite
+  - `_dropSampler()` when the tool is put away, since the overlay often
+  stays mounted for a selection or another tool and a page of RGBA is
+  megabytes.
+- **Off the UI isolate.** `PdfPageColorSampler.of` takes the viewer's
+  `PdfRenderWorker` (plumbed `PdfViewer` → `EditingPageOverlay` →
+  sampler) and records through it, exactly like page rendering. Only the
+  replay and the raster stay on the UI thread. A worker that declines (an
+  inline image, no worker on this platform) falls back to the local
+  render as before.
+- **A pixel ceiling.** `PdfPageColorSampler.maxPixels` (4 MP) caps the
+  raster; a bigger page is rasterized scaled-down and `colorAt` maps into
+  it, so callers still speak page points. An A0 sheet was 32 MB of RGBA,
+  a large-format plan far more. Images are capped to the raster's own
+  resolution now too.
+
+## 2. It only worked on the page it was armed over
+
+The overlay's `GestureDetector` kept its pan recognizer while the
+eyedropper was armed. `_panStart` does nothing for it (`case null: break;
+// eyedropper only - taps, no drags`) - but the recognizer still *claimed*
+the drag, so the document could not be scrolled for as long as the tool
+was armed. The eyedropper reached exactly the pages that were on screen
+when it was armed, which is what "doesn't work across more than one page"
+was.
+
+`onPanStart/Update/End` (and the double-tap callbacks) are now dropped
+while picking, the same way cropping drops them, so the scroll view wins
+the drag. Two consequences had to be handled:
+
+- The raw `Listener`'s pointer-up is the eyedropper's commit, and it
+  fires whether or not the gesture went to the scroll view - so ending a
+  touch scroll picked whatever colour the finger lifted over and put the
+  tool away. `_pickDragged` marks a touch/stylus pointer that has passed
+  `kTouchSlop`; a dragged pointer's lift commits nothing. Mouse and
+  trackpad keep press-drag-release (those devices don't drag-scroll a
+  list), which is a deliberate feature - you can watch the preview chip
+  while you hunt for the colour.
+- A gesture keeps being routed to the render object it went down on, so a
+  page scrolled out from under a live pointer delivers moves and an up to
+  an *unmounted* overlay - which promptly tripped
+  `ValueNotifier used after being disposed`. The raw handlers and both
+  repaint bumps now tolerate being called late.
+
+The viewer's `_touchPanEnabledAt` also stood the zoomed touch-pan
+recognizer down while picking, on the assumption that the overlay would
+handle those drags. It doesn't, so a zoomed page could not be panned at
+all. The eyedropper is now on the "viewer owns pan" side of that gate.
+
+## 3. The preview chip ignored zoom
+
+The chip lives inside the viewer's zoom transform, like everything else
+in the overlay - and unlike everything else it did not counter-scale, so
+at 800% it was a billboard covering the thing being sampled and at 25% it
+was unreadable. It now scales by `_chromeScale` (anchored top-left, with
+its offset from the pointer scaled to match), the same treatment the
+selection chrome, handles and rotate knob get.
+
+The *sample* is zoom-aware now too. The 3x3 patch exists so an
+anti-aliased stroke reads as its colour, but 3 points of a magnified page
+is most of a glyph stem, so at high zoom the reading was a blur of the
+paper either side of what the pointer was on.
+`PdfPageColorSampler.patchRadiusForZoom` sizes the patch in *screen*
+pixels instead: 3x3 at 1:1, a single pixel past 2x, wider when zoomed out.
+
+## 4. Sampling from the colour dialog
+
+`PdfEditingController.pickColorFromPage()` arms the eyedropper and
+resolves with the sample, and - unlike `startColorPick` - does **not**
+adopt it as the annotation `color`: the caller asked for a colour for its
+own purposes, and quietly repainting the tool with it would be a second
+edit nobody asked for. `finishColorPick` routes to a waiting caller when
+there is one; `cancelColorPick` and `dispose` resolve it null.
+
+`PdfColorPicker` grows an `onPickFromPage` callback, shown as an
+eyedropper button in the value row. The picker can't sample the page
+itself - it is a dialog *over* the page - so `showPdfColorPicker` closes
+the dialog immediately after firing the callback, and `pickEditingColor`
+loops: close, arm, wait for the tap, reopen seeded with the sample so the
+user can confirm or nudge it. A cancelled sample ends the whole choice
+rather than bouncing the dialog back.
+
+Because every piece of editing chrome already goes through
+`pickEditingColor`, that puts the eyedropper everywhere a colour is
+chosen. Pickers nested inside another modal pass `fromPage: false` (the
+signature dialog is the one stock case) - there is no reachable page from
+there, so the button would be a dead end.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_pick.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_pick.dart
@@ -10,24 +10,47 @@ import 'editing_controller.dart';
 /// is restored from and persisted back to the preferences, and a committed
 /// colour is recorded as a recent.
 ///
+/// The picker also offers the eyedropper, so any colour choice can be
+/// sampled off the page and not just the annotation colour the toolbar's
+/// own eyedropper sets. Pressing it takes the dialog down (it is covering
+/// the page it would sample), arms
+/// [PdfEditingController.pickColorFromPage], and reopens the picker on the
+/// sampled colour so the user can confirm or nudge it. Pass [fromPage]
+/// false where the picker is nested inside another modal - the page is not
+/// reachable from there, so the button would be a dead end.
+///
 /// Returns the chosen colour, or null when the dialog is dismissed. This is
 /// the entry point the editing chrome should use instead of
-/// [showPdfColorPicker] directly, so recents and document colours show up
-/// everywhere a colour is chosen.
+/// [showPdfColorPicker] directly, so recents, document colours and the
+/// eyedropper show up everywhere a colour is chosen.
 Future<Color?> pickEditingColor(
   BuildContext context,
   PdfEditingController controller, {
   required Color initial,
+  bool fromPage = true,
 }) async {
   final preferences = controller.preferences;
-  final picked = await showPdfColorPicker(
-    context,
-    initial: initial,
-    initialFormat: preferences.colorPickerFormat,
-    onFormatChanged: (format) => preferences.colorPickerFormat = format,
-    recentColors: preferences.recentColors,
-    documentColors: controller.documentAnnotationColors(),
-  );
-  if (picked != null) preferences.noteRecentColor(picked);
-  return picked;
+  var current = initial;
+  while (true) {
+    var sampling = false;
+    final picked = await showPdfColorPicker(
+      context,
+      initial: current,
+      initialFormat: preferences.colorPickerFormat,
+      onFormatChanged: (format) => preferences.colorPickerFormat = format,
+      recentColors: preferences.recentColors,
+      documentColors: controller.documentAnnotationColors(),
+      onPickFromPage: fromPage ? () => sampling = true : null,
+    );
+    if (!sampling) {
+      if (picked != null) preferences.noteRecentColor(picked);
+      return picked;
+    }
+    // The dialog closed itself for the eyedropper; wait for the page tap.
+    // A cancelled pick (Escape, the toolbar's own button) ends the whole
+    // choice rather than bouncing the dialog back at the user.
+    final sampled = await controller.pickColorFromPage();
+    if (sampled == null || !context.mounted) return null;
+    current = sampled;
+  }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
@@ -40,6 +40,7 @@ class PdfColorPicker extends StatefulWidget {
     this.swatches = defaultSwatches,
     this.recentColors = const [],
     this.documentColors = const [],
+    this.onPickFromPage,
   });
 
   final Color color;
@@ -63,6 +64,15 @@ class PdfColorPicker extends StatefulWidget {
   /// Colours already used in the open document (annotation strokes and
   /// fills) - shown in an "In document" grid when non-empty.
   final List<Color> documentColors;
+
+  /// Hands the eyedropper over: with this set the value row grows a
+  /// "pick color from page" button, and pressing it calls this back. The
+  /// picker cannot sample the page itself - it is showing over the page -
+  /// so the host takes the dialog down, arms the viewer's eyedropper, and
+  /// brings the picker back seeded with what was sampled. See
+  /// `showPdfColorPicker` and `pickEditingColor`. Null hides the button
+  /// (no editing session, or a picker nested inside another dialog).
+  final VoidCallback? onPickFromPage;
 
   /// A general-purpose palette: a grayscale ramp plus a spread of hues.
   /// Alpha is ignored - the picker deals in opaque colours.
@@ -313,6 +323,19 @@ class _PdfColorPickerState extends State<PdfColorPicker> {
             ),
             const SizedBox(width: 12),
             Expanded(child: _valueFields(context)),
+            if (widget.onPickFromPage case final pickFromPage?) ...[
+              const SizedBox(width: 4),
+              SizedBox(
+                height: 38,
+                child: IconButton(
+                  key: const ValueKey('pdf-color-eyedropper'),
+                  icon: const Icon(Icons.colorize, size: 20),
+                  tooltip: pdfL10n(context).tbPickColorFromPage,
+                  visualDensity: VisualDensity.compact,
+                  onPressed: pickFromPage,
+                ),
+              ),
+            ],
             const SizedBox(width: 8),
             // channel rows carry labels below the fields; pin the
             // switcher to the field row's height so it lines up
@@ -577,6 +600,13 @@ class _HuePainter extends CustomPainter {
 /// the device. [recentColors] and [documentColors] feed the picker's
 /// quick-pick grids (see [PdfColorPicker]); `pickEditingColor` wires
 /// them from the controller and preferences.
+///
+/// [onPickFromPage] adds the eyedropper button (see
+/// [PdfColorPicker.onPickFromPage]). The dialog closes itself - returning
+/// null, like a cancel - immediately after calling it, so the page is clear
+/// for sampling; the caller distinguishes the two by whether its callback
+/// ran. `pickEditingColor` does exactly that and reopens the picker on the
+/// sampled colour.
 Future<Color?> showPdfColorPicker(
   BuildContext context, {
   required Color initial,
@@ -584,6 +614,7 @@ Future<Color?> showPdfColorPicker(
   ValueChanged<PdfColorFormat>? onFormatChanged,
   List<Color> recentColors = const [],
   List<Color> documentColors = const [],
+  VoidCallback? onPickFromPage,
 }) {
   var current = initial;
   return showPdfDialog<Color>(
@@ -598,6 +629,12 @@ Future<Color?> showPdfColorPicker(
           onFormatChanged: onFormatChanged,
           recentColors: recentColors,
           documentColors: documentColors,
+          onPickFromPage: onPickFromPage == null
+              ? null
+              : () {
+                  onPickFromPage();
+                  Navigator.of(context).pop();
+                },
         ),
       ),
       actions: [

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -454,6 +454,7 @@ class PdfEditingController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _settlePick(null);
     _inkTimer?.cancel();
     _flashTimer?.cancel();
     _changeFeed?.close();
@@ -2016,6 +2017,10 @@ class PdfEditingController extends ChangeNotifier {
 
   bool _pickingColor = false;
 
+  /// Set while the eyedropper is serving a [pickColorFromPage] caller, which
+  /// wants the sample handed back rather than adopted as [color].
+  Completer<Color?>? _pickCompleter;
+
   /// Whether the eyedropper is armed: the next tap on a page samples the
   /// rendered color there and becomes [color].
   bool get isPickingColor => _pickingColor;
@@ -2030,15 +2035,48 @@ class PdfEditingController extends ChangeNotifier {
   void cancelColorPick() {
     if (!_pickingColor) return;
     _pickingColor = false;
+    _settlePick(null);
     notifyListeners();
   }
 
   /// Disarms the eyedropper and adopts [picked] (forced opaque - alpha is
   /// [preferences.opacity]'s job) as the annotation [color].
+  ///
+  /// A sample a [pickColorFromPage] caller is waiting on goes to that caller
+  /// instead: it opened the eyedropper to fill in a colour of its own (a
+  /// dialog's swatch, a form field's border), and silently repainting the
+  /// annotation tool with it would be a second, unasked-for edit.
   void finishColorPick(Color picked) {
     _pickingColor = false;
-    color = Color(0xFF000000 | (picked.toARGB32() & 0xFFFFFF));
+    final opaque = Color(0xFF000000 | (picked.toARGB32() & 0xFFFFFF));
+    if (!_settlePick(opaque)) color = opaque;
     notifyListeners();
+  }
+
+  /// Arms the eyedropper and resolves with the colour the next page tap
+  /// samples, or null if the pick is cancelled (Escape, the toolbar button,
+  /// another caller arming it). Unlike the toolbar's own eyedropper this
+  /// does *not* adopt the sample as [color] - the caller decides what the
+  /// colour is for. This is the seam the colour dialog's "pick from page"
+  /// button uses, so sampling off the page is available anywhere a colour is
+  /// chosen and not only from the toolbar.
+  Future<Color?> pickColorFromPage() {
+    _settlePick(null); // a second caller supersedes the first
+    final completer = Completer<Color?>();
+    _pickCompleter = completer;
+    _pickingColor = true;
+    notifyListeners();
+    return completer.future;
+  }
+
+  /// Hands [color] to a waiting [pickColorFromPage] caller. Returns whether
+  /// there was one.
+  bool _settlePick(Color? color) {
+    final completer = _pickCompleter;
+    if (completer == null) return false;
+    _pickCompleter = null;
+    if (!completer.isCompleted) completer.complete(color);
+    return true;
   }
 
   // ---------------------------------------------------------------------

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -15,6 +15,7 @@ import '../l10n/pdf_l10n.dart';
 import '../page_geometry.dart';
 import '../platform_cursors.dart';
 import '../popup_position.dart';
+import '../render_worker.dart';
 import '../renderer.dart';
 import '../theme.dart';
 import 'editing_color_pick.dart';
@@ -511,6 +512,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.onTextEditClosed,
     this.contextMenuEnabled = true,
     this.showSelectionChip = true,
+    this.renderWorker,
   });
 
   final PdfEditingController controller;
@@ -602,6 +604,11 @@ class EditingPageOverlay extends StatefulWidget {
   /// draws a forward-extrapolated lead so the painted line keeps up with
   /// the pen tip.
   final bool predictStrokes;
+
+  /// The viewer's render worker, used to build the eyedropper's sampling
+  /// raster off the UI isolate - see [PdfPageColorSampler.of]. Null falls
+  /// back to a local render.
+  final PdfRenderWorker? renderWorker;
 
   @override
   State<EditingPageOverlay> createState() => _EditingPageOverlayState();
@@ -730,6 +737,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Offset? _pickPosition;
   Color? _pickPreview;
 
+  /// Where the pointer that is currently down went down, and whether it has
+  /// since travelled far enough to be a drag rather than a tap. While the
+  /// eyedropper is armed the overlay stands aside for the scroll view (see
+  /// the pan callbacks in [build]) so the user can reach the rest of the
+  /// document, which means a touch scroll's pointer-up arrives here like any
+  /// other: only a tap may commit a sample. A mouse/trackpad press keeps its
+  /// press-drag-release pick - those devices don't drag-scroll the list.
+  Offset? _pickDownPosition;
+  bool _pickDragged = false;
+
   // ink
   List<(double, double)>? _activeStroke;
   List<double>? _activeStrokePressures;
@@ -745,7 +762,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// thing that drives it, including the clear on commit/bail).
   final ValueNotifier<int> _activeStrokeRepaint = ValueNotifier<int>(0);
 
-  void _bumpActiveStroke() => _activeStrokeRepaint.value++;
+  /// A pointer's whole gesture keeps being routed to the render object it
+  /// went down on, so a page scrolled out from under a live pointer - which
+  /// is exactly what a touch scroll with the eyedropper armed does - still
+  /// delivers moves and an up to this state after it has been unmounted.
+  /// Both repaint signals therefore have to tolerate being ticked late.
+  void _bumpActiveStroke() {
+    if (!mounted) return;
+    _activeStrokeRepaint.value++;
+  }
 
   /// Repaint signal for the hover-cursor layer - the pen dot, eraser ring,
   /// count/stamp/signature previews, the rotate glyph and the eyedropper
@@ -763,7 +788,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// painter's shouldRepaint is true - so the rarer paths keep using it).
   final ValueNotifier<int> _cursorRepaint = ValueNotifier<int>(0);
 
-  void _bumpCursor() => _cursorRepaint.value++;
+  void _bumpCursor() {
+    if (!mounted) return;
+    _cursorRepaint.value++;
+  }
 
   /// Extends the in-progress ink stroke to the view-space [localPosition].
   /// Normally each sample appends, tracing the freehand path; while Shift is
@@ -1309,6 +1337,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// stream, stylus detection for palm rejection, multi-touch bail, and
   /// - with ink or the eraser armed - the stroke itself.
   void _onPointerDown(PointerDownEvent event) {
+    // a gesture outlives the page it started on (see [_bumpActiveStroke])
+    if (!mounted) return;
     // the crop overlay owns all input while a crop is armed
     if (_controller.isCroppingImage) return;
     _pointerPressure = _normalizedPressure(event);
@@ -1330,6 +1360,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       }
     }
     if (_controller.isPickingColor) {
+      _pickDownPosition = event.localPosition;
+      _pickDragged = false;
       _updatePickPreview(event.localPosition);
       return;
     }
@@ -1392,9 +1424,20 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _onPointerMove(PointerMoveEvent event) {
+    if (!mounted) return;
     final pressure = _normalizedPressure(event);
     if (pressure != null) _pointerPressure = pressure;
     if (_controller.isPickingColor) {
+      final down = _pickDownPosition;
+      // A touch/stylus drag is the scroll view's, not a sample: mark it so
+      // pointer-up doesn't pick the colour the finger happened to lift over.
+      if (down != null &&
+          !_pickDragged &&
+          event.kind != PointerDeviceKind.mouse &&
+          event.kind != PointerDeviceKind.trackpad &&
+          (event.localPosition - down).distance > kTouchSlop) {
+        _pickDragged = true;
+      }
       _updatePickPreview(event.localPosition);
       return;
     }
@@ -3397,6 +3440,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// the menu is suppressed.
   bool _menuLongPressClaims(Offset position) {
     if (_pointers.gestureBailed) return false;
+    // The eyedropper owns the page: a press is a sample or a scroll.
+    if (_controller.isPickingColor) return false;
     final (x, y) = _geometry.toPagePoint(position);
     if (_tool == PdfEditTool.form) return false;
     if (!_selectMode || _host.showAnnotationMenu == null) {
@@ -4204,8 +4249,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   /// Rasterizes this page once for the eyedropper, keyed on the revision id
-  /// (it changes every revision). The page raster at scale 1 shares the
-  /// view's orientation, so view → raster is just the geometry scale.
+  /// (it changes every revision). The page raster shares the view's
+  /// orientation, so view → raster is just the geometry scale.
+  ///
+  /// Called only for the page the pointer is actually over ([_updatePickPreview]
+  /// and the mouse entering this page). Arming the eyedropper used to warm
+  /// every mounted overlay from [build] instead, so a multi-page view kicked
+  /// off one full page render per mounted page at once - and every one of them
+  /// ran the interpreter walk on the UI isolate, which is what the freeze was.
   Future<PdfPageColorSampler> _ensureSampler() {
     final document = _controller.document;
     final revisionId = _controller.revisionId;
@@ -4221,7 +4272,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _samplerFuture = PdfPageColorSampler.of(document.page(widget.pageIndex),
               pageColor: pageColor,
               annotations: annotations,
-              rotation: widget.geometry.rotation)
+              rotation: widget.geometry.rotation,
+              worker: widget.renderWorker,
+              pageIndex: widget.pageIndex)
           .then((s) {
         // resolve the preview that was waiting on the raster
         if (mounted &&
@@ -4232,7 +4285,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             _sampler = s;
             final position = _pickPosition;
             if (position != null) {
-              _pickPreview = s.colorAt(position / _geometry.scale);
+              _pickPreview = _sampleAt(position);
             }
           });
         }
@@ -4242,14 +4295,37 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     return _samplerFuture!;
   }
 
+  /// Releases the sampling raster (a page's worth of RGBA - megabytes) once
+  /// the eyedropper is put away. The overlay itself often stays mounted for
+  /// an armed tool or a live selection, so it cannot rely on being disposed.
+  void _dropSampler() {
+    if (_samplerFuture == null && _sampler == null) return;
+    _sampler = null;
+    _samplerFuture = null;
+    _samplerRevisionId = null;
+    _samplerPageColor = null;
+    _samplerAnnotations = null;
+  }
+
   /// Moves the eyedropper's swatch. Hover-frequency, so it repaints the
   /// cursor layer (and the chip, which rides its own ValueListenableBuilder)
   /// instead of rebuilding the overlay - see [_cursorRepaint].
   void _updatePickPreview(Offset position) {
     unawaited(_ensureSampler());
     _pickPosition = position;
-    _pickPreview = _sampler?.colorAt(position / _geometry.scale);
+    _pickPreview = _sampleAt(position);
     _bumpCursor();
+  }
+
+  /// The sampled colour under a view-space [position], read at the patch
+  /// width the current zoom makes sense of: at 1:1 the 3x3 default, tighter
+  /// as the page is magnified (the pointer then covers a fraction of a point,
+  /// and averaging 3 points would sample the paper either side of a stem).
+  Color? _sampleAt(Offset position) {
+    final sampler = _sampler;
+    if (sampler == null) return null;
+    return sampler.colorAt(position / _geometry.scale,
+        radius: sampler.patchRadiusForZoom(widget.zoom * _geometry.scale));
   }
 
   /// Releasing the pointer commits the raw gesture (stroke or erase
@@ -4257,21 +4333,34 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// plain tap and press-drag-release (watching the preview) work. A
   /// raw listener, so it fires regardless of the gesture arena.
   Future<void> _onPointerUp(PointerUpEvent event) async {
+    if (!mounted) return;
     _endRawPointer(event, canceled: false);
     if (!_controller.isPickingColor) return;
+    final dragged = _pickDragged;
+    _pickDownPosition = null;
+    _pickDragged = false;
+    // The lift that ends a scroll flings the document on; it must not also
+    // pick a colour and put the eyedropper away.
+    if (dragged) return;
     final revisionAtStart = _controller.revisionId;
     final sampler = await _ensureSampler();
     if (!mounted || revisionAtStart != _controller.revisionId) return;
+    if (!_controller.isPickingColor) return;
     setState(() {
       _pickPosition = null;
       _pickPreview = null;
     });
-    final color = sampler.colorAt(event.localPosition / _geometry.scale);
+    final color = sampler.colorAt(event.localPosition / _geometry.scale,
+        radius: sampler.patchRadiusForZoom(widget.zoom * _geometry.scale));
     if (color != null) _controller.finishColorPick(color);
   }
 
-  void _onPointerCancel(PointerCancelEvent event) =>
-      _endRawPointer(event, canceled: true);
+  void _onPointerCancel(PointerCancelEvent event) {
+    if (!mounted) return;
+    _pickDownPosition = null;
+    _pickDragged = false;
+    _endRawPointer(event, canceled: true);
+  }
 
   Future<void> _onTapUp(TapUpDetails details) async {
     // the crop overlay owns taps while a crop is armed
@@ -5189,6 +5278,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final selectedAnnotation = _controller.selectedAnnotation;
     final cropping = _controller.isCroppingImage &&
         _controller.selectedPage == widget.pageIndex;
+    final picking = _controller.isPickingColor;
     final washRestGhost = selectedAnnotation?.subtype == 'FreeText';
     final _AfterGhost? restGhost = !widget.rasterCurrent &&
             !dragging &&
@@ -5267,8 +5357,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _flashRect = _controller.annotationAt(flash.page, flash.slot)?.rect;
       if (_flashRect != null) _flashController.forward(from: 0);
     }
-    // warm the eyedropper's raster so the first preview is instant-ish
-    if (_controller.isPickingColor) unawaited(_ensureSampler());
+    // The sampling raster is built for the page the pointer reaches, not for
+    // every mounted page the moment the eyedropper is armed; put it away
+    // again as soon as the tool is.
+    if (!_controller.isPickingColor) _dropSampler();
     // placed vertices are already snapped; only the live rubber-band edge to
     // the hover point snaps here (and only while Shift is held)
     final polyPreview = _polyPoints == null
@@ -5318,18 +5410,28 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         dragStartBehavior: DragStartBehavior.down,
         // while cropping, the crop overlay owns the page: drop this detector's
         // recognizers entirely so they never win the gesture arena over the
-        // crop rectangle's own handles and confirm/cancel chips
-        onPanStart: cropping ? null : _panStart,
-        onPanUpdate: cropping ? null : _panUpdate,
-        onPanEnd: cropping ? null : _panEnd,
-        onTapUp: cropping ? null : _onTapUp,
+        // crop rectangle's own handles and confirm/cancel chips.
+        //
+        // The eyedropper drops them too. It has no drag of its own (a sample
+        // is a tap, and the hover/press preview is driven by the raw
+        // [Listener] above, which never enters the arena), but a pan
+        // recognizer that claims the gesture and does nothing with it left
+        // the document unscrollable for as long as the tool was armed - so
+        // the eyedropper only ever reached the pages that happened to be on
+        // screen when it was armed.
+        onPanStart: cropping || picking ? null : _panStart,
+        onPanUpdate: cropping || picking ? null : _panUpdate,
+        onPanEnd: cropping || picking ? null : _panEnd,
+        onTapUp: cropping || picking ? null : _onTapUp,
         onDoubleTapDown: !cropping &&
+                !picking &&
                 (_polyTool ||
                     _tool == PdfEditTool.cloudPolygon ||
                     _tool == PdfEditTool.form)
             ? _onDoubleTapDown
             : null,
         onDoubleTap: !cropping &&
+                !picking &&
                 (_polyTool ||
                     _tool == PdfEditTool.cloudPolygon ||
                     _tool == PdfEditTool.form)
@@ -5337,6 +5439,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             : null,
         child: MouseRegion(
           cursor: _cursor,
+          // the mouse arriving over this page is the cue to build its
+          // sampling raster - by the time the pointer stops moving the first
+          // preview is ready
+          onEnter: picking ? (_) => unawaited(_ensureSampler()) : null,
           onHover: _onHover,
           onExit: (_) {
             if (_pickPosition == null &&
@@ -5554,7 +5660,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                 ),
               // the eyedropper's swatch: a widget, so it can't join the
               // cursor painter - it subscribes to the same notifier instead,
-              // rebuilding just the chip as the pointer moves
+              // rebuilding just the chip as the pointer moves.
+              //
+              // It lives inside the viewer's zoom transform like the rest of
+              // the overlay, so - like every other piece of chrome here - it
+              // counter-scales by [_chromeScale]: the swatch stays the size
+              // the theme drew it at whether the page is at 25% or 800%,
+              // instead of becoming a billboard that hides what is being
+              // sampled. Its offset from the pointer scales with it, and it
+              // anchors at the top-left so the counter-scale doesn't drag it
+              // away from the cursor.
               Positioned.fill(
                 child: IgnorePointer(
                   child: ValueListenableBuilder<int>(
@@ -5563,11 +5678,19 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                       final preview =
                           _controller.isPickingColor ? _pickPosition : null;
                       if (preview == null) return const SizedBox.shrink();
+                      final scale = _chromeScale;
                       return Stack(children: [
                         Positioned(
-                          left: preview.dx + 14,
-                          top: preview.dy - 38,
-                          child: _EyedropperChip(color: _pickPreview),
+                          left: preview.dx + 14 * scale,
+                          top: preview.dy - 38 * scale,
+                          child: Transform.scale(
+                            scale: scale,
+                            alignment: Alignment.topLeft,
+                            child: _EyedropperChip(
+                              key: const ValueKey('pdf-eyedropper-chip'),
+                              color: _pickPreview,
+                            ),
+                          ),
                         ),
                       ]);
                     },
@@ -5818,7 +5941,7 @@ class _MenuLongPressRecognizer extends LongPressGestureRecognizer {
 /// The eyedropper's floating preview: the color under the pointer and
 /// its hex value, riding beside the cursor.
 class _EyedropperChip extends StatelessWidget {
-  const _EyedropperChip({required this.color});
+  const _EyedropperChip({super.key, required this.color});
 
   /// Null while the page raster is still being built (or off the page).
   final Color? color;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -768,8 +768,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       context,
       initialColor: controller.color,
       initialStrokeWidth: controller.preferences.strokeWidth,
-      pickColor: (context, initial) =>
-          pickEditingColor(context, controller, initial: initial),
+      // the signature dialog is modal over the page, so the picker it opens
+      // has no page to sample: no eyedropper there
+      pickColor: (context, initial) => pickEditingColor(context, controller,
+          initial: initial, fromPage: false),
     );
     if (signature == null) return false;
     controller.preferences.signature = signature;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -7538,10 +7538,15 @@ class _PdfViewerState extends State<PdfViewer>
     // An armed tool, eyedropper, or selected annotation mounts an editing
     // overlay whose touch pan already calls _touchGrabPanBy. Do not enter the
     // arena twice for those gestures.
+    //
+    // The eyedropper is the exception among those: it has no drag of its own
+    // (a sample is a tap), and while it is armed the overlay stands its pan
+    // recognizer down, so the viewer must take the drag or a zoomed page
+    // cannot be panned at all - which is half of why the eyedropper only ever
+    // reached the page it was armed over.
     if (editing == null ||
-        (editing.tool == null &&
-            !editing.isPickingColor &&
-            !editing.hasAnnotationSelection)) {
+        editing.isPickingColor ||
+        (editing.tool == null && !editing.hasAnnotationSelection)) {
       pdfLogGesture('touch-pan gate: ENABLED (viewer owns pan)',
           () => 'tool=${editing?.tool?.name ?? 'none'} zoomed=$_zoomed');
       return true;
@@ -9409,6 +9414,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                                 predictStrokes: widget.predictStrokes,
                                 contextMenuEnabled: widget.contextMenuEnabled,
                                 showSelectionChip: widget.showSelectionChip,
+                                renderWorker: widget.renderWorker,
                               ),
                             ),
                           );

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -9,6 +9,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'canvas_device.dart';
 import 'image_decoder.dart';
+import 'render_worker.dart';
 import 'strips/strip_device.dart';
 
 /// Which device family [PdfPageRenderer.renderImageWithPlan] paints with.
@@ -802,39 +803,75 @@ class PdfPageRenderer {
 /// per event would be far too slow.
 ///
 /// Points are page raster space: post-rotation points with y down, the
-/// view position divided by the view scale.
+/// view position divided by the view scale. The backing raster may be
+/// smaller than that (see [maxPixels]); [colorAt] maps into it, so callers
+/// never deal in the raster's own pixels.
 class PdfPageColorSampler {
-  PdfPageColorSampler._(this._pixels, this._width, this._height);
+  PdfPageColorSampler._(this._pixels, this._width, this._height, this._scale);
 
   final ByteData _pixels;
   final int _width;
   final int _height;
 
-  /// Renders and rasterizes [page] at 1 px per point. [pageColor] and
+  /// Raster pixels per page point. 1 unless the page was too large for
+  /// [maxPixels] and the raster was scaled down to fit.
+  final double _scale;
+
+  /// The pixel ceiling a sampler's raster is built under. A page is
+  /// rasterized at 1 px per point until that would exceed this, and scaled
+  /// down to fit beyond it: an ISO A0 sheet (3370x2384 pt) would otherwise
+  /// allocate 32 MB of RGBA on the UI thread for what is only ever read a
+  /// few pixels at a time, and a large-format CAD plan is worse again.
+  /// 4 MP keeps every ordinary page (a letter page is 0.5 MP) at 1:1.
+  static const maxPixels = 4 * 1000 * 1000;
+
+  /// Renders and rasterizes [page] for sampling. [pageColor] and
   /// [annotations] must match how the page is displayed, so samples
   /// read the color the user actually sees.
+  ///
+  /// [worker] (with [pageIndex]) moves the interpreter walk - the dominant
+  /// cost, and the reason a UI-thread render of a busy page reads as a
+  /// freeze - onto the render worker's isolate, exactly as page rendering
+  /// does. The worker's cache usually already holds the buffer for a page
+  /// on screen, so an eyedropper armed over a rendered page pays only the
+  /// replay and the raster. A worker that declines (an inline image, no
+  /// worker on this platform) falls back to the local render.
   static Future<PdfPageColorSampler> of(PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
       int? rotation,
-      PdfPageRenderPlan? plan}) async {
+      PdfPageRenderPlan? plan,
+      PdfRenderWorker? worker,
+      int? pageIndex}) async {
     final renderPlan = plan ??
         PdfPageRenderPlan(
           pageColor: pageColor,
           annotations: annotations,
           rotation: rotation,
         );
-    final picture =
-        await PdfPageRenderer.renderPictureRecordedWithPlan(page, renderPlan);
+    final size = renderPlan.pageSize(page);
+    // 1 px per point, scaled down only when the page is big enough that a
+    // full-resolution raster would be a memory event of its own.
+    final area = size.width * size.height;
+    final scale = area > maxPixels ? math.sqrt(maxPixels / area) : 1.0;
+    final commands = worker == null || pageIndex == null
+        ? null
+        : await worker.record(pageIndex,
+            annotations: renderPlan.annotations, imagePixelRatio: scale);
+    final picture = commands != null
+        ? await PdfPageRenderer.pictureFromCommandsWithPlan(
+            page, commands, renderPlan, maxImagePixelRatio: scale)
+        : await PdfPageRenderer.renderPictureRecordedWithPlan(page, renderPlan,
+            maxImagePixelRatio: scale, imageDecodeHeadroom: 1);
     try {
-      final image = await PdfPageRenderer.rasterize(
-          picture, renderPlan.pageSize(page), 1);
+      final image = await PdfPageRenderer.rasterize(picture, size, scale);
       try {
         final data = await image.toByteData();
         if (data == null) {
           throw StateError('page raster yielded no pixels');
         }
-        return PdfPageColorSampler._(data, image.width, image.height);
+        return PdfPageColorSampler._(
+            data, image.width, image.height, image.width / size.width);
       } finally {
         image.dispose();
       }
@@ -843,22 +880,44 @@ class PdfPageColorSampler {
     }
   }
 
-  /// The color at [point], averaged over a 3×3-point patch so
-  /// anti-aliased strokes still read as their color. Null off the page.
-  ui.Color? colorAt(ui.Offset point) {
-    final cx = point.dx.round(), cy = point.dy.round();
-    var r = 0, g = 0, b = 0, n = 0;
-    for (var y = cy - 1; y <= cy + 1; y++) {
-      for (var x = cx - 1; x <= cx + 1; x++) {
+  /// The color at [point] (page raster space - see the class docs),
+  /// averaged over the (2*[radius]+1)-square patch of raster pixels around
+  /// it so anti-aliased strokes still read as their color. Null off the
+  /// page.
+  ///
+  /// [radius] is in raster pixels, so a caller showing the page zoomed in
+  /// can narrow the patch to what the pointer actually covers on screen -
+  /// see [patchRadiusForZoom]. The default 1 (a 3x3 patch) is the
+  /// unzoomed reading.
+  ui.Color? colorAt(ui.Offset point, {int radius = 1}) {
+    final cx = (point.dx * _scale).round(), cy = (point.dy * _scale).round();
+    final r = radius < 0 ? 0 : radius;
+    var red = 0, green = 0, blue = 0, n = 0;
+    for (var y = cy - r; y <= cy + r; y++) {
+      for (var x = cx - r; x <= cx + r; x++) {
         if (x < 0 || y < 0 || x >= _width || y >= _height) continue;
         final i = (y * _width + x) * 4;
         if (_pixels.getUint8(i + 3) == 0) continue; // past the page edge
-        r += _pixels.getUint8(i);
-        g += _pixels.getUint8(i + 1);
-        b += _pixels.getUint8(i + 2);
+        red += _pixels.getUint8(i);
+        green += _pixels.getUint8(i + 1);
+        blue += _pixels.getUint8(i + 2);
         n++;
       }
     }
-    return n == 0 ? null : ui.Color.fromARGB(255, r ~/ n, g ~/ n, b ~/ n);
+    return n == 0
+        ? null
+        : ui.Color.fromARGB(255, red ~/ n, green ~/ n, blue ~/ n);
+  }
+
+  /// The [colorAt] patch radius that covers about the same *screen* area at
+  /// [zoom] as the default 3x3 patch does unzoomed - so the sample tracks
+  /// what the pointer is over rather than blurring a 3pt disc of the page
+  /// at 8x, where 3pt is most of a glyph stem. Zoomed in past 2x it
+  /// collapses to the single pixel under the pointer.
+  int patchRadiusForZoom(double zoom) {
+    if (!zoom.isFinite || zoom <= 0) return 1;
+    // (2r+1) raster px should span ~3 screen px; screen px per raster px
+    // is zoom / _scale.
+    return ((3 * _scale / zoom - 1) / 2).floor().clamp(0, 8);
   }
 }

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_color_pick.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -151,6 +152,28 @@ void main() {
       expect(editing.isPickingColor, isFalse);
       // the sample is adopted opaque - annotation alpha is [opacity]'s job
       expect(editing.color, const Color(0xFF00A040));
+    });
+
+    test('pickColorFromPage hands the sample back instead of adopting it', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      final before = editing.color;
+
+      final pick = editing.pickColorFromPage();
+      expect(editing.isPickingColor, isTrue);
+      editing.finishColorPick(const Color(0x8000A040));
+      expect(editing.isPickingColor, isFalse);
+      expect(editing.color, before,
+          reason: 'a dialog asked for the colour; the tool keeps its own');
+      expect(pick, completion(const Color(0xFF00A040)));
+    });
+
+    test('a cancelled pickColorFromPage resolves null', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      final pick = editing.pickColorFromPage();
+      editing.cancelColorPick();
+      expect(pick, completion(isNull));
     });
 
     test('discardInk throws the buffer away without a revision', () {
@@ -968,6 +991,92 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('the eyedropper samples a page other than the first',
+        (tester) async {
+      final (editing, viewer) = await pumpEditor(tester, pages: 3);
+      editing.apply((e) => e.addSquare(
+            1,
+            const PdfRect(200, 500, 400, 700),
+            strokeColor: null,
+            fillColor: 0x00A040,
+          ));
+      await tester.pump();
+      // don't await: the returned future completes only as frames pump
+      unawaited(viewer.jumpToPage(1));
+      await settle(tester);
+      expect(viewer.currentPage, 1);
+
+      editing.startColorPick();
+      await tester.pump();
+      await tester.tapAt(view(300, 600));
+      await settle(tester);
+      await tester.runAsync(() async {
+        for (var i = 0; i < 40 && editing.isPickingColor; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        }
+      });
+      await tester.pump();
+
+      expect(editing.isPickingColor, isFalse);
+      expect(editing.color, const Color(0xFF00A040),
+          reason: 'every page samples, not just the one the tool armed over');
+      await settle(tester);
+    });
+
+    testWidgets('a touch drag scrolls while the eyedropper is armed',
+        (tester) async {
+      final (editing, viewer) = await pumpEditor(tester, pages: 5);
+      editing.startColorPick();
+      await tester.pump();
+
+      final touch = await tester.startGesture(view(300, 600),
+          kind: PointerDeviceKind.touch);
+      for (var i = 0; i < 24; i++) {
+        await touch.moveBy(const Offset(0, -100));
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await touch.up();
+      await settle(tester);
+
+      // the eyedropper has no drag of its own: the document must still
+      // scroll under it, or the tool can only ever reach the page it was
+      // armed over
+      expect(viewer.currentPage, greaterThan(0));
+      expect(editing.isPickingColor, isTrue,
+          reason: 'the lift that ends a scroll is not a sample');
+      await settle(tester);
+    });
+
+    testWidgets('the eyedropper chip keeps its size when the page is zoomed',
+        (tester) async {
+      final (editing, viewer) = await pumpEditor(tester);
+      editing.startColorPick();
+      await tester.pump();
+
+      final chip = find.byKey(const ValueKey('pdf-eyedropper-chip'));
+      final mouse =
+          await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 9);
+      await mouse.addPointer(location: view(300, 600));
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(view(300, 601));
+      await tester.pump();
+      expect(chip, findsOne);
+      final unzoomed = tester.getRect(chip).size;
+
+      viewer.setZoom(4);
+      await settle(tester);
+      await mouse.moveTo(view(300, 602));
+      await tester.pump();
+      expect(chip, findsOne);
+      final zoomed = tester.getRect(chip).size;
+
+      // the chip lives inside the viewer's zoom transform; it counter-scales
+      // so the swatch stays readable instead of becoming a billboard
+      expect(zoomed.width, closeTo(unzoomed.width, 1));
+      expect(zoomed.height, closeTo(unzoomed.height, 1));
+      await settle(tester);
+    });
+
     testWidgets('tap selects, delete key removes', (tester) async {
       final (editing, _) = await pumpEditor(tester);
       editing
@@ -1753,6 +1862,105 @@ void main() {
       await tester
           .tap(find.byKey(const ValueKey('pdf-color-swatch-document-778899')));
       expect(last, const Color(0xFF778899));
+    });
+
+    testWidgets('the eyedropper button shows only when the host offers it',
+        (tester) async {
+      var picks = 0;
+      Widget picker({VoidCallback? onPickFromPage}) => MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: PdfColorPicker(
+                  color: const Color(0xFFE53935),
+                  onChanged: (_) {},
+                  onPickFromPage: onPickFromPage,
+                ),
+              ),
+            ),
+          );
+      const key = ValueKey('pdf-color-eyedropper');
+
+      await tester.pumpWidget(picker());
+      expect(find.byKey(key), findsNothing);
+
+      await tester.pumpWidget(picker(onPickFromPage: () => picks++));
+      expect(find.byKey(key), findsOne);
+      await tester.tap(find.byKey(key));
+      expect(picks, 1);
+    });
+
+    testWidgets('pick-from-page closes the dialog and reopens on the sample',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      Color? result;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () async {
+                result = await pickEditingColor(context, editing,
+                    initial: const Color(0xFFE53935));
+              },
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsOne);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-color-eyedropper')));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsNothing,
+          reason: 'the dialog covers the page it would sample');
+      expect(editing.isPickingColor, isTrue);
+
+      editing.finishColorPick(const Color(0xFF1E88E5));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfColorPicker), findsOne,
+          reason: 'the picker comes back on the sampled colour');
+      expect(find.text('1E88E5'), findsOne);
+
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(result, const Color(0xFF1E88E5));
+      expect(editing.preferences.recentColors.first, const Color(0xFF1E88E5));
+    });
+
+    testWidgets('cancelling the page sample ends the whole choice',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      var done = false;
+      Color? result;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () async {
+                result = await pickEditingColor(context, editing,
+                    initial: const Color(0xFFE53935));
+                done = true;
+              },
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('go'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-color-eyedropper')));
+      await tester.pumpAndSettle();
+
+      editing.cancelColorPick();
+      await tester.pumpAndSettle();
+      expect(done, isTrue);
+      expect(result, isNull);
+      expect(find.byType(PdfColorPicker), findsNothing);
     });
 
     testWidgets('a grid deduplicates repeated colours by RGB', (tester) async {

--- a/packages/dart_pdf_editor/test/page_color_test.dart
+++ b/packages/dart_pdf_editor/test/page_color_test.dart
@@ -64,6 +64,40 @@ void main() {
     });
   });
 
+  testWidgets('the sampler narrows its patch as the page is magnified',
+      (tester) async {
+    await tester.runAsync(() async {
+      final document = PdfDocument.open(buildMultiPagePdf(1));
+      final sampler = await PdfPageColorSampler.of(document.page(0));
+      // 3x3 at 1:1, and no wider than the pointer covers once zoomed in -
+      // 3 points of a magnified page is most of a glyph stem
+      expect(sampler.patchRadiusForZoom(1), 1);
+      expect(sampler.patchRadiusForZoom(2), 0);
+      expect(sampler.patchRadiusForZoom(8), 0);
+      expect(sampler.patchRadiusForZoom(0.5), 2);
+      // a nonsense zoom falls back to the unzoomed reading
+      expect(sampler.patchRadiusForZoom(0), 1);
+      expect(sampler.patchRadiusForZoom(double.nan), 1);
+    });
+  });
+
+  testWidgets('an oversized page samples through a scaled-down raster',
+      (tester) async {
+    await tester.runAsync(() async {
+      // 4000x4000 pt is 16 MP at 1 px per point - 64 MB of RGBA for a
+      // handful of reads. The raster scales down; sampling still speaks
+      // page points.
+      final document =
+          PdfDocument.open(buildMultiPagePdf(1, width: 4000, height: 4000));
+      final sampler = await PdfPageColorSampler.of(document.page(0),
+          pageColor: const Color(0xFF1B5E20));
+      expect(
+          sampler.colorAt(const Offset(2000, 2000)), const Color(0xFF1B5E20));
+      expect(sampler.colorAt(const Offset(4200, 2000)), isNull,
+          reason: 'off the page is still off the page');
+    });
+  });
+
   testWidgets('PdfViewer pages display on the given paper', (tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(

--- a/packages/dart_pdf_editor/test/page_color_test.dart
+++ b/packages/dart_pdf_editor/test/page_color_test.dart
@@ -4,8 +4,75 @@ import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+/// An in-process [PdfRenderWorker] that records on the test isolate, so the
+/// sampler's off-thread path runs deterministically under a test.
+class _SyncWorker extends PdfRenderWorker {
+  _SyncWorker(this._bytes);
+
+  final Uint8List _bytes;
+  late final PdfDocument _doc = PdfDocument.open(_bytes);
+  bool _disposed = false;
+
+  /// The page indices [record] was asked for - the sampler's own claim to
+  /// have gone through the worker rather than quietly rendering locally.
+  final List<int> recorded = [];
+
+  @override
+  bool get isActive => !_disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true,
+      int? commandLimit,
+      PdfRect? imageDecodeRegion,
+      PdfPartialRecordSink? onPartial}) async {
+    if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
+    recorded.add(pageIndex);
+    final page = _doc.page(pageIndex);
+    final ops = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    PdfInterpreter(cos: _doc.cos, device: recorder)
+        .drawPageOperations(page, ops);
+    final bytes = serializeCommands(recorder.commands,
+        cos: _doc.cos,
+        maxImagePixelRatio: imagePixelRatio,
+        compactStateScopes: true);
+    return bytes == null ? null : deserializeCommands(bytes);
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _disposed = true;
+}
+
+/// A worker that declines every page, as the real one does for an inline
+/// image or on a platform with no worker at all.
+class _DecliningWorker extends _SyncWorker {
+  _DecliningWorker(super.bytes);
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true,
+      int? commandLimit,
+      PdfRect? imageDecodeRegion,
+      PdfPartialRecordSink? onPartial}) async {
+    recorded.add(pageIndex);
+    return null;
+  }
+}
 
 void main() {
   (int, int, int) pixelAt(ByteData pixels, int width, int x, int y) {
@@ -95,6 +162,54 @@ void main() {
           sampler.colorAt(const Offset(2000, 2000)), const Color(0xFF1B5E20));
       expect(sampler.colorAt(const Offset(4200, 2000)), isNull,
           reason: 'off the page is still off the page');
+    });
+  });
+
+  testWidgets('the sampler reads the same page through a worker as locally',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildMultiPagePdf(2);
+      // Every sample the eyedropper can take must agree whether the walk ran
+      // on the worker or here - the worker path is the whole point of the
+      // freeze fix, and a wrong replay would show up as a wrong colour.
+      final local =
+          await PdfPageColorSampler.of(PdfDocument.open(bytes).page(0));
+      final worker = _SyncWorker(bytes);
+      addTearDown(worker.dispose);
+      final offloaded = await PdfPageColorSampler.of(
+          PdfDocument.open(bytes).page(0),
+          worker: worker,
+          pageIndex: 0);
+      expect(worker.recorded, [0], reason: 'the walk went to the worker');
+
+      var ink = 0;
+      for (var y = 40.0; y < 100; y += 4) {
+        for (var x = 60.0; x < 200; x += 4) {
+          final point = Offset(x, y);
+          final here = local.colorAt(point);
+          expect(offloaded.colorAt(point), here, reason: 'differs at $point');
+          if (here != const Color(0xFFFFFFFF)) ink++;
+        }
+      }
+      // the sweep crosses the page's "Page 1" text, so the agreement above is
+      // about drawn content and not just blank paper
+      expect(ink, greaterThan(0));
+    });
+  });
+
+  testWidgets('a worker that declines falls back to the local render',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildMultiPagePdf(1);
+      final worker = _DecliningWorker(bytes);
+      addTearDown(worker.dispose);
+      final sampler = await PdfPageColorSampler.of(
+          PdfDocument.open(bytes).page(0),
+          pageColor: const Color(0xFF1B5E20),
+          worker: worker,
+          pageIndex: 0);
+      expect(worker.recorded, [0]);
+      expect(sampler.colorAt(const Offset(5, 5)), const Color(0xFF1B5E20));
     });
   });
 

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -138,7 +138,14 @@ Uint8List buildXrefStreamPdf() {
 }
 
 /// Builds a [pageCount]-page PDF; page N shows the text "Page N".
-Uint8List buildMultiPagePdf(int pageCount) {
+///
+/// [width]/[height] size the /MediaBox in points - US Letter by default.
+/// Oversize a page when the test is about what a page's dimensions cost
+/// (raster budgets, sampling rasters), not about its content.
+Uint8List buildMultiPagePdf(int pageCount,
+    {double width = 612, double height = 792}) {
+  // whole points write as integers - PDF accepts either, tests read better
+  String num(double v) => v == v.roundToDouble() ? '${v.round()}' : '$v';
   final objects = <String>[];
   final kids = [
     for (var i = 0; i < pageCount; i++) '${3 + i * 2} 0 R',
@@ -148,7 +155,8 @@ Uint8List buildMultiPagePdf(int pageCount) {
   objects.add('<< /Type /Pages /Kids [$kids] /Count $pageCount >>');
   for (var i = 0; i < pageCount; i++) {
     final content = 'BT /F1 24 Tf 72 720 Td (Page ${i + 1}) Tj ET';
-    objects.add('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+    objects.add('<< /Type /Page /Parent 2 0 R '
+        '/MediaBox [0 0 ${num(width)} ${num(height)}] '
         '/Contents ${4 + i * 2} 0 R '
         '/Resources << /Font << /F1 $fontNumber 0 R >> >> >>');
     objects.add('<< /Length ${content.length} >>\nstream\n$content\nendstream');


### PR DESCRIPTION
## Summary

Four complaints about the colour picker, which turned out to be four separate defects in the same tool.

**1. Arming the eyedropper froze the app.** `_EditingPageOverlayState.build` warmed the sampling raster for whichever page it was building — and the overlay is mounted for every page in the lazy list's cache extent, so arming the tool kicked off one **full page render per mounted page at once**. Each went through `PdfPageColorSampler.of`, which ran the content-stream parse and interpreter walk on the **UI isolate**, then a rasterize and a `toByteData`. It also passed no `maxImagePixelRatio`, so every image decoded at native resolution for a raster that is only ever read three pixels at a time.

The warm is now lazy — only the page the pointer actually reaches (`MouseRegion.onEnter`, `_updatePickPreview`) — and `build` does the opposite, releasing the raster when the tool is put away (the overlay often stays mounted for a selection, and a page of RGBA is megabytes). `PdfPageColorSampler.of` now takes the viewer's `PdfRenderWorker` and records through it like page rendering does, leaving only the replay and the raster on the UI thread; a worker that declines still falls back to the local render. `PdfPageColorSampler.maxPixels` (4 MP) caps the raster — an A0 sheet was 32 MB of RGBA — and `colorAt` maps into the scaled raster, so callers still speak page points.

**2. It only worked on the page it was armed over.** The overlay kept its pan recognizer while the eyedropper was armed. `_panStart` does nothing for it (`case null: break; // eyedropper only - taps, no drags`) but the recognizer still *claimed* the drag, so the document could not be scrolled for as long as the tool was armed. The pan/tap/double-tap callbacks are now dropped while picking, the way cropping drops them. Two consequences fell out: the raw `Listener`'s pointer-up is the commit and fires even when the scroll view won the gesture, so ending a touch scroll picked whatever colour the finger lifted over — a touch/stylus pointer past `kTouchSlop` is now marked a drag and commits nothing (mouse/trackpad keep press-drag-release, which is deliberate); and a page scrolled out from under a live pointer still delivers moves and an up to an unmounted overlay, which tripped `ValueNotifier used after being disposed`. The viewer's `_touchPanEnabledAt` also stood the zoomed touch-pan down while picking on the assumption the overlay handled it, so a zoomed page could not be panned at all — the eyedropper is now on the "viewer owns pan" side of that gate.

**3. The preview chip ignored zoom.** It lives inside the viewer's zoom transform like the rest of the overlay, and alone among the chrome did not counter-scale — a billboard at 800%, unreadable at 25%. It now scales by `_chromeScale` (top-left anchored, offset scaled to match). The *sample* is zoom-aware too: `PdfPageColorSampler.patchRadiusForZoom` sizes the patch in screen pixels — 3×3 at 1:1, a single pixel past 2×, wider zoomed out — instead of always averaging a 3pt disc, which at high zoom is most of a glyph stem.

**4. Sampling from the colour dialog.** `PdfEditingController.pickColorFromPage()` arms the eyedropper and resolves with the sample, and unlike `startColorPick` does *not* adopt it as the annotation colour — the caller asked for a colour of its own. `PdfColorPicker` grows an `onPickFromPage` eyedropper button; the picker can't sample the page it is covering, so `showPdfColorPicker` closes the dialog after firing it and `pickEditingColor` loops: close, arm, wait for the tap, reopen seeded with the sample. Since all editing chrome already routes through `pickEditingColor`, that puts the eyedropper everywhere a colour is chosen. Pickers nested in another modal pass `fromPage: false` (the signature dialog is the one stock case).

Notes: [doc/dev-log/2026-08-28-eyedropper-freeze-reach-dialog.md](doc/dev-log/2026-08-28-eyedropper-freeze-reach-dialog.md).

### API impact

- `EditingPageOverlay(renderWorker:)` — new optional parameter.
- `PdfPageColorSampler.of(worker:, pageIndex:)`, `colorAt(radius:)`, `patchRadiusForZoom`, `maxPixels` — additive.
- `PdfColorPicker(onPickFromPage:)` / `showPdfColorPicker(onPickFromPage:)` — additive, null keeps today's behaviour.
- `PdfEditingController.pickColorFromPage()` — new.
- `buildMultiPagePdf(width:, height:)` — additive, defaults to US Letter.

`finishColorPick` no longer sets `color` when a `pickColorFromPage` caller is waiting; with no such caller it behaves exactly as before.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [x] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Full `dart_pdf_editor` suite: 2486 passed, 27 skipped, 0 failed. `dart analyze` clean across `dart_pdf_editor` and `pdf_test_fixtures`. The three pure-Dart packages and the corpus/Ghent suites were not run: nothing here touches the parser, the COS layer, or page rendering — the only rendering-adjacent change is on the eyedropper's own sampling raster, which no baseline covers.

New tests:

- the eyedropper samples a page other than the first;
- a touch drag scrolls while the eyedropper is armed, and its lift is not a sample;
- the chip keeps its size when the page is zoomed;
- `patchRadiusForZoom` across zooms; an oversized page samples through a scaled-down raster;
- `pickColorFromPage` hands the sample back instead of adopting it, and resolves null on cancel;
- the dialog's eyedropper button shows only when the host offers it, closes the dialog, and reopens on the sample; a cancelled sample ends the whole choice.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

On cancellation: Escape and the toolbar button both resolve a waiting `pickColorFromPage` with null, which ends the dialog flow rather than bouncing the picker back at the user; `dispose` resolves it too, so a closed tab can't strand an awaiting caller. Loading: the chip shows `…` until the raster lands, unchanged. Per device — mouse keeps hover preview and press-drag-release; touch and stylus get tap-to-sample with drags going to the scroll view; the zoomed touch-pan path was the specific fix in the viewer.

The perf checkbox is left unticked deliberately. No scenario in `tool/perf/scenarios.json` or `app/tool/perf/scenarios.json` exercises the eyedropper, and the change is a strict reduction in work on that path — N page renders become at most one, the walk moves off the UI isolate, image decodes gain a resolution cap, an unbounded raster gains a 4 MP ceiling, and the raster is released when the tool is put away. Nothing on the ordinary scroll/open/search/edit paths is touched, so the existing scenarios have nothing to say about it. Adding an eyedropper scenario would be worthwhile follow-up if you want a number rather than an argument.

## PDF fixtures and screenshots

Fixtures are programmatic: `buildMultiPagePdf` gained optional `width`/`height` so the oversized-page raster test can ask for a 4000×4000 pt page.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

`renderer.dart` now imports `render_worker.dart`; no cycle (`render_worker.dart` is Flutter-free and imports nothing from the render side), and `preview_cache.dart` already depends on it the same way.

## Notes for reviewers

- `editing_overlay.dart` had pre-existing formatter drift — running `tool/format.dart` on the untouched file rewrites ~310 lines. That reformatting was reverted so the diff is only the change; the file is still not what the formatter would emit, exactly as on `main`.
- The worker path passes `imagePixelRatio: scale` (≈1), which will usually miss `PdfCachingRenderWorker`'s ratio bucket for a page already recorded at display resolution, so it records afresh. That is fine for the goal here — the walk is off the UI isolate either way — but it is a knob if the extra record ever matters.
- Image overprint and other cases where the sampler and the on-screen device can disagree are unchanged; the sampler renders through the same plan it always did.

---
_Generated by [Claude Code](https://claude.ai/code/session_013snEHgVFmzGCL1WhKiJMz7)_