### PR TITLE
Don't read a page's /Rotate as an annotation rotation

### DIFF
--- a/doc/dev-log/2026-09-04-rotated-page-selection-chrome.md
+++ b/doc/dev-log/2026-09-04-rotated-page-selection-chrome.md
@@ -1,0 +1,90 @@
+# A page's /Rotate is not an annotation's rotation
+
+## Symptom
+
+A free-text box on a real-world drawing sits upright on screen, its
+selection chrome hugging it. Grab the **right-middle** handle and the
+cursor reads up-down; drag it right and the preview shows the box (text
+and all) spun a quarter turn, growing *down* the screen; release and the
+committed box is the transpose of the one you dragged — a 200×50 label
+becomes 50×200, its text clipped to the first line.
+
+Reproduces on any annotation on a `/Rotate 90` (or 270) page.
+
+## Cause
+
+The overlay's `_selectionChrome` derived the selection's resting rotation
+from `appearanceQuad` mapped into **view** space (`_quadAngle`), which is
+the corner order of the appearance's /BBox×/Matrix fit onto /Rect — in
+page space — pushed through `PdfPageGeometry.toViewOffset`. That mapping
+folds in the page's display `/Rotate`, so on a `/Rotate 90` page the
+lower-left→lower-right edge of *every* square annotation runs down the
+screen and the angle reads ±90°.
+
+Everything downstream then treats the box as a rotated one:
+
+- the chrome box becomes the transposed local rect (spun back by the
+  painter, so it still *looks* right — which is why the bug is invisible
+  until you grab a handle);
+- `_handleAt` unrotates the pointer, so the screen-right-middle handle
+  resolves to the local top/bottom-middle one — hence the up-down cursor;
+- `_wrappedTextBox(rotation: _resizeAngle)` draws the live free-text
+  preview spun 90°;
+- double-clicking to edit the text opened the inline editor at that same
+  transposed box, spun (`_textEditRotation`);
+- the commit takes the local path, `resizeSelectedLocal(toPageRect(...))`,
+  handing the editor a transposed page rect. `resizeAnnotationLocal`
+  measures the annotation's *page-space* rotation itself, finds 0, and
+  falls through to the plain `resizeAnnotation` — which faithfully applies
+  the transposed rect.
+
+Our own authoring is a case in point: `addFreeText` &co. counter-rotate
+oriented artwork inside the appearance's *content stream*
+(`_orientedCounterRotation`), never in its /Matrix, so the quad stays
+square to the page while the artwork reads upright on screen.
+
+## Fix
+
+The gate is the rotation the **annotation** carries, in page space —
+which is what the editor side (`resizeAnnotationLocal`, `restyleAnnotation`,
+`_regenerateResizedAppearance`) has always used:
+
+- `PdfAnnotation.appearanceRotation` (annotation.dart) — the angle of
+  `appearanceQuad`'s ll→lr edge, radians CCW, ~0.3° of noise reads as 0.
+  `PdfEditingController` drops its private `_appearanceRotationOf` for it.
+- `_selectionChrome` returns the plain axis-aligned view rect whenever
+  `appearanceRotation == 0`, whatever the page's `/Rotate`. A page's
+  rotation turns the whole page, chrome included, so an annotation square
+  to its page is square to its chrome.
+
+A rotated *appearance* (`rotateAnnotation`, or a producer that bakes the
+turn into the /Matrix) is unaffected: it keeps the local-frame chrome,
+preview and resize, on rotated and unrotated pages alike.
+
+Second, `_resizeCursorFor` now takes the resting angle and picks the
+cursor from the direction the handle actually points on screen (the eight
+compass points folded onto the four resize cursors). A 90°-rotated
+annotation's local right-middle handle sits on the screen's top edge and
+moves up and down; it used to promise left-right.
+
+## Tests
+
+`editing_rotated_page_resize_test.dart` drives the real viewer over a
+`/Rotate 90` page (`buildMultiPagePdf(1, rotation: 90)`, new parameter):
+the right-middle handle's cursor, the drag that must widen the box on
+screen (page /Rect grows along page +y, page x untouched), the
+top-middle handle in the other axis, and a genuinely rotated square on an
+unrotated page keeping its spun chrome and its follow-the-handle cursor.
+`annotation_test.dart` covers `appearanceRotation` directly.
+
+Gotcha: a *vertical* drag started with the default (touch) gesture goes
+to the scroll view, not the overlay — the vertical resize drags in that
+file use `kind: PointerDeviceKind.mouse`.
+
+## Still open
+
+An appearance rotated by a non-quarter angle **on a rotated page** takes
+the local path, and `_geometry.toPageRect` transposes a sideways page's
+local box on the way to `resizeSelectedLocal`. Unchanged by this fix, and
+it needs the local rect built from the page-space quad centre + view
+lengths rather than a view rect mapping.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -7172,7 +7172,7 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation!;
     final text = pdfNormalizeLineEndings(annotation.contents ?? '');
     if (text.isEmpty) return false;
