### PR TITLE
Allow dragging page content between pages

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -7616,10 +7616,10 @@ class PdfEditingController extends ChangeNotifier {
     // hides it, and unlike an annotation nothing reaches past the edge to
     // pick it up again ([PdfEditingReach] works on the annotation
     // selection, and hit-testing an element needs bounds under the
-    // pointer). So a drag toward a neighbouring page parks the element at
-    // this page's edge with a strip still on the paper, rather than
-    // committing it out of sight. Content does not cross pages; moving it
-    // to another page is a copy/paste, not a drag.
+    // pointer). So a same-page move that ends outside every page parks the
+    // element at this page's edge with a strip still on the paper, rather
+    // than committing it out of sight. A drop resolved onto a different page
+    // takes the dedicated [moveSelectedElementToPage] path instead.
     final bounds = element.bounds;
     if (bounds != null) {
       final box = _page(selected.$1).cropBox;
@@ -7642,6 +7642,108 @@ class PdfEditingController extends ChangeNotifier {
     _selectedElement = selected;
     notifyListeners();
     return true;
+  }
+
+  /// Re-homes the selected page-content element onto [targetPage].
+  ///
+  /// [sourceX], [sourceY] are the point where the drag started in the source
+  /// page's user space; [targetX], [targetY] are the drop point in the target
+  /// page's user space. Mapping the two anchors through each page's /Rotate
+  /// keeps the drawing under the pointer and preserves its displayed
+  /// orientation even when the pages have different rotations.
+  ///
+  /// The element's original content operators and resources move to the
+  /// target page, so text remains editable text and images remain replaceable
+  /// images. One revision; the moved element stays selected. A same-page
+  /// target falls back to [moveSelectedElement].
+  bool moveSelectedElementToPage(
+    int targetPage, {
+    required double sourceX,
+    required double sourceY,
+    required double targetX,
+    required double targetY,
+  }) {
+    if (targetPage < 0 || targetPage >= _document.pageCount) return false;
+    final selected = _selectedElement;
+    final element = selectedElement;
+    if (selected == null || element == null || !canMoveSelectedElement) {
+      return false;
+    }
+    if (selected.$1 == targetPage) {
+      return moveSelectedElement(targetX - sourceX, targetY - sourceY);
+    }
+
+    final transform = _elementPageTransform(
+      selected.$1,
+      targetPage,
+      sourceX: sourceX,
+      sourceY: sourceY,
+      targetX: targetX,
+      targetY: targetY,
+    );
+    final elements = elementsOn(selected.$1);
+    var moved = 0;
+    final changed = apply(
+      (editor) => moved = editor.moveElementsToPage(
+        elements,
+        [element.id],
+        targetPage,
+        transform: transform,
+      ),
+    );
+    if (!changed || moved == 0) return false;
+    final targetElements = elementsOn(targetPage).elements;
+    if (targetElements.isEmpty) return true;
+    // The moved operators append to the target page, so their one drawing is
+    // the last content element there. Keep it live for a follow-up nudge,
+    // retype, image replacement, or another drag.
+    _selectedElement = (targetPage, targetElements.length - 1);
+    notifyListeners();
+    return true;
+  }
+
+  /// Source page user space -> target page user space, preserving the
+  /// direction the drawing has on screen and pinning the drag anchors.
+  PdfMatrix _elementPageTransform(
+    int sourcePage,
+    int targetPage, {
+    required double sourceX,
+    required double sourceY,
+    required double targetX,
+    required double targetY,
+  }) {
+    PdfPageGeometry geometry(int pageIndex) {
+      final page = _page(pageIndex);
+      return PdfPageGeometry(
+        cropBox: page.cropBox,
+        rotation: page.rotation,
+        viewSize: ui.Size(
+          _visualPageWidth(pageIndex),
+          _visualPageHeight(pageIndex),
+        ),
+      );
+    }
+
+    final source = geometry(sourcePage);
+    final target = geometry(targetPage);
+    final sourceAnchor = source.toViewOffset(sourceX, sourceY);
+    final targetAnchor = target.toViewOffset(targetX, targetY);
+    (double, double) map(double x, double y) {
+      final displayed = source.toViewOffset(x, y) - sourceAnchor + targetAnchor;
+      return target.toPagePoint(displayed);
+    }
+
+    final origin = map(0, 0);
+    final xAxis = map(1, 0);
+    final yAxis = map(0, 1);
+    return PdfMatrix(
+      xAxis.$1 - origin.$1,
+      xAxis.$2 - origin.$2,
+      yAxis.$1 - origin.$1,
+      yAxis.$2 - origin.$2,
+      origin.$1,
+      origin.$2,
+    );
   }
 
   /// Rewrites the selected text element's characters to [text] and

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -949,16 +949,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Offset? _moveStart;
   Offset? _moveCurrent;
 
-  /// The global position of [_moveCurrent] - captured during a move drag
-  /// so a drop over another page can be resolved to a page point (drag-end
-  /// details carry no position).
+  /// The global position of the annotation or content move's current point -
+  /// captured so a drop over another page can be resolved to a page point
+  /// (drag-end details carry no position).
   Offset? _moveCurrentGlobal;
 
   // Content-tool drags: repositioning the selected page-content element (a
   // text run, a placed image or logo, a filled path) rather than an
-  // annotation. Kept apart from the select-tool move state above because
-  // none of that machinery - cross-page drops, annotation ghosts, resize
-  // handles - applies to a drawing inside the content stream.
+  // annotation. Kept apart from the select-tool move state above because its
+  // lift is a filtered page picture rather than an annotation appearance.
   Offset? _elementMoveStart;
   Offset? _elementMoveCurrent;
 
@@ -2270,6 +2269,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     setState(() {
       _elementMoveStart = position;
       _elementMoveCurrent = position;
+      _moveCurrentGlobal = null;
     });
     unawaited(_ensureElementLift());
   }
@@ -2347,11 +2347,41 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _elementClean = clean;
         _elementOnly = only;
       });
