### PR TITLE
Add cursor guides and grid snapping

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -10,8 +10,9 @@
   cross-document placement, cursor-following drop previews, repeat Paste, and
   a direct path to the custom-stamp collection.
 - Add independently configurable horizontal and vertical cursor guide lines,
-  plus persisted page-space grid snapping for annotation placement, movement,
-  resizing, and vertices (hold Alt to bypass snapping temporarily).
+  an optional visible page-space grid, and persisted grid snapping for
+  annotation placement, movement, resizing, and vertices (hold Alt to bypass
+  snapping temporarily). These controls live in the editor Settings popup.
 - Add an optional asynchronous tile-backend retry hook and exact retained-scene
   re-recording, while preserving the existing Canvas fallback when a retry is
   unavailable, fails, or remains inexact.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -9,6 +9,9 @@
   `PdfAnnotationSnapshot`s, with named groups, context-menu capture,
   cross-document placement, cursor-following drop previews, repeat Paste, and
   a direct path to the custom-stamp collection.
+- Add independently configurable horizontal and vertical cursor guide lines,
+  plus persisted page-space grid snapping for annotation placement, movement,
+  resizing, and vertices (hold Alt to bypass snapping temporarily).
 - Add an optional asynchronous tile-backend retry hook and exact retained-scene
   re-recording, while preserving the existing Canvas fallback when a retry is
   unavailable, fails, or remains inexact.

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -74,6 +74,20 @@ PdfEditorView(
 )
 ```
 
+The stock toolbar includes cursor-guide and grid controls. Custom chrome can
+configure the same persisted preferences directly (grid units are PDF points):
+
+```dart
+editing.preferences
+  ..showVerticalCursorGuide = true
+  ..showHorizontalCursorGuide = true
+  ..snapToGrid = true
+  ..gridSpacing = 10;
+```
+
+Grid snapping covers annotation placement, movement, resizing, and line or
+polygon vertices. Hold Alt during a gesture for a temporary off-grid edit.
+
 Try the [live demo](https://dart-pdf-demo.web.app) of the example app
 on Flutter web, with a built-in feature showcase document.
 

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -74,19 +74,22 @@ PdfEditorView(
 )
 ```
 
-The stock toolbar includes cursor-guide and grid controls. Custom chrome can
-configure the same persisted preferences directly (grid units are PDF points):
+The stock editor's Settings popup includes cursor-guide and grid controls.
+Custom chrome can configure the same persisted preferences directly (grid
+units are PDF points):
 
 ```dart
 editing.preferences
   ..showVerticalCursorGuide = true
   ..showHorizontalCursorGuide = true
+  ..showSnapGrid = true
   ..snapToGrid = true
   ..gridSpacing = 10;
 ```
 
