### PR TITLE
fix(viewer): Fix text markup hit testing for disjoint highlight quads

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5762,7 +5762,17 @@ class _PdfViewerState extends State<PdfViewer>
     final annots = actionsOnly ? _interactiveAnnots(i) : _visibleAnnots(i);
     // later /Annots entries paint on top, so they win the hit test
     for (final annotation in annots.reversed) {
-      if (annotation.rect.contains(x, y)) {
+      // Text markups may contain several disjoint runs. Their bounding
+      // /Rect includes the whitespace between those runs, so using it here
+      // makes the host tap callback and click cursor claim visibly empty
+      // text. Match the editing controller's selection hit test: visible
+      // /QuadPoints are authoritative, with /Rect as the fallback for every
+      // other annotation type (and malformed markups without quads).
+      final quads = annotation.behavior.markupQuads;
+      final hit = quads != null && quads.isNotEmpty
+          ? quads.any((quad) => quad.contains(x, y))
+          : annotation.rect.contains(x, y);
+      if (hit) {
         return (
           pageIndex: i,
           annotation: annotation,
@@ -6398,7 +6408,10 @@ class _PdfViewerState extends State<PdfViewer>
       } else if (_hoverTextCursorAt(event.localPosition, at: at)) {
         cursor = SystemMouseCursors.text;
       } else {
-        cursor = grabCursor;
+        // Keep the existing gesture behaviour (blank areas may begin a page
+        // pan), but use a neutral cursor so nearby text-markup annotations do
+        // not appear movable.
+        cursor = SystemMouseCursors.basic;
       }
     } else {
       // Off any page. Every probe above resolves through _pagePointAt, so

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5768,10 +5768,8 @@ class _PdfViewerState extends State<PdfViewer>
       // text. Match the editing controller's selection hit test: visible
       // /QuadPoints are authoritative, with /Rect as the fallback for every
       // other annotation type (and malformed markups without quads).
-      final quads = annotation.behavior.markupQuads;
-      final hit = quads != null && quads.isNotEmpty
-          ? quads.any((quad) => quad.contains(x, y))
-          : annotation.rect.contains(x, y);
+      final quadHit = _textMarkupQuadHit(annotation, x, y);
+      final hit = quadHit ?? annotation.rect.contains(x, y);
       if (hit) {
         return (
           pageIndex: i,
@@ -5782,6 +5780,86 @@ class _PdfViewerState extends State<PdfViewer>
       }
     }
     return null;
+  }
+
+  /// Whether ([x], [y]) lands on a usable text-markup `/QuadPoints` group.
+  ///
+  /// Unlike [PdfAnnotationBehavior.markupQuads], hit testing must accept the
+  /// general rotated/skewed quadrilaterals found in external PDFs. Malformed
+  /// groups are skipped independently so one broken group does not make the
+  /// annotation's bounding `/Rect` swallow every gap between valid runs.
+  /// Returns null only when no usable quad exists, which is the sole case in
+  /// which the caller should fall back to `/Rect`.
+  bool? _textMarkupQuadHit(PdfAnnotation annotation, double x, double y) {
+    if (annotation.subtype != 'Highlight' &&
+        annotation.subtype != 'Underline' &&
+        annotation.subtype != 'StrikeOut' &&
+        annotation.subtype != 'Squiggly') {
+      return null;
+    }
+    final cos = annotation.document.cos;
+    final raw = cos.resolve(annotation.dict['QuadPoints']);
+    if (raw is! CosArray) return null;
+    var hasUsableQuad = false;
+    for (var i = 0; i + 7 < raw.length; i += 8) {
+      final points = <Offset>[];
+      var malformed = false;
+      for (var p = 0; p < 8; p += 2) {
+        final px = _cosNumber(cos.resolve(raw[i + p]));
+        final py = _cosNumber(cos.resolve(raw[i + p + 1]));
+        if (px == null || py == null || !px.isFinite || !py.isFinite) {
+          malformed = true;
+          break;
+        }
+        points.add(Offset(px, py));
+      }
+      if (malformed) continue;
+      final contains = _pointInPdfQuad(points, Offset(x, y));
+      if (contains == null) continue;
+      hasUsableQuad = true;
+      if (contains) return true;
+    }
+    return hasUsableQuad ? false : null;
+  }
+
+  static double? _cosNumber(CosObject? value) => switch (value) {
+        CosInteger(:final value) => value.toDouble(),
+        CosReal(:final value) => value,
+        _ => null,
+      };
+
+  /// Point-in-convex-quadrilateral for the non-cyclic corner order commonly
+  /// used by PDF writers (upper-left, upper-right, lower-left, lower-right).
+  /// Null marks a degenerate group as unusable.
+  static bool? _pointInPdfQuad(List<Offset> points, Offset point) {
+    if (points.length != 4) return null;
+    final center = Offset(
+      points.fold<double>(0, (sum, p) => sum + p.dx) / points.length,
+      points.fold<double>(0, (sum, p) => sum + p.dy) / points.length,
+    );
+    final ordered = [...points]..sort((a, b) => math
+        .atan2(a.dy - center.dy, a.dx - center.dx)
+        .compareTo(math.atan2(b.dy - center.dy, b.dx - center.dx)));
+    var twiceArea = 0.0;
+    for (var i = 0; i < ordered.length; i++) {
+      final a = ordered[i];
+      final b = ordered[(i + 1) % ordered.length];
+      twiceArea += a.dx * b.dy - b.dx * a.dy;
+    }
+    if (twiceArea.abs() <= 1e-7) return null;
+
+    int? side;
+    for (var i = 0; i < ordered.length; i++) {
+      final a = ordered[i];
+      final b = ordered[(i + 1) % ordered.length];
+      final cross =
+          (b.dx - a.dx) * (point.dy - a.dy) - (b.dy - a.dy) * (point.dx - a.dx);
+      if (cross.abs() <= 1e-7) continue;
+      final current = cross > 0 ? 1 : -1;
+      if (side != null && current != side) return false;
+      side = current;
+    }
+    return true;
   }
 
   PdfAnnotation? _annotationAt(Offset local, {(int, double, double)? at}) =>

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -6408,10 +6408,7 @@ class _PdfViewerState extends State<PdfViewer>
       } else if (_hoverTextCursorAt(event.localPosition, at: at)) {
         cursor = SystemMouseCursors.text;
       } else {
-        // Keep the existing gesture behaviour (blank areas may begin a page
-        // pan), but use a neutral cursor so nearby text-markup annotations do
-        // not appear movable.
-        cursor = SystemMouseCursors.basic;
+        cursor = grabCursor;
       }
     } else {
       // Off any page. Every probe above resolves through _pagePointAt, so

--- a/packages/dart_pdf_editor/test/hover_text_warm_test.dart
+++ b/packages/dart_pdf_editor/test/hover_text_warm_test.dart
@@ -53,11 +53,11 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump();
 
-    // Hover over 'Page 1' text on a "heavy" page: cursor stays neutral because
+    // Hover over 'Page 1' text on a "heavy" page: cursor stays grab because
     // the cold text cache is NOT extracted synchronously from a hover.
     await gesture.moveTo(view(100, 720));
     await tester.pump();
-    expect(region(tester).cursor, SystemMouseCursors.basic,
+    expect(region(tester).cursor, SystemMouseCursors.grab,
         reason: 'heavy page must not extract text just to pick a hover cursor');
 
     // A real action warms the cache (selection drag over the same text)...

--- a/packages/dart_pdf_editor/test/hover_text_warm_test.dart
+++ b/packages/dart_pdf_editor/test/hover_text_warm_test.dart
@@ -14,7 +14,8 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 void main() {
   MouseRegion region(WidgetTester tester) => tester.widget<MouseRegion>(find
-      .descendant(of: find.byType(PdfViewer), matching: find.byType(MouseRegion))
+      .descendant(
+          of: find.byType(PdfViewer), matching: find.byType(MouseRegion))
       .first);
 
   testWidgets('hover over a heavy page does not extract text synchronously',
@@ -22,8 +23,7 @@ void main() {
     final previous = PdfViewer.hoverTextExtractMaxRawContentBytes;
     // Treat every page as "heavy" so the ordinary fixture exercises the gate.
     PdfViewer.hoverTextExtractMaxRawContentBytes = 0;
-    addTearDown(
-        () => PdfViewer.hoverTextExtractMaxRawContentBytes = previous);
+    addTearDown(() => PdfViewer.hoverTextExtractMaxRawContentBytes = previous);
 
     final document = PdfDocument.open(buildClassicPdf());
     final controller = PdfViewerController();
@@ -53,11 +53,11 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump();
 
-    // Hover over 'Page 1' text on a "heavy" page: cursor stays grab because
+    // Hover over 'Page 1' text on a "heavy" page: cursor stays neutral because
     // the cold text cache is NOT extracted synchronously from a hover.
     await gesture.moveTo(view(100, 720));
     await tester.pump();
-    expect(region(tester).cursor, SystemMouseCursors.grab,
+    expect(region(tester).cursor, SystemMouseCursors.basic,
         reason: 'heavy page must not extract text just to pick a hover cursor');
 
     // A real action warms the cache (selection drag over the same text)...

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/gestures.dart' show kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_cos/perf.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -76,12 +77,23 @@ Uint8List buildPlainAnnotationPdf() {
   return editor.save();
 }
 
-Uint8List buildDisjointHighlightPdf() {
-  final editor = PdfEditor(PdfDocument.open(buildClassicPdf()))
+Uint8List buildDisjointHighlightPdf({bool rotated = false}) {
+  final document = PdfDocument.open(buildClassicPdf());
+  final editor = PdfEditor(document)
     ..addHighlight(0, const [
       PdfRect(80, 680, 140, 700),
       PdfRect(220, 680, 280, 700),
+      PdfRect(330, 680, 390, 700),
     ]);
+  if (rotated) {
+    final annotation = document.page(0).annotations.single;
+    editor.rotateAnnotation(0, annotation, 20);
+    // One malformed group must not discard the two usable rotated groups and
+    // reinstate the broad /Rect hit target.
+    final points = document.cos.resolve(annotation.dict['QuadPoints']);
+    (points as CosArray).items[16] = const CosName('broken');
+    editor.setAnnotationContents(0, annotation, 'rotated fixture');
+  }
   return editor.save();
 }
 
@@ -1146,6 +1158,30 @@ void main() {
     expect(region().cursor, SystemMouseCursors.click);
 
     await tester.tapAt(annotView(110, 690));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(taps, hasLength(1));
+    expect(taps.single.annotation.subtype, 'Highlight');
+  });
+
+  testWidgets(
+      'rotated markup uses valid quadrilaterals despite a malformed group',
+      (tester) async {
+    final taps = <PdfAnnotationTapDetails>[];
+    await pumpViewer(
+      tester,
+      bytes: buildDisjointHighlightPdf(rotated: true),
+      onAnnotationTap: taps.add,
+    );
+
+    // All source points turn 20 degrees around the annotation centre
+    // (235,690). This point is the turned centre of the whitespace between
+    // the first two colored runs: inside /Rect, outside both usable quads.
+    await tester.tapAt(annotView(183.32, 671.19));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(taps, isEmpty);
+
+    // Turned centre of the first run.
+    await tester.tapAt(annotView(117.54, 647.25));
     await tester.pump(const Duration(milliseconds: 400));
     expect(taps, hasLength(1));
     expect(taps.single.annotation.subtype, 'Highlight');

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -76,6 +76,15 @@ Uint8List buildPlainAnnotationPdf() {
   return editor.save();
 }
 
+Uint8List buildDisjointHighlightPdf() {
+  final editor = PdfEditor(PdfDocument.open(buildClassicPdf()))
+    ..addHighlight(0, const [
+      PdfRect(80, 680, 140, 700),
+      PdfRect(220, 680, 280, 700),
+    ]);
+  return editor.save();
+}
+
 void main() {
   Future<PdfViewerController> pumpViewer(WidgetTester tester,
       {int pages = 5,
@@ -448,8 +457,9 @@ void main() {
     // onHover fires on moves, not on the pointer appearing
     await gesture.moveTo(view(301, 500));
     await tester.pump();
-    // empty page area: a drag grab-pans, so the cursor advertises it
-    expect(region().cursor, SystemMouseCursors.grab);
+    // Empty page area keeps a neutral cursor. Its existing pan gesture is
+    // independent of the cursor used to advertise that area.
+    expect(region().cursor, SystemMouseCursors.basic);
 
     await gesture.moveTo(view(100, 720)); // over 'Page 1'
     await tester.pump();
@@ -460,7 +470,7 @@ void main() {
 
     await gesture.moveTo(view(300, 500));
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.grab);
+    expect(region().cursor, SystemMouseCursors.basic);
 
     // leaving the viewer entirely must also reset the cursor
     await gesture.moveTo(view(100, 720));
@@ -1103,6 +1113,45 @@ void main() {
     expect(tap.pageViewPosition.dy, closeTo(annotView(110, 690).dy, 0.5));
   });
 
+  testWidgets('text markup callback and click cursor only hit visible quads',
+      (tester) async {
+    final taps = <PdfAnnotationTapDetails>[];
+    await pumpViewer(
+      tester,
+      bytes: buildDisjointHighlightPdf(),
+      onAnnotationTap: taps.add,
+    );
+
+    MouseRegion region() => tester.widget<MouseRegion>(find
+        .descendant(
+          of: find.byType(PdfViewer),
+          matching: find.byType(MouseRegion),
+        )
+        .first);
+    final gesture =
+        await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 13);
+    await gesture.addPointer(location: annotView(170, 690));
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.moveTo(annotView(171, 690));
+    await tester.pump();
+    expect(region().cursor, SystemMouseCursors.basic,
+        reason: 'the invisible gap inside a markup /Rect is not draggable');
+
+    await tester.tapAt(annotView(170, 690));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(taps, isEmpty);
+
+    await gesture.moveTo(annotView(110, 690));
+    await tester.pump();
+    expect(region().cursor, SystemMouseCursors.click);
+
+    await tester.tapAt(annotView(110, 690));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(taps, hasLength(1));
+    expect(taps.single.annotation.subtype, 'Highlight');
+  });
+
   testWidgets('tapping an http link opens it via the default launcher',
       (tester) async {
     final fake = _FakeUrlLauncher();
@@ -1251,7 +1300,7 @@ void main() {
     // onHover fires on moves, not on the pointer appearing
     await gesture.moveTo(annotView(451, 690));
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.grab);
+    expect(region().cursor, SystemMouseCursors.basic);
 
     await gesture.moveTo(annotView(136, 652)); // over the URI link
     await tester.pump();
@@ -1261,10 +1310,10 @@ void main() {
     await tester.pump();
     expect(region().cursor, SystemMouseCursors.text);
 
-    await gesture.moveTo(annotView(350, 612)); // hidden link: grab like
+    await gesture.moveTo(annotView(350, 612)); // hidden link: neutral like
     // any other empty area
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.grab);
+    expect(region().cursor, SystemMouseCursors.basic);
   });
 
   testWidgets('jumpToPage scrolls to the requested page', (tester) async {

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -457,9 +457,8 @@ void main() {
     // onHover fires on moves, not on the pointer appearing
     await gesture.moveTo(view(301, 500));
     await tester.pump();
-    // Empty page area keeps a neutral cursor. Its existing pan gesture is
-    // independent of the cursor used to advertise that area.
-    expect(region().cursor, SystemMouseCursors.basic);
+    // empty page area: a drag grab-pans, so the cursor advertises it
+    expect(region().cursor, SystemMouseCursors.grab);
 
     await gesture.moveTo(view(100, 720)); // over 'Page 1'
     await tester.pump();
@@ -470,7 +469,7 @@ void main() {
 
     await gesture.moveTo(view(300, 500));
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.basic);
+    expect(region().cursor, SystemMouseCursors.grab);
 
     // leaving the viewer entirely must also reset the cursor
     await gesture.moveTo(view(100, 720));
@@ -1135,8 +1134,8 @@ void main() {
     await tester.pump();
     await gesture.moveTo(annotView(171, 690));
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.basic,
-        reason: 'the invisible gap inside a markup /Rect is not draggable');
+    expect(region().cursor, SystemMouseCursors.grab,
+        reason: 'the invisible gap inside a markup /Rect is not clickable');
 
     await tester.tapAt(annotView(170, 690));
     await tester.pump(const Duration(milliseconds: 400));
@@ -1300,7 +1299,7 @@ void main() {
     // onHover fires on moves, not on the pointer appearing
     await gesture.moveTo(annotView(451, 690));
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.basic);
+    expect(region().cursor, SystemMouseCursors.grab);
 
     await gesture.moveTo(annotView(136, 652)); // over the URI link
     await tester.pump();
@@ -1310,10 +1309,10 @@ void main() {
     await tester.pump();
     expect(region().cursor, SystemMouseCursors.text);
 
-    await gesture.moveTo(annotView(350, 612)); // hidden link: neutral like
+    await gesture.moveTo(annotView(350, 612)); // hidden link: grab like
     // any other empty area
     await tester.pump();
-    expect(region().cursor, SystemMouseCursors.basic);
+    expect(region().cursor, SystemMouseCursors.grab);
   });
 
   testWidgets('jumpToPage scrolls to the requested page', (tester) async {


### PR DESCRIPTION
## Summary

### Text markup hit testing included invisible gaps
Text markup annotations can contain multiple disjoint /QuadPoints, while their /Rect covers the entire bounding area.
Previously, annotation hit testing used only /Rect. As a result:
- Empty gaps between highlighted text runs were treated as part of the annotation.
- The click cursor appeared over non-highlighted content.
- Clicking those gaps could trigger the annotation callback.

<img width="1017" height="258" alt="image" src="https://github.com/user-attachments/assets/2ec35382-3365-44fc-8d05-df71939a9b2b" />


### Fix
### For text markup annotations:
- Use /QuadPoints as the authoritative hit-test geometry.
- Fall back to /Rect only when no valid quad geometry is available.
- Preserve the existing /Rect behavior for other annotation types.

<img width="779" height="243" alt="image" src="https://github.com/user-attachments/assets/1810b80c-de7b-4c0c-9649-0985e5054f92" />


## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [ ] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [ ] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [ ] No `dart:io` imports in any `lib/` directory.
- [ ] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [ ] Parsers remain lenient on real-world input and writers remain strict on output.
- [ ] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [ ] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