+      if (_elementMoveStart != null) _reportElementMovePreview();
     } catch (_) {
       // no lift: the drag still moves its chrome box, and the commit
       // re-renders the page either way
       _elementLiftKey = null;
     }
+  }
+
+  /// Pushes a content-element drag's isolated drawing up to the viewer when
+  /// it crosses this page's boundary, so the destination page can paint the
+  /// part that lands there. The source overlay keeps painting its own slice.
+  void _reportElementMovePreview() {
+    final report = _host.moveDragPreview;
+    if (report == null) return;
+    final picture = _elementOnly;
+    final from = _selectedElementRestRect;
+    final start = _elementMoveStart;
+    final current = _elementMoveCurrent;
+    if (picture == null || from == null || start == null || current == null) {
+      report(null);
+      return;
+    }
+    final to = from.shift(current - start);
+    final page = Offset.zero & _geometry.viewSize;
+    if (page.contains(to.topLeft) && page.contains(to.bottomRight)) {
+      report(null);
+      return;
+    }
+    report(PdfMoveDragPreview(
+      pageIndex: widget.pageIndex,
+      picture: picture,
+      from: from,
+      to: to,
+      scale: _geometry.scale,
+    ));
   }
 
   /// Hands the drag's pictures to the commit afterimage, which paints the
@@ -2370,6 +2400,23 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _afterElementOnly = only;
     _afterElementFrom = from;
     _afterElementOffset = offset;
+    _afterRevisionId = _controller.revisionId;
+  }
+
+  /// Holds the clean source page after a cross-page drop. The isolated
+  /// drawing now belongs to the destination, so only the clean half remains
+  /// on this page while its new raster catches up.
+  void _holdElementSourceAfterimage(Rect from) {
+    final clean = _elementClean;
+    if (clean == null) return;
+    _elementClean = null;
+    _elementOnly?.dispose();
+    _elementOnly = null;
+    _elementLiftKey = null;
+    _clearAfterimage();
+    _afterElementClean = clean;
+    _afterElementFrom = from;
+    _afterElementOffset = Offset.zero;
     _afterRevisionId = _controller.revisionId;
   }
 
@@ -2581,7 +2628,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // before disposing [_ghost] so a neighbour page can't paint freed
     // pixels. Guarded by _moveStart so disposing some other (off-screen)
     // page's overlay never clears a preview the dragging page still owns.