-    final box = _appearanceRotationOf(annotation) == 0
+    final box = annotation.appearanceRotation == 0
         ? annotation.rect
         : _localFrameOf(annotation);
     const pad = 3.0;
@@ -7320,10 +7320,10 @@ class PdfEditingController extends ChangeNotifier {
           page: target.page,
           slot: target.slot,
           annotation: target.annotation,
-          rect: _appearanceRotationOf(target.annotation) == 0
+          rect: target.annotation.appearanceRotation == 0
               ? target.annotation.rect
               : _localFrameOf(target.annotation),
-          rotation: _appearanceRotationOf(target.annotation),
+          rotation: target.annotation.appearanceRotation,
           pageRotation: _page(target.page).rotation,
           textFont: _freeTextFontOf(target.annotation),
           parsed: target.annotation.freeTextStyle,
@@ -7642,7 +7642,7 @@ class PdfEditingController extends ChangeNotifier {
     // re-add (addFreeText/addStamp/addNote bake a horizontal matrix), so
     // re-create it in its un-rotated local frame and re-apply the resting
     // rotation afterwards - the same shape resizeAnnotationLocal uses.
-    final rotation = _appearanceRotationOf(annotation);
+    final rotation = annotation.appearanceRotation;
     final rect = rotation == 0 ? annotation.rect : _localFrameOf(annotation);
     final color = annotation.color;
     final by = annotation.author; // a text edit doesn't change ownership
@@ -7738,7 +7738,7 @@ class PdfEditingController extends ChangeNotifier {
   }) {
     if (_selected.isEmpty || annotation.subtype != 'FreeText') return false;
     final page = _selected.last.$1;
-    final rotation = _appearanceRotationOf(annotation);
+    final rotation = annotation.appearanceRotation;
     final rect = rotation == 0 ? annotation.rect : _localFrameOf(annotation);
     final by = annotation.author;
     final nm = annotation.name;
@@ -7783,19 +7783,6 @@ class PdfEditingController extends ChangeNotifier {
       notifyListeners();
     }
     return changed;
-  }
-
-  /// The page-space rotation baked into [annotation]'s appearance (radians
-  /// CCW, derived from its appearance quad), or 0 when it carries no
-  /// rotation or has no appearance stream.
-  static double _appearanceRotationOf(PdfAnnotation annotation) {
-    final quad = annotation.appearanceQuad;
-    if (quad == null) return 0;
-    final dx = quad[1].$1 - quad[0].$1;
-    final dy = quad[1].$2 - quad[0].$2;
-    if (dx == 0 && dy == 0) return 0;
-    final angle = math.atan2(dy, dx);
-    return angle.abs() < 0.005 ? 0 : angle;
   }
 
   /// The un-rotated local box of a rotated [annotation]: its appearance

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1896,9 +1896,22 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// (pre-rotation) rectangle - the painter spins it back into place,
   /// so the chrome hugs the rotated artwork instead of boxing its
   /// axis-aligned bounds.
+  ///
+  /// Only a rotation the *annotation* carries counts
+  /// ([PdfAnnotation.appearanceRotation], measured in page space). The
+  /// view quad also carries the page's display /Rotate: on a /Rotate 90
+  /// page every square annotation's lower edge runs down the screen, so
+  /// the view angle alone reads a plain text box as turned 90° - which
+  /// transposed its handles (the right-middle one resized vertically,
+  /// with an up-down cursor) and committed a transposed box. A page's
+  /// rotation turns the whole page, chrome included, so an annotation
+  /// square to its page is square to the chrome too.
   (Rect, double)? get _selectionChrome {
     final selected = _selectedViewRect;
     if (selected == null) return null;
+    if (_controller.selectedAnnotation?.appearanceRotation == 0) {
+      return (selected, 0);
+    }
     final quad = _selectedViewQuad;
     if (quad == null) return (selected, 0);
     final angle = _quadAngle(quad);
@@ -2881,15 +2894,26 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         rotateHandleDistance: _rotateHandleDistance,
       );
 
-  /// The resize cursor for a handle by its corner/edge: orthogonal edges
-  /// get the straight resize cursors, corners the matching diagonal.
-  static MouseCursor _resizeCursorFor(_Handle handle) =>
-      switch ((handle.dx, handle.dy)) {
-        (0, _) => SystemMouseCursors.resizeUpDown,
-        (_, 0) => SystemMouseCursors.resizeLeftRight,
-        (-1, -1) || (1, 1) => SystemMouseCursors.resizeUpLeftDownRight,
-        _ => SystemMouseCursors.resizeUpRightDownLeft,
-      };
+  /// The resize cursor for a handle by the direction it actually points
+  /// on screen: the handle's outward direction in the selection's local
+  /// frame, spun by its resting [rotation] and snapped to the nearest of
+  /// the four resize cursors. Unrotated, that is the plain corner/edge
+  /// mapping (edges straight, corners diagonal); rotated, the cursor
+  /// follows the handle round instead of promising an axis the drag
+  /// won't move along.
+  static MouseCursor _resizeCursorFor(_Handle handle, [double rotation = 0]) {
+    final angle =
+        math.atan2(handle.dy.toDouble(), handle.dx.toDouble()) + rotation;
+    // eight compass points, folded to the four cursors (each covers a
+    // direction and its opposite): E, SE, S, SW
+    const cursors = [
+      SystemMouseCursors.resizeLeftRight,
+      SystemMouseCursors.resizeUpLeftDownRight,
+      SystemMouseCursors.resizeUpDown,
+      SystemMouseCursors.resizeUpRightDownLeft,
+    ];
+    return cursors[(angle / (math.pi / 4)).round() % 4];
+  }
 
   _Handle? _handleAt(Rect rect, Offset position) {
     if (!_controller.canResizeSelected) return null;
@@ -3717,7 +3741,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           _moveCurrent = position;
           // hold the matching resize cursor through the drag (hover stops
           // firing once the pointer is down)
-          _cursor = _resizeCursorFor(handle);
+          _cursor = _resizeCursorFor(handle, resting);
         });
         // lift the box off the page for a re-wrapping (free-text) resize:
         // render the page without it so the preview floats over the real
