### PR TITLE
chore: prepare 4.1.0 release

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
-## 4.0.0
+## 4.1.0
 
+- Save and manage named handwritten signatures, and reuse saved annotations
+  across documents from a searchable library.
+- Add cursor guides, a visible page grid, and optional grid snapping for
+  precise annotation placement and resizing.
+- Reposition selected page content and drag it between pages.
 - Fix importing private keys and certificate chains for digital signatures in
   the cross-origin-isolated web app.
 - Allow a visible digital signature to be selected and removed, with
   confirmation and undo.
+- Keep the colour eyedropper responsive across every page and expose it from
+  the colour dialog.
+- Improve rendering speed and fidelity for complex blends, transparency,
+  overprint, images, and large engineering drawings.
+- Fix sparse remote-PDF loading and a colorant clip error that could display a
+  blank page.
+
+## 4.0.0
+
 - Add slimmer, dockable editor controls and improve page, panel, and
   recent-document navigation.
 - Auto-fit free text to its box, flatten selected annotations, and reliably

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -5,7 +5,7 @@ resolution: workspace
 
 # version is the single source of truth for every platform build; CI passes
 # --build-name / --build-number derived from it (see app/RELEASING.md).
-version: 4.0.0+33
+version: 4.1.0+34
 
 environment:
   sdk: ^3.5.0
@@ -23,19 +23,19 @@ dependencies:
   cupertino_icons: ^1.0.8
 
   # The PDF engine and editing UI live in the workspace packages.
-  dart_pdf_editor: ^4.0.0
+  dart_pdf_editor: ^4.1.0
   # Optional Impeller-backed renderer for the existing deep-zoom tile store.
   # Its web export is an inert capability stub and Canvas remains the fallback.
-  dart_pdf_editor_flutter_gpu: ^0.2.0
+  dart_pdf_editor_flutter_gpu: ^0.3.0
   # The optional editor fonts + web render worker; registered at startup so the
   # app keeps the full-featured editor. A viewer-only app would omit this.
-  dart_pdf_editor_assets: ^4.0.0
-  pdf_document: ^4.0.0
-  pdf_cos: ^4.0.0
+  dart_pdf_editor_assets: ^4.1.0
+  pdf_document: ^4.1.0
+  pdf_cos: ^4.1.0
 
   # On-device, downloadable OCR - adds a selectable text layer over scans
   # without leaving the device (native platforms only).
-  pdf_ocr_ondevice: ^4.0.0
+  pdf_ocr_ondevice: ^4.1.0
 
   # Cross-platform file I/O and OS integration.
   file_selector: ^1.0.3
@@ -98,11 +98,11 @@ dev_dependencies:
     path: ../packages/dart_pdf_editor/example
 
   # Programmatically-built PDFs for widget tests.
-  pdf_test_fixtures: ^4.0.0
+  pdf_test_fixtures: ^4.1.0
 
   # Text extraction, used by the on-device OCR integration test to assert
   # the recognized layer is selectable (pdf_ocr_ondevice is a runtime dep).
-  pdf_graphics: ^4.0.0
+  pdf_graphics: ^4.1.0
   # Points the crash-recovery store at a temp directory so its append/truncate
   # behaviour can be tested against a real filesystem (see
   # test/unsaved_changes_store_io_test.dart).

--- a/app/release-notes/4.1.0-appstore.txt
+++ b/app/release-notes/4.1.0-appstore.txt
@@ -1,0 +1,16 @@
+New in 4.1.0
+
+SIGNATURES AND REUSABLE CONTENT
+- Save and manage multiple named handwritten signatures, with previews and quick selection.
+- Keep a searchable library of reusable annotations and place them across documents.
+- Select and remove visible digital signatures with confirmation and undo.
+
+PRECISION EDITING
+- Add horizontal and vertical cursor guides, show a page grid, and optionally snap annotations to it. Hold Alt to bypass snapping temporarily.
+- Reposition selected PDF content within a page or drag it to another page.
+- Reach every page with the colour eyedropper and open it directly from the colour dialog.
+
+PERFORMANCE AND RELIABILITY
+- Render large engineering drawings, complex blends, transparency groups, overprint, images, and fine linework faster and more accurately.
+- Import digital-signature keys and certificate chains more reliably, and show new signatures immediately after signing.
+- Fix sparse remote-PDF loading and a colour clipping error that could display a blank page.

