### PR TITLE
Fix deterministic GPU reuse and Linux release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,20 @@ jobs:
       - name: Validate .desktop entry
         run: desktop-file-validate app/linux/dev.milanko.dartpdf.desktop
       - name: Validate AppStream metainfo
-        run: appstreamcli validate --no-net app/linux/dev.milanko.dartpdf.metainfo.xml
+        run: |
+          set -euo pipefail
+          metainfo=app/linux/dev.milanko.dartpdf.metainfo.xml
+          appstreamcli validate --no-net "$metainfo"
+          version="$(sed -n 's/^version:[[:space:]]*\([^+[:space:]]*\).*/\1/p' app/pubspec.yaml)"
+          grep -Fq "<release version=\"$version\"" "$metainfo" || {
+            echo "::error::$metainfo does not describe app version $version"
+            exit 1
+          }
+          cmp "$metainfo" \
+            app/packaging/flatpak/desktop-assets/dev.milanko.dartpdf.metainfo.xml || {
+            echo "::error::Flatpak desktop assets are stale; run app/packaging/flatpak/sync-desktop-assets.sh"
+            exit 1
+          }
       - name: Confirm desktop files landed in the bundle
         working-directory: app
         run: |

--- a/.github/workflows/publish-pub.yml
+++ b/.github/workflows/publish-pub.yml
@@ -26,6 +26,13 @@ on:
       - 'pdf_ocr_vlm-v*'
       - 'pdf_ocr_ondevice-v*'
 
+# GitHub can occasionally deliver the same tag push more than once. Serialize
+# each immutable tag so a duplicate waits, observes the published version in
+# check-publish-needed, and exits as a successful no-op.
+concurrency:
+  group: pub-publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-publish-needed:
     runs-on: ubuntu-latest

--- a/app/linux/dev.milanko.dartpdf.metainfo.xml
+++ b/app/linux/dev.milanko.dartpdf.metainfo.xml
@@ -95,6 +95,17 @@
     <!-- Generated from app/fastlane/metadata/android/en-US/changelogs/ and
          app/release-notes/. Newest first; keep the top entry in sync with the
          version the Flatpak/AUR packages pin. -->
+    <release version="4.1.0" date="2026-09-02">
+      <description>
+        <ul>
+          <li>Save named handwritten signatures and reuse saved annotations across documents.</li>
+          <li>Place edits precisely with cursor guides, a visible grid, and optional snapping.</li>
+          <li>Move selected PDF content within a page or drag it to another page.</li>
+          <li>Improve digital-signature reliability and colour picking.</li>
+          <li>Render large drawings, complex blends, transparency, images, and remote PDFs faster and more accurately.</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.0.0" date="2026-08-25">
       <description>
         <ul>

--- a/app/packaging/flatpak/desktop-assets/dev.milanko.dartpdf.metainfo.xml
+++ b/app/packaging/flatpak/desktop-assets/dev.milanko.dartpdf.metainfo.xml
@@ -95,6 +95,17 @@
     <!-- Generated from app/fastlane/metadata/android/en-US/changelogs/ and
          app/release-notes/. Newest first; keep the top entry in sync with the
          version the Flatpak/AUR packages pin. -->
+    <release version="4.1.0" date="2026-09-02">
+      <description>
+        <ul>
+          <li>Save named handwritten signatures and reuse saved annotations across documents.</li>
+          <li>Place edits precisely with cursor guides, a visible grid, and optional snapping.</li>
+          <li>Move selected PDF content within a page or drag it to another page.</li>
+          <li>Improve digital-signature reliability and colour picking.</li>
+          <li>Render large drawings, complex blends, transparency, images, and remote PDFs faster and more accurately.</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.0.0" date="2026-08-25">
       <description>
         <ul>

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -8548,10 +8548,13 @@ class _GpuTransientArena {
         if (completed) return;
         completed = true;
         try {
-          completionCallback(success);
-        } finally {
           _pendingSubmissions--;
           _releaseIfReady();
+        } finally {
+          // Publish completion only after pooled resources are reusable. In
+          // particular, an observer that sees inFlightSubmissions reach zero
+          // must not race the arena's return to its pools.
+          completionCallback(success);
         }
       });
     } catch (_) {


### PR DESCRIPTION
## Summary
- return completed transient GPU arenas to their pools before publishing zero in-flight submissions
- add the missing 4.1.0 AppStream release entry and sync Flatpak desktop metadata
- make CI reject app/AppStream version mismatches and stale Flatpak metadata

## Validation
- focused Flutter GPU benchmark test passes with Impeller/flutter_gpu enabled
- focused Dart analysis passes
- AppStream XML parses, declares app version 4.1.0, and matches the staged Flatpak copy

This fixes the post-merge CI race and the Snap/Flatpak 4.1.0 publishing failures.