-    if (_moveStart != null) _host.moveDragPreview?.call(null);
+    if (_moveStart != null || _elementMoveStart != null) {
+      _host.moveDragPreview?.call(null);
+    }
     if (_chipFocusHeld) {
       _chipFocusHeld = false;
       _controller.endEditingTextFocusHold();
@@ -3751,7 +3800,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _resizeRect = _anchorResized(resized);
       });
     } else if (_elementMoveStart != null) {
+      _moveCurrentGlobal = _autoScrollGlobal;
       setState(() => _elementMoveCurrent = position);
+      _reportElementMovePreview();
     } else if (_moveStart != null) {
       _moveCurrentGlobal = _autoScrollGlobal;
       setState(() => _moveCurrent = position);
@@ -4003,6 +4054,22 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       }
       // mapping both endpoints keeps the delta right on a rotated page
       final (x0, y0) = _geometry.toPagePoint(elementMoveStart);
+      final resolve = _host.resolvePagePoint;
+      if (resolve != null && moveCurrentGlobal != null) {
+        final drop = resolve(moveCurrentGlobal);
+        if (drop != null && drop.$1 != widget.pageIndex) {
+          final from = _selectedElementRestRect;
+          final moved = _controller.moveSelectedElementToPage(
+            drop.$1,
+            sourceX: x0,
+            sourceY: y0,
+            targetX: drop.$2,
+            targetY: drop.$3,
+          );
+          if (moved && from != null) _holdElementSourceAfterimage(from);
+          return;
+        }
+      }
       final (x1, y1) = _geometry.toPagePoint(elementMoveCurrent);
       final from = _selectedElementRestRect;
       final before = _controller.revisionId;