--- a/app/release-notes/4.1.0-stores.txt
+++ b/app/release-notes/4.1.0-stores.txt
@@ -1,0 +1,7 @@
+New in 4.1.0
+
+- Save named handwritten signatures and reuse saved annotations across documents.
+- Place edits precisely with cursor guides, a visible grid, and optional snapping.
+- Move selected PDF content within a page or drag it to another page.
+- More reliable digital signatures and colour picking.
+- Faster, more accurate rendering for large drawings, complex blends, transparency, images, and remote PDFs.

--- a/app/tool/perf_harness/pubspec.yaml
+++ b/app/tool/perf_harness/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_pdf_editor: ^4.0.0
-  pdf_document: ^4.0.0
+  dart_pdf_editor: ^4.1.0
+  pdf_document: ^4.1.0
 
 flutter:
   uses-material-design: true

--- a/packages/dart_pdf_cli/CHANGELOG.md
+++ b/packages/dart_pdf_cli/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4
+
+- Align the command-line and MCP sidecar with the 4.1.0 package suite. No
+  command, JSON, or MCP protocol changes since 0.1.3.
+
 ## 0.1.3
 
 - Align the command-line and MCP sidecar with the 4.0.0 package suite. No

--- a/packages/dart_pdf_cli/pubspec.yaml
+++ b/packages/dart_pdf_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_pdf_cli
 description: Pure-Dart command line and MCP tools for inspecting PDF documents.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_cli
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -20,9 +20,9 @@ dependencies:
   args: ^2.7.0
   mcp_dart: ^2.4.1
   path: ^1.9.0
-  pdf_cos: ^4.0.0
-  pdf_document: ^4.0.0
-  pdf_graphics: ^4.0.0
+  pdf_cos: ^4.1.0
+  pdf_document: ^4.1.0
+  pdf_graphics: ^4.1.0
 
 dev_dependencies:
   lints: ^6.1.0

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.0.0
+## 4.1.0
 
 - Add a persistent named handwritten-signature library with previews,
   selection, rename/redraw/delete management, and automatic migration from the
@@ -20,6 +20,17 @@
   contextual toolbar on desktop or mobile, with confirmation and undo.
 - Refresh signed pages immediately after placement so the visible signature
   box appears as soon as signing completes.
+- Let the content tool reposition selected page content and drag it across
+  pages with destination-aware previews and undo.
+- Add the eyedropper to the colour dialog and keep it responsive across every
+  page in a document.
+- Improve retained rendering and the optional GPU route for complex blends,
+  transparency groups, images, text, and large engineering drawings.
+- Fix sparse progressive loading, digital-signature key import, and selection
+  refresh across supported platforms.
+
+## 4.0.0
+
 - Add an optional asynchronous tile-backend retry hook and exact retained-scene
   re-recording, while preserving the existing Canvas fallback when a retry is
   unavailable, fails, or remains inexact.

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_viewer_example
 description: Example PDF viewer built on dart_pdf_editor.
-version: 4.0.0
+version: 4.1.0
 publish_to: none
 resolution: workspace
 
@@ -15,13 +15,13 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.2
-  pdf_document: ^4.0.0
-  pdf_graphics: ^4.0.0
-  dart_pdf_editor: ^4.0.0
-  dart_pdf_editor_flutter_gpu: ^0.2.0
+  pdf_document: ^4.1.0
+  pdf_graphics: ^4.1.0
+  dart_pdf_editor: ^4.1.0
+  dart_pdf_editor_flutter_gpu: ^0.3.0
   # Optional bundled editor fonts + web render worker (registered in main()).
-  dart_pdf_editor_assets: ^4.0.0
-  pdf_ocr_vlm: ^4.0.0
+  dart_pdf_editor_assets: ^4.1.0
+  pdf_ocr_vlm: ^4.1.0
   share_plus: ^13.3.0
   url_launcher: ^6.3.0
   web: ^1.1.0
