### PR TITLE
Accelerate MRC JPEG 2000 rendering on Apple platforms

### DIFF
--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -716,8 +716,12 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
   // synchronous portable path. A stencil stays as a companion GPU mask: that
   // avoids both reading the JPX surface back and multiplying every RGBA pixel
   // in Dart. Unsupported/malformed codestreams fall through unchanged.
-  if (_canUseAppleJpxCodec(cos, dict, filters,
-      luminosityMask: luminosityMask)) {
+  if (_isApplePlatform &&
+      pdfCanUsePlatformJpxCodec(
+        cos,
+        dict,
+        luminosityMask: luminosityMask,
+      )) {
     final accelerated = await _decodeAppleJpx(
       cos,
       stream,
@@ -1066,45 +1070,22 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
 }
 
 bool get _isApplePlatform =>
-    !kIsWeb &&
-    (defaultTargetPlatform == TargetPlatform.macOS ||
-        defaultTargetPlatform == TargetPlatform.iOS);
+    debugAppleJpxDecoder != null ||
+    (!kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.macOS ||
+            defaultTargetPlatform == TargetPlatform.iOS));
 
-/// Whether an Apple platform codec can preserve every PDF semantic this layer
-/// needs while decoding [dict]'s JPX bytes directly.
+/// Test seam for the asynchronous Apple JPX codec.
 ///
-/// Keep the gate intentionally narrow. ImageIO returns display RGB rather than
-/// the raw component samples, so PDF-side colour transforms, non-identity
-/// `/Decode`, colour-key masks, stencils-as-images, and `/SMask` stay on the
-/// portable decoder. The common scanner shape is plain DeviceRGB
-/// (or DeviceGray), optionally under an explicit 1-bit `/Mask` stream.
-bool _canUseAppleJpxCodec(
-  CosDocument cos,
-  CosDictionary dict,
-  List<String> filters, {
-  required bool luminosityMask,
-}) {
-  if (!_isApplePlatform || luminosityMask || !filters.contains('JPXDecode')) {
-    return false;
-  }
-  if (cos.resolve(dict['ImageMask']) == const CosBoolean(true) ||
-      dict.containsKey('SMask')) {
-    return false;
-  }
-  final space = cos.resolve(dict['ColorSpace']);
-  if (space is! CosName ||
-      const {'DeviceRGB', 'RGB', 'DeviceGray', 'G'}.contains(space.value) ==
-          false) {
-    return false;
-  }
-  final components = space.value == 'DeviceGray' || space.value == 'G' ? 1 : 3;
-  if (pdfImageDecodeRanges(cos, dict, components) != null ||
-      pdfImageColorKeyRanges(cos, dict, components) != null) {
-    return false;
-  }
-  final mask = cos.resolve(dict['Mask']);
-  return !dict.containsKey('Mask') || mask is CosStream;
-}
+/// Installing this also enables the Apple route on non-Apple test hosts. It is
+/// intentionally not exported from the package entry point.
+@visibleForTesting
+Future<ui.Image?> Function(
+  Uint8List bytes, {
+  int? targetWidth,
+  int? targetHeight,
+  required bool allowUpscaling,
+})? debugAppleJpxDecoder;
 
 Future<ui.Image?> _decodeAppleJpx(
   CosDocument cos,
@@ -1142,18 +1123,30 @@ Future<ui.Image?> _decodeAppleJpx(
         decodeHeight = maskHeight;
       }
     }
-    codec = decodeWidth != null && decodeHeight != null
-        ? await ui.instantiateImageCodec(
-            bytes,
-            targetWidth: decodeWidth,
-            targetHeight: decodeHeight,
-            // A high-resolution stencil carries real detail beyond the colour
-            // plane's own grid. Upscaling the colour to the display-sized mask
-            // is the same operation the portable composite performs.
-            allowUpscaling: declaredMask,
-          )
-        : await ui.instantiateImageCodec(bytes);
-    base = (await codec.getNextFrame()).image;
+    final testDecoder = debugAppleJpxDecoder;
+    if (testDecoder != null) {
+      base = await testDecoder(
+        bytes,
+        targetWidth: decodeWidth,
+        targetHeight: decodeHeight,
+        allowUpscaling: declaredMask,
+      );
+      if (base == null) return null;
+    } else {
+      codec = decodeWidth != null && decodeHeight != null
+          ? await ui.instantiateImageCodec(
+              bytes,
+              targetWidth: decodeWidth,
+              targetHeight: decodeHeight,
+              // A high-resolution stencil carries real detail beyond the
+              // colour plane's own grid. Upscaling the colour to the
+              // display-sized mask is the same operation the portable
+              // composite performs.
+              allowUpscaling: declaredMask,
+            )
+          : await ui.instantiateImageCodec(bytes);
+      base = (await codec.getNextFrame()).image;
+    }
 
     if (declaredMask) {
       final mask = await _maskImageForGpu(

--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -3,7 +3,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb, visibleForTesting;
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
@@ -578,7 +579,7 @@ final class _DctGrayBatchCache {
   final decoded = request.decoded;
   if (decoded != null) return (decoded.width, decoded.height);
   if (target != null) return target;
-  return _nativeSize(cos, request);
+  return _compositeNativeSize(cos, request);
 }
 
 /// [request]'s declared source dimensions, or null when absent or degenerate.
@@ -588,6 +589,22 @@ final class _DctGrayBatchCache {
   final h = _intOrNull(cos.resolve(dict['Height']));
   if (w == null || h == null || w < 1 || h < 1) return null;
   return (w, h);
+}
+
+/// The native resolution of the pixels the image can contribute after its
+/// separate soft/stencil mask is applied. MRC scanners deliberately pair a
+/// low-resolution colour plane with a much sharper 1-bit text mask.
+(int, int)? _compositeNativeSize(CosDocument cos, PdfImageRequest request) {
+  final base = _nativeSize(cos, request);
+  if (base == null) return null;
+  final dict = request.stream.dictionary;
+  final softMask = cos.resolve(dict['SMask']);
+  final mask = softMask is CosStream ? softMask : cos.resolve(dict['Mask']);
+  if (mask is! CosStream) return base;
+  final width = _intOrNull(cos.resolve(mask.dictionary['Width']));
+  final height = _intOrNull(cos.resolve(mask.dictionary['Height']));
+  if (width == null || height == null || width < 1 || height < 1) return base;
+  return width * height > base.$1 * base.$2 ? (width, height) : base;
 }
 
 /// The display-capped decode size for [request]'s image, or null to decode at
@@ -604,7 +621,7 @@ final class _DctGrayBatchCache {
   double? ratio,
   double headroom,
 ) {
-  final native = _nativeSize(cos, request);
+  final native = _compositeNativeSize(cos, request);
   if (native == null) return null;
   final (w, h) = native;
   final t = request.transform;
@@ -692,6 +709,23 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
   final dict = stream.dictionary;
   final filters = pdfImageFilters(cos, dict);
   final dctMaskBytes = pdfImageDctSoftMaskBytes(cos, dict);
+  // ImageIO, which backs Flutter's codec on Apple platforms, decodes JPEG
+  // 2000 many times faster than the portable Dart codec on large
+  // scanner/MRC sheets. The native render worker deliberately leaves this
+  // narrow shape encoded, so try the asynchronous platform codec before the
+  // synchronous portable path. A stencil stays as a companion GPU mask: that
+  // avoids both reading the JPX surface back and multiplying every RGBA pixel
+  // in Dart. Unsupported/malformed codestreams fall through unchanged.
+  if (_canUseAppleJpxCodec(cos, dict, filters,
+      luminosityMask: luminosityMask)) {
+    final accelerated = await _decodeAppleJpx(
+      cos,
+      stream,
+      targetWidth: targetWidth,
+      targetHeight: targetHeight,
+    );
+    if (accelerated != null) return accelerated;
+  }
   // pdf_graphics can decode DCT masks portably for worker isolates. Once back
   // in a dart:ui isolate, keep the platform-codec path: it avoids running the
   // JPEG decoder synchronously here and lets the engine/browser codec handle
@@ -1029,6 +1063,161 @@ Future<ui.Image?> _decodeOne(CosDocument cos, CosStream stream,
       : await _imageFromPremultiplied(m.$1, m.$2, m.$3);
   base.dispose();
   return result;
+}
+
+bool get _isApplePlatform =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.iOS);
+
+/// Whether an Apple platform codec can preserve every PDF semantic this layer
+/// needs while decoding [dict]'s JPX bytes directly.
+///
+/// Keep the gate intentionally narrow. ImageIO returns display RGB rather than
+/// the raw component samples, so PDF-side colour transforms, non-identity
+/// `/Decode`, colour-key masks, stencils-as-images, and `/SMask` stay on the
+/// portable decoder. The common scanner shape is plain DeviceRGB
+/// (or DeviceGray), optionally under an explicit 1-bit `/Mask` stream.
+bool _canUseAppleJpxCodec(
+  CosDocument cos,
+  CosDictionary dict,
+  List<String> filters, {
+  required bool luminosityMask,
+}) {
+  if (!_isApplePlatform || luminosityMask || !filters.contains('JPXDecode')) {
+    return false;
+  }
+  if (cos.resolve(dict['ImageMask']) == const CosBoolean(true) ||
+      dict.containsKey('SMask')) {
+    return false;
+  }
+  final space = cos.resolve(dict['ColorSpace']);
+  if (space is! CosName ||
+      const {'DeviceRGB', 'RGB', 'DeviceGray', 'G'}.contains(space.value) ==
+          false) {
+    return false;
+  }
+  final components = space.value == 'DeviceGray' || space.value == 'G' ? 1 : 3;
+  if (pdfImageDecodeRanges(cos, dict, components) != null ||
+      pdfImageColorKeyRanges(cos, dict, components) != null) {
+    return false;
+  }
+  final mask = cos.resolve(dict['Mask']);
+  return !dict.containsKey('Mask') || mask is CosStream;
+}
+
+Future<ui.Image?> _decodeAppleJpx(
+  CosDocument cos,
+  CosStream stream, {
+  int? targetWidth,
+  int? targetHeight,
+}) async {
+  final dict = stream.dictionary;
+  final clock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
+  ui.Codec? codec;
+  ui.Image? base;
+  try {
+    final bytes = cos.decodeStreamData(
+      stream,
+      stopBeforeFilter: 'JPXDecode',
+    );
+    final declaredMask = cos.resolve(dict['Mask']) is CosStream;
+    var decodeWidth = targetWidth;
+    var decodeHeight = targetHeight;
+    if (declaredMask && decodeWidth == null && decodeHeight == null) {
+      final baseWidth = _intOrNull(cos.resolve(dict['Width']));
+      final baseHeight = _intOrNull(cos.resolve(dict['Height']));
+      final mask = cos.resolve(dict['Mask']) as CosStream;
+      final maskWidth = _intOrNull(cos.resolve(mask.dictionary['Width']));
+      final maskHeight = _intOrNull(cos.resolve(mask.dictionary['Height']));
+      if (baseWidth != null &&
+          baseHeight != null &&
+          maskWidth != null &&
+          maskHeight != null &&
+          maskWidth * maskHeight > baseWidth * baseHeight) {
+        // With no display cap the composite still has the mask's native
+        // resolution. Preserve the existing issue4246 behaviour instead of
+        // crushing a scanner's 300-DPI text mask onto its 75-DPI colour grid.
+        decodeWidth = maskWidth;
+        decodeHeight = maskHeight;
+      }
+    }
+    codec = decodeWidth != null && decodeHeight != null
+        ? await ui.instantiateImageCodec(
+            bytes,
+            targetWidth: decodeWidth,
+            targetHeight: decodeHeight,
+            // A high-resolution stencil carries real detail beyond the colour
+            // plane's own grid. Upscaling the colour to the display-sized mask
+            // is the same operation the portable composite performs.
+            allowUpscaling: declaredMask,
+          )
+        : await ui.instantiateImageCodec(bytes);
+    base = (await codec.getNextFrame()).image;
+
+    if (declaredMask) {
+      final mask = await _maskImageForGpu(
+        cos,
+        dict,
+        base.width,
+        base.height,
+      );
+      if (mask == null) return null;
+      _gpuSoftMasks[base] = mask;
+    }
+    if (clock != null) {
+      PdfPerfLog.log('image apple-jpx '
+          '${base.width}x${base.height} mask=$declaredMask '
+          'ms=${(clock.elapsedMicroseconds / 1000).toStringAsFixed(1)}');
+    }
+    final result = base;
+    base = null;
+    return result;
+  } on Exception {
+    return null;
+  } finally {
+    base?.dispose();
+    codec?.dispose();
+  }
+}
+
+/// Uploads a resolved stencil/soft-mask alpha plane as opaque grayscale.
+/// `CanvasPdfDevice` converts the red sample to alpha while applying `dstIn`.
+/// Keeping the source opaque is important: colour filters observe an
+/// unpremultiplied source, so encoding coverage in both RGB and alpha would
+/// turn every partial edge sample back into white and make MRC text too heavy.
+Future<ui.Image?> _maskImageForGpu(
+  CosDocument cos,
+  CosDictionary dict,
+  int width,
+  int height,
+) async {
+  final mask = await _resolveDartUiMask(
+    cos,
+    dict,
+    targetWidth: width,
+    targetHeight: height,
+  );
+  if (mask == null || mask.matte != null) return null;
+  final count = mask.width * mask.height;
+  final rgba = Uint8List(count * 4);
+  if (Endian.host == Endian.little) {
+    final words = Uint32List.view(rgba.buffer);
+    for (var i = 0; i < count; i++) {
+      final alpha = mask.alpha[i * mask.sampleStride];
+      words[i] = 0xFF000000 | alpha * 0x010101;
+    }
+  } else {
+    for (var i = 0; i < count; i++) {
+      final alpha = mask.alpha[i * mask.sampleStride];
+      final offset = i * 4;
+      rgba[offset] = alpha;
+      rgba[offset + 1] = alpha;
+      rgba[offset + 2] = alpha;
+      rgba[offset + 3] = 255;
+    }
+  }
+  return _imageFromPremultiplied(rgba, mask.width, mask.height);
 }
 
 /// Keeps the simple and overwhelmingly common grayscale /SMask on the GPU.

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -5,8 +5,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, defaultTargetPlatform;
-import 'package:pdf_cos/pdf_cos.dart'
-    show CosBoolean, CosDocument, CosName, CosStream;
+import 'package:pdf_cos/pdf_cos.dart' show CosDocument;
 import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 
@@ -1253,27 +1252,11 @@ bool _preferAppleJpxCodec(
       defaultTargetPlatform != TargetPlatform.iOS) {
     return false;
   }
-  final dict = request.stream.dictionary;
-  final filters = pdfImageFilters(document, dict);
-  if (!filters.contains('JPXDecode') ||
-      request.isLuminosityMask ||
-      document.resolve(dict['ImageMask']) == const CosBoolean(true) ||
-      dict.containsKey('SMask')) {
-    return false;
-  }
-  final space = document.resolve(dict['ColorSpace']);
-  if (space is! CosName ||
-      const {'DeviceRGB', 'RGB', 'DeviceGray', 'G'}.contains(space.value) ==
-          false) {
-    return false;
-  }
-  final components = space.value == 'DeviceGray' || space.value == 'G' ? 1 : 3;
-  if (pdfImageDecodeRanges(document, dict, components) != null ||
-      pdfImageColorKeyRanges(document, dict, components) != null) {
-    return false;
-  }
-  final mask = document.resolve(dict['Mask']);
-  return !dict.containsKey('Mask') || mask is CosStream;
+  return pdfCanUsePlatformJpxCodec(
+    document,
+    request.stream.dictionary,
+    luminosityMask: request.isLuminosityMask,
+  );
 }
 
 /// A full-page record cancelled mid-walk, held so the next record of the same

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -3,8 +3,10 @@ import 'dart:developer' as developer;
 import 'dart:isolate';
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart' show debugPrint;
-import 'package:pdf_cos/pdf_cos.dart' show CosDocument;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugPrint, defaultTargetPlatform;
+import 'package:pdf_cos/pdf_cos.dart'
+    show CosBoolean, CosDocument, CosName, CosStream;
 import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 
@@ -1230,11 +1232,48 @@ bool _decodeImageInBackgroundIsolate(
   CosDocument document,
   PdfImageRequest request,
 ) {
+  // Apple's asynchronous ImageIO-backed codec is dramatically faster for the
+  // plain JPX layers emitted by MRC scanners. Leave that narrow shape encoded
+  // in the command buffer so the consumer can use the platform codec and keep
+  // an explicit JBIG2 stencil as a GPU mask. Other platforms and uncommon PDF
+  // colour/mask semantics retain the portable worker decode.
+  if (_preferAppleJpxCodec(document, request)) return false;
   if (pdfImageDctSoftMaskBytes(document, request.stream.dictionary) == null) {
     return true;
   }
   final filters = pdfImageFilters(document, request.stream.dictionary);
   return filters.contains('DCTDecode') || filters.contains('DCT');
+}
+
+bool _preferAppleJpxCodec(
+  CosDocument document,
+  PdfImageRequest request,
+) {
+  if (defaultTargetPlatform != TargetPlatform.macOS &&
+      defaultTargetPlatform != TargetPlatform.iOS) {
+    return false;
+  }
+  final dict = request.stream.dictionary;
+  final filters = pdfImageFilters(document, dict);
+  if (!filters.contains('JPXDecode') ||
+      request.isLuminosityMask ||
+      document.resolve(dict['ImageMask']) == const CosBoolean(true) ||
+      dict.containsKey('SMask')) {
+    return false;
+  }
+  final space = document.resolve(dict['ColorSpace']);
+  if (space is! CosName ||
+      const {'DeviceRGB', 'RGB', 'DeviceGray', 'G'}.contains(space.value) ==
+          false) {
+    return false;
+  }
+  final components = space.value == 'DeviceGray' || space.value == 'G' ? 1 : 3;
+  if (pdfImageDecodeRanges(document, dict, components) != null ||
+      pdfImageColorKeyRanges(document, dict, components) != null) {
+    return false;
+  }
+  final mask = document.resolve(dict['Mask']);
+  return !dict.containsKey('Mask') || mask is CosStream;
 }
 
 /// A full-page record cancelled mid-walk, held so the next record of the same

--- a/packages/dart_pdf_editor/test/image_decoder_test.dart
+++ b/packages/dart_pdf_editor/test/image_decoder_test.dart
@@ -1,8 +1,8 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show TargetPlatform;
 import 'package:image/image.dart' as img;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_cos/pdf_cos.dart';
@@ -17,6 +17,23 @@ Future<Uint8List> pixelsOf(ui.Image image) async {
   return data!.buffer.asUint8List();
 }
 
+Future<ui.Image> solidGrayImage(int width, int height) {
+  final pixels = Uint8List(width * height * 4);
+  for (var i = 0; i < pixels.length; i += 4) {
+    pixels[i] = pixels[i + 1] = pixels[i + 2] = 128;
+    pixels[i + 3] = 255;
+  }
+  final completer = Completer<ui.Image>();
+  ui.decodeImageFromPixels(
+    pixels,
+    width,
+    height,
+    ui.PixelFormat.rgba8888,
+    completer.complete,
+  );
+  return completer.future;
+}
+
 /// Wraps a stream the way the interpreter hands images to the decoder.
 PdfImageRequest req(CosStream stream) =>
     PdfImageRequest(stream: stream, transform: PdfMatrix.identity);
@@ -25,6 +42,7 @@ void main() {
   late CosDocument cos;
 
   setUp(() => cos = CosDocument.open(buildClassicPdf()));
+  tearDown(() => debugAppleJpxDecoder = null);
 
   test('inline image key survives the worker-pixel handoff', () {
     final stream = CosStream(
@@ -411,6 +429,17 @@ void main() {
   testWidgets(
       'Apple JPX codec preserves and antialiases a higher-res MRC stencil',
       (tester) async {
+    final calls = <(int?, int?, bool)>[];
+    debugAppleJpxDecoder = (
+      bytes, {
+      targetWidth,
+      targetHeight,
+      required allowUpscaling,
+    }) async {
+      expect(bytes, grayJpxCodestream);
+      calls.add((targetWidth, targetHeight, allowUpscaling));
+      return solidGrayImage(targetWidth ?? 16, targetHeight ?? 16);
+    };
     await tester.runAsync(() async {
       const maskWidth = 32;
       const height = 16;
@@ -474,9 +503,8 @@ void main() {
       picture.dispose();
       disposePdfDecodedImage(decoded);
     });
-  },
-      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
-      skip: !Platform.isMacOS);
+    expect(calls, [(32, 16, true), (16, 16, true)]);
+  });
 
   testWidgets('/Decode [1 0] inverts gray samples', (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor/test/image_decoder_test.dart
+++ b/packages/dart_pdf_editor/test/image_decoder_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart' show TargetPlatform;
 import 'package:image/image.dart' as img;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_cos/pdf_cos.dart';
@@ -406,6 +407,76 @@ void main() {
       expect(pixels.sublist(12, 16), [0, 0, 0, 0]);
     });
   });
+
+  testWidgets(
+      'Apple JPX codec preserves and antialiases a higher-res MRC stencil',
+      (tester) async {
+    await tester.runAsync(() async {
+      const maskWidth = 32;
+      const height = 16;
+      final mask = CosStream(
+        CosDictionary({
+          'ImageMask': const CosBoolean(true),
+          'Width': const CosInteger(maskWidth),
+          'Height': const CosInteger(height),
+          'BitsPerComponent': const CosInteger(1),
+        }),
+        Uint8List.fromList(List.filled(height * 4, 0x55)),
+      );
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(16),
+          'Height': const CosInteger(height),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceGray'),
+          'Filter': const CosName('JPXDecode'),
+          'Mask': mask,
+        }),
+        grayJpxCodestream,
+      );
+
+      // Without a display cap, the colour plane is promoted to the stencil's
+      // native resolution instead of flattening its 300-DPI detail to the
+      // scanner's lower-resolution colour grid.
+      final full = (await decodeImages(cos, [req(stream)]))[stream]!;
+      expect((full.width, full.height), (maskWidth, height));
+      expect(pdfGpuSoftMaskOf(full), isNotNull);
+      disposePdfDecodedImage(full);
+
+      // At a 16px display footprint every adjacent paint/skip pair becomes a
+      // half-covered edge. The companion mask must upload coverage as opaque
+      // grayscale: storing it in both RGB and alpha makes the canvas colour
+      // filter unpremultiply every partial sample back to fully opaque.
+      final request = PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(16, 0, 0, 16, 0, 0),
+      );
+      final decoded = (await decodeImages(
+        cos,
+        [request],
+        maxImagePixelRatio: 1,
+        imageDecodeHeadroom: 1,
+      ))[stream]!;
+      expect((decoded.width, decoded.height), (16, height));
+      expect(pdfGpuSoftMaskOf(decoded), isNotNull);
+
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      CanvasPdfDevice(canvas, images: {stream: decoded}).drawImage(request);
+      final picture = recorder.endRecording();
+      final rendered = await picture.toImage(16, height);
+      final pixels = await pixelsOf(rendered);
+      for (var i = 3; i < pixels.length; i += 4) {
+        expect(pixels[i], inInclusiveRange(120, 135));
+      }
+
+      rendered.dispose();
+      picture.dispose();
+      disposePdfDecodedImage(decoded);
+    });
+  },
+      variant: TargetPlatformVariant.only(TargetPlatform.macOS),
+      skip: !Platform.isMacOS);
 
   testWidgets('/Decode [1 0] inverts gray samples', (tester) async {
     await tester.runAsync(() async {

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -712,14 +712,14 @@ PdfDecodedPixels? _decodePdfImagePixelsTargeted(
     final mask = pdfImageSoftMask(
           cos,
           dict,
-          targetWidth: base.width,
-          targetHeight: base.height,
+          targetWidth: targetWidth,
+          targetHeight: targetHeight,
         ) ??
         pdfImageStencilMask(
           cos,
           dict,
-          targetWidth: base.width,
-          targetHeight: base.height,
+          targetWidth: targetWidth,
+          targetHeight: targetHeight,
         );
     if (mask == null && pdfImageDctSoftMaskBytes(cos, dict) != null) {
       return null;

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -3255,6 +3255,39 @@ List<String> pdfImageFilters(CosDocument cos, CosDictionary dict) {
   return const [];
 }
 
+/// Whether a platform JPX codec can preserve every PDF semantic required by
+/// [dict] without exposing the codestream's raw component samples.
+///
+/// Platform codecs commonly return display RGB. Keep the gate narrow so PDF
+/// colour transforms, non-identity `/Decode`, colour-key masks, image-mask
+/// stencils, and `/SMask` processing stay on the portable decoder. A caller
+/// must separately check that its platform actually supplies a JPX codec.
+bool pdfCanUsePlatformJpxCodec(
+  CosDocument cos,
+  CosDictionary dict, {
+  required bool luminosityMask,
+}) {
+  if (luminosityMask || !pdfImageFilters(cos, dict).contains('JPXDecode')) {
+    return false;
+  }
+  if (cos.resolve(dict['ImageMask']) == const CosBoolean(true) ||
+      dict.containsKey('SMask')) {
+    return false;
+  }
+  final space = cos.resolve(dict['ColorSpace']);
+  if (space is! CosName ||
+      !const {'DeviceRGB', 'RGB', 'DeviceGray', 'G'}.contains(space.value)) {
+    return false;
+  }
+  final components = space.value == 'DeviceGray' || space.value == 'G' ? 1 : 3;
+  if (pdfImageDecodeRanges(cos, dict, components) != null ||
+      pdfImageColorKeyRanges(cos, dict, components) != null) {
+    return false;
+  }
+  final mask = cos.resolve(dict['Mask']);
+  return !dict.containsKey('Mask') || mask is CosStream;
+}
+
 double _numOf(CosObject? value) {
   if (value is CosInteger) return value.value.toDouble();
   if (value is CosReal) return value.value;

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -397,7 +397,7 @@ double _imageBudgetScale(List<PdfRenderCommand> commands, CosDocument cos,
         if (regionPlan != null) {
           total += regionPlan.targetWidth * regionPlan.targetHeight;
         } else {
-          final size = _declaredImageSize(cos, c.request.stream);
+          final size = _declaredCompositeImageSize(cos, c.request.stream);
           if (size == null) continue;
           final t = c.request.transform;
           final wPts = math.sqrt(t.a * t.a + t.b * t.b);
@@ -433,6 +433,25 @@ double _imageBudgetScale(List<PdfRenderCommand> commands, CosDocument cos,
   final h = _cosInt(cos.resolve(stream.dictionary['Height']));
   if (w == null || h == null || w < 1 || h < 1) return null;
   return (w, h);
+}
+
+/// The resolution carried by an image after a separate `/SMask` or stencil
+/// `/Mask` is applied. A scanner's MRC colour plane is commonly 75 DPI while
+/// its 1-bit text mask is 300 DPI; the composited image can resolve the mask's
+/// pixels, so treating only the colour plane as native crushes text detail and
+/// also prevents the display-resolution cap from engaging.
+(int, int)? _declaredCompositeImageSize(CosDocument cos, CosStream stream) {
+  final base = _declaredImageSize(cos, stream);
+  if (base == null) return null;
+  final dict = stream.dictionary;
+  final softMask = cos.resolve(dict['SMask']);
+  final mask = softMask is CosStream ? softMask : cos.resolve(dict['Mask']);
+  if (mask is! CosStream) return base;
+  final maskSize = _declaredImageSize(cos, mask);
+  if (maskSize == null || maskSize.$1 * maskSize.$2 <= base.$1 * base.$2) {
+    return base;
+  }
+  return maskSize;
 }
 
 int? _cosInt(CosObject? o) {
@@ -940,7 +959,7 @@ _CommandImage? _decodeImageForCommand(
   double ratio,
   double budgetScale,
 ) {
-  final size = _declaredImageSize(document, request.stream);
+  final size = _declaredCompositeImageSize(document, request.stream);
   if (size == null) return null;
   final transform = request.transform;
   final widthPts =

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -29,6 +29,83 @@ void main() {
   CosStream flateImage(Map<String, CosObject> dict, List<int> data) => image(
       {...dict, 'Filter': const CosName('FlateDecode')}, zlib.encode(data));
 
+  group('platform JPX codec eligibility', () {
+    CosDictionary jpx(String colorSpace) => CosDictionary({
+          'Filter': const CosName('JPXDecode'),
+          'ColorSpace': CosName(colorSpace),
+        });
+
+    test('accepts simple device colour with an optional stream mask', () {
+      for (final colorSpace in const ['DeviceRGB', 'RGB', 'DeviceGray', 'G']) {
+        expect(
+          pdfCanUsePlatformJpxCodec(
+            cos,
+            jpx(colorSpace),
+            luminosityMask: false,
+          ),
+          isTrue,
+        );
+      }
+      expect(
+        pdfCanUsePlatformJpxCodec(
+          cos,
+          CosDictionary({
+            ...jpx('DeviceGray').entries,
+            'Mask': CosStream(CosDictionary({}), Uint8List(0)),
+          }),
+          luminosityMask: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects semantics a display-RGB codec cannot preserve', () {
+      expect(
+        pdfCanUsePlatformJpxCodec(
+          cos,
+          jpx('DeviceRGB'),
+          luminosityMask: true,
+        ),
+        isFalse,
+      );
+
+      final rejected = <CosDictionary>[
+        CosDictionary({'ColorSpace': const CosName('DeviceRGB')}),
+        CosDictionary({
+          ...jpx('DeviceRGB').entries,
+          'ImageMask': const CosBoolean(true),
+        }),
+        CosDictionary({
+          ...jpx('DeviceRGB').entries,
+          'SMask': CosStream(CosDictionary({}), Uint8List(0)),
+        }),
+        jpx('DeviceCMYK'),
+        CosDictionary({
+          'Filter': const CosName('JPXDecode'),
+          'ColorSpace': CosArray([const CosName('Indexed')]),
+        }),
+        CosDictionary({
+          ...jpx('DeviceGray').entries,
+          'Decode': CosArray([const CosInteger(1), const CosInteger(0)]),
+        }),
+        CosDictionary({
+          ...jpx('DeviceGray').entries,
+          'Mask': CosArray([const CosInteger(0), const CosInteger(1)]),
+        }),
+        CosDictionary({
+          ...jpx('DeviceRGB').entries,
+          'Mask': const CosName('unexpected'),
+        }),
+      ];
+      for (final dict in rejected) {
+        expect(
+          pdfCanUsePlatformJpxCodec(cos, dict, luminosityMask: false),
+          isFalse,
+        );
+      }
+    });
+  });
+
   test('DeviceRGB 8-bit decodes opaque, straight through', () {
     final stream = image({
       'Width': const CosInteger(2),

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -475,6 +475,43 @@ void main() {
     expect(decodePdfImageBase(cos, stream), isNull);
   });
 
+  test('targeted MRC decode keeps detail from a higher-res stencil', () {
+    // Scanner MRC: the 1x1 colour plane is deliberately low resolution and
+    // the 4x1 stencil carries the sharp text edges. At a 2x1 display target,
+    // each adjacent paint/skip mask pair averages to half coverage. Passing
+    // the base's 1x1 size into the mask decoder would crush the result to a
+    // single pixel before the two halves meet.
+    final mask = image({
+      'ImageMask': const CosBoolean(true),
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(1),
+      'BitsPerComponent': const CosInteger(1),
+    }, [
+      0x50, // bits 0,1,0,1 -> paint,skip,paint,skip
+    ]);
+    final stream = image({
+      'Width': const CosInteger(1),
+      'Height': const CosInteger(1),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceRGB'),
+      'Mask': mask,
+    }, [
+      255,
+      0,
+      0,
+    ]);
+
+    final pixels = decodePdfImage(
+      cos,
+      stream,
+      targetWidth: 2,
+      targetHeight: 1,
+    )!;
+
+    expect((pixels.width, pixels.height), (2, 1));
+    expect(pixels.rgba, [127, 0, 0, 127, 127, 0, 0, 127]);
+  });
+
   group('CMYK JPEG polarity (#370)', () {
     // Two 16x8 baseline JPEGs, hand-built with constant 8x8 blocks and custom
     // Huffman tables so the stored samples are exact by construction. The

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -1108,6 +1108,46 @@ void main() {
   // them; a null/huge ratio must leave them at native resolution; and the
   // command transcript must be untouched either way (only the pixels change).
   group('image resolution cap', () {
+    test('uses a higher-resolution MRC stencil as the composite source size',
+        () {
+      final cos = CosDocument.open(buildClassicPdf());
+      final mask = CosStream(
+        CosDictionary({
+          'ImageMask': const CosBoolean(true),
+          'Width': const CosInteger(4),
+          'Height': const CosInteger(1),
+          'BitsPerComponent': const CosInteger(1),
+        }),
+        Uint8List.fromList([0x50]),
+      );
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(1),
+          'Height': const CosInteger(1),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Mask': mask,
+        }),
+        Uint8List.fromList([255, 0, 0]),
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(2, 0, 0, 1, 0, 0),
+      ));
+
+      final bytes = serializeCommands(
+        [command],
+        cos: cos,
+        decodeImages: true,
+        maxImagePixelRatio: 1,
+      );
+      final decoded =
+          _imageCommands(deserializeCommands(bytes!)).single.request.decoded!;
+
+      expect((decoded.width, decoded.height), (2, 1));
+      expect(decoded.rgba, [127, 0, 0, 127, 127, 0, 0, 127]);
+    });
+
     final files = <String>[
       '../../test_corpora/ghent/1-CMYK/'
           'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',


### PR DESCRIPTION
## Summary

- use the ImageIO-backed Flutter codec for semantically compatible JPEG 2000 image layers on macOS and iOS
- keep explicit scanner stencils as GPU masks, preserving high-resolution MRC text detail and antialiased coverage
- size local and worker decodes from the composite image resolution when a mask is sharper than its colour plane
- retain the portable decoder for unsupported colour spaces, decode transforms, soft masks, colour-key masks, or codec failures

The supplied 23-page MRC scan combines six JPEG 2000 colour layers per page with high-resolution JBIG2/CCITT masks. Page 1 at 1x improved from about 7.47 seconds to 1.41 seconds on the first cold run, with later cache-cleared runs at 1.04-1.09 seconds. Forcing the current implementation through the portable path took 3.75-4.30 seconds.

## Affected packages

- [ ] pdf_cos
- [ ] pdf_document
- [x] pdf_graphics
- [x] dart_pdf_editor
- [ ] pdf_test_fixtures
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [ ] fvm flutter pub get
- [x] fvm dart analyze
- [ ] cd packages/pdf_cos && fvm dart test
- [ ] cd packages/pdf_document && fvm dart test
- [ ] cd packages/pdf_graphics && fvm dart test
- [ ] cd packages/dart_pdf_editor && fvm flutter test
- [x] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Focused checks:
- pdf_graphics image_pixels_test.dart
- pdf_graphics render_command_codec_test.dart
- dart_pdf_editor image_decoder_test.dart
- dart_pdf_editor render_worker_test.dart
- Ghent pure-Dart and raster baseline suites
- PDF.js pure-Dart and render smoke suites
- end-to-end worker render of page 1 from the supplied PDF

Full package suites were not rerun; the focused suites plus both checked-in corpora cover the changed decode, command-buffer, and raster paths.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

The change affects initial rendering of image-heavy scanned PDFs. Input and editing interactions are unchanged.

## PDF fixtures and screenshots

The source PDF is private and was not uploaded. Regression tests build minimal MRC-style colour-plane plus high-resolution stencil fixtures programmatically.

## Compatibility checklist

- [x] No dart:ui or Flutter imports outside packages/dart_pdf_editor.
- [x] No dart:io imports in any lib directory.
- [x] Layering is preserved: pdf_cos <- pdf_document <- pdf_graphics <- dart_pdf_editor.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The ImageIO path is intentionally narrow: DeviceRGB or DeviceGray JPX images, optionally with an explicit mask stream. Unsupported semantics and platform codec failures fall back to the existing portable decoder. No corpus baselines changed.