### PR TITLE
Fix digital signatures across platforms

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.0.0
 
+- Fix importing private keys and certificate chains for digital signatures in
+  the cross-origin-isolated web app.
+- Allow a visible digital signature to be selected and removed, with
+  confirmation and undo.
 - Add slimmer, dockable editor controls and improve page, panel, and
   recent-document navigation.
 - Auto-fit free text to its box, flatten selected annotations, and reliably

--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:pdf_cos/pdf_cos.dart' show X509Certificate;
 import 'package:pdf_document/pdf_document.dart';
@@ -10,6 +11,8 @@ import 'package:pdf_document/pdf_document.dart';
 import 'l10n/app_l10n.dart';
 import 'signature_appearance_store.dart';
 import 'signature_raster.dart';
+import 'web_file_picker_stub.dart'
+    if (dart.library.js_interop) 'web_file_picker.dart';
 
 /// How opaque the logo backdrop is drawn - a light watermark so the signer
 /// name and details stay readable. Kept in sync between the live preview and
@@ -93,7 +96,7 @@ class DigitalSignatureOptions {
     this.contactInfo,
     this.signingTime,
     this.appearance,
-  }) : assert(
+  })  : assert(
             (identity == null ? 0 : 1) +
                     (selfSignedIdentity == null ? 0 : 1) +
                     (keylessIdentity == null ? 0 : 1) ==
@@ -132,9 +135,7 @@ class DigitalSignatureOptions {
 
   /// The signer name to show, regardless of which identity kind is set.
   String? get signerName =>
-      identity?.signerName ??
-      selfSignedIdentity?.name ??
-      keylessIdentity?.name;
+      identity?.signerName ?? selfSignedIdentity?.name ?? keylessIdentity?.name;
 }
 
 Future<DigitalSignatureOptions?> showDigitalSigningDialog(
@@ -174,13 +175,24 @@ Future<DigitalSignatureOptions?> showDigitalSigningDialog(
       ),
     );
 
-Future<XFile?> _pickPrivateKey(String label) => openFile(
-      acceptedTypeGroups: [digitalSignatureKeyTypeGroup(label)],
-    );
+Future<XFile?> _pickPrivateKey(String label) => kIsWeb
+    ? pickInMemoryFileWeb(
+        accept: '.pem,.key,.der,application/x-pem-file,application/pkcs8',
+        fallbackMimeType: 'application/octet-stream',
+      )
+    : openFile(
+        acceptedTypeGroups: [digitalSignatureKeyTypeGroup(label)],
+      );
 
-Future<List<XFile>> _pickCertificates(String label) => openFiles(
-      acceptedTypeGroups: [digitalSignatureCertificateTypeGroup(label)],
-    );
+Future<List<XFile>> _pickCertificates(String label) => kIsWeb
+    ? pickInMemoryFilesWeb(
+        accept: '.pem,.crt,.cer,.der,application/pkix-cert,'
+            'application/x-x509-ca-cert',
+        fallbackMimeType: 'application/octet-stream',
+      )
+    : openFiles(
+        acceptedTypeGroups: [digitalSignatureCertificateTypeGroup(label)],
+      );
 
 class DigitalSignatureDialog extends StatefulWidget {
   const DigitalSignatureDialog({
@@ -512,8 +524,7 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
     try {
       PdfEmbeddableImage.decode(bytes);
     } catch (_) {
-      setState(
-          () => _appearanceError = appL10n(context).appSigChoosePngOrJpeg);
+      setState(() => _appearanceError = appL10n(context).appSigChoosePngOrJpeg);
       return;
     }
     setState(() {
@@ -783,8 +794,8 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
                   child: ListTile(
                     key: const ValueKey('digital-signature-identity'),
                     leading: const Icon(Icons.verified_outlined),
-                    title: Text(
-                        identity.signerName ?? appL10n(context).appSigX509Signer),
+                    title: Text(identity.signerName ??
+                        appL10n(context).appSigX509Signer),
                     subtitle: Text(
                       appL10n(context).appSigIdentitySubtitle(
                         identity.certificateCount,
@@ -910,9 +921,8 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
                 _AppearancePreview(
                   signaturePng: _signaturePng,
                   logoBytes: _logoBytes,
-                  signerName: identity?.signerName ??
-                      selfSigned?.name ??
-                      keyless?.name,
+                  signerName:
+                      identity?.signerName ?? selfSigned?.name ?? keyless?.name,
                   reason: _value(_reason),
                   aspectRatio: widget.placement == null
                       ? 2.0
@@ -950,7 +960,8 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
         ),
         FilledButton.icon(
           key: const ValueKey('digital-signature-sign'),
-          onPressed: (canSign && !_submitting) ? () => unawaited(_submit()) : null,
+          onPressed:
+              (canSign && !_submitting) ? () => unawaited(_submit()) : null,
           icon: _submitting
               ? const SizedBox(
                   width: 18,
@@ -1058,9 +1069,7 @@ class _AppearancePreview extends StatelessWidget {
                 for (final line in details)
                   Text(line,
                       style: const TextStyle(
-                          fontSize: 9,
-                          height: 1.3,
-                          color: Color(0xFF1A1A1A))),
+                          fontSize: 9, height: 1.3, color: Color(0xFF1A1A1A))),
               ],
             ),
             Alignment.centerLeft,

--- a/app/lib/web_file_picker.dart
+++ b/app/lib/web_file_picker.dart
@@ -4,25 +4,29 @@ import 'dart:js_interop';
 import 'package:file_selector/file_selector.dart';
 import 'package:web/web.dart' as web;
 
-/// Web PDF picker that reads each chosen file's bytes straight from the browser
-/// [web.File] with `File.arrayBuffer()`, returning in-memory [XFile]s built via
-/// [XFile.fromData].
+/// Web file picker that reads each chosen file's bytes straight from the
+/// browser [web.File] with `File.arrayBuffer()`, returning in-memory [XFile]s
+/// built via [XFile.fromData].
 ///
 /// It deliberately bypasses `file_selector_web`, whose picked XFiles are
 /// blob-URL-only (`XFile(URL.createObjectURL(file))`). Their [XFile.readAsBytes]
 /// re-hydrates the blob by firing an `XMLHttpRequest` at that `blob:` URL, and
 /// that request never completes under the cross-origin isolation (COOP +
 /// COEP `credentialless`) the deployed site sets for SharedArrayBuffer - so
-/// opening a picked PDF hung forever on app.dart-pdf.com. Reading the [web.File]
-/// directly touches only the in-memory blob, which works under isolation, and
-/// [XFile.fromData] keeps those bytes so a later [XFile.readAsBytes] never hits
-/// the XHR path. See doc/dev-log/2026-07-19-web-pick-coep-hang.md.
-Future<List<XFile>> pickPdfFilesWeb({bool multiple = true}) {
-  final input =
-      web.document.createElement('input') as web.HTMLInputElement
-        ..type = 'file'
-        ..accept = '.pdf,application/pdf'
-        ..multiple = multiple;
+/// opening a picked PDF - and later a signing key/certificate - hung forever
+/// on app.dart-pdf.com. Reading the [web.File] directly touches only the
+/// in-memory blob, which works under isolation, and [XFile.fromData] keeps
+/// those bytes so a later [XFile.readAsBytes] never hits the XHR path. See
+/// doc/dev-log/2026-07-19-web-pick-coep-hang.md.
+Future<List<XFile>> pickInMemoryFilesWeb({
+  required String accept,
+  required String fallbackMimeType,
+  bool multiple = true,
+}) {
+  final input = web.document.createElement('input') as web.HTMLInputElement
+    ..type = 'file'
+    ..accept = accept
+    ..multiple = multiple;
   // A detached input can misfire in some browsers; keep it out of layout but in
   // the document, and remove it once we have an answer.
   input.style.display = 'none';
@@ -56,7 +60,7 @@ Future<List<XFile>> pickPdfFilesWeb({bool multiple = true}) {
             out.add(XFile.fromData(
               bytes,
               name: file.name,
-              mimeType: 'application/pdf',
+              mimeType: file.type.isEmpty ? fallbackMimeType : file.type,
               length: bytes.length,
             ));
           }
@@ -73,16 +77,37 @@ Future<List<XFile>> pickPdfFilesWeb({bool multiple = true}) {
 
   // Fired when the dialog is dismissed with no selection (Chromium/Firefox);
   // browsers without it just leave the picker resolved only on a real pick.
-  input.addEventListener('cancel', (web.Event _) {
-    finish(const <XFile>[]);
-  }.toJS);
+  input.addEventListener(
+      'cancel',
+      (web.Event _) {
+        finish(const <XFile>[]);
+      }.toJS);
 
   input.click();
   return completer.future;
 }
 
-/// Single-file variant: the first pick, or null when cancelled.
-Future<XFile?> pickPdfFileWeb() async {
-  final files = await pickPdfFilesWeb(multiple: false);
+Future<XFile?> pickInMemoryFileWeb({
+  required String accept,
+  required String fallbackMimeType,
+}) async {
+  final files = await pickInMemoryFilesWeb(
+    accept: accept,
+    fallbackMimeType: fallbackMimeType,
+    multiple: false,
+  );
   return files.isEmpty ? null : files.first;
 }
+
+Future<List<XFile>> pickPdfFilesWeb({bool multiple = true}) =>
+    pickInMemoryFilesWeb(
+      accept: '.pdf,application/pdf',
+      fallbackMimeType: 'application/pdf',
+      multiple: multiple,
+    );
+
+/// Single-file variant: the first pick, or null when cancelled.
+Future<XFile?> pickPdfFileWeb() => pickInMemoryFileWeb(
+      accept: '.pdf,application/pdf',
+      fallbackMimeType: 'application/pdf',
+    );

--- a/app/lib/web_file_picker_stub.dart
+++ b/app/lib/web_file_picker_stub.dart
@@ -8,3 +8,16 @@ Future<List<XFile>> pickPdfFilesWeb({bool multiple = true}) =>
 
 Future<XFile?> pickPdfFileWeb() =>
     throw UnsupportedError('pickPdfFileWeb is web-only');
+
+Future<List<XFile>> pickInMemoryFilesWeb({
+  required String accept,
+  required String fallbackMimeType,
+  bool multiple = true,
+}) =>
+    throw UnsupportedError('pickInMemoryFilesWeb is web-only');
+
+Future<XFile?> pickInMemoryFileWeb({
+  required String accept,
+  required String fallbackMimeType,
+}) =>
+    throw UnsupportedError('pickInMemoryFileWeb is web-only');

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -18,6 +18,8 @@
   `PdfEditorView` when a host has not supplied a signing handler.
 - Let users select a signed box and remove its digital signature from the
   contextual toolbar on desktop or mobile, with confirmation and undo.
+- Refresh signed pages immediately after placement so the visible signature
+  box appears as soon as signing completes.
 - Add an optional asynchronous tile-backend retry hook and exact retained-scene
   re-recording, while preserving the existing Canvas fallback when a retry is
   unavailable, fails, or remains inexact.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -13,6 +13,11 @@
   an optional visible page-space grid, and persisted grid snapping for
   annotation placement, movement, resizing, and vertices (hold Alt to bypass
   snapping temporarily). These controls live in the editor Settings popup.
+- Enable the example's visible digital-signature tool with a secure, persisted
+  signing identity on macOS and web, and hide that tool from the stock
+  `PdfEditorView` when a host has not supplied a signing handler.
+- Let users select a signed box and remove its digital signature from the
+  contextual toolbar on desktop or mobile, with confirmation and undo.
 - Add an optional asynchronous tile-backend retry hook and exact retained-scene
   re-recording, while preserving the existing Canvas fallback when a retry is
   unavailable, fails, or remains inexact.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -77,14 +77,16 @@ XTypeGroup _imageTypeGroup(String label) => XTypeGroup(
 /// The form tool's image picker: tapped push-button fields (signature
 /// and logo slots in templates) fill with the chosen PNG or JPEG.
 Future<Uint8List?> _pickFormImage(BuildContext context, PdfFormField field) =>
-    openFile(acceptedTypeGroups: [_imageTypeGroup(appL10n(context).exFileTypeImages)])
-        .then((file) => file?.readAsBytes());
+    openFile(acceptedTypeGroups: [
+      _imageTypeGroup(appL10n(context).exFileTypeImages)
+    ]).then((file) => file?.readAsBytes());
 
 /// The image tool's picker: inserts the chosen PNG or JPEG as a stamp
 /// annotation the user can move, resize, and rotate.
 Future<Uint8List?> _pickImage(BuildContext context) =>
-    openFile(acceptedTypeGroups: [_imageTypeGroup(appL10n(context).exFileTypeImages)])
-        .then((file) => file?.readAsBytes());
+    openFile(acceptedTypeGroups: [
+      _imageTypeGroup(appL10n(context).exFileTypeImages)
+    ]).then((file) => file?.readAsBytes());
 
 /// Fonts the "Load font…" entry accepts.
 XTypeGroup _fontTypeGroup(String label) => XTypeGroup(
@@ -99,9 +101,9 @@ XTypeGroup _fontTypeGroup(String label) => XTypeGroup(
 
 /// The font menu's "Load font…" picker: embeds the chosen TrueType or
 /// OpenType file so new text can use any font.
-Future<Uint8List?> _pickFont(BuildContext context) =>
-    openFile(acceptedTypeGroups: [_fontTypeGroup(appL10n(context).exFileTypeFonts)])
-        .then((file) => file?.readAsBytes());
+Future<Uint8List?> _pickFont(BuildContext context) => openFile(
+        acceptedTypeGroups: [_fontTypeGroup(appL10n(context).exFileTypeFonts)])
+    .then((file) => file?.readAsBytes());
 
 @visibleForTesting
 String pdfSavePathWithExtension(String path) {
@@ -147,12 +149,16 @@ void main() {
 }
 
 class ViewerApp extends StatefulWidget {
-  const ViewerApp({super.key, this.cacheStore});
+  const ViewerApp({super.key, this.cacheStore, this.identityStore});
 
   /// The persistent backend the on-disk caches and the recent-files list
   /// share. Defaults to the platform store (filesystem / IndexedDB); tests
   /// inject an in-memory one.
   final PdfCacheStore? cacheStore;
+
+  /// Where one-tap signing identities are persisted. The production default
+  /// is the platform secure store; tests can inject an in-memory backend.
+  final PdfIdentityStore? identityStore;
 
   @override
   State<ViewerApp> createState() => _ViewerAppState();
@@ -209,19 +215,31 @@ class _ViewerAppState extends State<ViewerApp> {
           useMaterial3: true,
         ),
         themeMode: _prefs.themeMode,
-        home: ViewerScreen(prefs: _prefs, cacheStore: widget.cacheStore),
+        home: ViewerScreen(
+          prefs: _prefs,
+          cacheStore: widget.cacheStore,
+          identityStore: widget.identityStore,
+        ),
       ),
     );
   }
 }
 
 class ViewerScreen extends StatefulWidget {
-  const ViewerScreen({super.key, required this.prefs, this.cacheStore});
+  const ViewerScreen({
+    super.key,
+    required this.prefs,
+    this.cacheStore,
+    this.identityStore,
+  });
 
   final PdfEditingPreferences prefs;
 
   /// Optional override for the persistent cache backend (see [ViewerApp]).
   final PdfCacheStore? cacheStore;
+
+  /// Optional override for the digital-signing identity backend.
+  final PdfIdentityStore? identityStore;
 
   @override
   State<ViewerScreen> createState() => _ViewerScreenState();
@@ -244,6 +262,13 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// namespaces keep their byte budgets independent.
   late final PdfCacheStore _cacheStore =
       widget.cacheStore ?? createPersistentCacheStore();
+
+  /// Private keys live in the platform Keychain/secure browser store. The
+  /// namespace is example-specific so a host app can choose its own policy.
+  late final PdfIdentityStore _signingIdentities = widget.identityStore ??
+      SecureIdentityStore(
+        keyPrefix: 'dart_pdf_editor.example.signing_identity.',
+      );
 
   /// `fullRasters` opts the demo into the persistent exact-raster tier: an
   /// already-rendered page at the same physical size reopens straight from
@@ -299,9 +324,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// re-running a hit test. App-wide.
   Future<void> _onContextMenuRequested(PdfContextMenuRequest request) async {
     if (!mounted) return;
-    final overlay =
-        Overlay.of(context, rootOverlay: true).context.findRenderObject()
-            as RenderBox?;
+    final overlay = Overlay.of(context, rootOverlay: true)
+        .context
+        .findRenderObject() as RenderBox?;
     if (overlay == null) return;
     // showMenu anchors at the tap point in the root overlay's coordinate
     // space; flip the global position to local with the root overlay's box.
@@ -631,8 +656,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
         PopupMenuItem(
           value: () => unawaited(Navigator.of(menuContext).push(
             MaterialPageRoute<void>(
-              builder: (_) =>
-                  ScrollIndicatorDemoScreen(bytes: buildDemoPdf()),
+              builder: (_) => ScrollIndicatorDemoScreen(bytes: buildDemoPdf()),
             ),
           )),
           child: _appMenuTile(
@@ -670,8 +694,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
           ),
         ),
         PopupMenuItem(
-          value: () => setState(
-              () => _contextMenuEnabled = !_contextMenuEnabled),
+          value: () =>
+              setState(() => _contextMenuEnabled = !_contextMenuEnabled),
           enabled: tab?.session != null,
           child: _appMenuTile(
             icon: _contextMenuEnabled ? Icons.touch_app : Icons.do_not_touch,
@@ -681,13 +705,10 @@ class _ViewerScreenState extends State<ViewerScreen> {
           ),
         ),
         PopupMenuItem(
-          value: () =>
-              setState(() => _horizontalLayout = !_horizontalLayout),
+          value: () => setState(() => _horizontalLayout = !_horizontalLayout),
           enabled: tab?.session != null,
           child: _appMenuTile(
-            icon: _horizontalLayout
-                ? Icons.swap_vert
-                : Icons.swap_horiz,
+            icon: _horizontalLayout ? Icons.swap_vert : Icons.swap_horiz,
             title: _horizontalLayout
                 ? appL10n(context).exVerticalLayout
                 : appL10n(context).exHorizontalLayout,
@@ -864,6 +885,55 @@ class _ViewerScreenState extends State<ViewerScreen> {
       ));
   }
 
+  Future<PdfSigningIdentity?> _signingIdentity(
+      BuildContext dialogContext) async {
+    for (final id in await _signingIdentities.ids()) {
+      final identity = await _signingIdentities.load(id);
+      if (identity != null) return identity;
+    }
+    if (!mounted || !dialogContext.mounted) return null;
+    return showCreateSigningIdentityDialog(
+      dialogContext,
+      store: _signingIdentities,
+    );
+  }
+
+  Future<void> _placeDigitalSignature(
+    BuildContext dialogContext,
+    _DocumentTab tab, {
+    required int pageIndex,
+    required PdfRect pageRect,
+  }) async {
+    final session = tab.session;
+    if (session == null) return;
+    try {
+      final identity = await _signingIdentity(dialogContext);
+      if (identity == null ||
+          !mounted ||
+          !_tabs.contains(tab) ||
+          !identical(tab.session, session)) {
+        return;
+      }
+      final signed = await session.addSelfSignedSignature(
+        identity,
+        appearance: PdfSignatureAppearance(
+          page: pageIndex,
+          rect: pageRect,
+        ),
+      );
+      if (signed && mounted) {
+        _toast('Digitally signed by ${identity.name ?? 'signer'}');
+      }
+    } catch (e, s) {
+      AppLog.instance.error(
+        'Digital signature failed',
+        error: e,
+        stackTrace: s,
+      );
+      if (mounted) _toast('Could not digitally sign: $e');
+    }
+  }
+
   /// Opens [bytes] in a brand-new tab and makes it the active one.
   void _openBytes(Uint8List bytes, String title, {bool isDemo = false}) {
     _addTab(_DocumentTab.document(
@@ -1035,8 +1105,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
   }
 
   Future<void> _pickFile() async {
-    final file =
-        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
+    final file = await openFile(
+        acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     if (file == null) return;
     final loading = _openLoading(file.name);
     try {
@@ -1082,13 +1152,13 @@ class _ViewerScreenState extends State<ViewerScreen> {
       _openError(input, l10n.exNotAValidUrl(input));
       return;
     }
-    final name =
-        uri.pathSegments.isNotEmpty && uri.pathSegments.last.isNotEmpty
-            ? uri.pathSegments.last
-            : uri.host;
+    final name = uri.pathSegments.isNotEmpty && uri.pathSegments.last.isNotEmpty
+        ? uri.pathSegments.last
+        : uri.host;
 
     final progress = ValueNotifier<double>(0);
-    final loading = _DocumentTab.loading(title: name, loadingProgress: progress);
+    final loading =
+        _DocumentTab.loading(title: name, loadingProgress: progress);
     _addTab(loading);
 
     final source = remoteByteSourceFactory(uri);
@@ -1105,8 +1175,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
       final bytes = doc.cos.bytes;
       _replaceLoadingTab(
         loading,
-        _DocumentTab.document(
-            title: name, bytes: bytes, preferences: _prefs),
+        _DocumentTab.document(title: name, bytes: bytes, preferences: _prefs),
       );
       unawaited(_recents.record(name, bytes));
     } catch (e, s) {
@@ -1129,14 +1198,15 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// Returns null when cancelled.
   Future<String?> _promptForUrl() => showDialog<String>(
         context: context,
-        builder: (context) => const _OpenUrlDialog(initial: _sampleRemotePdfUrl),
+        builder: (context) =>
+            const _OpenUrlDialog(initial: _sampleRemotePdfUrl),
       );
 
   /// Picks a PDF and returns its bytes (null when cancelled) - the source
   /// for the editor's "Insert PDF…" action.
   Future<Uint8List?> _pickPdfBytes() async {
-    final file =
-        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
+    final file = await openFile(
+        acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     return file?.readAsBytes();
   }
 
@@ -1147,8 +1217,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
     final current = tab?.session?.bytes;
     if (current == null) return;
     final l10n = appL10n(context);
-    final file =
-        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
+    final file = await openFile(
+        acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     if (file == null) return;
     try {
       final other = await file.readAsBytes();
@@ -1163,8 +1233,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
     } catch (e, s) {
       AppLog.instance
           .error('Could not open ${file.name}', error: e, stackTrace: s);
-      _openError(
-          file.name, l10n.exCouldNotOpenFile(file.name, '$e'));
+      _openError(file.name, l10n.exCouldNotOpenFile(file.name, '$e'));
     }
   }
 
@@ -1190,7 +1259,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
       _replaceLoadingTab(
         loading,
         _DocumentTab.error(
-            title: name, error: appL10n(context).exCouldNotOpenPath(path, '$e')),
+            title: name,
+            error: appL10n(context).exCouldNotOpenPath(path, '$e')),
       );
     }
   }
@@ -1519,7 +1589,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
       _openBytes(result, appL10n(context).exOcrDocumentTitle(tab.title));
       _toast(appL10n(context).exOcrAddedSpans(spans));
     } on VlmOcrException catch (e, s) {
-      AppLog.instance.error('OCR failed: ${e.message}', error: e, stackTrace: s);
+      AppLog.instance
+          .error('OCR failed: ${e.message}', error: e, stackTrace: s);
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
       _toast(appL10n(context).exOcrFailed(e.message));
@@ -1663,10 +1734,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 textCache: _textCache,
                                 pageLayout: _pageLayout,
                                 contextMenuEnabled: _contextMenuEnabled,
-                                onContextMenuRequested:
-                                    _contextMenuEnabled
-                                        ? null
-                                        : _onContextMenuRequested,
+                                onContextMenuRequested: _contextMenuEnabled
+                                    ? null
+                                    : _onContextMenuRequested,
                                 onAction: _onAction,
                                 pageOverlayBuilder:
                                     tab.isDemo ? _demoOverlays : null,
@@ -1697,6 +1767,15 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 imagePicker: _pickImage,
                                 fontPicker: _pickFont,
                                 onSnapshot: _saveSnapshot,
+                                onPlaceSignature: (context,
+                                        {required pageIndex,
+                                        required pageRect}) =>
+                                    _placeDigitalSignature(
+                                  context,
+                                  tab,
+                                  pageIndex: pageIndex,
+                                  pageRect: pageRect,
+                                ),
                                 onShareReflowImage: (context, png) =>
                                     _saveImageBytes(
                                         png, 'figure.png', 'image/png'),

--- a/packages/dart_pdf_editor/example/test/editing_test.dart
+++ b/packages/dart_pdf_editor/example/test/editing_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -5,7 +6,10 @@ import 'package:pdf_viewer_example/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  Future<void> openDemo(WidgetTester tester) async {
+  Future<void> openDemo(
+    WidgetTester tester, {
+    PdfIdentityStore? identityStore,
+  }) async {
     // the mock store is process-global: start every test from defaults
     SharedPreferences.setMockInitialValues({});
     // These exercise the desktop dock. At the default 800px test width the
@@ -14,7 +18,7 @@ void main() {
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
-    await tester.pumpWidget(const ViewerApp());
+    await tester.pumpWidget(ViewerApp(identityStore: identityStore));
     // use-deferred-loading makes the localizations delegate load
     // asynchronously, so the app subtree - and the post-frame demo open -
     // only appear after the deferred unit resolves over several frames.
@@ -49,7 +53,8 @@ void main() {
           (widget) =>
               widget is Tooltip &&
               (widget.message == label ||
-                  (widget.message?.startsWith('$label (') ?? false)),
+                  (widget.message?.startsWith('$label (') ?? false) ||
+                  (widget.message?.startsWith('$label -') ?? false)),
         );
 
     final group = switch (tooltip) {
@@ -57,6 +62,7 @@ void main() {
       'Draw' => 'draw',
       'Rectangle' => 'shapes',
       'Note' => 'insert',
+      'Digital signature' => 'insert',
       _ => null,
     };
     if (group != null) {
@@ -222,5 +228,39 @@ void main() {
     // committed: the select tool finds the stroke
     await selectAt(tester, start + const Offset(30, 0));
     expect(find.byTooltip('Delete annotation'), findsOneWidget);
+  });
+
+  testWidgets('digital signature creates an identity and signs the PDF',
+      (tester) async {
+    final identities = InMemoryIdentityStore();
+    await openDemo(tester, identityStore: identities);
+    await tapToolbar(tester, 'Digital signature');
+
+    final start = onPage(tester, 0.25, 0.3);
+    final gesture = await tester.startGesture(
+      start,
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(30, 20));
+    await tester.pump();
+    await gesture.moveBy(const Offset(160, 55));
+    await gesture.up();
+    await tester.pump();
+
+    expect(find.text('Create signing identity'), findsOneWidget);
+    await tester.enterText(find.byType(TextFormField).first, 'Example Signer');
+    await tester.tap(find.text('Create'));
+    await tester.pumpAndSettle();
+
+    final viewer = tester.widget<PdfViewer>(find.byType(PdfViewer));
+    expect(viewer.editing!.signatures, hasLength(1));
+    final validation = viewer.editing!.signatures.single.validate();
+    expect(validation.intact, isTrue);
+    expect(validation.coversWholeDocument, isTrue);
+    expect(await identities.ids(), ['Example Signer']);
+
+    // The demo runs a periodic clock, so explicitly unmount it rather than
+    // leaving that timer for the test binding's invariant check.
+    await tester.pumpWidget(const SizedBox.shrink());
   });
 }

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -26,6 +26,7 @@ export 'src/editing/editing_color_processing.dart';
 export 'src/editing/editing_controller.dart';
 export 'src/editing/create_signing_identity_dialog.dart';
 export 'src/editing/digital_signature.dart';
+export 'src/editing/digital_signature_removal.dart';
 export 'src/editing/signing_identity_store.dart';
 export 'src/editing/editing_annotation_clipboard.dart';
 export 'src/editing/editing_annotation_library.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/digital_signature_removal.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/digital_signature_removal.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfSignature;
+
+import '../dialog.dart';
+import '../l10n/pdf_l10n.dart';
+
+/// Confirms removal of an active digital signature from the document.
+///
+/// This only asks the question; call `PdfEditingController.removeSignature`
+/// when it returns true. Removing the signature is undoable, but its signed
+/// bytes remain in the PDF's incremental history and cannot be scrubbed.
+Future<bool> showPdfRemoveSignatureDialog(
+  BuildContext context,
+  PdfSignature signature,
+) async {
+  final name = signature.signerName;
+  final confirmed = await showPdfDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(pdfL10n(context).sidebarRemoveSignatureTitle),
+      content: Text(name == null || name.isEmpty
+          ? pdfL10n(context).sidebarRemoveSignatureBody
+          : pdfL10n(context).sidebarRemoveSignatureBodyNamed(name)),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(pdfL10n(context).cancel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: Text(pdfL10n(context).remove),
+        ),
+      ],
+    ),
+  );
+  return confirmed == true;
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -927,7 +927,11 @@ class PdfEditingController extends ChangeNotifier {
       signingTime: signingTime,
       appearance: appearance,
     );
-    return _adoptDigitalSignature(signed, before: before);
+    return _adoptDigitalSignature(
+      signed,
+      before: before,
+      appearance: appearance,
+    );
   }
 
   /// Like [addDigitalSignature] but signs with a one-tap self-signed
@@ -954,7 +958,11 @@ class PdfEditingController extends ChangeNotifier {
       signingTime: signingTime,
       appearance: appearance,
     );
-    return _adoptDigitalSignature(signed, before: before);
+    return _adoptDigitalSignature(
+      signed,
+      before: before,
+      appearance: appearance,
+    );
   }
 
   /// Signs with a **keyless** [PdfSigningIdentity] - a short-lived
@@ -988,10 +996,18 @@ class PdfEditingController extends ChangeNotifier {
       signingTime: signingTime,
       appearance: appearance,
     );
-    return _adoptDigitalSignature(signed, before: before);
+    return _adoptDigitalSignature(
+      signed,
+      before: before,
+      appearance: appearance,
+    );
   }
 
-  bool _adoptDigitalSignature(Uint8List signed, {required Uint8List before}) {
+  bool _adoptDigitalSignature(
+    Uint8List signed, {
+    required Uint8List before,
+    PdfSignatureAppearance? appearance,
+  }) {
     if (signed.length <= before.length) {
       throw const FormatException(
         'The signer did not return a new incremental PDF revision.',
@@ -1020,10 +1036,28 @@ class PdfEditingController extends ChangeNotifier {
                 '${validation.problems.join('; ')}',
       );
     }
+    final signature = signatures.last;
+    final visualPages = <int>{
+      for (var i = 0; i < signature.field.widgets.length; i++)
+        if (signature.field.widgetPageIndex(i) case final page when page >= 0)
+          page,
+      if (appearance != null)
+        for (final page in appearance.repeatPages)
+          if (page >= 0 && page < candidate.pageCount) page,
+    };
     _commitSavedRevision(
       signed,
       beforeLength: before.length,
-      impact: PdfEditImpact.none,
+      // A signature is an annotation-only edit, but it is still visible: its
+      // widget gains an /AP and apply-to-pages boxes add Stamp annotations.
+      // Reporting no impact retains the old PdfPage wrapper in the viewer's
+      // incremental reconcile, so its annotation layer never discovers the
+      // new appearance until an unrelated refresh.
+      impact: PdfEditImpact.reported(
+        visualPages: visualPages,
+        contentPages: const <int>[],
+        annotationPages: visualPages,
+      ),
     );
     return true;
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1146,16 +1146,29 @@ class PdfEditingController extends ChangeNotifier {
     final fieldName = signature.field.name;
     // The appearance stream object shared by the widget and its repeat stamps.
     final apObjectNumber = _appearanceObjectNumber(signature.field.widgets);
+    return _removeFormFieldsAndSignatureCopies(
+      {fieldName},
+      {if (apObjectNumber != null) apObjectNumber},
+    );
+  }
+
+  bool _removeFormFieldsAndSignatureCopies(
+    Set<String> fieldNames,
+    Set<int> signatureAppearanceObjectNumbers,
+  ) {
     clearAnnotationSelection();
     return apply((editor) {
-      final field = editor.acroForm?.fieldNamed(fieldName);
-      if (field != null) editor.removeField(field);
-      if (apObjectNumber == null) return;
+      for (final fieldName in fieldNames) {
+        final field = editor.acroForm?.fieldNamed(fieldName);
+        if (field != null) editor.removeField(field);
+      }
+      if (signatureAppearanceObjectNumbers.isEmpty) return;
       for (var page = 0; page < editor.document.pageCount; page++) {
         final copies = [
           for (final annotation in editor.document.page(page).annotations)
             if (annotation.subtype == 'Stamp' &&
-                _appearanceObjectNumber([annotation.dict]) == apObjectNumber)
+                signatureAppearanceObjectNumbers
+                    .contains(_appearanceObjectNumber([annotation.dict])))
               annotation,
         ];
         if (copies.isNotEmpty) editor.removeAnnotations(page, copies);
@@ -4743,7 +4756,9 @@ class PdfEditingController extends ChangeNotifier {
   /// entries draw on top, so they win). Skips hidden widgets and ones
   /// the host or /F Locked flag protects ([isAnnotationEditable]); a
   /// read-only field (one whose *value* can't change) is still
-  /// selectable for move/resize/rename. Null when nothing is hit.
+  /// selectable for move/resize/rename. A signed signature widget is also
+  /// selectable even when protected, so its dedicated remove action remains
+  /// reachable (matching the annotation sidebar). Null when nothing is hit.
   (int index, PdfAnnotation)? selectableWidgetAt(
     int pageIndex,
     double x,
@@ -4754,13 +4769,20 @@ class PdfEditingController extends ChangeNotifier {
       final annotation = annotations[i];
       if (annotation.subtype != 'Widget' ||
           annotation.isHidden ||
-          !isAnnotationEditable(annotation)) {
+          (!isAnnotationEditable(annotation) &&
+              !_isSignedSignatureWidget(annotation))) {
         continue;
       }
       if (annotation.rect.contains(x, y)) return (i, annotation);
     }
     return null;
   }
+
+  bool _isSignedSignatureWidget(PdfAnnotation annotation) =>
+      annotation is PdfWidgetAnnotation &&
+      annotation.fieldType == 'Sig' &&
+      annotation.fieldName != null &&
+      signatureByFieldName.containsKey(annotation.fieldName);
 
   /// Selects the topmost form-field widget under ([x], [y]) on
   /// [pageIndex] for manipulation (move/resize/toolbar controls) - the form tool's
@@ -6866,13 +6888,14 @@ class PdfEditingController extends ChangeNotifier {
       if (field != null) fieldNames.add(field.$1);
     }
     if (fieldNames.isNotEmpty) {
-      clearAnnotationSelection();
-      apply((e) {
-        for (final name in fieldNames) {
-          final field = e.acroForm?.fieldNamed(name);
-          if (field != null) e.removeField(field);
-        }
-      });
+      final signatureAppearances = <int>{};
+      for (final name in fieldNames) {
+        final signature = signatureByFieldName[name];
+        if (signature == null) continue;
+        final objectNumber = _appearanceObjectNumber(signature.field.widgets);
+        if (objectNumber != null) signatureAppearances.add(objectNumber);
+      }
+      _removeFormFieldsAndSignatureCopies(fieldNames, signatureAppearances);
       return;
     }
     deleteAnnotations(List.of(_selected));

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -99,7 +99,8 @@ class FormFieldLabelLayer extends StatelessWidget {
 /// coexists with plain reading and annotation selection but yields the
 /// whole page to the drawing/authoring tools. Tap targets cover only the
 /// field rects, leaving the rest of the page transparent so scrolling,
-/// link taps, and text selection are untouched.
+/// link taps, and text selection are untouched. A signed signature field is
+/// a selection target too, exposing its confirmed remove action.
 class FormInteractionLayer extends StatefulWidget {
   const FormInteractionLayer({
     super.key,
@@ -263,6 +264,17 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
 
   Future<void> _onFieldTap(
       PdfFormField field, int widgetIndex, Rect viewRect) async {
+    if (field.type == PdfFieldType.signature) {
+      if (_isSigned(field)) {
+        final pageRect = widget.geometry.toPageRect(viewRect);
+        _controller.selectFormWidgetAt(
+          widget.pageIndex,
+          (pageRect.left + pageRect.right) / 2,
+          (pageRect.bottom + pageRect.top) / 2,
+        );
+      }
+      return;
+    }
     if (field.isReadOnly) return;
     switch (field.type) {
       case PdfFieldType.text:
@@ -319,6 +331,9 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
   }
 
   MouseCursor _cursorFor(PdfFormField field) {
+    if (field.type == PdfFieldType.signature && _isSigned(field)) {
+      return SystemMouseCursors.click;
+    }
     if (field.isReadOnly) return SystemMouseCursors.basic;
     return switch (field.type) {
       PdfFieldType.text => SystemMouseCursors.text,
@@ -330,6 +345,7 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
   }
 
   bool _interactive(PdfFormField field) {
+    if (field.type == PdfFieldType.signature) return _isSigned(field);
     if (field.isReadOnly) return false;
     return switch (field.type) {
       PdfFieldType.text ||
@@ -344,13 +360,15 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
     };
   }
 
+  bool _isSigned(PdfFormField field) =>
+      _controller.signatureByFieldName.containsKey(field.name);
+
   @override
   Widget build(BuildContext context) {
     // the afterimage has served once the committed revision's raster is
     // on screen, or is stale once the document moved past it
     if (_afterRevisionId != null &&
-        (widget.rasterCurrent ||
-            _afterRevisionId != _controller.revisionId)) {
+        (widget.rasterCurrent || _afterRevisionId != _controller.revisionId)) {
       _afterValue = null;
       _afterRect = null;
       _afterRevisionId = null;
@@ -454,10 +472,10 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
               // long-press selection menu off-screen
               contextMenuBuilder: (context, editableTextState) =>
                   pdfPlacedTextSelectionMenu(
-                    editableTextState,
-                    AdaptiveTextSelectionToolbar.editableText(
-                        editableTextState: editableTextState),
-                  ),
+                editableTextState,
+                AdaptiveTextSelectionToolbar.editableText(
+                    editableTextState: editableTextState),
+              ),
               textDirection: _flutterTextDirection(_text.text),
               textAlign: _flutterTextDirection(_text.text) == TextDirection.rtl
                   ? TextAlign.right

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -5,11 +5,11 @@ import 'package:flutter/services.dart' show HardwareKeyboard;
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
-import '../dialog.dart';
 import '../l10n/pdf_l10n.dart';
 import '../pdf_viewer.dart';
 import '../search_field_style.dart';
 import 'annotation_presentation.dart';
+import 'digital_signature_removal.dart';
 import 'editing_controller.dart';
 import 'editing_panel.dart';
 import 'editing_preferences.dart';
@@ -465,27 +465,10 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
 
   Future<void> _confirmRemoveSignature(
       BuildContext context, PdfSignature signature) async {
-    final name = signature.signerName;
-    final confirmed = await showPdfDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(pdfL10n(context).sidebarRemoveSignatureTitle),
-        content: Text(name == null || name.isEmpty
-            ? pdfL10n(context).sidebarRemoveSignatureBody
-            : pdfL10n(context).sidebarRemoveSignatureBodyNamed(name)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: Text(pdfL10n(context).cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: Text(pdfL10n(context).remove),
-          ),
-        ],
-      ),
-    );
-    if (confirmed == true) widget.controller.removeSignature(signature);
+    if (!await showPdfRemoveSignatureDialog(context, signature) || !mounted) {
+      return;
+    }
+    widget.controller.removeSignature(signature);
   }
 
   /// The inline validation section under a signed signature-field row: a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -9,6 +9,7 @@ import 'package:pdf_document/pdf_document.dart'
         PdfFieldType,
         PdfFormField,
         PdfLineEnding,
+        PdfSignature,
         PdfStandardFont,
         PdfTextAlign,
         PdfTextFont;
@@ -18,6 +19,7 @@ import '../l10n/pdf_l10n.dart';
 import '../pdf_viewer.dart';
 import '../toast.dart';
 import 'annotation_presentation.dart';
+import 'digital_signature_removal.dart';
 import 'editing_annotation_library.dart';
 import 'editing_color_pick.dart';
 import 'editing_color_processing.dart';
@@ -1246,6 +1248,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final name = controller.selectedWidgetFieldName;
     final field = name == null ? null : controller.acroForm?.fieldNamed(name);
     if (field == null) return const [];
+    final signature = controller.signatureByFieldName[name];
+    if (signature != null) {
+      return [_digitalSignatureDeleteButton(context, signature)];
+    }
     final edit = _selectedFormEditAction(field);
     return [
       IconButton(
@@ -1288,6 +1294,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final name = controller.selectedWidgetFieldName;
     final field = name == null ? null : controller.acroForm?.fieldNamed(name);
     if (field == null) return const [];
+    final signature = controller.signatureByFieldName[name];
+    if (signature != null) {
+      return [_digitalSignatureDeleteButton(context, signature)];
+    }
     final edit = _selectedFormEditAction(field);
     return [
       PopupMenuButton<_SelectedFormOverflowAction>(
@@ -1409,6 +1419,23 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       ),
     ];
   }
+
+  Widget _digitalSignatureDeleteButton(
+    BuildContext context,
+    PdfSignature signature,
+  ) =>
+      IconButton(
+        key: const ValueKey('pdf-selected-signature-delete'),
+        icon: const Icon(Icons.delete_outline),
+        tooltip: pdfL10n(context).sidebarDeleteSignature,
+        onPressed: () async {
+          if (!await showPdfRemoveSignatureDialog(context, signature) ||
+              !context.mounted) {
+            return;
+          }
+          controller.removeSignature(signature);
+        },
+      );
 
   void _flattenToast(BuildContext context, String message,
       {required bool undoable}) {

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -569,7 +569,9 @@ class PdfEditorView extends StatefulWidget {
   /// exports the captured raster image (copy/save/share).
   final PdfSnapshotHandler? onSnapshot;
 
-  /// See [PdfViewer.onPlaceSignature].
+  /// See [PdfViewer.onPlaceSignature]. Supply this to enable the digital-
+  /// signature box tool; when null it is hidden from the stock toolbar rather
+  /// than left as a no-op button.
   final PdfSignaturePlacer? onPlaceSignature;
 
   /// Saves or shares a figure the reader taps to open fullscreen in the text
@@ -904,6 +906,20 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   Widget build(BuildContext context) {
     if (_isSource) return _buildFromSource();
     final features = widget.features;
+    // A signature box is only a placement request; the host still has to
+    // supply the identity/signing flow. Do not advertise an inert tool in the
+    // stock shell when that callback is absent.
+    final availableTools = widget.onPlaceSignature != null
+        ? features.tools
+        : <PdfEditTool>{
+            for (final tool in features.tools ?? PdfEditTool.values)
+              if (tool != PdfEditTool.signatureBox) tool,
+          };
+    final availableShortcuts =
+        Map<PdfEditTool, PdfToolShortcut>.of(_toolShortcuts);
+    if (widget.onPlaceSignature == null) {
+      availableShortcuts.remove(PdfEditTool.signatureBox);
+    }
     Widget body = LayoutBuilder(builder: (context, constraints) {
       return ListenableBuilder(
         // the session owns the document revisions: the viewer must
@@ -1282,9 +1298,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                             !prefs.showAnnotationLibraryPanel
                         : null,
                     palette: widget.palette,
-                    tools: features.tools,
+                    tools: availableTools,
                     groups: features.toolGroups,
-                    toolShortcuts: _toolShortcuts,
+                    toolShortcuts: availableShortcuts,
                     showMarkup: features.markup,
                     showUndoRedo: features.undoRedo,
                     showColor: features.colorControls,
@@ -1324,10 +1340,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 author: features.author,
                 authorName: session.preferences.author,
                 onAuthorPressed: _promptAuthor,
-                toolShortcuts: _toolShortcuts,
+                toolShortcuts: availableShortcuts,
                 onToolShortcutsChanged: (value) =>
                     setState(() => _toolShortcuts = value),
-                tools: features.tools,
+                tools: availableTools,
               );
             },
           );
@@ -1448,10 +1464,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         author: features.author,
                         authorName: session.preferences.author,
                         onAuthorPressed: _promptAuthor,
-                        toolShortcuts: _toolShortcuts,
+                        toolShortcuts: availableShortcuts,
                         onToolShortcutsChanged: (value) =>
                             setState(() => _toolShortcuts = value),
-                        tools: features.tools),
+                        tools: availableTools),
                   PdfShellPanelSwitch(
                     key: const ValueKey('pdf-shell-panels'),
                     items: panelItems,
@@ -1529,9 +1545,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         editingTextPrompt: widget.textPrompt,
                         editingStyledTextPrompt: widget.styledTextPrompt,
                         editingPalette: widget.palette,
-                        textSelectionEditing: (features.tools == null ||
-                                features.tools!
-                                    .contains(PdfEditTool.content)) &&
+                        textSelectionEditing: (availableTools == null ||
+                                availableTools.contains(PdfEditTool.content)) &&
                             (features.toolGroups == null ||
                                 features.toolGroups!
                                     .contains(PdfEditToolGroup.edit)),
@@ -1551,7 +1566,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                             : 0,
                         pageLayout: widget.pageLayout,
                         initialFit: widget.initialFit,
-                        toolShortcuts: _toolShortcuts,
+                        toolShortcuts: availableShortcuts,
                         backgroundColor: widget.backgroundColor,
                         pageColor: pageColor,
                         showAnnotations: prefs.showAnnotations,

--- a/packages/dart_pdf_editor/test/editing_digital_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_digital_signature_test.dart
@@ -80,12 +80,14 @@ void main() {
     // A chosen certificate file that isn't valid X.509 (1-based index).
     expectCode(PdfSignatureIdentityError.invalidCertificate,
         privateKey: key,
-        certificates: [Uint8List.fromList(const [1, 2, 3, 4])],
+        certificates: [
+          Uint8List.fromList(const [1, 2, 3, 4])
+        ],
         certificateIndex: 1);
     // An encrypted PEM private key (unsupported).
     expectCode(PdfSignatureIdentityError.encryptedKeyUnsupported,
-        privateKey: Uint8List.fromList(
-            '-----BEGIN ENCRYPTED PRIVATE KEY-----\nAAAA\n'
+        privateKey:
+            Uint8List.fromList('-----BEGIN ENCRYPTED PRIVATE KEY-----\nAAAA\n'
                     '-----END ENCRYPTED PRIVATE KEY-----\n'
                 .codeUnits),
         certificates: [cert]);
@@ -155,6 +157,33 @@ void main() {
     expect(rect.top, closeTo(720, 0.5));
     // a rendered appearance stream was installed (visible box)
     expect(widget['AP'], isNotNull);
+  });
+
+  test('a placed appearance invalidates every page that displays it', () async {
+    final editing = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(editing.dispose);
+    final before = [
+      for (var page = 0; page < 3; page++) editing.pageRenderStamp(page),
+    ];
+
+    expect(
+      await editing.addDigitalSignature(
+        identity(),
+        appearance: const PdfSignatureAppearance(
+          page: 0,
+          rect: PdfRect(72, 640, 320, 720),
+          repeatPages: [2],
+        ),
+      ),
+      isTrue,
+    );
+
+    expect(editing.lastRevisionImpact!.visualPages, {0, 2});
+    expect(editing.lastRevisionImpact!.contentPages, isEmpty);
+    expect(editing.lastRevisionImpact!.annotationPages, {0, 2});
+    expect(editing.pageRenderStamp(0), greaterThan(before[0]));
+    expect(editing.pageRenderStamp(1), before[1]);
+    expect(editing.pageRenderStamp(2), greaterThan(before[2]));
   });
 
   test('removeSignature drops the field and its apply-to-pages copies',

--- a/packages/dart_pdf_editor/test/editing_signature_delete_ui_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_delete_ui_test.dart
@@ -1,0 +1,116 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  List<PdfAnnotation> stamps(PdfEditingController editing, int page) =>
+      editing.document
+          .page(page)
+          .annotations
+          .where((annotation) => annotation.subtype == 'Stamp')
+          .toList();
+
+  testWidgets('a signed box can be selected and deleted from the toolbar',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    expect(
+      await editing.addSelfSignedSignature(
+        PdfSigningIdentity.generate(name: 'Ada Lovelace'),
+        appearance: const PdfSignatureAppearance(
+          page: 0,
+          rect: PdfRect(72, 640, 320, 720),
+          repeatPages: [1],
+        ),
+      ),
+      isTrue,
+    );
+    final fieldName = editing.signatures.single.field.name;
+    expect(stamps(editing, 1), hasLength(1));
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            controller: viewer,
+            editing: editing,
+          ),
+        ),
+        bottomNavigationBar: PdfEditingToolbar(
+          controller: editing,
+          viewerController: viewer,
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    final signedBox = find.byKey(ValueKey('pdf-form-field-0-$fieldName-0'));
+    expect(signedBox, findsOneWidget);
+    await tester.tap(signedBox, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+
+    expect(editing.selectedWidgetFieldName, fieldName);
+    final delete = find.byKey(const ValueKey('pdf-selected-signature-delete'));
+    expect(delete, findsOneWidget);
+    await tester.tap(delete);
+    await tester.pumpAndSettle();
+    expect(find.text('Remove signature?'), findsOneWidget);
+
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(editing.signatures, isEmpty);
+    expect(stamps(editing, 1), isEmpty,
+        reason: 'apply-to-pages appearance copies must be removed too');
+
+    editing.undo();
+    expect(editing.signatures, hasLength(1));
+    expect(stamps(editing, 1), hasLength(1));
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  test('Delete/Backspace cleanup removes signature appearance copies',
+      () async {
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    addTearDown(editing.dispose);
+    expect(
+      await editing.addSelfSignedSignature(
+        PdfSigningIdentity.generate(name: 'Grace Hopper'),
+        appearance: const PdfSignatureAppearance(
+          page: 0,
+          rect: PdfRect(72, 640, 320, 720),
+          repeatPages: [1],
+        ),
+      ),
+      isTrue,
+    );
+    final rect = editing.signatures.single.field.widgetRect(0)!;
+    expect(
+      editing.selectFormWidgetAt(
+        0,
+        (rect.left + rect.right) / 2,
+        (rect.bottom + rect.top) / 2,
+      ),
+      isTrue,
+    );
+
+    editing.deleteSelected();
+
+    expect(editing.signatures, isEmpty);
+    expect(stamps(editing, 1), isEmpty);
+  });
+}

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -873,6 +873,57 @@ void main() {
       expect(find.byIcon(Icons.palette), findsNothing);
     });
 
+    testWidgets('digital signature is hidden without a signing handler',
+        (tester) async {
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(1)));
+
+      final insert = find.byKey(const ValueKey('pdf-group-insert'));
+      final dock = find
+          .descendant(
+            of: find.byType(PdfEditingToolbar),
+            matching: find.byType(Scrollable),
+          )
+          .last;
+      await tester.scrollUntilVisible(insert, 80, scrollable: dock);
+      await tester.tap(insert);
+      await tester.pump();
+
+      expect(find.byIcon(Icons.draw_outlined), findsNothing);
+    });
+
+    testWidgets('digital signature is enabled by a signing handler',
+        (tester) async {
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          onPlaceSignature: (context,
+              {required pageIndex, required pageRect}) async {},
+        ),
+      );
+
+      final insert = find.byKey(const ValueKey('pdf-group-insert'));
+      final dock = find
+          .descendant(
+            of: find.byType(PdfEditingToolbar),
+            matching: find.byType(Scrollable),
+          )
+          .last;
+      await tester.scrollUntilVisible(insert, 80, scrollable: dock);
+      await tester.tap(insert);
+      await tester.pump();
+
+      final signature = find.byIcon(Icons.draw_outlined);
+      final strip = find
+          .descendant(
+            of: find.byType(PdfEditingToolbar),
+            matching: find.byType(Scrollable),
+          )
+          .first;
+      await tester.scrollUntilVisible(signature, 100, scrollable: strip);
+      expect(signature, findsOneWidget);
+    });
+
     testWidgets('toolGroups hides whole tool types', (tester) async {
       await pump(
         tester,


### PR DESCRIPTION
## Summary

- use direct in-memory browser file reads so certificate and private-key selection works under the web app's cross-origin isolation policy
- wire a secure self-signed signer into the example and hide the stock signature-box tool when a host provides no signing callback
- let users select and delete signed fields from the page, toolbar, sidebar, or keyboard, including repeated appearance cleanup and undo

## Verification

- fvm dart analyze
- DartPDF digital signature tests (15 passed)
- dart_pdf_editor shell tests (80 passed)
- example editing and end-to-end signing tests (7 passed)
- form, mobile toolbar, sidebar, and signature suites (61 passed)
- macOS and web debug builds for the package example
- browser signing/validation and macOS Keychain smoke checks