@@ -32,7 +32,7 @@ dev_dependencies:
     sdk: flutter
   image: ^4.9.2
   patrol: 4.9.0
-  pdf_test_fixtures: ^4.0.0
+  pdf_test_fixtures: ^4.1.0
   shared_preferences: ^2.3.0
 
 patrol:

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_pdf_editor
 description: >-
   Flutter PDF editor and viewer for Dart: native rendering, text selection,
   search, annotations, forms, signatures, page editing, and document comparison.
-version: 4.0.0
+version: 4.1.0
 homepage: https://dart-pdf.com/flutter-pdf-editor
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
@@ -35,9 +35,9 @@ dependencies:
   # code. See src/http_byte_source.dart.
   http: ^1.2.0
   image: ^4.9.2
-  pdf_cos: ^4.0.0
-  pdf_document: ^4.0.0
-  pdf_graphics: ^4.0.0
+  pdf_cos: ^4.1.0
+  pdf_document: ^4.1.0
+  pdf_graphics: ^4.1.0
   shared_preferences: ^2.3.0
   # Opens hyperlink (/URI) actions the viewer follows itself; see
   # PdfViewer.onLaunchUrl. Web-safe, no dart:io.

--- a/packages/dart_pdf_editor_assets/CHANGELOG.md
+++ b/packages/dart_pdf_editor_assets/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0
+
+- Regenerate the bundled web render worker for `dart_pdf_editor` 4.1.0 and
+  align the optional assets package with the lockstep minor release.
+
 ## 4.0.0
 
 - Regenerate the bundled web render worker for `dart_pdf_editor` 4.0.0 and

--- a/packages/dart_pdf_editor_assets/pubspec.yaml
+++ b/packages/dart_pdf_editor_assets/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   prebuilt web render worker. Depend on it (and call
   registerBundledEditorAssets) for the full-featured editor; omit it for a
   size-minimal viewer that ships neither.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor_assets
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   # The registration API and the PdfBundledFont / global-config symbols it
   # populates live in the editor package; this package supplies the bytes.
-  dart_pdf_editor: ^4.0.0
+  dart_pdf_editor: ^4.1.0
 
 flutter:
   # The optional editor assets. These are declared here, not in

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -1,168 +1,33 @@
 # Changelog
 
+## 0.3.0
+
+- Greatly expand exact retained-GPU coverage for blends, transparency groups,
+  soft masks, gradients, images, stroked text, overprint, and knockout groups,
+  while preserving the Canvas fallback for unsupported or inexact scenes.
+- Reduce GPU allocation and submission overhead with completion-fenced buffer
+  and attachment pools, compact transient arenas, scene-level texture leases,
+  retained bindings, and bounded advanced-blend source targets.
+- Import compatible platform-decoded image textures directly, keep mipmapped
+  fallback pixels only when needed, and accelerate MRC JPEG 2000 rendering on
+  supported Apple devices.
+- Add proactive pipeline and live-scene warm-up, exact high-resolution
+  colourant retries, off-crop command culling, and deterministic route and
+  performance diagnostics.
+- Keep dense CAD linework conservative at subpixel scale, retain more exact
+  hairlines and clipped vector content, and fix lifetime hazards around
+  in-flight GPU resources.
+- Require the dart-pdf 4.1.0 package suite. No existing public constructor or
+  rendering entry point was removed.
+
 ## 0.2.0
 