-Grid snapping covers annotation placement, movement, resizing, and line or
-polygon vertices. Hold Alt during a gesture for a temporary off-grid edit.
+The visible grid and snapping are independent. Grid snapping covers annotation
+placement, movement, resizing, and line or polygon vertices. Hold Alt during a
+gesture for a temporary off-grid edit.
 
 Try the [live demo](https://dart-pdf-demo.web.app) of the example app
 on Flutter web, with a built-in feature showcase document.

--- a/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
+++ b/packages/dart_pdf_editor/example/patrol_test/demo_e2e_test.dart
@@ -248,13 +248,11 @@ void main() {
         'Revised Patrol note',
       );
       await $.tester.tap(find.text('OK'));
-      await $.pump(const Duration(milliseconds: 400));
-
-      expect(
-        demo.editing.pageAt(0).annotations.any(
+      await demo.waitFor(
+        () => demo.editing.pageAt(0).annotations.any(
               (a) => a.subtype == 'Text' && a.contents == 'Revised Patrol note',
             ),
-        isTrue,
+        reason: 'the edited note should be committed',
       );
     } finally {
       await demo.close();

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -4954,8 +4954,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _updatePickPreview(event.localPosition);
       cursor = SystemMouseCursors.precise;
     } else if (_controller.activeSavedAnnotation != null) {
-      if (_savedAnnotationPreview != event.localPosition) {
-        _savedAnnotationPreview = event.localPosition;
+      final snapped = _snapPointToGrid(event.localPosition);
+      if (_savedAnnotationPreview != snapped) {
+        _savedAnnotationPreview = snapped;
         _bumpCursor();
       }
       unawaited(_ensureSavedAnnotationPicture());
@@ -5735,7 +5736,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // In that passive state the MouseRegion paints the guides, but no gesture
     // recognizer may enter the arena and steal scrolling or text selection
     // from the viewer underneath.
-    final acceptsEditingGestures = _tool != null || _selectMode;
+    final acceptsEditingGestures = _tool != null ||
+        _selectMode ||
+        _controller.activeSavedAnnotation != null;
     final washRestGhost = selectedAnnotation?.subtype == 'FreeText';
     final _AfterGhost? restGhost = !widget.rasterCurrent &&
             !dragging &&
@@ -5947,6 +5950,24 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               ),
             },
             child: Stack(children: [
+              if (_controller.preferences.showSnapGrid)
+                Positioned.fill(
+                  child: RepaintBoundary(
+                    child: CustomPaint(
+                      key: const ValueKey('pdf-snap-grid'),
+                      painter: _SnapGridPainter(
+                        geometry: _geometry,
+                        gridSpacing: _controller.preferences.gridSpacing,
+                        chromeScale: _chromeScale,
+                        color:
+                            (PdfViewerTheme.of(context).annotationChromeColor ??
+                                    Theme.of(context).colorScheme.primary)
+                                .withValues(alpha: 0.22),
+                      ),
+                      size: Size.infinite,
+                    ),
+                  ),
+                ),
               Positioned.fill(
                 child: CustomPaint(
                   painter: _EditingPreviewPainter(
@@ -6663,6 +6684,12 @@ class _HoverCursorPainter extends CustomPainter {
   bool get horizontalGuide =>
       _state._controller.preferences.showHorizontalCursorGuide;
 
+  @visibleForTesting
+  double get guideStrokeWidth => 0.75 * _state._chromeScale;
+
+  @visibleForTesting
+  double get guideHaloWidth => 1.75 * _state._chromeScale;
+
   /// The marks this layer would paint right now, as the old snapshot fields
   /// exposed them. These *are* the paint gates (paint() reads them), so a
   /// test asserting on them asserts on what is drawn - the state fields
@@ -6751,10 +6778,10 @@ class _HoverCursorPainter extends CustomPainter {
       final color = theme.annotationChromeColor ?? const Color(0xFF1E88E5);
       final halo = Paint()
         ..color = const Color(0x52000000)
-        ..strokeWidth = 3 * chromeScale;
+        ..strokeWidth = guideHaloWidth;
       final line = Paint()
         ..color = color.withValues(alpha: 0.88)
-        ..strokeWidth = 1 * chromeScale;
+        ..strokeWidth = guideStrokeWidth;
       if (verticalGuide) {
         final from = Offset(guide.dx, 0);
         final to = Offset(guide.dx, size.height);
@@ -6900,6 +6927,80 @@ class _HoverCursorPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_HoverCursorPainter oldDelegate) => true;
+}
+
+/// Draws the page-space snapping grid above the page raster but below all
+/// live editing previews and selection chrome.
+class _SnapGridPainter extends CustomPainter {
+  const _SnapGridPainter({
+    required this.geometry,
+    required this.gridSpacing,
+    required this.chromeScale,
+    required this.color,
+  });
+
+  final PdfPageGeometry geometry;
+
+  @visibleForTesting
+  final double gridSpacing;
+
+  final double chromeScale;
+  final Color color;
+
+  @visibleForTesting
+  double get strokeWidth => 0.5 * chromeScale;
+
+  /// Returns the visible grid segments in view coordinates. When the chosen
+  /// interval would place lines less than four screen pixels apart, a stable
+  /// multiple of the interval is drawn to avoid a solid moire pattern; every
+  /// visible line remains an actual snap line.
+  @visibleForTesting
+  List<(Offset, Offset)> segmentsFor(Size size) {
+    if (!gridSpacing.isFinite || gridSpacing <= 0 || size.isEmpty) {
+      return const [];
+    }
+    final interval = gridSpacing * geometry.scale;
+    final stride = math.max(1, (4 * chromeScale / interval).ceil());
+    final box = geometry.cropBox;
+    final segments = <(Offset, Offset)>[];
+    final xCount = (box.width / gridSpacing).floor();
+    for (var i = 0; i <= xCount; i += stride) {
+      final x = box.left + i * gridSpacing;
+      segments.add((
+        geometry.toViewOffset(x, box.bottom),
+        geometry.toViewOffset(x, box.top),
+      ));
+    }
+    final yCount = (box.height / gridSpacing).floor();
+    for (var i = 0; i <= yCount; i += stride) {
+      final y = box.bottom + i * gridSpacing;
+      segments.add((
+        geometry.toViewOffset(box.left, y),
+        geometry.toViewOffset(box.right, y),
+      ));
+    }
+    return segments;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.clipRect(Offset.zero & size);
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth;
+    for (final (from, to) in segmentsFor(size)) {
+      canvas.drawLine(from, to, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_SnapGridPainter oldDelegate) =>
+      oldDelegate.geometry.cropBox != geometry.cropBox ||
+      oldDelegate.geometry.rotation != geometry.rotation ||
+      oldDelegate.geometry.viewSize != geometry.viewSize ||
+      oldDelegate.gridSpacing != gridSpacing ||
+      oldDelegate.chromeScale != chromeScale ||
+      oldDelegate.color != color;
 }
 
 /// Paints a stamp/count afterimage (or hover preview) at its already

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -873,6 +873,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// drawn colour and width are visible before a stroke is started.
   Offset? _penCursor;
 
+  /// The latest mouse position on this page. The optional horizontal and
+  /// vertical cursor guides are painted through it on the cursor-only layer,
+  /// so pointer motion never rebuilds the editing overlay.
+  Offset? _guideCursor;
+
   /// The count tool's check-mark cursor: the mark that will be placed by a
   /// click, centered on the mouse and clamped the same way the commit is.
   Offset? _countCursor;
@@ -1303,6 +1308,43 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// distance/slope measurement).
   bool get _lineDragTool => _behavior?.isLineDrag ?? false;
 
+  /// Whether this gesture should currently use the persisted page grid.
+  /// Alt is the conventional temporary bypass: it lets a user make one
+  /// off-grid adjustment without visiting the settings popup.
+  bool get _gridSnapping {
+    final preferences = _controller.preferences;
+    return preferences.snapToGrid &&
+        !HardwareKeyboard.instance.isAltPressed &&
+        preferences.gridSpacing.isFinite &&
+        preferences.gridSpacing > 0;
+  }
+
+  /// Snaps a view-space point to the nearest page-space grid intersection.
+  /// The grid begins at the crop box's lower-left corner, so it is stable
+  /// across layout zoom, transform zoom, and /Rotate.
+  Offset _snapPointToGrid(Offset point) {
+    if (!_gridSnapping) return point;
+    final spacing = _controller.preferences.gridSpacing;
+    final box = _geometry.cropBox;
+    final (x, y) = _geometry.toPagePoint(point);
+    final snappedX =
+        box.left + ((x - box.left) / spacing).roundToDouble() * spacing;
+    final snappedY =
+        box.bottom + ((y - box.bottom) / spacing).roundToDouble() * spacing;
+    return _geometry.toViewOffset(snappedX, snappedY);
+  }
+
+  /// Applies grid snapping to a move without making the result depend on
+  /// where inside the annotation the user grabbed it. The primary box's
+  /// top-left corner is the anchor that lands on the grid; the pointer keeps
+  /// its original grab offset from that box.
+  Offset _snapMovePosition(Offset start, Offset current, Rect? anchorRect) {
+    if (!_gridSnapping || anchorRect == null) return current;
+    final delta = current - start;
+    final target = anchorRect.topLeft + delta;
+    return current + (_snapPointToGrid(target) - target);
+  }
+
   /// Constrains [point] to the nearest 45° direction from [anchor] while
   /// Shift is held, so the line / polyline / polygon tools lay down
   /// axis-aligned or diagonal straight segments. The pointer's reach along
@@ -1386,6 +1428,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // the crop overlay owns all input while a crop is armed
     if (_controller.isCroppingImage) return;
     _pointerPressure = _normalizedPressure(event);
+    if (event.kind == PointerDeviceKind.mouse ||
+        event.kind == PointerDeviceKind.trackpad) {
+      _guideCursor = event.localPosition;
+      _bumpCursor();
+    }
     if (_lastPointerKind != event.kind) {
       // the selection action chip shows for touch/stylus input only
       setState(() => _lastPointerKind = event.kind);
@@ -1469,6 +1516,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   void _onPointerMove(PointerMoveEvent event) {
     if (!mounted) return;
+    if (event.kind == PointerDeviceKind.mouse ||
+        event.kind == PointerDeviceKind.trackpad) {
+      _guideCursor = event.localPosition;
+      _bumpCursor();
+    }
     final pressure = _normalizedPressure(event);
     if (pressure != null) _pointerPressure = pressure;
     if (_controller.isPickingColor) {
@@ -3502,6 +3554,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       // rectangle over the vertices already placed
       return;
     }
+    final snappedPosition = _snapPointToGrid(position);
     switch (_tool) {
       case null:
         break; // eyedropper only - taps, no drags
@@ -3547,8 +3600,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.link:
         _beginInteraction(PdfEditingInteractionIntent.create, details.kind);
         setState(() {
-          _dragStart = position;
-          _dragCurrent = position;
+          _dragStart = snappedPosition;
+          _dragCurrent = snappedPosition;
         });
       case PdfEditTool.form:
         // a resize handle or the body of the selected widget manipulates
@@ -3578,8 +3631,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         if (_controller.formFieldAt(widget.pageIndex, x, y) == null) {
           _beginInteraction(PdfEditingInteractionIntent.create, details.kind);
           setState(() {
-            _dragStart = position;
-            _dragCurrent = position;
+            _dragStart = snappedPosition;
+            _dragCurrent = snappedPosition;
           });
         }
       case PdfEditTool.signature:
@@ -3590,7 +3643,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               PdfEditingInteractionIntent.signature, details.kind);
           setState(() {
             _signatureDrag = true;
-            _signaturePreview = position;
+            _signaturePreview = snappedPosition;
           });
         }
       case PdfEditTool.polyline ||
@@ -3808,7 +3861,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_signatureDrag) {
       // drag-frequency, and the preview is painted on the cursor layer:
       // repaint it, don't rebuild the overlay
-      _signaturePreview = position;
+      _signaturePreview = _snapPointToGrid(position);
       _bumpCursor();
       return;
     }
@@ -3843,15 +3896,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     } else if (_vertexHandle != null) {
       setState(() {
         final points = List<Offset>.of(_vertexPoints!);
-        points[_vertexHandle!] = position;
+        points[_vertexHandle!] = _snapPointToGrid(position);
         _vertexPoints = points;
       });
     } else if (_resizeHandle != null) {
       setState(() {
-        _moveCurrent = position;
+        final snapped = _snapPointToGrid(position);
+        _moveCurrent = snapped;
         // a rotated selection's handles move along its own axes, so the
         // pointer delta rotates into the local frame
-        final delta = position - _moveStart!;
+        final delta = snapped - _moveStart!;
         // holding Shift locks the original aspect ratio
         final aspectRatio =
             HardwareKeyboard.instance.isShiftPressed && _resizeFrom!.height > 0
@@ -3870,19 +3924,22 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       });
     } else if (_elementMoveStart != null) {
       _moveCurrentGlobal = _autoScrollGlobal;
-      setState(() => _elementMoveCurrent = position);
+      setState(() => _elementMoveCurrent = _snapMovePosition(
+          _elementMoveStart!, position, _selectedElementRestRect));
       _reportElementMovePreview();
     } else if (_moveStart != null) {
       _moveCurrentGlobal = _autoScrollGlobal;
-      setState(() => _moveCurrent = position);
+      setState(() => _moveCurrent =
+          _snapMovePosition(_moveStart!, position, _selectedViewRect));
       // float the artwork above every page so a move dragged onto the
       // page below isn't clipped behind it (this overlay can't paint
       // over a sibling list item)
       _reportMovePreview();
     } else if (_dragStart != null) {
       // holding Shift snaps a line/arrow/measure drag to a straight 45° axis
+      final snapped = _snapPointToGrid(position);
       setState(() => _dragCurrent =
-          _lineDragTool ? _straightSnap(_dragStart!, position) : position);
+          _lineDragTool ? _straightSnap(_dragStart!, snapped) : snapped);
     }
   }
 
@@ -4351,15 +4408,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     var reachedFixed = false;
     setState(() {
       final points = _polyPoints ?? <Offset>[];
+      final snapped = _snapPointToGrid(point);
       // only the segment being drawn snaps: holding Shift straightens this
       // new vertex against the previous one, leaving already-placed vertices
       // exactly where they landed. Dedup against the raw tap so a snapped
       // vertex doesn't make the finishing double-tap add a stray segment.
       if (points.isEmpty) {
-        _polyPoints = [point];
+        _polyPoints = [snapped];
         _polyLastRaw = point;
       } else if ((point - _polyLastRaw!).distance >= 2) {
-        _polyPoints = [...points, _straightSnap(points.last, point)];
+        _polyPoints = [...points, _straightSnap(points.last, snapped)];
         _polyLastRaw = point;
       }
       _polyHover = null;
@@ -4375,13 +4433,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (existing == null) return;
     final points = List<Offset>.of(existing);
     if (finalPoint != null) {
+      final snappedFinal = _snapPointToGrid(finalPoint);
       // the closing double-tap only adds a vertex if it moved off the last
       // one (raw dedup); when it does, that final segment snaps like any other
       if (points.isEmpty) {
-        points.add(finalPoint);
+        points.add(snappedFinal);
       } else if (_polyLastRaw == null ||
           (finalPoint - _polyLastRaw!).distance >= 2) {
-        points.add(_straightSnap(points.last, finalPoint));
+        points.add(_straightSnap(points.last, snappedFinal));
       }
     }
     final closed = _tool == PdfEditTool.polygon ||
@@ -4717,7 +4776,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_controller.isPickingColor) return;
     if (_pointers.gestureBailed) return;
     if (_controller.activeSavedAnnotation != null) {
-      final (x, y) = _geometry.toPagePoint(details.localPosition);
+      final snapped = _snapPointToGrid(details.localPosition);
+      final (x, y) = _geometry.toPagePoint(snapped);
       final before = _controller.revisionId;
       _beginInteraction(PdfEditingInteractionIntent.create, details.kind);
       final transition = _interaction.state.transition;
@@ -4755,6 +4815,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     final (x, y) = _geometry.toPagePoint(details.localPosition);
+    final placementPosition = _snapPointToGrid(details.localPosition);
+    final (placementX, placementY) = _geometry.toPagePoint(placementPosition);
     if (_selectMode) {
       // tapping the already-selected free text edits it in place,
       // like clicking into a text box in any editor
@@ -4799,35 +4861,36 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           final text = await widget.textPrompt(context,
               title: pdfL10n(context).overlayNote, multiline: true);
           if (text == null || text.isEmpty) return;
-          _controller.addNote(widget.pageIndex, x, y, text);
+          _controller.addNote(widget.pageIndex, placementX, placementY, text);
         case PdfEditTool.count:
           // each tap drops a check-mark and bumps the running tally
           final before = _controller.revisionId;
-          _controller.placeCheckMark(widget.pageIndex, x, y);
+          _controller.placeCheckMark(widget.pageIndex, placementX, placementY);
           _captureLastStampAfterimage(before,
               check: true, text: null, color: _controller.color);
         case PdfEditTool.signature:
-          _placeSignature(details.localPosition);
+          _placeSignature(placementPosition);
         case PdfEditTool.freeText:
           // tapping without dragging out a box opens a default-sized one
-          _openTextEditor(_defaultPlacementRect(details.localPosition),
+          _openTextEditor(_defaultPlacementRect(placementPosition),
               existing: false);
         case PdfEditTool.callout:
           // a plain tap makes the tap the terminus and offsets the box; a drag
           // (handled in _panEnd) instead aims the box where the drag released
           _openCalloutEditor(
-              _defaultPlacementRect(
-                  details.localPosition + const Offset(28, -28)),
-              details.localPosition);
+              _defaultPlacementRect(placementPosition + const Offset(28, -28)),
+              placementPosition);
         case PdfEditTool.stamp:
           final stamp = _controller.activeStamp;
           if (stamp != null) {
             // an active custom stamp drops at its auto-size on tap
-            final preview = _activeStampAfterimageAt(details.localPosition);
+            final preview = _activeStampAfterimageAt(placementPosition);
             if (preview == null) return;
             if (_stampPreview != null) setState(() => _stampPreview = null);
             await _commitStampWithAfterimage(
-                preview, () => _controller.placeStamp(widget.pageIndex, x, y));
+                preview,
+                () => _controller.placeStamp(
+                    widget.pageIndex, placementX, placementY));
           } else {
             // the classic flow normally drags out a box; a plain tap places
             // a default-sized stamp after prompting for its caption
@@ -4836,15 +4899,17 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             if (text == null || text.isEmpty) return;
             await _commitStampWithAfterimage(
                 _textStampAfterimageAt(
-                    details.localPosition, text, _controller.color),
-                () => _controller.placeTextStamp(widget.pageIndex, x, y, text));
+                    placementPosition, text, _controller.color),
+                () => _controller.placeTextStamp(
+                    widget.pageIndex, placementX, placementY, text));
           }
         case PdfEditTool.image:
           final picker = widget.imagePicker;
           if (picker == null) return;
           final bytes = await picker(context);
           if (bytes == null) return;
-          await _controller.placeImageAsync(widget.pageIndex, x, y, bytes);
+          await _controller.placeImageAsync(
+              widget.pageIndex, placementX, placementY, bytes);
         case PdfEditTool.form:
           // single tap selects the field for move/resize/menu; double-tap
           // fills it (read mode is the no-tool path to just fill)
@@ -4880,6 +4945,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _onHover(PointerHoverEvent event) {
+    if (_guideCursor != event.localPosition) {
+      _guideCursor = event.localPosition;
+      _bumpCursor();
+    }
     final MouseCursor cursor;
     if (_controller.isPickingColor) {
       _updatePickPreview(event.localPosition);
@@ -4952,8 +5021,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     } else if (_tool == PdfEditTool.count) {
       // the painted check-mark is the cursor, showing exactly what a click
       // will place before the page gets a new annotation.
-      if (_countCursor != event.localPosition) {
-        _countCursor = event.localPosition;
+      final snapped = _snapPointToGrid(event.localPosition);
+      if (_countCursor != snapped) {
+        _countCursor = snapped;
         _bumpCursor();
       }
       cursor = SystemMouseCursors.none;
@@ -4962,22 +5032,24 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       // auto-sized placement before committing it. The prompt-for-text
       // fallback has no caption yet, so it previews a 'TEXT' placeholder to
       // make the click target visible.
-      final preview = _stampHoverAfterimageAt(event.localPosition);
+      final snapped = _snapPointToGrid(event.localPosition);
+      final preview = _stampHoverAfterimageAt(snapped);
       if (preview == null) {
         if (_stampPreview != null) {
           _stampPreview = null;
           _bumpCursor();
         }
-      } else if (_stampPreview != event.localPosition) {
-        _stampPreview = event.localPosition;
+      } else if (_stampPreview != snapped) {
+        _stampPreview = snapped;
         _bumpCursor();
       }
       cursor = SystemMouseCursors.precise;
     } else if (_tool == PdfEditTool.signature) {
       // the live preview rides the mouse; a click commits it
+      final snapped = _snapPointToGrid(event.localPosition);
       if (_controller.preferences.signature != null &&
-          event.localPosition != _signaturePreview) {
-        _signaturePreview = event.localPosition;
+          snapped != _signaturePreview) {
+        _signaturePreview = snapped;
         _bumpCursor();
       }
       cursor = SystemMouseCursors.precise;
@@ -5395,7 +5467,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           ...points,
           // the live edge to the hover snaps with Shift like the drawn one
           if (_polyHover != null && (_polyHover! - points.last).distance >= 2)
-            _straightSnap(points.last, _polyHover!),
+            _straightSnap(points.last, _snapPointToGrid(_polyHover!)),
         ];
         final pagePoints = [for (final p in view) _geometry.toPagePoint(p)];
         // volume's depth isn't known until placement finishes, so the live
@@ -5659,6 +5731,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final cropping = _controller.isCroppingImage &&
         _controller.selectedPage == widget.pageIndex;
     final picking = _controller.isPickingColor;
+    // Cursor guides also mount this overlay in ordinary reader/hand mode.
+    // In that passive state the MouseRegion paints the guides, but no gesture
+    // recognizer may enter the arena and steal scrolling or text selection
+    // from the viewer underneath.
+    final acceptsEditingGestures = _tool != null || _selectMode;
     final washRestGhost = selectedAnnotation?.subtype == 'FreeText';
     final _AfterGhost? restGhost = !widget.rasterCurrent &&
             !dragging &&
@@ -5749,7 +5826,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             ..._polyPoints!,
             if (_polyHover != null &&
                 (_polyHover! - _polyPoints!.last).distance >= 2)
-              _straightSnap(_polyPoints!.last, _polyHover!),
+              _straightSnap(_polyPoints!.last, _snapPointToGrid(_polyHover!)),
           ];
     final vertexHandles = _vertexPoints ?? _selectedVertexPoints;
     final vertexPreview =
@@ -5799,10 +5876,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // the document unscrollable for as long as the tool was armed - so
         // the eyedropper only ever reached the pages that happened to be on
         // screen when it was armed.
-        onPanStart: cropping || picking ? null : _panStart,
-        onPanUpdate: cropping || picking ? null : _panUpdate,
-        onPanEnd: cropping || picking ? null : _panEnd,
-        onTapUp: cropping || picking ? null : _onTapUp,
+        onPanStart:
+            cropping || picking || !acceptsEditingGestures ? null : _panStart,
+        onPanUpdate:
+            cropping || picking || !acceptsEditingGestures ? null : _panUpdate,
+        onPanEnd:
+            cropping || picking || !acceptsEditingGestures ? null : _panEnd,
+        onTapUp:
+            cropping || picking || !acceptsEditingGestures ? null : _onTapUp,
         onDoubleTapDown: !cropping &&
                 !picking &&
                 (_polyTool ||
@@ -5826,6 +5907,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           onHover: _onHover,
           onExit: (_) {
             if (_pickPosition == null &&
+                _guideCursor == null &&
                 (_signaturePreview == null || _signatureDrag) &&
                 (_eraserCursor == null || _erasePath.isNotEmpty) &&
                 _penCursor == null &&
@@ -5839,6 +5921,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             setState(() {
               _pickPosition = null;
               _pickPreview = null;
+              _guideCursor = null;
               if (!_signatureDrag) _signaturePreview = null;
               if (_erasePath.isEmpty) _eraserCursor = null;
               _penCursor = null;
@@ -6008,7 +6091,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               Positioned.fill(
                 child: RepaintBoundary(
                   child: CustomPaint(
-                    painter: _HoverCursorPainter(this),
+                    painter:
+                        _HoverCursorPainter(this, PdfViewerTheme.of(context)),
                     size: Size.infinite,
                   ),
                 ),
@@ -6555,9 +6639,29 @@ void _paintPenCursor(
 /// circles and an arc, so repainting it then is cheaper than tracking which of
 /// those inputs moved.
 class _HoverCursorPainter extends CustomPainter {
-  _HoverCursorPainter(this._state) : super(repaint: _state._cursorRepaint);
+  _HoverCursorPainter(this._state, this.theme)
+      : super(repaint: _state._cursorRepaint);
 
   final _EditingPageOverlayState _state;
+  final PdfViewerThemeData theme;
+
+  /// The point the enabled page-width/page-height guide lines cross.
+  @visibleForTesting
+  Offset? get guideCursor {
+    final preferences = _state._controller.preferences;
+    return preferences.showVerticalCursorGuide ||
+            preferences.showHorizontalCursorGuide
+        ? _state._guideCursor
+        : null;
+  }
+
+  @visibleForTesting
+  bool get verticalGuide =>
+      _state._controller.preferences.showVerticalCursorGuide;
+
+  @visibleForTesting
+  bool get horizontalGuide =>
+      _state._controller.preferences.showHorizontalCursorGuide;
 
   /// The marks this layer would paint right now, as the old snapshot fields
   /// exposed them. These *are* the paint gates (paint() reads them), so a
@@ -6638,6 +6742,34 @@ class _HoverCursorPainter extends CustomPainter {
     final geometry = state._geometry;
     final chromeScale = state._chromeScale;
     final preferences = state._controller.preferences;
+
+    // Full-page cursor guides paint first, leaving the pen/eraser/stamp
+    // cursor itself on top at the crossing point. A dark halo keeps the
+    // thin themed line readable over both white paper and dense drawings.
+    final guide = guideCursor;
+    if (guide != null) {
+      final color = theme.annotationChromeColor ?? const Color(0xFF1E88E5);
+      final halo = Paint()
+        ..color = const Color(0x52000000)
+        ..strokeWidth = 3 * chromeScale;
+      final line = Paint()
+        ..color = color.withValues(alpha: 0.88)
+        ..strokeWidth = 1 * chromeScale;
+      if (verticalGuide) {
+        final from = Offset(guide.dx, 0);
+        final to = Offset(guide.dx, size.height);
+        canvas
+          ..drawLine(from, to, halo)
+          ..drawLine(from, to, line);
+      }
+      if (horizontalGuide) {
+        final from = Offset(0, guide.dy);
+        final to = Offset(size.width, guide.dy);
+        canvas
+          ..drawLine(from, to, halo)
+          ..drawLine(from, to, line);
+      }
+    }
 
     final saved = savedAnnotationPreview;
     if (saved != null) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -57,6 +57,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   double _eraserRadius = 8;
   bool _showVerticalCursorGuide = false;
   bool _showHorizontalCursorGuide = false;
+  bool _showSnapGrid = false;
   bool _snapToGrid = false;
   double _gridSpacing = 10;
   double _fontSize = 14;
@@ -183,6 +184,7 @@ class PdfEditingPreferences extends ChangeNotifier {
       _showHorizontalCursorGuide =
           store.getBool('${_prefix}showHorizontalCursorGuide') ??
               _showHorizontalCursorGuide;
+      _showSnapGrid = store.getBool('${_prefix}showSnapGrid') ?? _showSnapGrid;
       _snapToGrid = store.getBool('${_prefix}snapToGrid') ?? _snapToGrid;
       final gridSpacing = store.getDouble('${_prefix}gridSpacing');
       if (gridSpacing != null && gridSpacing.isFinite && gridSpacing > 0) {
@@ -737,6 +739,17 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _showHorizontalCursorGuide) return;
     _showHorizontalCursorGuide = value;
     _write((s) => s.setBool('${_prefix}showHorizontalCursorGuide', value));
+    notifyListeners();
+  }
+
+  /// Whether the page-space snap grid is drawn over the page. This is a
+  /// display-only preference and is independent of [snapToGrid].
+  bool get showSnapGrid => _showSnapGrid;
+
+  set showSnapGrid(bool value) {
+    if (value == _showSnapGrid) return;
+    _showSnapGrid = value;
+    _write((s) => s.setBool('${_prefix}showSnapGrid', value));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -55,6 +55,10 @@ class PdfEditingPreferences extends ChangeNotifier {
   double _strokeWidth = 2;
   double _cornerRadius = 0;
   double _eraserRadius = 8;
+  bool _showVerticalCursorGuide = false;
+  bool _showHorizontalCursorGuide = false;
+  bool _snapToGrid = false;
+  double _gridSpacing = 10;
   double _fontSize = 14;
   PdfStandardFont _fontFamily = PdfStandardFont.helvetica;
   PdfTextAlign? _textAlign;
@@ -173,6 +177,17 @@ class PdfEditingPreferences extends ChangeNotifier {
           store.getDouble('${_prefix}cornerRadius') ?? _cornerRadius;
       _eraserRadius =
           store.getDouble('${_prefix}eraserRadius') ?? _eraserRadius;
+      _showVerticalCursorGuide =
+          store.getBool('${_prefix}showVerticalCursorGuide') ??
+              _showVerticalCursorGuide;
+      _showHorizontalCursorGuide =
+          store.getBool('${_prefix}showHorizontalCursorGuide') ??
+              _showHorizontalCursorGuide;
+      _snapToGrid = store.getBool('${_prefix}snapToGrid') ?? _snapToGrid;
+      final gridSpacing = store.getDouble('${_prefix}gridSpacing');
+      if (gridSpacing != null && gridSpacing.isFinite && gridSpacing > 0) {
+        _gridSpacing = gridSpacing;
+      }
       _fontSize = store.getDouble('${_prefix}fontSize') ?? _fontSize;
       final fontFamily = store.getString('${_prefix}fontFamily');
       if (fontFamily != null) {
@@ -700,6 +715,53 @@ class PdfEditingPreferences extends ChangeNotifier {
     _eraserRadius = value;
     _write((s) => s.setDouble('${_prefix}eraserRadius', value));
     _recordScoped('eraserRadius', value);
+    notifyListeners();
+  }
+
+  /// Whether a page-height guide follows the mouse pointer's horizontal
+  /// position. The guide is display-only and is not written into the PDF.
+  bool get showVerticalCursorGuide => _showVerticalCursorGuide;
+
+  set showVerticalCursorGuide(bool value) {
+    if (value == _showVerticalCursorGuide) return;
+    _showVerticalCursorGuide = value;
+    _write((s) => s.setBool('${_prefix}showVerticalCursorGuide', value));
+    notifyListeners();
+  }
+
+  /// Whether a page-width guide follows the mouse pointer's vertical
+  /// position. The guide is display-only and is not written into the PDF.
+  bool get showHorizontalCursorGuide => _showHorizontalCursorGuide;
+
+  set showHorizontalCursorGuide(bool value) {
+    if (value == _showHorizontalCursorGuide) return;
+    _showHorizontalCursorGuide = value;
+    _write((s) => s.setBool('${_prefix}showHorizontalCursorGuide', value));
+    notifyListeners();
+  }
+
+  /// Whether annotation placement, movement, resizing, and line vertices
+  /// snap to a page-space grid. Hold Alt during a gesture to bypass it.
+  bool get snapToGrid => _snapToGrid;
+
+  set snapToGrid(bool value) {
+    if (value == _snapToGrid) return;
+    _snapToGrid = value;
+    _write((s) => s.setBool('${_prefix}snapToGrid', value));
+    notifyListeners();
+  }
+
+  /// The grid interval in PDF points. Grid coordinates are measured from
+  /// the visible crop box's lower-left corner and stay stable across zoom.
+  double get gridSpacing => _gridSpacing;
+
+  set gridSpacing(double value) {
+    if (!value.isFinite || value <= 0) {
+      throw ArgumentError.value(value, 'gridSpacing', 'must be positive');
+    }
+    if (value == _gridSpacing) return;
+    _gridSpacing = value;
+    _write((s) => s.setDouble('${_prefix}gridSpacing', value));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -95,6 +95,14 @@ Future<void> showPdfEditingGuidesDialog(
                 value: preferences.snapToGrid,
                 onChanged: (value) => preferences.snapToGrid = value,
               ),
+              SwitchListTile(
+                key: const ValueKey('pdf-grid-visible'),
+                secondary: const Icon(Icons.grid_on_outlined),
+                title: const Text('Show grid lines'),
+                subtitle: const Text('Display only; not added to the PDF'),
+                value: preferences.showSnapGrid,
+                onChanged: (value) => preferences.showSnapGrid = value,
+              ),
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
                 child: Row(children: [
@@ -132,38 +140,6 @@ Future<void> showPdfEditingGuidesDialog(
       ],
     ),
   );
-}
-
-/// The compact stock button for [showPdfEditingGuidesDialog].
-class PdfEditingGuidesButton extends StatelessWidget {
-  const PdfEditingGuidesButton({
-    super.key,
-    required this.preferences,
-    this.visualDensity,
-  });
-
-  final PdfEditingPreferences preferences;
-  final VisualDensity? visualDensity;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: preferences,
-      builder: (context, _) => IconButton(
-        key: const ValueKey('pdf-editing-guides'),
-        icon: const Icon(Icons.grid_4x4),
-        tooltip: 'Cursor guides and grid',
-        isSelected: preferences.showVerticalCursorGuide ||
-            preferences.showHorizontalCursorGuide ||
-            preferences.snapToGrid,
-        visualDensity: visualDensity,
-        onPressed: () => showPdfEditingGuidesDialog(
-          context,
-          preferences: preferences,
-        ),
-      ),
-    );
-  }
 }
 
 /// A ready-made toolbar for [PdfEditingController].
@@ -213,7 +189,6 @@ class PdfEditingToolbar extends StatefulWidget {
     this.showFlatten = true,
     this.showColorProcessing = true,
     this.showAnnotationLibrary = true,
-    this.showGuides = true,
     this.dock = PdfPanelDock.bottom,
     this.compact,
     this.cardAlignment = Alignment.center,
@@ -330,10 +305,6 @@ class PdfEditingToolbar extends StatefulWidget {
 
   /// Whether the Insert strip includes the reusable annotation library.
   final bool showAnnotationLibrary;
-
-  /// Whether the dock exposes the cursor-guide and grid-snap settings.
-  /// The preferences remain directly configurable when this is false.
-  final bool showGuides;
 
   /// The edge this toolbar is docked to.
   ///
@@ -1731,11 +1702,6 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           vertical: axis == Axis.vertical,
           onTap: () => _openGroupTap(group),
         ),
-      if (widget.showGuides) ...[
-        if (showNavigationModes || editingGroups.isNotEmpty)
-          _DockDivider(axis: axis),
-        PdfEditingGuidesButton(preferences: controller.preferences),
-      ],
       // Flatten now lives in the Edit group's strip, not the dock.
       // Save stays available for standalone hosts, but the drop-in
       // shells hide it here and surface it in their header (near Open).
@@ -3130,21 +3096,6 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                     ),
                     const SizedBox(height: 10),
                     _sheetToolGrid(sheetContext, group),
-                    if (widget.showGuides) ...[
-                      const SizedBox(height: 10),
-                      Align(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: OutlinedButton.icon(
-                          key: const ValueKey('pdf-mobile-editing-guides'),
-                          icon: const Icon(Icons.grid_4x4),
-                          label: const Text('Cursor guides and grid'),
-                          onPressed: () => showPdfEditingGuidesDialog(
-                            sheetContext,
-                            preferences: controller.preferences,
-                          ),
-                        ),
-                      ),
-                    ],
                     ..._sheetSettings(sheetContext, group),
                   ],
                 ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -28,6 +28,7 @@ import 'editing_form_style.dart';
 import 'editing_measure.dart';
 import 'editing_panel.dart';
 import 'editing_value_field.dart';
+import 'editing_preferences.dart';
 import 'editing_takeoff.dart';
 import 'line_style.dart';
 import 'editing_signature.dart';
@@ -43,6 +44,127 @@ typedef PdfEditingToolbarWidgetBuilder = Widget Function(
   PdfEditingController controller,
   PdfViewerController viewerController,
 );
+
+/// Opens the stock cursor-guide and grid-snap settings.
+///
+/// The switches update [preferences] live and persist through
+/// [PdfEditingPreferences]. They are display/interaction settings only; no
+/// guide or grid is written into the PDF.
+Future<void> showPdfEditingGuidesDialog(
+  BuildContext context, {
+  required PdfEditingPreferences preferences,
+}) async {
+  String spacingLabel(double value) => value == value.roundToDouble()
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
+
+  await showPdfDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Cursor guides and grid'),
+      contentPadding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      content: SizedBox(
+        width: 360,
+        child: ListenableBuilder(
+          listenable: preferences,
+          builder: (context, _) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SwitchListTile(
+                key: const ValueKey('pdf-cursor-guide-vertical'),
+                secondary: const Icon(Icons.vertical_align_center),
+                title: const Text('Vertical cursor line'),
+                value: preferences.showVerticalCursorGuide,
+                onChanged: (value) =>
+                    preferences.showVerticalCursorGuide = value,
+              ),
+              SwitchListTile(
+                key: const ValueKey('pdf-cursor-guide-horizontal'),
+                secondary: const Icon(Icons.horizontal_rule),
+                title: const Text('Horizontal cursor line'),
+                value: preferences.showHorizontalCursorGuide,
+                onChanged: (value) =>
+                    preferences.showHorizontalCursorGuide = value,
+              ),
+              const Divider(height: 1),
+              SwitchListTile(
+                key: const ValueKey('pdf-grid-snap'),
+                secondary: const Icon(Icons.grid_4x4),
+                title: const Text('Snap to grid'),
+                subtitle: const Text('Hold Alt to bypass snapping'),
+                value: preferences.snapToGrid,
+                onChanged: (value) => preferences.snapToGrid = value,
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+                child: Row(children: [
+                  const Text('Grid spacing'),
+                  Expanded(
+                    child: Slider(
+                      key: const ValueKey('pdf-grid-spacing'),
+                      value: preferences.gridSpacing.clamp(1, 144),
+                      min: 1,
+                      max: 144,
+                      divisions: 143,
+                      label: '${spacingLabel(preferences.gridSpacing)} pt',
+                      onChanged: (value) => preferences.gridSpacing = value,
+                    ),
+                  ),
+                  SizedBox(
+                    width: 48,
+                    child: Text(
+                      '${spacingLabel(preferences.gridSpacing)} pt',
+                      textAlign: TextAlign.end,
+                    ),
+                  ),
+                ]),
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          key: const ValueKey('pdf-guides-done'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(pdfL10n(context).done),
+        ),
+      ],
+    ),
+  );
+}
+
+/// The compact stock button for [showPdfEditingGuidesDialog].
+class PdfEditingGuidesButton extends StatelessWidget {
+  const PdfEditingGuidesButton({
+    super.key,
+    required this.preferences,
+    this.visualDensity,
+  });
+
+  final PdfEditingPreferences preferences;
+  final VisualDensity? visualDensity;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: preferences,
+      builder: (context, _) => IconButton(
+        key: const ValueKey('pdf-editing-guides'),
+        icon: const Icon(Icons.grid_4x4),
+        tooltip: 'Cursor guides and grid',
+        isSelected: preferences.showVerticalCursorGuide ||
+            preferences.showHorizontalCursorGuide ||
+            preferences.snapToGrid,
+        visualDensity: visualDensity,
+        onPressed: () => showPdfEditingGuidesDialog(
+          context,
+          preferences: preferences,
+        ),
+      ),
+    );
+  }
+}
 
 /// A ready-made toolbar for [PdfEditingController].
 ///
@@ -91,6 +213,7 @@ class PdfEditingToolbar extends StatefulWidget {
     this.showFlatten = true,
     this.showColorProcessing = true,
     this.showAnnotationLibrary = true,
+    this.showGuides = true,
     this.dock = PdfPanelDock.bottom,
     this.compact,
     this.cardAlignment = Alignment.center,
@@ -207,6 +330,10 @@ class PdfEditingToolbar extends StatefulWidget {
 
   /// Whether the Insert strip includes the reusable annotation library.
   final bool showAnnotationLibrary;
+
+  /// Whether the dock exposes the cursor-guide and grid-snap settings.
+  /// The preferences remain directly configurable when this is false.
+  final bool showGuides;
 
   /// The edge this toolbar is docked to.
   ///
@@ -1593,11 +1720,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           onHand: _activateHandMode,
           onSelect: _activateSelectMode,
         ),
-        if (editingGroups.isNotEmpty ||
-            widget.onSave != null ||
-            widget.trailing.isNotEmpty)
-          _DockDivider(axis: axis),
       ],
+      if (showNavigationModes && editingGroups.isNotEmpty)
+        _DockDivider(axis: axis),
       for (final group in editingGroups)
         _GroupChip(
           key: ValueKey('pdf-group-${group.id}'),
@@ -1606,6 +1731,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           vertical: axis == Axis.vertical,
           onTap: () => _openGroupTap(group),
         ),
+      if (widget.showGuides) ...[
+        if (showNavigationModes || editingGroups.isNotEmpty)
+          _DockDivider(axis: axis),
+        PdfEditingGuidesButton(preferences: controller.preferences),
+      ],
       // Flatten now lives in the Edit group's strip, not the dock.
       // Save stays available for standalone hosts, but the drop-in
       // shells hide it here and surface it in their header (near Open).
@@ -3000,6 +3130,21 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                     ),
                     const SizedBox(height: 10),
                     _sheetToolGrid(sheetContext, group),
+                    if (widget.showGuides) ...[
+                      const SizedBox(height: 10),
+                      Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: OutlinedButton.icon(
+                          key: const ValueKey('pdf-mobile-editing-guides'),
+                          icon: const Icon(Icons.grid_4x4),
+                          label: const Text('Cursor guides and grid'),
+                          onPressed: () => showPdfEditingGuidesDialog(
+                            sheetContext,
+                            preferences: controller.preferences,
+                          ),
+                        ),
+                      ),
+                    ],
                     ..._sheetSettings(sheetContext, group),
                   ],
                 ),

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -106,7 +106,8 @@ class PdfEditorFeatures {
   final bool authorEditable;
 
   /// The view-options menu: annotation visibility, form-field
-  /// highlight, text reflow, and page (paper) color - display settings only.
+  /// highlight, text reflow, page (paper) color, cursor guides, and the snap
+  /// grid - display and interaction settings only.
   final bool viewOptions;
 
   /// Whether the view-options menu offers "Reflow text". Reflow is a
@@ -1319,6 +1320,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 reflow: features.reflowView,
                 pageGrid: features.thumbnails,
                 pageColor: features.pageColorEditable,
+                editingGuides: true,
                 author: features.author,
                 authorName: session.preferences.author,
                 onAuthorPressed: _promptAuthor,
@@ -1442,6 +1444,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         reflow: features.reflowView,
                         pageGrid: features.thumbnails,
                         pageColor: features.pageColorEditable,
+                        editingGuides: true,
                         author: features.author,
                         authorName: session.preferences.author,
                         onAuthorPressed: _promptAuthor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -9381,7 +9381,9 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                   // mounted for an armed tool, the eyedropper, a
                   // default-mode (mouse click) annotation selection, or
                   // a pending attention flash (the sidebar's zoom-to -
-                  // links and form fields flash without a selection)
+                  // links and form fields flash without a selection). Cursor
+                  // guides mount the same low-latency hover layer even in
+                  // ordinary reader/hand mode.
                   builder: (context, _) {
                     final rasterCurrent = _rastered &&
                         _annotationLayerCurrent &&
@@ -9397,6 +9399,8 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                             editing.activeSavedAnnotation == null &&
                             !editing.hasAnnotationSelection &&
                             editing.pendingFlash == null &&
+                            !editing.preferences.showVerticalCursorGuide &&
+                            !editing.preferences.showHorizontalCursorGuide &&
                             (rasterCurrent ||
                                 editing.committedInkOn(widget.index) == null)
                         ? const SizedBox.shrink()

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -9401,6 +9401,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                             editing.pendingFlash == null &&
                             !editing.preferences.showVerticalCursorGuide &&
                             !editing.preferences.showHorizontalCursorGuide &&
+                            !editing.preferences.showSnapGrid &&
                             (rasterCurrent ||
                                 editing.committedInkOn(widget.index) == null)
                         ? const SizedBox.shrink()

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -8,6 +8,7 @@ import 'editing/editing_color_picker.dart';
 import 'editing/editing_controller.dart';
 import 'editing/editing_panel.dart';
 import 'editing/editing_preferences.dart';
+import 'editing/editing_toolbar.dart' show showPdfEditingGuidesDialog;
 import 'editing/tool_shortcuts.dart';
 import 'l10n/pdf_l10n.dart';
 import 'pdf_viewer.dart';
@@ -1371,6 +1372,7 @@ enum _ViewOption {
   reflow,
   pageGrid,
   pageColor,
+  editingGuides,
   author,
   shortcuts
 }
@@ -1413,6 +1415,11 @@ Future<void> _selectViewOption(
         preferences.noteRecentColor(color);
         preferences.pageColor = color;
       }
+    case _ViewOption.editingGuides:
+      await showPdfEditingGuidesDialog(
+        context,
+        preferences: preferences,
+      );
     case _ViewOption.author:
       onAuthorPressed?.call();
     case _ViewOption.shortcuts:
@@ -1676,6 +1683,7 @@ Future<void> showPdfShellViewOptionsSheet(
   bool reflow = false,
   bool pageGrid = false,
   bool pageColor = true,
+  bool editingGuides = false,
   bool author = false,
   String? authorName,
   VoidCallback? onAuthorPressed,
@@ -1827,6 +1835,23 @@ Future<void> showPdfShellViewOptionsSheet(
                     setSheetState(() {});
                   },
                 ),
+              if (editingGuides)
+                ListTile(
+                  key: const ValueKey('pdf-shell-editing-guides'),
+                  leading: const Icon(Icons.grid_4x4),
+                  title: const Text('Cursor guides and grid'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () async {
+                    await _selectViewOption(
+                      context,
+                      _ViewOption.editingGuides,
+                      preferences: preferences,
+                      pageColor: pageColor,
+                      onAuthorPressed: onAuthorPressed,
+                    );
+                    setSheetState(() {});
+                  },
+                ),
               if (author)
                 ListTile(
                   key: const ValueKey('pdf-shell-author'),
@@ -1864,8 +1889,9 @@ Future<void> showPdfShellViewOptionsSheet(
 }
 
 /// The "view options" popup both shells offer: display-only settings
-/// (annotation visibility, form-field highlight, paper color) that live
-/// in [PdfEditingPreferences] and never touch the document.
+/// (annotation visibility, form-field highlight, paper color, and optional
+/// editing guides) that live in [PdfEditingPreferences] and never touch the
+/// document.
 class PdfShellViewOptionsButton extends StatelessWidget {
   const PdfShellViewOptionsButton({
     super.key,
@@ -1873,6 +1899,7 @@ class PdfShellViewOptionsButton extends StatelessWidget {
     this.reflow = false,
     this.pageGrid = false,
     this.pageColor = true,
+    this.editingGuides = false,
     this.author = false,
     this.authorName,
     this.onAuthorPressed,
@@ -1892,6 +1919,9 @@ class PdfShellViewOptionsButton extends StatelessWidget {
   /// color can't be changed here - for hosts that set [pageColor] from
   /// the document programmatically and lock it.
   final bool pageColor;
+
+  /// Whether the menu offers the cursor-guide and snap-grid settings.
+  final bool editingGuides;
 
   /// Whether the display menu includes the default annotation author.
   /// The shell owns the prompt because the author affects new annotations,
@@ -1985,6 +2015,17 @@ class PdfShellViewOptionsButton extends StatelessWidget {
               ),
               title: Text(pdfL10n(context).shellPageColor),
               trailing: Text(_hex(preferences.pageColor)),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        if (editingGuides)
+          const PopupMenuItem(
+            key: ValueKey('pdf-shell-editing-guides'),
+            value: _ViewOption.editingGuides,
+            child: ListTile(
+              leading: Icon(Icons.grid_4x4),
+              title: Text('Cursor guides and grid'),
+              trailing: Icon(Icons.chevron_right),
               contentPadding: EdgeInsets.zero,
             ),
           ),

--- a/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
+++ b/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
@@ -17,6 +17,16 @@ dynamic cursorPainter(WidgetTester tester) => tester
       (painter) => painter.runtimeType.toString() == '_HoverCursorPainter',
     );
 
+dynamic gridPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .singleWhere(
+      (painter) => painter.runtimeType.toString() == '_SnapGridPainter',
+    );
+
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
@@ -77,12 +87,43 @@ void main() {
     final painter = cursorPainter(tester);
     expect(painter.verticalGuide, isTrue);
     expect(painter.horizontalGuide, isTrue);
+    expect(painter.guideStrokeWidth, 0.75);
+    expect(painter.guideHaloWidth, 1.75);
     expect(painter.guideCursor.dx, closeTo(view(220, 700).dx, 0.1));
     expect(painter.guideCursor.dy, closeTo(view(220, 700).dy, 0.1));
 
     await gesture.moveTo(const Offset(-30, -30));
     await tester.pump();
     expect(cursorPainter(tester).guideCursor, isNull);
+  });
+
+  testWidgets('visible snap grid follows the page-space snapping interval',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing.preferences
+      ..gridSpacing = 25
+      ..showSnapGrid = true;
+    await tester.pump();
+
+    // A visible grid alone mounts the otherwise passive overlay. It does not
+    // require snapping or an editing tool to be enabled.
+    expect(editing.tool, isNull);
+    expect(editing.preferences.snapToGrid, isFalse);
+    expect(find.byKey(const ValueKey('pdf-snap-grid')), findsWidgets);
+    final painter = gridPainter(tester);
+    expect(painter.gridSpacing, 25);
+    expect(painter.strokeWidth, 0.5);
+
+    final paint = find.byKey(const ValueKey('pdf-snap-grid')).first;
+    final segments = List<dynamic>.from(
+        painter.segmentsFor(tester.getSize(paint)) as Iterable);
+    expect(
+      segments.any((segment) =>
+          (segment.$1 - view(100, 0)).distance < 0.1 &&
+          (segment.$2 - view(100, 792)).distance < 0.1),
+      isTrue,
+      reason: 'the x=100pt grid line should span the crop box',
+    );
   });
 
   testWidgets('grid snaps creation, movement, and resizing in page points',
@@ -145,47 +186,35 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 400));
   });
 
-  testWidgets('stock toolbar exposes persistent guide and grid controls',
+  testWidgets('editor settings exposes persistent guide and grid controls',
       (tester) async {
-    final editing = PdfEditingController(buildMultiPagePdf(1));
-    final viewer = PdfViewerController();
-    addTearDown(editing.dispose);
-    addTearDown(viewer.dispose);
+    final preferences = PdfEditingPreferences();
+    addTearDown(preferences.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
-        body: const SizedBox.expand(),
-        bottomNavigationBar: PdfEditingToolbar(
-          controller: editing,
-          viewerController: viewer,
+        body: PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          preferences: preferences,
         ),
       ),
     ));
+    await tester.pump();
 
-    final guidesButton = find.byKey(const ValueKey('pdf-editing-guides'));
-    await tester.scrollUntilVisible(
-      guidesButton,
-      100,
-      scrollable: find
-          .descendant(
-            of: find.byType(PdfEditingToolbar),
-            matching: find.byType(Scrollable),
-          )
-          .first,
-    );
-    await tester.tap(guidesButton);
+    expect(find.byKey(const ValueKey('pdf-editing-guides')), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+        kind: PointerDeviceKind.mouse);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-editing-guides')),
+        kind: PointerDeviceKind.mouse);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('pdf-cursor-guide-vertical')));
     await tester.tap(find.byKey(const ValueKey('pdf-grid-snap')));
+    await tester.tap(find.byKey(const ValueKey('pdf-grid-visible')));
     await tester.pump();
 
-    expect(editing.preferences.showVerticalCursorGuide, isTrue);
-    expect(editing.preferences.snapToGrid, isTrue);
-    expect(
-        tester
-            .widget<IconButton>(
-                find.byKey(const ValueKey('pdf-editing-guides')))
-            .isSelected,
-        isTrue);
+    expect(preferences.showVerticalCursorGuide, isTrue);
+    expect(preferences.snapToGrid, isTrue);
+    expect(preferences.showSnapGrid, isTrue);
 
     await tester.tap(find.byKey(const ValueKey('pdf-guides-done')));
     await tester.pumpAndSettle();
@@ -197,6 +226,7 @@ void main() {
     first
       ..showVerticalCursorGuide = true
       ..showHorizontalCursorGuide = true
+      ..showSnapGrid = true
       ..snapToGrid = true
       ..gridSpacing = 12.5;
     await pumpEventQueue();
@@ -205,6 +235,7 @@ void main() {
     await second.ready;
     expect(second.showVerticalCursorGuide, isTrue);
     expect(second.showHorizontalCursorGuide, isTrue);
+    expect(second.showSnapGrid, isTrue);
     expect(second.snapToGrid, isTrue);
     expect(second.gridSpacing, 12.5);
     first.dispose();

--- a/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
+++ b/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_overlay.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+dynamic cursorPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .singleWhere(
+      (painter) => painter.runtimeType.toString() == '_HoverCursorPainter',
+    );
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  // 800px viewport over a 612x792pt page at fit-width.
+  const scale = 800 / 612;
+  Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+  Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            controller: viewer,
+            editing: editing,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return editing;
+  }
+
+  Future<void> dragMouse(WidgetTester tester, Offset from, Offset to) async {
+    final gesture =
+        await tester.startGesture(from, kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(Offset.lerp(from, to, 0.5)!);
+    await gesture.moveTo(to);
+    await gesture.up();
+    await tester.pump();
+  }
+
+  testWidgets('horizontal and vertical cursor guides follow page hover',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing.preferences
+      ..showVerticalCursorGuide = true
+      ..showHorizontalCursorGuide = true;
+    await tester.pump();
+
+    // Guides alone mount a passive editing overlay even with no tool or
+    // annotation selection.
+    expect(editing.tool, isNull);
+    expect(find.byType(EditingPageOverlay), findsWidgets);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(5, 5));
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(view(220, 700));
+    await tester.pump();
+
+    final painter = cursorPainter(tester);
+    expect(painter.verticalGuide, isTrue);
+    expect(painter.horizontalGuide, isTrue);
+    expect(painter.guideCursor.dx, closeTo(view(220, 700).dx, 0.1));
+    expect(painter.guideCursor.dy, closeTo(view(220, 700).dy, 0.1));
+
+    await gesture.moveTo(const Offset(-30, -30));
+    await tester.pump();
+    expect(cursorPainter(tester).guideCursor, isNull);
+  });
+
+  testWidgets('grid snaps creation, movement, and resizing in page points',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing.preferences
+      ..gridSpacing = 25
+      ..snapToGrid = true;
+    editing.tool = PdfEditTool.rectangle;
+    await tester.pump();
+
+    await dragMouse(tester, view(103, 703), view(247, 612));
+    var rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(100, 0.01));
+    expect(rect.bottom, closeTo(600, 0.01));
+    expect(rect.right, closeTo(250, 0.01));
+    expect(rect.top, closeTo(700, 0.01));
+
+    editing
+      ..tool = PdfEditTool.select
+      ..selectAnnotation(0, 0);
+    await tester.pump();
+
+    // A raw +13/-17pt move snaps the primary box's left/top corner from
+    // (100,700) to (125,675), independent of the center grab position.
+    await dragMouse(tester, view(175, 650), view(188, 633));
+    rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(125, 0.01));
+    expect(rect.bottom, closeTo(575, 0.01));
+    expect(rect.right, closeTo(275, 0.01));
+    expect(rect.top, closeTo(675, 0.01));
+
+    // The bottom-right handle lands at the nearest grid intersection.
+    await dragMouse(tester, view(275, 575), view(292, 541));
+    rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(125, 0.01));
+    expect(rect.bottom, closeTo(550, 0.01));
+    expect(rect.right, closeTo(300, 0.01));
+    expect(rect.top, closeTo(675, 0.01));
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('Alt temporarily bypasses grid snapping', (tester) async {
+    final editing = await pumpEditor(tester);
+    editing.preferences
+      ..gridSpacing = 25
+      ..snapToGrid = true;
+    editing.tool = PdfEditTool.rectangle;
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+    await dragMouse(tester, view(103, 703), view(247, 612));
+
+    final rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(103, 0.5));
+    expect(rect.bottom, closeTo(612, 0.5));
+    expect(rect.right, closeTo(247, 0.5));
+    expect(rect.top, closeTo(703, 0.5));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('stock toolbar exposes persistent guide and grid controls',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: const SizedBox.expand(),
+        bottomNavigationBar: PdfEditingToolbar(
+          controller: editing,
+          viewerController: viewer,
+        ),
+      ),
+    ));
+
+    final guidesButton = find.byKey(const ValueKey('pdf-editing-guides'));
+    await tester.scrollUntilVisible(
+      guidesButton,
+      100,
+      scrollable: find
+          .descendant(
+            of: find.byType(PdfEditingToolbar),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+    await tester.tap(guidesButton);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-cursor-guide-vertical')));
+    await tester.tap(find.byKey(const ValueKey('pdf-grid-snap')));
+    await tester.pump();
+
+    expect(editing.preferences.showVerticalCursorGuide, isTrue);
+    expect(editing.preferences.snapToGrid, isTrue);
+    expect(
+        tester
+            .widget<IconButton>(
+                find.byKey(const ValueKey('pdf-editing-guides')))
+            .isSelected,
+        isTrue);
+
+    await tester.tap(find.byKey(const ValueKey('pdf-guides-done')));
+    await tester.pumpAndSettle();
+  });
+
+  test('guide and grid preferences persist', () async {
+    final first = PdfEditingPreferences();
+    await first.ready;
+    first
+      ..showVerticalCursorGuide = true
+      ..showHorizontalCursorGuide = true
+      ..snapToGrid = true
+      ..gridSpacing = 12.5;
+    await pumpEventQueue();
+
+    final second = PdfEditingPreferences();
+    await second.ready;
+    expect(second.showVerticalCursorGuide, isTrue);
+    expect(second.showHorizontalCursorGuide, isTrue);
+    expect(second.snapToGrid, isTrue);
+    expect(second.gridSpacing, 12.5);
+    first.dispose();
+    second.dispose();
+  });
+}


### PR DESCRIPTION
## Summary

- add independent vertical and horizontal cursor guide lines
- add persisted page-space grid snapping for placement, movement, resizing, and vertices
- expose stock desktop/mobile controls with configurable spacing and Alt bypass
- document the feature and cover guides, snapping, toolbar integration, persistence, and shell layout regressions

## Validation

- fvm dart analyze
- cd packages/dart_pdf_editor && fvm flutter test (2,509 passed; 27 environment-gated skips)