@@ -4980,7 +5004,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       if (vertex != null) {
         cursor = grabCursor;
       } else if (handle != null) {
-        cursor = _resizeCursorFor(handle);
+        cursor = _resizeCursorFor(handle, resting);
       } else if (chrome != null &&
           _hitsRotateHandle(chrome.$1, resting, event.localPosition)) {
         // no system rotation cursor: hide it and paint a curved-arrow glyph

--- a/packages/dart_pdf_editor/test/editing_rotated_page_resize_test.dart
+++ b/packages/dart_pdf_editor/test/editing_rotated_page_resize_test.dart
@@ -1,0 +1,175 @@
+// Resizing an annotation on a display-rotated (/Rotate 90) page.
+//
+// The selection chrome spins for an annotation whose *appearance* is
+// rotated inside its /Rect. A page's /Rotate is not that: it turns the
+// whole page, chrome included, so an annotation square to its page is
+// square on screen too. Reading the on-screen quad alone conflated the
+// two - every box on a rotated page looked turned 90°, which transposed
+// its handles (the right-middle one resized vertically, with an up-down
+// cursor) and committed a transposed box.
+
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_overlay.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The overlay's own MouseRegion cursor - what the system shows on hover.
+MouseCursor regionCursor(WidgetTester tester) {
+  final paint = find
+      .descendant(
+          of: find.byType(EditingPageOverlay),
+          matching: find.byType(CustomPaint))
+      .first;
+  final region =
+      find.ancestor(of: paint, matching: find.byType(MouseRegion)).first;
+  return tester.widget<MouseRegion>(region).cursor;
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  // A 612×792 page with /Rotate 90 displays landscape: 792pt across an
+  // 800px viewport. Page (x, y) lands at view (y, x) · scale.
+  const scale = 800 / 792;
+  Offset view(double x, double y) => Offset(y * scale, x * scale);
+
+  Future<PdfEditingController> pumpViewer(WidgetTester tester,
+      {int rotation = 90}) async {
+    final editing =
+        PdfEditingController(buildMultiPagePdf(1, rotation: rotation));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            controller: viewer,
+            editing: editing,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return editing;
+  }
+
+  Future<TestGesture> hoverAt(WidgetTester tester, Offset target) async {
+    final g = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await g.addPointer(location: const Offset(5, 5));
+    addTearDown(g.removePointer);
+    await tester.pump();
+    await g.moveTo(target);
+    await tester.pump();
+    return g;
+  }
+
+  // A text box that reads as a wide one on screen: page-space 50×200
+  // (x 100..150, y 500..700), which the page's quarter turn shows as
+  // 200 wide and 50 tall.
+  Future<PdfEditingController> selectedTextBox(WidgetTester tester) async {
+    final editing = await pumpViewer(tester);
+    editing
+      ..preferences.fontSize = 12
+      ..addFreeText(0, const PdfRect(100, 500, 150, 700), 'BPM')
+      ..tool = PdfEditTool.select;
+    expect(editing.selectAnnotationAt(0, 125, 600), isTrue);
+    await tester.pump();
+    return editing;
+  }
+
+  testWidgets('a text box on a rotated page is not treated as rotated',
+      (tester) async {
+    final editing = await selectedTextBox(tester);
+    expect(editing.selectedAnnotation!.appearanceRotation, 0);
+  });
+
+  testWidgets('the right-middle handle shows the left-right resize cursor',
+      (tester) async {
+    await selectedTextBox(tester);
+    // the middle of the box's right edge on screen: page (125, 700)
+    await hoverAt(tester, view(125, 700));
+    expect(regionCursor(tester), SystemMouseCursors.resizeLeftRight);
+  });
+
+  testWidgets('dragging the right-middle handle widens the box on screen',
+      (tester) async {
+    final editing = await selectedTextBox(tester);
+
+    // drag it 50pt to the right on screen - which is +y in page space
+    final gesture = await tester.startGesture(view(125, 700));
+    await gesture.moveBy(Offset(25 * scale, 0));
+    await gesture.moveBy(Offset(25 * scale, 0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(const Duration(milliseconds: 350));
+
+    // the box grew along its screen width only: page x untouched, page
+    // y extended past the dragged edge. Transposing it (the bug) turned
+    // the wide box into a tall one instead.
+    final rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(100, 0.5));
+    expect(rect.right, closeTo(150, 0.5));
+    expect(rect.bottom, closeTo(500, 0.5));
+    expect(rect.top, closeTo(750, 0.5));
+  });
+
+  testWidgets('the top-middle handle still resizes the box vertically',
+      (tester) async {
+    final editing = await selectedTextBox(tester);
+
+    // the middle of the box's top edge on screen is page (100, 600) -
+    // dragged with a mouse, since a vertical touch drag over the page
+    // belongs to the scroll view
+    final gesture = await tester.startGesture(view(100, 600),
+        kind: PointerDeviceKind.mouse);
+    await gesture.moveBy(Offset(0, -10 * scale));
+    await gesture.moveBy(Offset(0, -10 * scale));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle(const Duration(milliseconds: 350));
+
+    // screen-up is -x in page space
+    final rect = editing.document.page(0).annotations.single.rect;
+    expect(rect.left, closeTo(80, 0.5));
+    expect(rect.right, closeTo(150, 0.5));
+    expect(rect.bottom, closeTo(500, 0.5));
+    expect(rect.top, closeTo(700, 0.5));
+  });
+
+  testWidgets('a genuinely rotated annotation still spins its chrome',
+      (tester) async {
+    // same viewer, unrotated page: a square turned 90° by the rotate
+    // knob keeps the local-frame treatment (its cursor follows the
+    // handle round, and the resize runs along the artwork's own axes)
+    final editing = await pumpViewer(tester, rotation: 0);
+    const scale0 = 800 / 612;
+    Offset view0(double x, double y) => Offset(x * scale0, (792 - y) * scale0);
+    editing
+      ..color = const Color(0xFFFF0000)
+      ..addRectangle(0, const PdfRect(150, 450, 300, 550))
+      ..tool = PdfEditTool.select
+      ..selectAnnotation(0, 0)
+      ..rotateSelected(90);
+    await tester.pump();
+
+    final annotation = editing.selectedAnnotation!;
+    expect(annotation.appearanceRotation, closeTo(math.pi / 2, 1e-6));
+    // 150×100 about (225,500) → page rect 100×150; the local +x axis
+    // points up on screen, so the local right-middle handle sits on the
+    // top edge - and its cursor reads up-down, the direction it moves
+    await hoverAt(tester, view0(225, 575));
+    expect(regionCursor(tester), SystemMouseCursors.resizeUpDown);
+  });
+}

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -873,6 +873,29 @@ class PdfAnnotation {
     ];
   }
 
+  /// The rotation the normal appearance carries in **page space**: the
+  /// angle of [appearanceQuad]'s lower-left → lower-right edge, radians
+  /// counterclockwise. 0 for an unrotated appearance (and without one);
+  /// non-zero only when the artwork is turned inside its /Rect, as
+  /// [PdfEditor.rotateAnnotation] leaves it.
+  ///
+  /// This is the annotation's *own* rotation, so it is the right gate for
+  /// "does this need the rotated (local-frame) treatment?". A viewer's
+  /// on-screen quad also carries the page's display /Rotate, which is not
+  /// a property of the annotation - an unrotated box on a /Rotate 90 page
+  /// has a quad running down the screen and must still be treated as
+  /// square.
+  double get appearanceRotation {
+    final quad = appearanceQuad;
+    if (quad == null) return 0;
+    final dx = quad[1].$1 - quad[0].$1;
+    final dy = quad[1].$2 - quad[0].$2;
+    if (dx == 0 && dy == 0) return 0;
+    final angle = math.atan2(dy, dx);
+    // numeric noise within ~0.3° reads as unrotated
+    return angle.abs() < 0.005 ? 0 : angle;
+  }
+
   static PdfGoToAction? _destAsGoTo(PdfDocument document, CosObject? raw) {
     final destination = PdfDestination.parse(document, raw);
     return destination == null ? null : PdfGoToAction(destination);

--- a/packages/pdf_document/test/annotation_test.dart
+++ b/packages/pdf_document/test/annotation_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
@@ -141,6 +143,29 @@ void main() {
 
     test('fieldValue is null without a /V anywhere', () {
       expect(widget('address').fieldValue, isNull);
+    });
+  });
+
+  group('appearanceRotation', () {
+    test('is 0 for an appearance square to its /Rect', () {
+      final doc = PdfDocument.open(buildAppearanceAnnotationsPdf());
+      // the Square's /AP is a plain BBox scaled onto its /Rect
+      expect(doc.page(0).annotations.first.appearanceRotation, 0);
+    });
+
+    test("reads the quarter turn out of an /AP's /Matrix", () {
+      final doc = PdfDocument.open(buildAppearanceAnnotationsPdf());
+      // the Stamp's /AP carries /Matrix [0 1 -1 0 0 0]
+      final stamp =
+          doc.page(0).annotations.firstWhere((a) => a.subtype == 'Stamp');
+      expect(stamp.appearanceRotation, closeTo(math.pi / 2, 1e-9));
+    });
+
+    test('is 0 without an appearance stream', () {
+      final doc = PdfDocument.open(buildAnnotatedPdf());
+      final bare =
+          doc.page(0).annotations.firstWhere((a) => a.normalAppearance == null);
+      expect(bare.appearanceRotation, 0);
     });
   });
 }

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -142,8 +142,12 @@ Uint8List buildXrefStreamPdf() {
 /// [width]/[height] size the /MediaBox in points - US Letter by default.
 /// Oversize a page when the test is about what a page's dimensions cost
 /// (raster budgets, sampling rasters), not about its content.
+///
+/// [rotation] writes /Rotate on every page (0 - the default - omits it),
+/// for tests about a display-rotated page: what the viewer shows is the
+/// page turned clockwise by that many degrees.
 Uint8List buildMultiPagePdf(int pageCount,
-    {double width = 612, double height = 792}) {
+    {double width = 612, double height = 792, int rotation = 0}) {
   // whole points write as integers - PDF accepts either, tests read better
   String num(double v) => v == v.roundToDouble() ? '${v.round()}' : '$v';
   final objects = <String>[];
@@ -157,6 +161,7 @@ Uint8List buildMultiPagePdf(int pageCount,
     final content = 'BT /F1 24 Tf 72 720 Td (Page ${i + 1}) Tj ET';
     objects.add('<< /Type /Page /Parent 2 0 R '
         '/MediaBox [0 0 ${num(width)} ${num(height)}] '
+        '${rotation == 0 ? '' : '/Rotate $rotation '}'
         '/Contents ${4 + i * 2} 0 R '
         '/Resources << /Font << /F1 $fontNumber 0 R >> >> >>');
     objects.add('<< /Length ${content.length} >>\nstream\n$content\nendstream');


### PR DESCRIPTION
## Summary

Resizing a free-text box on a `/Rotate 90` page transposed it: grabbing the right-middle handle showed an up-down cursor, the drag preview spun the box (text and all) a quarter turn, and the committed result turned a 200×50 label into a 50×200 one with its text clipped.

The overlay derived a selection's resting rotation from the appearance quad mapped into **view** space, which folds in the page's display `/Rotate` — so on a rotated page the lower-left→lower-right edge of *every* square annotation runs down the screen and read as ±90°. Everything downstream then took the rotated (local-frame) path: handle hit-testing unrotated the pointer, the free-text preview drew spun, the inline text editor opened on the transposed box, and the commit handed the editor a transposed page rect.

The gate is now the rotation the **annotation** carries, in page space — the same measure the editor side (`resizeAnnotationLocal`, `restyleAnnotation`) has always used:

- `PdfAnnotation.appearanceRotation` (new, `pdf_document`) — the angle of `appearanceQuad`'s ll→lr edge, radians CCW. `PdfEditingController` drops its private `_appearanceRotationOf` for it.
- `_selectionChrome` returns the plain axis-aligned view rect whenever that is 0, whatever the page's `/Rotate`. A page's rotation turns the whole page, chrome included, so an annotation square to its page is square to its chrome.

A genuinely rotated appearance (`rotateAnnotation`, or a producer that bakes the turn into the `/Matrix`) is unaffected: it keeps the local-frame chrome, preview and resize, on rotated and unrotated pages alike.

Second, `_resizeCursorFor` now takes the resting angle and picks the cursor from the direction the handle actually points on screen (eight compass points folded onto the four resize cursors) — a rotated selection stops promising an axis its drag won't move along.

Write-up: `doc/dev-log/2026-09-04-rotated-page-selection-chrome.md`.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [x] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log entry)

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test` (870 passing)
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2536 passing)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Also ran the app package suite (503 passing). `pdf_cos` and `pdf_graphics` are untouched, and nothing here changes rendering, so the corpus/Ghent sweeps were not run — the change is confined to editing chrome geometry and one new read-only getter.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out (one extra appearance-quad read per chrome query; no render-path change).

## PDF fixtures and screenshots

`buildMultiPagePdf` gains an optional `rotation` parameter that writes `/Rotate` on every page, so the new tests drive the real viewer over a display-rotated page rather than needing a sample file.

`packages/dart_pdf_editor/test/editing_rotated_page_resize_test.dart` covers the right-middle handle's cursor, the drag that must widen the box on screen (page `/Rect` grows along page +y, page x untouched), the top-middle handle in the other axis, and a genuinely rotated square on an unrotated page keeping its spun chrome and follow-the-handle cursor. `annotation_test.dart` covers `appearanceRotation` directly. Each new test was checked against the unpatched source and fails there.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

One case is knowingly left as it was: an appearance rotated by a **non-quarter** angle **on a rotated page** still takes the local path, where `_geometry.toPageRect` transposes a sideways page's local box on the way to `resizeSelectedLocal`. Fixing it needs the local rect built from the page-space quad centre plus view-space edge lengths instead of mapping a view rect; noted under "Still open" in the dev-log.

Note also that a content-stream counter-rotation (how `addFreeText` &co. keep artwork upright on a rotated page) is invisible to `/BBox`×`/Matrix`, so the quad genuinely cannot distinguish that from an annotation drawn sideways on a rotated page. Treating "square to its page" as "square to its chrome" is right for both: the chrome box is the same rectangle either way, and a `/Rect` resize along the view axes is what both want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g46MFspv4QxSJVq5ekCT7

---
_Generated by [Claude Code](https://claude.ai/code/session_012g46MFspv4QxSJVq5ekCT7)_