-- Reuse page-level advanced-blend multisample and stencil attachments only
-  after every command buffer in the destination-sampling route completes.
-  Repeated tiles no longer allocate a fresh attachment pair, while the page
-  ping-pong and source textures keep their existing exact ownership.
-- Reuse final-pass multisample color and stencil attachments only after every
-  command buffer that references them reaches its completion fence. Final
-  resolve textures still remain one-shot because their `ui.Image` escapes to
-  Flutter; settled tiles avoid two native texture allocations where MSAA is
-  available without risking an in-use output surface. Retention is bounded by
-  the configurable `maxTransientAttachmentBytes` budget.
-- Reuse transient host-visible buffers only after every command buffer that
-  references them reaches its completion fence. Settled tiles stop allocating
-  one native `DeviceBuffer` apiece, while concurrent and multi-pass group
-  submissions retain independent leases until all of their GPU work finishes.
-- Start per-submission transient GPU arenas at 4 KiB instead of 64 KiB, then
-  grow geometrically through 1 MiB for dense dynamic geometry. Common tiles
-  keep their single transform upload without reserving sixteen times as much
-  host-visible device memory.
-- Carry ordinary image tint, alpha, and stencil mode in retained vertex data
-  instead of binding a separately aligned fragment uniform for every draw.
-  Dense image scenes halve their pooled arena size and avoid one native bind
-  call per image without changing texture sampling or PDF mask semantics.
-- Pack immutable image, soft-mask, and glyph-atlas uniforms into the
-  lifetime-fenced scene arena with device-required alignment. Image-dense
-  scenes avoid one standalone native `DeviceBuffer` allocation per draw.
-- Pin each unique image texture once per compiled scene instead of once per
-  draw. Repeated image commands bypass the shared cache's lease bookkeeping,
-  while distinct scenes still acquire independent lifetime-safe leases.
-- Retain the image pipeline and page transform across adjacent image draws,
-  reusing an unchanged texture/sampler while updating only per-image metadata.
-  Intervening geometry invalidates the retained bindings.
-- Retain the glyph pipeline, transform, atlas metadata, and sampler bindings
-  across adjacent analytic text runs. Intervening geometry invalidates that
-  state, while dense text tiles avoid five redundant native calls per run.
-- Retain portable decoder RGBA only for scenes whose tiled bitmap-font images
-  need a hand-built mip chain, upload those pixels directly, and release them
-  after scene compilation. Ordinary images continue through zero-copy platform
-  texture import; mipmapped scenes avoid a GPU-to-CPU readback per image.
-- Preserve a distinct arbitrary path-clip stack for every paint in an isolated
-  offscreen transparency group. Each paint rebuilds its exact stencil before
-  the group alpha is resolved, rather than forcing the page onto Canvas.
-- Retain every PDF blend mode between paints inside isolated offscreen groups.
-  Non-Normal paints sample the group's possibly translucent destination through
-  bounded ping-pong attachments before group alpha and the outer blend are
-  applied once. The programmable path now implements Multiply and Screen as
-  well as the advanced modes instead of falling through to Exclusion.
-- Retain ordinary soft-masked images, fills, strokes, gradients, and text as
-  individual paints inside transparency groups. Common opaque vector/text mask
-  stacks expand into the parent with their exact stencil, composite, clip, and
-  conservative blend bounds instead of forcing the whole page onto Canvas.
-- Expand alpha-one nested knockout groups with a uniform declared backdrop into
-  an isolated parent attachment. The seed becomes a bounded first paint and
-  later siblings preserve their shape-limited source-replacement semantics.
-- Import compatible platform-decoded `ui.Image` textures directly into
-  Flutter GPU instead of reading their pixels back to the CPU and uploading
-  them again. CPU-backed and mipmapped images keep the proven upload fallback.
-- Stage proactive pipeline compilation: the context-wide idle pass now primes
-  only common stencil, solid, and texture variants, while the existing live-
-  scene warm-up compiles glyph, soft-mask, and destination-sampling variants
-  only for pages that use them. This shortens the universal Metal warm-up
-  without moving compilation back onto the first real tile.
-- Retry only non-black-overprint scene rejections with a lazily re-recorded
-  512-cell colourant grid. Exact scenes such as Ghent GWG164 move to native
-  Flutter GPU, while any remaining mismatch continues through Canvas.
-- Cull paint units wholly outside the page crop before compatibility checks
-  and scene compilation. Unreachable imposition or malformed-form content can
-  no longer force a Canvas fallback or consume retained geometry.
-- Keep the unsupported-platform/web constructor surface in sync with the
-  native transient-attachment budget option.
 - Require the dart-pdf 4.0.0 suite and its expanded tile-backend warm-up and
   transparency interfaces.