@@ -7417,7 +7484,7 @@ class _EditingPreviewPainter extends CustomPainter {
     final liftFrom = elementLiftFrom;
     final liftClean = elementClean;
     final liftOnly = elementOnly;
-    if (liftFrom != null && liftClean != null && liftOnly != null) {
+    if (liftFrom != null && liftClean != null) {
       canvas.save();
       if (!elementLiftSettled) {
         // mid-drag the page's own raster is still right everywhere but the
@@ -7431,11 +7498,13 @@ class _EditingPreviewPainter extends CustomPainter {
       canvas.drawPicture(liftClean);
       canvas.restore();
 
-      canvas.save();
-      canvas.translate(elementLiftOffset.dx, elementLiftOffset.dy);
-      canvas.scale(geometry.scale);
-      canvas.drawPicture(liftOnly);
-      canvas.restore();
+      if (liftOnly != null) {
+        canvas.save();
+        canvas.translate(elementLiftOffset.dx, elementLiftOffset.dy);
+        canvas.scale(geometry.scale);
+        canvas.drawPicture(liftOnly);
+        canvas.restore();
+      }
     }
 
     // the wash goes under every stroke preview: the eraser's sliced

--- a/packages/dart_pdf_editor/test/editing_content_move_test.dart
+++ b/packages/dart_pdf_editor/test/editing_content_move_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -25,6 +26,40 @@ const mixedContent = 'BT /F1 12 Tf 14 TL 72 700 Td '
     '(Alpha beta gamma delta) Tj '
     'T* (epsilon zeta eta theta) Tj ET\n'
     '0 0 1 rg 100 600 80 40 re f\n';
+
+Uint8List buildTwoPageContentPdf({int targetRotation = 0}) {
+  const targetContent = 'BT /F1 12 Tf 72 500 Td (Target page) Tj ET\n';
+  final rotate = targetRotation == 0 ? '' : '/Rotate $targetRotation ';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>',
+    '<< /Length ${mixedContent.length} >>\nstream\n$mixedContent\nendstream',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] $rotate'
+        '/Contents 6 0 R /Resources << /Font << /F1 8 0 R >> >> >>',
+    '<< /Length ${targetContent.length} >>\nstream\n$targetContent\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii.encode(buffer.toString());
+}
 
 double bottomOf(PdfEditingController editing, String text) => textRuns(
       editing.document,
@@ -197,6 +232,102 @@ void main() {
       expect(after.width, closeTo(before.width, 0.05));
       expect(after.height, closeTo(before.height, 0.05));
     });
+
+    test('moves a text element onto another page and keeps it editable', () {
+      final editing = PdfEditingController(buildTwoPageContentPdf());
+      addTearDown(editing.dispose);
+      expect(selectElementByText(editing, 'Alpha beta gamma delta'), isTrue);
+      final source = editing.selectedElement!.bounds!;
+      final sourceX = (source.left + source.right) / 2;
+      final sourceY = (source.bottom + source.top) / 2;
+
+      expect(
+        editing.moveSelectedElementToPage(
+          1,
+          sourceX: sourceX,
+          sourceY: sourceY,
+          targetX: 240,
+          targetY: 420,
+        ),
+        isTrue,
+      );
+
+      expect(
+        editing.elementsOn(0).elements.map((e) => e.text),
+        isNot(contains('Alpha beta gamma delta')),
+      );
+      expect(bottomOf(editing, 'epsilon zeta eta theta'), closeTo(683.6, 0.1),
+          reason: 'the following source line stays where it was');
+      expect(editing.selectedElementPage, 1);
+      expect(editing.selectedElement?.kind, PdfElementKind.text);
+      expect(editing.selectedElement?.text, 'Alpha beta gamma delta');
+      expect(editing.canEditSelectedElementText, isTrue);
+      final moved = editing.selectedElement!.bounds!;
+      expect((moved.left + moved.right) / 2, closeTo(240, 0.1));
+      expect((moved.bottom + moved.top) / 2, closeTo(420, 0.1));
+
+      // Page 2 already owns a different /F1 (Courier). The moved run keeps
+      // its source Helvetica under a remapped resource name.
+      final page = editing.document.page(1);
+      final fonts =
+          editing.document.cos.resolve(page.resources['Font']) as CosDictionary;
+      final font = editing.document.cos
+              .resolve(fonts[editing.selectedElement!.resourceName!])
+          as CosDictionary;
+      expect(font['BaseFont'], const CosName('Helvetica'));
+
+      // The cross-page move is one revision.
+      editing.undo();
+      expect(
+        editing.elementsOn(0).elements.map((e) => e.text),
+        contains('Alpha beta gamma delta'),
+      );
+      expect(
+        editing.elementsOn(1).elements.map((e) => e.text),
+        isNot(contains('Alpha beta gamma delta')),
+      );
+    });
+
+    test('a cross-page move preserves screen orientation across /Rotate', () {
+      final editing = PdfEditingController(
+        buildTwoPageContentPdf(targetRotation: 90),
+      );
+      addTearDown(editing.dispose);
+      expect(selectElementByText(editing, 'Alpha beta gamma delta'), isTrue);
+      final before = editing.selectedElement!.bounds!;
+      final sourceGeometry = PdfPageGeometry(
+        cropBox: editing.document.page(0).cropBox,
+        rotation: 0,
+        viewSize: const Size(612, 792),
+      );
+      final sourceRect = sourceGeometry.toViewRect(before);
+      final sourceX = (before.left + before.right) / 2;
+      final sourceY = (before.bottom + before.top) / 2;
+
+      expect(
+        editing.moveSelectedElementToPage(
+          1,
+          sourceX: sourceX,
+          sourceY: sourceY,
+          targetX: 300,
+          targetY: 400,
+        ),
+        isTrue,
+      );
+
+      final targetGeometry = PdfPageGeometry(
+        cropBox: editing.document.page(1).cropBox,
+        rotation: 90,
+        viewSize: const Size(792, 612),
+      );
+      final movedRect = targetGeometry.toViewRect(
+        editing.selectedElement!.bounds!,
+      );
+      expect(movedRect.center,
+          offsetMoreOrLessEquals(targetGeometry.toViewOffset(300, 400)));
+      expect(movedRect.size.width, closeTo(sourceRect.width, 0.1));
+      expect(movedRect.size.height, closeTo(sourceRect.height, 0.1));
+    });
   });
 
   group('dragging page content in the viewer', () {
@@ -253,8 +384,13 @@ void main() {
       await tester.pump();
     }
 
-    Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
-      final editing = PdfEditingController(buildParagraphPdf(mixedContent));
+    Future<PdfEditingController> pumpEditor(
+      WidgetTester tester, {
+      Uint8List? bytes,
+      PdfPageLayout pageLayout = const PdfPageLayout.verticalContinuous(),
+    }) async {
+      final editing =
+          PdfEditingController(bytes ?? buildParagraphPdf(mixedContent));
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);
@@ -267,6 +403,7 @@ void main() {
               document: editing.document,
               controller: viewer,
               editing: editing,
+              pageLayout: pageLayout,
             ),
           ),
         ),
@@ -378,6 +515,68 @@ void main() {
           reason: 'settled paints the whole page, covering the dropped raster');
       expect(after.elementLiftOffset, const Offset(40, 25),
           reason: 'the afterimage sits where the element was dropped');
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    });
+
+    testWidgets('dropping content on another page re-homes it there',
+        (tester) async {
+      final editing = await pumpEditor(
+        tester,
+        bytes: buildTwoPageContentPdf(),
+        pageLayout: const PdfPageLayout.horizontalContinuous(),
+      );
+      editing.tool = PdfEditTool.content;
+      await tester.pump();
+      expect(selectElementByText(editing, 'Alpha beta gamma delta'), isTrue);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 80));
+
+      final overlays = find.byType(EditingPageOverlay);
+      expect(overlays, findsNWidgets(2));
+      final sourcePage = tester.getRect(overlays.at(0));
+      final targetPage = tester.getRect(overlays.at(1));
+      final sourceGeometry = PdfPageGeometry(
+        cropBox: editing.document.page(0).cropBox,
+        rotation: 0,
+        viewSize: sourcePage.size,
+      );
+      final targetGeometry = PdfPageGeometry(
+        cropBox: editing.document.page(1).cropBox,
+        rotation: 0,
+        viewSize: targetPage.size,
+      );
+      final from = sourcePage.topLeft + sourceGeometry.toViewOffset(100, 703);
+      final to = targetPage.topLeft + targetGeometry.toViewOffset(160, 500);
+
+      final gesture = await tester.startGesture(
+        from,
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveTo(Offset.lerp(from, to, 0.5)!);
+      await gesture.moveTo(to);
+      await tester.pump();
+
+      expect(
+        tester.widgetList<CustomPaint>(find.byType(CustomPaint)).where(
+            (paint) =>
+                paint.painter.runtimeType.toString() ==
+                '_MoveDragPreviewPainter'),
+        isNotEmpty,
+        reason: 'the isolated content paints over the destination page',
+      );
+
+      await gesture.up();
+      await tester.pump();
+
+      expect(editing.selectedElementPage, 1);
+      expect(editing.selectedElement?.text, 'Alpha beta gamma delta');
+      expect(
+        editing.elementsOn(0).elements.map((element) => element.text),
+        isNot(contains('Alpha beta gamma delta')),
+      );
+      final moved = editing.selectedElement!.bounds!;
+      expect((moved.left + moved.right) / 2, greaterThan(100));
+      expect((moved.bottom + moved.top) / 2, closeTo(500, 2));
       await tester.pumpAndSettle(const Duration(milliseconds: 300));
     });
 