-- Keep sparse native system-font outlines on retained stencil geometry instead
-  of allocating a curve atlas for fewer than 32 glyph placements. Dense text
-  still uses the atlas; short Latin/CJK pages avoid its texture construction
-  and driver setup while producing the same pixels.
-- Render content-free interior tiles with a color-only pass that clears
-  directly to the folded paper color. This avoids stencil, MSAA, host-buffer,
-  and pipeline work when spatial selection proves that no retained command can
-  affect the tile, while boundary tiles keep the exact antialiased paper path.
-- Replace Flutter's four-frame `HostBuffer` in tile submissions with a
-  completion-fenced single-submission arena. It starts at 64 KiB, grows from
-  256 KiB to 1 MiB only for dense dynamic geometry, validates the full aligned
-  emplacement before every write, and fixes CAD hairline pages that could
-  cross Flutter 3.47's 1,024,000-byte block boundary and throw. An ordinary
-  tile now reserves 64 KiB instead of 4,096,000 bytes.
-- Discard exactly transparent advanced-blend source texels before sampling the
-  backdrop or evaluating the PDF blend equation. The destination is already a
-  native copy of that backdrop, so sparse sources avoid redundant fragment
-  reads, arithmetic, and writes without changing the resolved pixels.
-- Pool retained geometry in power-of-two size classes starting at 64 KiB
-  instead of rounding every scene up to 16 MiB. Dense scenes still flush at
-  the existing 16 MiB arena boundary and all active buffers remain under the
-  same hard byte budget.
-- Retire a GPU session to the viewer's exact Canvas fallback when one tile
-  selects at least 128 paint units containing positive-width strokes that
-  resolve below the 0.25 px coverage quantum of 4x MSAA. This prevents dense
-  CAD linework from becoming faint or disappearing at low zoom while isolated
-  subpixel strokes retain the established GPU parity and routing.
-- Retain positive-width vector strokes under image and axial-gradient soft
-  masks, including dashed caps and joins. Zero-width masked hairlines remain
-  on the exact Canvas fallback because their geometry depends on tile scale.
-- Retain a single ordinary soft-masked source nested inside a transparency
-  group by resolving the mask in one bounded offscreen target before applying
-  the enclosing group alpha. Explicit backdrops, non-Normal internal blends,
-  enabled overprint, and additional paints remain exact Canvas fallbacks.
-- Treat paints behind a provably empty rectangular clip as no-ops while
-  parsing transparency groups, carrying that clip state through save/restore
-  and balanced soft-mask structures. Empty group content no longer forces an
-  otherwise supported page onto Canvas.
-- Retain arbitrary content-side path clips for a single soft-masked source,
-  including the single-image transparency-group route. The resolved source is
-  constrained by the existing exact stencil clip instead of requiring an
-  axis-aligned shortcut.
-- Retain arbitrary path clips inside a single-image soft-mask transcript when
-  the alpha/luminosity backdrop and transfer function prove that the mask is
-  zero outside the clip. Non-zero outside-mask values remain on Canvas.
-- Retain arbitrary path clips around one fill, stroke, text run, image,
-  gradient, or mesh inside a single-paint transparency group.
-- Consume `pdf_graphics` exact region-clipped spatial overprint strokes as
-  ordinary retained clip and stroke commands. Three additional Ghent pages
-  stay on the GPU path; unresolved non-black overprint remains on Canvas.
-- Preserve shared and per-paint arbitrary path clips while flattening
-  alpha-one Normal transparency groups, and keep sub-cell strokes visible to
-  the colorant compositor before exact vector replay. One additional Ghent
-  transparency page stays on the GPU path.
-- Keep sub-cell embedded glyphs represented in the colorant compositor so one
-  additional Ghent overprint page stays on the GPU path. Sub-cell multi-glyph
-  and unresolved process-color cases remain conservative Canvas fallbacks.
-- Initialize tiles wholly inside the transformed crop box with the folded
-  opaque paper color in the render-pass clear, skipping the transparent clear
-  and full-tile paper draw. A one-device-pixel guard keeps rotated and
-  translucent page boundaries on the exact antialiased-quad path.
-- Keep intermediate transparency-group targets single-sample while retaining
-  4x MSAA on the final page target. This removes a redundant color/stencil
-  raster and resolve, cuts live group attachment estimates from 40 to 8 bytes
-  per pixel, and preserves diagonal-edge parity with Canvas.
-- Flatten nested alpha-one, normal source-over groups into their parent
-  retained group, preserving distinct per-paint clips without a nested render
-  target or Canvas fallback.
+
 - Run requested scene warm-up for route-change benchmarks, matching the
   viewer's idle-prepared production path while suppressing the unmatched timing
   marker when the Canvas base has no GPU session.
-- Add a deterministic repeated-advanced-blend CI workload whose twelve ordered
-  destination-sampling passes provide a higher-signal same-host comparison for
-  future blend optimizations.
-- Coalesce consecutive same-mode straight strokes into one exact advanced-blend
-  source and destination-sampling pass when conservative raster-space capsules
-  prove that no resolved pixel can contain both strokes. The mixed group/blend
-  benchmark now uses two advanced passes per tile instead of thirteen while
-  overlapping strokes retain ordered passes.
-- Rasterize advanced-blend sources into page-pixel-aligned cropped attachments
-  when their conservative union occupies at most half the tile. The full-sized
-  backdrop ping-pong targets remain byte-exact, while the blend shader remaps
-  the bounded source coordinates; padded offscreen groups and low-LoD
-  hairlines stay inside the crop.
-- Retain solid-black overprint paints inside single- and multi-paint
-  transparency groups, matching the existing exact top-level path. Unsafe
-  process-color, gradient, and mesh overprint still fall back to Canvas and
-  now report that cause instead of a generic group rejection.
-- Retain axial/radial gradient and Gouraud mesh paints in single-paint and
-  mixed offscreen transparency groups.
 - Preserve per-paint Normal, Multiply, and Screen state inside isolated
   offscreen transparency groups.
 - Retain ordinary images in single-paint and mixed vector/text transparency
@@ -176,20 +41,12 @@
   same-host scenario.
 - Render every PDF blend mode exactly with retained GPU destination sampling.
   Advanced modes use bounded ping-pong tile attachments; provably disjoint
-  paints share one blend pass, while overlapping paints retain painter order
-  and scissor each sequential shader draw to its conservative command bounds.
-  Preserve the untouched ping-pong destination with a byte-exact GPU texture
-  blit instead of a full-tile textured draw before every advanced blend.
-  Offscreen groups can now coexist with those destination-sampling paints in
-  exact painter order and can use one advanced outer blend themselves;
-  oversized tiles keep the conservative Canvas fallback.
+  paints share one blend pass, while overlapping paints retain painter order.
+  Oversized tiles and scenes that combine advanced blends with offscreen
+  transparency groups keep the conservative Canvas fallback.
 - Retain isolated knockout groups made entirely from vector fills. Later
   sibling shapes use exact source replacement only inside their retained path,
   while the group's alpha and outer blend remain a single offscreen composite.
-- Retain opaque non-isolated knockout groups whose declared backdrop is one
-  uniform color. The bounded single-sample group target is seeded with that
-  color and clipped to the form BBox, preserving exact Canvas output for
-  ordered vector fills and strokes without admitting unsafe overprint.
 - Retain isolated knockout groups containing a base fill and one
   vector-soft-masked fill, including clipped vector mask bounds.
 - Render overlapping Normal paints in isolated transparency groups into a

--- a/packages/dart_pdf_editor_flutter_gpu/pubspec.yaml
+++ b/packages/dart_pdf_editor_flutter_gpu/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_pdf_editor_flutter_gpu
 description: Opt-in Impeller flutter_gpu tile backend for dart_pdf_editor.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor_flutter_gpu
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -21,10 +21,10 @@ dependencies:
   flutter_gpu:
     sdk: flutter
   vector_math: ^2.1.4