--- a/packages/pdf_document/lib/src/content_editor.dart
+++ b/packages/pdf_document/lib/src/content_editor.dart
@@ -226,6 +226,293 @@ extension PdfContentEditing on PdfEditor {
     return moved;
   }
 
+  /// Moves the [ids] from [elements]' source page into [targetPage], mapping
+  /// their source-page coordinates through [transform]. Returns how many
+  /// elements moved.
+  ///
+  /// Unlike wrapping the drawing in a Form XObject, this appends the original
+  /// operators to the destination page. A text run therefore remains a text
+  /// run, an image remains an image, and the content tool can keep editing the
+  /// dropped element. Graphics-state operators needed by the drawing travel
+  /// with it; the source page is rewritten with the same stand-ins
+  /// [PdfPageElements.operationsRetaining] uses for a drag preview, so text
+  /// following a moved run holds its position.
+  ///
+  /// Page resource names are local to a page. Referenced fonts, XObjects,
+  /// colour spaces, patterns, shadings, graphics states, and marked-content
+  /// properties are imported into the target under non-conflicting names and
+  /// the appended operators are remapped to those names. The resource objects
+  /// themselves stay shared within this document; only the page dictionaries
+  /// and content streams are rewritten.
+  ///
+  /// [transform] maps source page user space onto target page user space. A
+  /// simple same-orientation move is a [PdfMatrix.translation]. A viewer
+  /// moving between differently rotated pages can supply the corresponding
+  /// rotation-and-translation so the drawing keeps its displayed orientation.
+  int moveElementsToPage(
+    PdfPageElements elements,
+    Iterable<int> ids,
+    int targetPage, {
+    required PdfMatrix transform,
+  }) {
+    if (targetPage < 0 || targetPage >= document.pageCount) {
+      throw RangeError.range(
+          targetPage, 0, document.pageCount - 1, 'targetPage');
+    }
+    if (targetPage == elements.pageIndex) {
+      final origin = transform.apply(0, 0);
+      final xAxis = transform.apply(1, 0);
+      final yAxis = transform.apply(0, 1);
+      final translationOnly = (xAxis.$1 - origin.$1 - 1).abs() < 1e-9 &&
+          (xAxis.$2 - origin.$2).abs() < 1e-9 &&
+          (yAxis.$1 - origin.$1).abs() < 1e-9 &&
+          (yAxis.$2 - origin.$2 - 1).abs() < 1e-9;
+      if (!translationOnly) {
+        throw ArgumentError.value(
+            transform, 'transform', 'a same-page move must be a translation');
+      }
+      return moveElements(
+        elements,
+        ids,
+        dx: origin.$1,
+        dy: origin.$2,
+      );
+    }
+
+    final moving = <int>{};
+    for (final id in ids) {
+      if (id < 0 || id >= elements.elements.length) {
+        throw RangeError.range(id, 0, elements.elements.length - 1, 'ids');
+      }
+      final element = elements.elements[id];
+      if (!_canMoveElement(elements, element)) continue;
+      moving.add(id);
+    }
+    if (moving.isEmpty) return 0;
+
+    final source = document.page(elements.pageIndex);
+    final target = document.page(targetPage);
+    final sourceOps = elements.operationsRetaining(
+      (element) => moving.contains(element.id),
+    );
+    final resourceNames = _importContentResources(source, target, sourceOps);
+    final movedOps = [
+      for (final op in sourceOps) _remapContentResources(op, resourceNames),
+    ];
+    final movedBytes = BytesBuilder(copy: false)
+      ..add(latin1.encode('q ${_matrixOperands(transform)} cm\n'))
+      ..add(ContentStreamSerializer.serialize(movedOps))
+      ..add(latin1.encode('Q\n'));
+
+    _setContent(
+      elements.pageIndex,
+      source,
+      ContentStreamSerializer.serialize(
+        elements.operationsRetaining((element) => !moving.contains(element.id)),
+      ),
+    );
+    _appendContent(targetPage, target, movedBytes.takeBytes());
+    return moving.length;
+  }
+
+  static bool _canMoveElement(
+      PdfPageElements elements, PdfContentElement element) {
+    if (element.ctm.inverted() == null) return false;
+    if (element.kind == PdfElementKind.text) {
+      final placement = element.textPlacement;
+      return placement != null && placement.fontSize > 0;
+    }
+    return !_establishesClip(elements, element);
+  }
+
+  /// Imports the page resources referenced by [operations] and returns their
+  /// source-name -> target-name maps, keyed by resource category.
+  Map<String, Map<String, String>> _importContentResources(
+    PdfPage source,
+    PdfPage target,
+    List<ContentOperation> operations,
+  ) {
+    final references = _contentResourceReferences(operations);
+    if (references.isEmpty) return const {};
+    final cos = document.cos;
+    final sourceResources = source.resources;
+    final targetResources = _ownResources(target);
+    final out = <String, Map<String, String>>{};
+    const prefixes = {
+      'Font': 'MvF',
+      'XObject': 'MvX',
+      'ExtGState': 'MvG',
+      'ColorSpace': 'MvC',
+      'Pattern': 'MvP',
+      'Shading': 'MvS',
+      'Properties': 'MvR',
+    };
+
+    bool sameResource(CosObject a, CosObject b) {
+      if (a == b) return true;
+      try {
+        return identical(cos.resolve(a), cos.resolve(b));
+      } catch (_) {
+        return false;
+      }
+    }
+
+    for (final category in references.entries) {
+      final sourceCategory = cos.resolve(sourceResources[category.key]);
+      final targetCategory = cos.resolve(targetResources[category.key]);
+      final targetEntries = targetCategory is CosDictionary
+          ? CosDictionary({...targetCategory.entries})
+          : CosDictionary();
+      final names = <String, String>{};
+      final reserved = <String>{...targetEntries.entries.keys};
+      var changed = false;
+
+      String freshName() {
+        final prefix = prefixes[category.key] ?? 'MvR';
+        var i = 1;
+        while (!reserved.add('$prefix$i')) {
+          i++;
+        }
+        return '$prefix$i';
+      }
+
+      for (final sourceName in category.value) {
+        final sourceValue =
+            sourceCategory is CosDictionary ? sourceCategory[sourceName] : null;
+        String? targetName;
+        if (sourceValue != null) {
+          for (final entry in targetEntries.entries.entries) {
+            if (sameResource(sourceValue, entry.value)) {
+              targetName = entry.key;
+              break;
+            }
+          }
+        }
+        if (targetName == null && sourceValue != null) {
+          targetName =
+              targetEntries.containsKey(sourceName) ? freshName() : sourceName;
+          reserved.add(targetName);
+          targetEntries[targetName] = sourceValue;
+          changed = true;
+        } else {
+          // Preserve a missing source resource as missing. If the target has
+          // a resource under that name, remap to an unused name rather than
+          // accidentally changing the drawing's meaning.
+          targetName ??=
+              targetEntries.containsKey(sourceName) ? freshName() : sourceName;
+        }
+        names[sourceName] = targetName;
+      }
+      if (changed) targetResources[category.key] = targetEntries;
+      out[category.key] = names;
+    }
+    return out;
+  }
+
+  static Map<String, Set<String>> _contentResourceReferences(
+      List<ContentOperation> operations) {
+    final out = <String, Set<String>>{};
+    void add(String category, CosObject? value) {
+      if (value case CosName(:final value)) {
+        (out[category] ??= <String>{}).add(value);
+      }
+    }
+
+    for (final op in operations) {
+      final operands = op.operands;
+      switch (op.operator) {
+        case 'Tf':
+          if (operands.isNotEmpty) add('Font', operands.first);
+        case 'Do':
+          if (operands.isNotEmpty) add('XObject', operands.first);
+        case 'gs':
+          if (operands.isNotEmpty) add('ExtGState', operands.first);
+        case 'CS' || 'cs':
+          if (operands.isNotEmpty && operands.first is CosName) {
+            final name = (operands.first as CosName).value;
+            if (!const {'DeviceGray', 'DeviceRGB', 'DeviceCMYK', 'Pattern'}
+                .contains(name)) {
+              add('ColorSpace', operands.first);
+            }
+          }
+        case 'SCN' || 'scn':
+          if (operands.isNotEmpty) add('Pattern', operands.last);
+        case 'sh':
+          if (operands.isNotEmpty) add('Shading', operands.first);
+        case 'BDC' || 'DP':
+          if (operands.length >= 2) add('Properties', operands[1]);
+        case 'BI':
+          if (operands.isNotEmpty && operands.first is CosDictionary) {
+            final dict = operands.first as CosDictionary;
+            final colorSpace = dict['CS'] ?? dict['ColorSpace'];
+            if (colorSpace is! CosName ||
+                !const {'G', 'RGB', 'CMYK', 'I'}.contains(colorSpace.value)) {
+              add('ColorSpace', colorSpace);
+            }
+          }
+      }
+    }
+    return out;
+  }
+
+  static ContentOperation _remapContentResources(
+    ContentOperation op,
+    Map<String, Map<String, String>> names,
+  ) {
+    CosObject rename(String category, CosObject value) {
+      if (value is! CosName) return value;
+      final renamed = names[category]?[value.value];
+      return renamed == null || renamed == value.value
+          ? value
+          : CosName(renamed);
+    }
+
+    final operands = List<CosObject>.of(op.operands);
+    switch (op.operator) {
+      case 'Tf':
+        if (operands.isNotEmpty) operands[0] = rename('Font', operands[0]);
+      case 'Do':
+        if (operands.isNotEmpty) operands[0] = rename('XObject', operands[0]);
+      case 'gs':
+        if (operands.isNotEmpty) {
+          operands[0] = rename('ExtGState', operands[0]);
+        }
+      case 'CS' || 'cs':
+        if (operands.isNotEmpty) {
+          operands[0] = rename('ColorSpace', operands[0]);
+        }
+      case 'SCN' || 'scn':
+        if (operands.isNotEmpty) {
+          operands[operands.length - 1] = rename('Pattern', operands.last);
+        }
+      case 'sh':
+        if (operands.isNotEmpty) operands[0] = rename('Shading', operands[0]);
+      case 'BDC' || 'DP':
+        if (operands.length >= 2) {
+          operands[1] = rename('Properties', operands[1]);
+        }
+      case 'BI':
+        if (operands.isNotEmpty && operands.first is CosDictionary) {
+          final original = operands.first as CosDictionary;
+          final dict = CosDictionary({...original.entries});
+          if (dict['CS'] case final value?) {
+            if (value is! CosName ||
+                !const {'G', 'RGB', 'CMYK', 'I'}.contains(value.value)) {
+              dict['CS'] = rename('ColorSpace', value);
+            }
+          }
+          if (dict['ColorSpace'] case final value?) {
+            if (value is! CosName ||
+                !const {'G', 'RGB', 'CMYK', 'I'}.contains(value.value)) {
+              dict['ColorSpace'] = rename('ColorSpace', value);
+            }
+          }
+          operands[0] = dict;
+        }
+    }
+    return ContentOperation(op.operator, operands);
+  }
+
   /// How far into its line the run already sits: the text matrix differs
   /// from the line matrix only by the advances of the runs before it, so
   /// `matrix × lineMatrix⁻¹` is that pure translation.