-  dart_pdf_editor: ^4.0.0
-  pdf_cos: ^4.0.0
-  pdf_document: ^4.0.0
-  pdf_graphics: ^4.0.0
+  dart_pdf_editor: ^4.1.0
+  pdf_cos: ^4.1.0
+  pdf_document: ^4.1.0
+  pdf_graphics: ^4.1.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/packages/pdf_cos/CHANGELOG.md
+++ b/packages/pdf_cos/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.1.0
+
+- Treat holes in sparse progressive byte sources as cache misses tied to the
+  source buffer, avoiding invalid scan recovery and stale reads while remote
+  PDFs are still arriving.
+- Update `archive` to 4.2.0.
+
 ## 4.0.0
 
 - Decode TIFF Predictor 2 streams with 16-bit samples, preserving carries

--- a/packages/pdf_cos/pubspec.yaml
+++ b/packages/pdf_cos/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_cos
 description: >-
   COS object layer for PDF: tokenizer, parser, filters (incl. CCITT, JBIG2,
   JPEG 2000), xref machinery, encryption, and serializer. Pure Dart, web-ready.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_cos
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 4.1.0
+
+- Add document-level content movement between positions and pages, retaining
+  resource references and clipping the moved content to its destination page.
+- Preserve reusable annotation snapshots and digital-signature removal through
+  incremental edits.
+- Align dependency constraints with the dart-pdf 4.1.0 package suite and
+  update `archive` to 4.2.0.
+
 ## 4.0.0
 
 - Allow `flattenAnnotations` to target a supplied annotation selection and

--- a/packages/pdf_document/pubspec.yaml
+++ b/packages/pdf_document/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_document
 description: >-
   Document-level PDF semantics: page tree, annotations, AcroForm filling,
   digital signatures, and an incremental-save editor. Pure Dart, web-ready.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_document
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -18,7 +18,7 @@ environment:
 dependencies:
   archive: ^4.2.0
   crypto: ^3.0.0
-  pdf_cos: ^4.0.0
+  pdf_cos: ^4.1.0
 
 dev_dependencies:
   pdf_test_fixtures: '>=1.4.0 <5.0.0'

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
-## 4.0.0
+## 4.1.0
 
 - Allow retained renderers to request a larger overprint colourant grid when
   retrying a scene that the default exact-GPU route conservatively rejected.
+- Replay spatially varying stroked overprint through exact clipped regions,
+  retain narrow-stroke and embedded-glyph colourant samples, and keep compound
+  sub-cell paths conservative.
+- Accelerate supported MRC JPEG 2000 image decoding on Apple platforms while
+  preserving the portable fallback.
+- Fix an inverted colorant-buffer clip range that could blank an otherwise
+  renderable page.
+- Align dependency constraints with the dart-pdf 4.1.0 package suite.
+
+## 4.0.0
+
 - **Breaking:** `PdfOverprintCompositor.image` now requires the image
   transform, source dimensions, and a spatial resolver. Custom compositor
   callers must pass those values so one image can be resolved against several
@@ -15,20 +26,6 @@
 - Add public `PdfColorContext`, `PdfRenderingIntent`, spatial overprint and
   transparency-group device interfaces, plus intent-aware colour-space and ICC
   conversion APIs.
-- Replay spatially varying stroked overprint through the compositor's exact
-  per-backdrop regions instead of leaving those strokes to an RGB `darken`
-  approximation. The region clips preserve the original vector stroke edge
-  and let retained GPU scenes accept three additional Ghent pages exactly.
-- Preserve one colorant-grid sample for a single straight stroke narrower than
-  a grid cell so spatial overprint can discover every crossed backdrop; keep
-  compound sub-cell paths conservative rather than inflating their joins and
-  caps into unrelated backdrops. Substitute regions remain clipped through
-  the original vector stroke at replay.
-- Retain an intersected colorant-grid cell for a single embedded glyph whose
-  real outline is smaller than the grid sampling interval. The original glyph
-  remains the visible geometry while its overprint resolves against the
-  correct backdrop.
-
 - Export an OpenType CFF face reader that retains Unicode cmap mappings and
   selects collection entries, allowing native substitution adapters to obtain
   exact glyph outlines and advances from CFF-flavoured system fonts.