--- a/packages/pdf_document/test/content_move_test.dart
+++ b/packages/pdf_document/test/content_move_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -16,6 +17,40 @@ int move(PdfDocument doc, int id, double dx, double dy) => PdfEditor(doc)
 
 PdfRect shift(PdfRect rect, double dx, double dy) =>
     PdfRect(rect.left + dx, rect.bottom + dy, rect.right + dx, rect.top + dy);
+
+Uint8List buildTwoPageMovePdf() {
+  const source = 'BT /F1 12 Tf 72 700 Td (move me) Tj (stay put) Tj ET\n';
+  const target = 'BT /F1 12 Tf 72 500 Td (target) Tj ET\n';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> >>',
+    '<< /Length ${source.length} >>\nstream\n$source\nendstream',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 6 0 R /Resources << /Font << /F1 8 0 R >> >> >>',
+    '<< /Length ${target.length} >>\nstream\n$target\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii.encode(buffer.toString());
+}
 
 // The rewrite carries the shift through the drawing's own transform, so a
 // scaled placement pays one rounding of [ContentWriter.fmt] on the way in.
@@ -167,6 +202,48 @@ void main() {
       expect(move(doc, 3, 10, 0), 1);
       expect(move(doc, 3, 0, 10), 1);
       expectRect(boundsOf(doc)[3], shift(before[3]!, 10, 10));
+    });
+
+    test('moves operators and their resources onto another page', () {
+      final doc = PdfDocument.open(buildTwoPageMovePdf());
+      final source = PdfPageElements.of(doc, 0);
+      final moving = source.elements.singleWhere((e) => e.text == 'move me');
+      final staying = source.elements.singleWhere((e) => e.text == 'stay put');
+      final movingBefore = moving.bounds!;
+      final stayingBefore = staying.bounds!;
+      final editor = PdfEditor(doc);
+
+      expect(
+        editor.moveElementsToPage(
+          source,
+          [moving.id],
+          1,
+          transform: const PdfMatrix.translation(100, -200),
+        ),
+        1,
+      );
+      expect(editor.impact.visualPages, {0, 1});
+      expect(editor.impact.contentPages, {0, 1});
+
+      final out = PdfDocument.open(editor.save());
+      final sourceAfter = PdfPageElements.of(out, 0).elements;
+      expect(sourceAfter.map((e) => e.text), ['stay put']);
+      expectRect(sourceAfter.single.bounds, stayingBefore,
+          reason: 'removing the earlier run must not slide its neighbour');
+
+      final targetAfter = PdfPageElements.of(out, 1).elements;
+      expect(targetAfter.map((e) => e.text), ['target', 'move me']);
+      final moved = targetAfter.last;
+      expect(moved.kind, PdfElementKind.text);
+      expectRect(moved.bounds, shift(movingBefore, 100, -200));
+
+      // Both pages called their font /F1, but they meant different fonts.
+      // The appended Tf is remapped to the imported Helvetica resource.
+      expect(moved.resourceName, isNot('F1'));
+      final fonts =
+          out.cos.resolve(out.page(1).resources['Font']) as CosDictionary;
+      final font = out.cos.resolve(fonts[moved.resourceName!]) as CosDictionary;
+      expect(font['BaseFont'], const CosName('Helvetica'));
     });
 
     test('operationsRetaining drops the others and keeps the geometry', () {


### PR DESCRIPTION
Follows #856.

## Summary

- move selected content operators onto the destination page when a drag crosses page boundaries
- remap referenced resources safely and preserve displayed orientation across differently rotated pages
- show a cross-page drag preview and keep the source page visually clean while the edited pages rerender
- cover document-level moves, undo/editability, resource collisions, rotation, and the real viewer drag path

## Verification

- fvm dart analyze
- cd packages/pdf_document && fvm dart test test/content_move_test.dart
- cd packages/dart_pdf_editor && fvm flutter test test/editing_content_move_test.dart
- git diff --check