--- a/packages/pdf_graphics/pubspec.yaml
+++ b/packages/pdf_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_graphics
 description: >-
   PDF content interpreter, device interface, font engine, shadings, ICC color,
   and text extraction - render pages to any device. Pure Dart, web-ready.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_graphics
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -17,8 +17,8 @@ environment:
 
 dependencies:
   bidi: ^2.0.13
-  pdf_cos: ^4.0.0
-  pdf_document: ^4.0.0
+  pdf_cos: ^4.1.0
+  pdf_document: ^4.1.0
   image: ^4.9.2
 
 dev_dependencies:

--- a/packages/pdf_ocr_ondevice/CHANGELOG.md
+++ b/packages/pdf_ocr_ondevice/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0
+
+- Lockstep minor release aligned with `dart_pdf_editor` 4.1.0. No public
+  on-device OCR API changes since 4.0.0.
+
 ## 4.0.0
 
 - Lockstep major release to align with `dart_pdf_editor` 4.0.0. No public

--- a/packages/pdf_ocr_ondevice/pubspec.yaml
+++ b/packages/pdf_ocr_ondevice/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_ocr_ondevice
 description: >-
   On-device OCR engine for dart_pdf_editor that adds a selectable, searchable
   text layer to scanned PDFs with a downloadable PP-OCR ONNX model.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_ondevice
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_pdf_editor: ^4.0.0
-  pdf_document: ^4.0.0
+  dart_pdf_editor: ^4.1.0
+  pdf_document: ^4.1.0
   http: ^1.2.0
   crypto: ^3.0.0
   path_provider: ^2.1.6

--- a/packages/pdf_ocr_vlm/CHANGELOG.md
+++ b/packages/pdf_ocr_vlm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0
+
+- Lockstep minor release aligned with `dart_pdf_editor` 4.1.0. No public VLM
+  OCR API changes since 4.0.0.
+
 ## 4.0.0
 
 - Lockstep major release to align with `dart_pdf_editor` 4.0.0. No public VLM

--- a/packages/pdf_ocr_vlm/pubspec.yaml
+++ b/packages/pdf_ocr_vlm/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_ocr_vlm
 description: >-
   HTTP OCR engine for dart_pdf_editor that adds a selectable, searchable text
   layer to scanned PDFs using a self-hosted VLM or any JSON OCR service.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_vlm
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -19,8 +19,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_pdf_editor: ^4.0.0
-  pdf_document: ^4.0.0
+  dart_pdf_editor: ^4.1.0
+  pdf_document: ^4.1.0
   http: ^1.2.0
 
 dev_dependencies:

--- a/packages/pdf_test_fixtures/CHANGELOG.md
+++ b/packages/pdf_test_fixtures/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.1.0
+
+- Let `buildMultiPagePdf` create custom-size pages for deterministic raster,
+  sampling, and memory-budget tests.
+- Align with the dart-pdf 4.1.0 package suite and update `archive` to 4.2.0.
+
 ## 4.0.0
 
 - Lockstep major release for the dart-pdf 4.0.0 package suite. No public

--- a/packages/pdf_test_fixtures/pubspec.yaml
+++ b/packages/pdf_test_fixtures/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_test_fixtures
 description: >-
   Programmatically-built PDF files for testing PDF tooling. Builders compute
   every offset, so fixtures are always structurally correct.
-version: 4.0.0
+version: 4.1.0
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_test_fixtures
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -21,7 +21,7 @@ environment:
 dependencies:
   archive: ^4.2.0
   crypto: ^3.0.0
-  pdf_cos: ^4.0.0
+  pdf_cos: ^4.1.0
 
 dev_dependencies:
   lints: ^6.1.0


### PR DESCRIPTION
## Summary
- bump the DartPDF package suite and desktop/mobile app for the 4.1.0 release
- align inter-package constraints and add package changelogs
- add concise store release notes for mobile and desktop listings

## Validation
- fvm dart analyze --fatal-infos
- package tests for pdf_cos, pdf_document, pdf_graphics, and dart_pdf_cli
- fvm flutter test in dart_pdf_editor (2531 passed, 27 skipped)
- full ten-package pub.dev publish dry-run (zero warnings)
- lockstep constraint validation