### PR TITLE
Zoom around the pointer, on the wheel path and on the web's scale path

### DIFF
--- a/doc/dev-log/2026-09-04-ctrl-wheel-zoom-cursor-anchor.md
+++ b/doc/dev-log/2026-09-04-ctrl-wheel-zoom-cursor-anchor.md
@@ -1,0 +1,76 @@
+# Ctrl/Cmd+wheel zoom lands off the cursor
+
+Reported as "ctrl zoom does not accurately zoom on the cursor position,
+it's not aligned". Reproduced in `pdf_viewer.dart` `_zoomTo` - the shared
+focal-point path behind wheel zoom, touch pinch, trackpad pinch and
+`PdfViewerController.setZoom`.
+
+## Why it drifts
+
+The viewer splits zoom at the fit-width seam: at or below it the pages
+**lay out** smaller (and re-centre on the cross axis), above it they ride
+the InteractiveViewer transform. A notch that crosses the seam therefore
+moves the content under the pointer twice - once by the relayout, once by
+the transform - and `_zoomTo` only ever accounted for the second.
+
+Three concrete bugs fell out of that:
+
+- **The layout relayout was applied to a stale focal point.** Crossing up
+  through the seam calls `_setLayoutZoom(1, ...)` and *then* built the
+  transform around the same list-space focal point, which by then pointed
+  at different content. On the cross axis the pages had re-centred under
+  the pointer, so the anchor was off by the whole re-centring.
+- **Crossing down through the seam pinned the wrong thing.**
+  `_setLayoutZoom(focalMain:)` anchors in list space, and the caller passed
+  the gesture's list-space position - but the transform is dropped to
+  identity in the same breath, so the point had to be pinned where the
+  pointer is *in the viewport*, not where it maps to while still zoomed.
+  Off by the whole zoom-window translation (94 px in the regression test).
+- **`pageSpacing` does not scale with the layout zoom**, but the scroll
+  compensation was a flat `(pixels + anchor) * ratio`, so it drifted by one
+  gap per page ahead of the pointer - 37 px by page 4 of the test document,
+  and a whole page deep into a real one.
+
+`PdfViewerController.setZoom` had the same class of bug: it passed the raw
+viewport centre as a list-space focal point, so a zoomed, panned viewer
+zoomed around whatever happened to sit at the untransformed centre.
+
+## The shape of the fix
+
+`_zoomTo` now resolves the focal point into three values before touching
+anything: where the pointer is in the **viewport** (`viewFocal`), which
+**content** sits under it (`contentMain`, a list coordinate at the current
+layout zoom), and - after any relayout - where that content **ended up**
+(`scene`, via the new `_remapMain`/`_remapCross`). The transform is then
+built from scratch to put `scene` back under `viewFocal`:
+`T(viewFocal) · S(zoom) · T(-scene)`. With no layout change that is
+algebraically identical to the old post-multiply, so the pure-transform
+path is unchanged.
+
+`_remapMain` walks the pages so the constant `pageSpacing` gaps are carried
+across a layout-zoom change instead of being scaled with them;
+`_remapCross` is the closed form of the centring (every page is centred on
+the cross axis, so the whole axis scales about the viewport centre).
+`_setLayoutZoom` takes the content coordinate to pin as well as the
+viewport anchor to pin it at.
+
+## Deliberately still not anchored
+
+The cross axis at the seam. Zooming in one notch from `PdfViewerFit.page`
+wants to hold a point that would need the page pushed off its own left
+edge, and `_clampedTransform` refuses to show canvas beside the page once
+zoom lives in the transform (below the seam it is the layout that centres
+the page, with no offset to give). So that first notch grows the page about
+the viewport's cross centre - which is what Chrome's viewer does too - and
+every notch after it anchors exactly. The scroll axis anchors in all cases.
+
+`test/ctrl_wheel_zoom_focus_test.dart` covers both regimes and both seam
+crossings; two of its six cases fail on the old code.
+
+## Test gotcha (not a product bug)
+
+`await controller.jumpToPage(3)` deadlocks a widget test: the jump is close
+enough to animate, and nothing pumps frames while the test awaits it. Use
+`unawaited(...)` and `pumpAndSettle()`. `jumpToPage(4)` in the same fixture
+snaps instead (past the `max(_mainView * 2, 2400)` distance) and so looks
+fine - which is what makes it confusing.

--- a/doc/dev-log/2026-09-04-ctrl-wheel-zoom-cursor-anchor.md
+++ b/doc/dev-log/2026-09-04-ctrl-wheel-zoom-cursor-anchor.md
@@ -74,3 +74,44 @@ enough to animate, and nothing pumps frames while the test awaits it. Use
 `unawaited(...)` and `pumpAndSettle()`. `jumpToPage(4)` in the same fixture
 snaps instead (past the `max(_mainView * 2, 2400)` distance) and so looks
 fine - which is what makes it confusing.
+
+## The half that only shows up in a browser
+
+The fixes above are all on the wheel path - `PointerScrollEvent` - which is
+what a desktop ctrl+wheel is, and what the widget tests drive. On the **web**
+that path never runs: the browser reports ctrl+wheel as a *pinch*, so Flutter
+delivers a `PointerScaleEvent`, `_onPointerSignal` ignores it (`event is!
+PointerScrollEvent`), and InteractiveViewer handles it - correctly, around the
+pointer, in the transform.
+
+Then `_settleZoomGesture` (IV's `onInteractionEnd`, which fires for a pointer
+signal too) folded that transform into the page layout with
+`_setLayoutZoom(total)` - **no focal point** - and the fold re-anchored the
+whole document on the viewport centre. Measured in Chromium against the
+example app at its default fit-page open, one ctrl+wheel notch at (620, 400):
+the content under the cursor landed 84 px above it. The arithmetic agrees
+exactly: the fold's scroll jump differs from the pointer-anchored one by
+`(s - 1) x (focal - viewport centre)` = `0.822 x (290 - 395)` = -86 px.
+
+A fold is a pure scale, so holding any one viewport point holds every other:
+the settle now measures which content sits under the main axis' centre
+*through the transform it is about to drop*, and pins that. Scaling about the
+viewport centre is already right for the cross axis - the layout centres every
+page there - so only the main axis needed the leftover translation computed
+against the (possibly clamped) scroll jump.
+
+Same measurement after: drift `(-83, 0)` instead of `(-83, -84)`; the -83 is
+the cross-axis limit described above (that notch makes the page exactly fill
+the viewport width, so there is no offset left to give). A second notch, above
+the seam, holds within 1 px on both axes - and did before this change too,
+which is why the bug reads as "only the first notch is wrong" on a document
+opened at fit-page.
+
+How it was measured, in case it is useful again: build the example for web,
+serve `build/web`, drive Chromium through Playwright (`page.keyboard.down
+('Control')` + `page.mouse.wheel`), and cross-correlate the patch under the
+cursor from the before frame - scaled by the known `e^(120/200)` notch - with
+the after frame. Two gotchas: point the loader at the local `canvaskit/`
+(no network in the sandbox), and pass a locale, or the engine throws
+`Incorrect locale information provided` before the app boots - which is why
+CI's Patrol invocation carries `--web-locale en-US`.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -7675,18 +7675,43 @@ class _PdfViewerState extends State<PdfViewer>
   /// always hard-clamped; the cross axis is left untouched so
   /// [_springBackCross] can animate it back smoothly.
   void _settleZoomGesture() {
-    final total = _transform.value.getMaxScaleOnAxis() * _layoutZoom;
+    final before = _transform.value;
+    final scale = before.getMaxScaleOnAxis();
+    final total = scale * _layoutZoom;
+    // Whatever the gesture zoomed around survives only in the transform's
+    // translation, so both folds below have to carry it or the settle
+    // silently re-zooms the document around the viewport centre.
+    //
+    // That is what a **web** ctrl+wheel looked like: the browser reports it
+    // as a PointerScaleEvent, which this viewer leaves to InteractiveViewer
+    // (it zooms around the pointer, correctly) - and then this settle threw
+    // the focal point away and jumped the scroll to a centre-anchored zoom.
+    // A fold is a pure scale, so pinning the content under one viewport
+    // point pins every other one; pin the main axis' centre.
+    final anchor = _mainView / 2;
+    final pixels = _scroll.hasClients ? _scroll.position.pixels : 0.0;
+    final content = scale <= 0
+        ? pixels + anchor
+        : pixels + (anchor - before.storage[_mainTranslate]) / scale;
     if (total <= 1) {
       _transform.value = Matrix4.identity();
-      _setLayoutZoom(total);
+      _setLayoutZoom(total, focalMain: anchor, contentMain: content);
     } else if (_layoutZoom < 1) {
       // fold the layout factor into the transform zoom
       final fold = _layoutZoom;
-      _setLayoutZoom(1);
-      final matrix = _transform.value.clone()
+      _setLayoutZoom(1, focalMain: anchor, contentMain: content);
+      final matrix = before.clone()
         ..translateByDouble(_viewWidth / 2, _viewHeight / 2, 0, 1)
         ..scaleByDouble(fold, fold, fold, 1)
         ..translateByDouble(-_viewWidth / 2, -_viewHeight / 2, 0, 1);
+      // Scaling about the viewport centre is already right for the cross
+      // axis: the layout centres every page there, so the relayout and this
+      // fold scale about the same point. The main axis is pinned by the
+      // scroll jump above instead, and its translation is whatever that jump
+      // could not absorb once the extents clamped it.
+      final settled = _scroll.hasClients ? _scroll.position.pixels : 0.0;
+      matrix.storage[_mainTranslate] =
+          anchor - total * (_remapMain(content, fold, 1) - settled);
       _transform.value = _clampedTransformMainOnly(matrix);
     } else {
       _transform.value = _clampedTransformMainOnly(_transform.value.clone());

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2631,7 +2631,12 @@ class _PdfViewerState extends State<PdfViewer>
     // the public zoom is logical px per point (1 = actual size); the
     // internal layout/transform machinery works in fit-width multiples
     final target = _fitScale <= 0 ? scale : scale / _fitScale;
-    _zoomTo(target, Offset(_viewWidth / 2, _viewHeight / 2));
+    // [_zoomTo] takes a list-space focal point (every gesture caller sits
+    // inside the zoom transform), so the viewport centre has to be mapped
+    // back through the current transform - otherwise a zoomed, panned
+    // viewer zooms around whatever happens to sit at the untransformed
+    // centre instead of what the reader is looking at.
+    _zoomTo(target, _sceneOf(Offset(_viewWidth / 2, _viewHeight / 2)));
     _settleControllerViewportCommand();
   }
 
@@ -2658,36 +2663,120 @@ class _PdfViewerState extends State<PdfViewer>
     });
   }
 
-  void _zoomTo(double target, Offset focal) {
-    final zoom = target.clamp(widget.minZoom, _effectiveMaxZoom);
-    if (zoom <= 1) {
-      if (_transform.value.getMaxScaleOnAxis() > 1) {
-        _transform.value = Matrix4.identity();
-      }
-      _setLayoutZoom(zoom, focalMain: _mainOf(focal));
-    } else {
-      if (_layoutZoom < 1) _setLayoutZoom(1, focalMain: _mainOf(focal));
-      final matrix = _transform.value.clone();
-      final factor = zoom / matrix.getMaxScaleOnAxis();
-      matrix
-        ..translateByDouble(focal.dx, focal.dy, 0, 1)
-        ..scaleByDouble(factor, factor, factor, 1)
-        ..translateByDouble(-focal.dx, -focal.dy, 0, 1);
-      _transform.value = _touchPanning
-          ? _clampedTransformMainOnly(matrix)
-          : _clampedTransform(matrix);
-    }
+  /// The scene (list) point under viewport point [view] - the inverse of the
+  /// zoom transform, which is only ever a uniform scale plus a translation.
+  Offset _sceneOf(Offset view) {
+    final matrix = _transform.value;
+    final scale = matrix.getMaxScaleOnAxis();
+    if (scale <= 0) return view;
+    return Offset((view.dx - matrix.storage[12]) / scale,
+        (view.dy - matrix.storage[13]) / scale);
   }
 
-  /// Lays the pages out at [zoom] × fit (≤ 1), keeping the content at
-  /// [focalMain] (viewport coordinates along the scroll axis) as stationary
-  /// as the new scroll extents allow.
-  void _setLayoutZoom(double zoom, {double? focalMain}) {
+  /// Zooms to [target] (fit multiples) holding the content under [focal]
+  /// still. [focal] is a **list-space** point: every gesture that calls this
+  /// - wheel, touch pinch, trackpad pinch - is received inside the zoom
+  /// transform, so that is the space its local position arrives in.
+  ///
+  /// Two spaces meet here, which is what makes zoom-to-cursor subtle. The
+  /// pointer is fixed in *viewport* space, but the content under it lives in
+  /// list space and moves whenever the layout zoom changes: pages relay out
+  /// bigger or smaller and re-centre on the cross axis. So the focal point is
+  /// resolved into three values up front - where the pointer is on screen,
+  /// which content sits under it, and where that content ends up after any
+  /// relayout - and the new transform is then built to put the third back
+  /// under the first.
+  void _zoomTo(double target, Offset focal) {
+    final zoom = target.clamp(widget.minZoom, _effectiveMaxZoom);
+    final before = _transform.value;
+    final scale = before.getMaxScaleOnAxis();
+    // where the pointer is in the viewport (below fit the transform is
+    // identity and the two spaces coincide; above it they do not)
+    final viewFocal = Offset(focal.dx * scale + before.storage[12],
+        focal.dy * scale + before.storage[13]);
+    // the list coordinate of the content under the pointer, at the layout
+    // zoom in force right now
+    final contentMain =
+        (_scroll.hasClients ? _scroll.position.pixels : 0.0) + _mainOf(focal);
+    if (zoom <= 1) {
+      if (scale > 1) _transform.value = Matrix4.identity();
+      // the anchor is where the content must land once the transform is
+      // gone, which is the pointer's viewport position - not the list point
+      // it maps to today
+      _setLayoutZoom(zoom,
+          focalMain: _mainOf(viewFocal), contentMain: contentMain);
+      return;
+    }
+    var scene = focal;
+    if (_layoutZoom < 1) {
+      final from = _layoutZoom;
+      _setLayoutZoom(1,
+          focalMain: _mainOf(viewFocal), contentMain: contentMain);
+      // the pages just relaid out under the pointer: the scene point to hold
+      // has moved - along the main axis by as much of the scroll jump as the
+      // extents allowed, along the cross axis by the re-centring, which no
+      // scroll offset can absorb
+      final pixels = _scroll.hasClients ? _scroll.position.pixels : 0.0;
+      scene = _axisOffset(
+        _remapMain(contentMain, from, _layoutZoom) - pixels,
+        _remapCross(_crossOf(focal), from, _layoutZoom),
+      );
+    }
+    // hold [scene] under [viewFocal] at the new zoom
+    final matrix = Matrix4.identity()
+      ..translateByDouble(viewFocal.dx, viewFocal.dy, 0, 1)
+      ..scaleByDouble(zoom, zoom, zoom, 1)
+      ..translateByDouble(-scene.dx, -scene.dy, 0, 1);
+    _transform.value = _touchPanning
+        ? _clampedTransformMainOnly(matrix)
+        : _clampedTransform(matrix);
+  }
+
+  /// Maps a main-axis list coordinate from layout zoom [from] to [to].
+  ///
+  /// Page sizes scale with the layout zoom but [PdfViewer.pageSpacing] does
+  /// not, so the plain ratio drifts by one gap per page ahead of the point -
+  /// a whole page's worth deep into a long document.
+  double _remapMain(double main, double from, double to) {
+    if (from <= 0 || to == from) return main;
+    final ratio = to / from;
+    final spacing = widget.pageSpacing;
+    if (spacing == 0 || _pages.isEmpty) return main * ratio;
+    var oldStart = 0.0;
+    var newStart = 0.0;
+    for (var i = 0; i < _pages.length; i++) {
+      final extent = _mainPointOf(i) * _fitScale;
+      final oldMain = extent * from;
+      if (main < oldStart + oldMain || i == _pages.length - 1) {
+        return newStart + (main - oldStart) * ratio;
+      }
+      oldStart += oldMain + spacing;
+      newStart += extent * to + spacing;
+    }
+    return main * ratio;
+  }
+
+  /// Maps a cross-axis list coordinate from layout zoom [from] to [to]. Every
+  /// page is centred on the cross axis and scales about that centre, so the
+  /// whole axis does.
+  double _remapCross(double cross, double from, double to) {
+    if (from <= 0 || to == from) return cross;
+    final centre = _crossView / 2;
+    return centre + (cross - centre) * (to / from);
+  }
+
+  /// Lays the pages out at [zoom] × fit (≤ 1), keeping [contentMain] (a
+  /// list coordinate along the scroll axis, at the *current* layout zoom;
+  /// defaults to whatever sits at [focalMain] now) at [focalMain] (viewport
+  /// coordinates along the scroll axis) as stationary as the new scroll
+  /// extents allow.
+  void _setLayoutZoom(double zoom, {double? focalMain, double? contentMain}) {
     final z = zoom.clamp(widget.minZoom, 1.0);
     if (z == _layoutZoom) return;
     final anchor = focalMain ?? _mainView / 2;
     final pixels = _scroll.hasClients ? _scroll.position.pixels : 0.0;
-    final target = (pixels + anchor) * (z / _layoutZoom) - anchor;
+    final content = contentMain ?? pixels + anchor;
+    final target = _remapMain(content, _layoutZoom, z) - anchor;
     setState(() => _layoutZoom = z);
     _controller._bumpViewport();
     if (_scroll.hasClients) {

--- a/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
+++ b/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
@@ -1,0 +1,146 @@
+// Ctrl/Cmd+wheel zooms around the pointer: the document point under the
+// cursor must stay under the cursor.
+//
+// The subtle half is the fit-width seam. Below it zoom lives in the page
+// layout (pages relay out smaller and re-centre); above it in the viewer's
+// transform. A wheel notch that crosses the seam moves the content under the
+// pointer twice - once by the relayout, once by the transform - so the focal
+// point has to be carried across the change, not applied to a scene that has
+// already moved. Page spacing does not scale with the layout zoom either, so
+// the relayout's scroll compensation has to count the gaps rather than scale
+// the whole offset.
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  Future<PdfViewerController> pumpViewer(WidgetTester tester,
+      {PdfViewerFit fit = PdfViewerFit.width}) async {
+    final controller = PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: fit,
+          document: PdfDocument.open(buildMultiPagePdf(6)),
+          controller: controller,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  /// The page rendered under [at], as (its page object, its screen rect).
+  (Object, Rect) pageUnder(WidgetTester tester, Offset at) {
+    for (final element in find.byType(PdfPageView).evaluate()) {
+      final rect = tester.getRect(find.byElementPredicate((e) => e == element));
+      if (rect.contains(at)) {
+        return ((element.widget as PdfPageView).page, rect);
+      }
+    }
+    fail('no page under $at');
+  }
+
+  Rect rectOf(WidgetTester tester, Object page) => tester.getRect(find
+      .byWidgetPredicate((w) => w is PdfPageView && identical(w.page, page)));
+
+  Future<void> ctrlWheel(WidgetTester tester, Offset at, double dy) async {
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+    final pointer = TestPointer(301, PointerDeviceKind.mouse);
+    pointer.hover(at);
+    await tester.sendEventToBinding(pointer.scroll(Offset(0, dy)));
+    await tester.pump();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+  }
+
+  /// Where the document point that sat at [at] inside [before] has landed.
+  Offset moved(Rect before, Rect after, Offset at) => Offset(
+        after.left + (at.dx - before.left) / before.width * after.width,
+        after.top + (at.dy - before.top) / before.height * after.height,
+      );
+
+  group('ctrl+wheel zoom holds the point under the cursor', () {
+    testWidgets('zooming in at fit-width', (tester) async {
+      final controller = await pumpViewer(tester);
+      const at = Offset(250, 180);
+      final (page, before) = pageUnder(tester, at);
+      await ctrlWheel(tester, at, -120);
+      expect(controller.zoom, greaterThan(1.01));
+      expect(moved(before, rectOf(tester, page), at),
+          within(distance: 1, from: at));
+    });
+
+    testWidgets('four notches in a row', (tester) async {
+      await pumpViewer(tester);
+      const at = Offset(600, 420);
+      final (page, before) = pageUnder(tester, at);
+      for (var i = 0; i < 4; i++) {
+        await ctrlWheel(tester, at, -120);
+      }
+      expect(moved(before, rectOf(tester, page), at),
+          within(distance: 1, from: at));
+    });
+
+    testWidgets('zooming back out', (tester) async {
+      await pumpViewer(tester);
+      const at = Offset(250, 180);
+      await ctrlWheel(tester, at, -240);
+      final (page, before) = pageUnder(tester, at);
+      await ctrlWheel(tester, at, 120);
+      expect(moved(before, rectOf(tester, page), at),
+          within(distance: 1, from: at));
+    });
+
+    // Below fit-width the pages lay out smaller and centred, so a notch here
+    // crosses the seam: the relayout moves the content under the pointer
+    // before the transform ever sees it.
+    testWidgets('crossing the fit-width seam, scroll axis', (tester) async {
+      await pumpViewer(tester, fit: PdfViewerFit.page);
+      const at = Offset(250, 180);
+      final (page, before) = pageUnder(tester, at);
+      await ctrlWheel(tester, at, -120);
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    // ...and deep in the document, where the un-scaled page gaps used to
+    // drift the compensating scroll jump by a gap per page.
+    testWidgets('crossing the seam deep in the document', (tester) async {
+      final controller = await pumpViewer(tester, fit: PdfViewerFit.page);
+      unawaited(controller.jumpToPage(4));
+      await tester.pumpAndSettle();
+      const at = Offset(400, 300);
+      final (page, before) = pageUnder(tester, at);
+      await ctrlWheel(tester, at, -120);
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    // Zooming out below the seam is the mirror image: the transform is
+    // dropped, so the scroll jump has to pin the content to where the
+    // pointer is on screen, not to the list point it maps to while zoomed.
+    testWidgets('crossing the seam downwards, scroll axis', (tester) async {
+      final controller = await pumpViewer(tester, fit: PdfViewerFit.page);
+      unawaited(controller.jumpToPage(3));
+      await tester.pumpAndSettle();
+      // zoom in past the seam around a point away from the viewport centre,
+      // so the zoom window carries a translation the scroll jump must undo
+      await ctrlWheel(tester, const Offset(200, 150), -200);
+      expect(controller.zoom, greaterThan(1.01));
+      const at = Offset(600, 450);
+      final (page, before) = pageUnder(tester, at);
+      await ctrlWheel(tester, at, 200);
+      expect(controller.zoom, lessThan(1));
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+  });
+}
+
+Matcher within({required double distance, required Offset from}) =>
+    predicate<Offset>(
+        (o) => (o - from).distance <= distance, 'within $distance of $from');

--- a/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
+++ b/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
@@ -66,6 +66,60 @@ void main() {
         after.top + (at.dy - before.top) / before.height * after.height,
       );
 
+  // The web reports ctrl+wheel as a PointerScaleEvent, not a scroll: the
+  // viewer leaves those to InteractiveViewer (which zooms around the pointer)
+  // and folds the result into the page layout when the gesture settles. The
+  // fold used to be anchored on the viewport centre, so on web the document
+  // slid out from under the pointer however well the wheel path behaved.
+  Future<void> scaleSignal(WidgetTester tester, Offset at, double scale) async {
+    await tester.sendEventToBinding(PointerScaleEvent(
+      position: at,
+      kind: PointerDeviceKind.mouse,
+      scale: scale,
+    ));
+    await tester.pump();
+    await tester.pumpAndSettle();
+  }
+
+  group('web ctrl+wheel (a scale signal) holds the point under the cursor', () {
+    testWidgets('crossing up into the transform', (tester) async {
+      await pumpViewer(tester, fit: PdfViewerFit.page);
+      const at = Offset(300, 200);
+      final (page, before) = pageUnder(tester, at);
+      await scaleSignal(tester, at, 1.6);
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    testWidgets('staying below fit-width', (tester) async {
+      await pumpViewer(tester, fit: PdfViewerFit.page);
+      const at = Offset(300, 200);
+      final (page, before) = pageUnder(tester, at);
+      await scaleSignal(tester, at, 1.15);
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    testWidgets('deep in the document', (tester) async {
+      final controller = await pumpViewer(tester, fit: PdfViewerFit.page);
+      unawaited(controller.jumpToPage(4));
+      await tester.pumpAndSettle();
+      const at = Offset(400, 450);
+      final (page, before) = pageUnder(tester, at);
+      await scaleSignal(tester, at, 1.4);
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    testWidgets('already above fit-width, both axes', (tester) async {
+      final controller = await pumpViewer(tester);
+      await scaleSignal(tester, const Offset(400, 300), 2.0);
+      expect(controller.zoom, greaterThan(1.01));
+      const at = Offset(300, 200);
+      final (page, before) = pageUnder(tester, at);
+      await scaleSignal(tester, at, 1.5);
+      expect(moved(before, rectOf(tester, page), at),
+          within(distance: 1, from: at));
+    });
+  });
+
   group('ctrl+wheel zoom holds the point under the cursor', () {
     testWidgets('zooming in at fit-width', (tester) async {
       final controller = await pumpViewer(tester);

--- a/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
+++ b/packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart
@@ -82,11 +82,31 @@ void main() {
   }
 
   group('web ctrl+wheel (a scale signal) holds the point under the cursor', () {
-    testWidgets('crossing up into the transform', (tester) async {
-      await pumpViewer(tester, fit: PdfViewerFit.page);
+    // Still below the fit-width seam afterwards, so the settle drops the
+    // transform and the whole zoom goes back into the page layout. (The seam
+    // is a fit multiple, not a px/pt zoom: on this fixture fit-width is about
+    // 1.3 px/pt, so a 1.6x signal from fit-page lands short of it.)
+    testWidgets('below fit-width, where the transform is folded away',
+        (tester) async {
+      final controller = await pumpViewer(tester, fit: PdfViewerFit.page);
       const at = Offset(300, 200);
       final (page, before) = pageUnder(tester, at);
       await scaleSignal(tester, at, 1.6);
+      expect(controller.zoom, lessThan(1.3));
+      expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
+    });
+
+    // Past the seam the settle folds the other way - the layout zoom is
+    // folded *into* the transform - and the focal point has to survive that
+    // fold too. A big enough scale clears the seam in one signal.
+    testWidgets('crossing up into the transform', (tester) async {
+      final controller = await pumpViewer(tester, fit: PdfViewerFit.page);
+      const at = Offset(300, 200);
+      final (page, before) = pageUnder(tester, at);
+      await scaleSignal(tester, at, 2.2);
+      expect(controller.zoom, greaterThan(1.4),
+          reason: 'past fit-width, so the settle folds the layout zoom into '
+              'the transform rather than the other way round');
       expect(moved(before, rectOf(tester, page), at).dy, closeTo(at.dy, 1));
     });
 


### PR DESCRIPTION
## Summary

Ctrl/Cmd+wheel zoom did not hold the document point under the cursor: the page slid out from under the pointer as it zoomed. There turned out to be two independent causes — one on each of the two paths a ctrl+wheel can take — and the second one is the one a browser actually hits.

Zoom lives in two places. At or below fit-width the pages **lay out** smaller (and re-centre on the cross axis); above it they ride the InteractiveViewer transform. Crossing that seam moves the content under the pointer twice — once by the relayout, once by the transform.

### 1. The wheel path (`PointerScrollEvent` — desktop ctrl+wheel, touch and trackpad pinch)

`_zoomTo` only ever accounted for the transform half. It now resolves the focal point into three values before touching anything: where the pointer is in the **viewport**, which **content** sits under it, and where that content **ends up** after any relayout. The new transform is then built to put the third back under the first (`T(viewFocal) · S(zoom) · T(-scene)`), which with no layout change is algebraically identical to the old post-multiply — so the pure-transform path is unchanged.

Three concrete bugs fixed there:

- **Crossing the seam upwards** applied the transform around a focal point the relayout had already invalidated (the pages had re-centred under the pointer).
- **Crossing the seam downwards** pinned the gesture's list-space position while dropping the transform that defined it, losing the whole zoom-window translation — 94 px in the regression test.
- **`pageSpacing` does not scale with the layout zoom**, but the compensating scroll jump scaled the whole offset, drifting one gap per page ahead of the pointer (37 px by page 4 of the test document, a whole page deep into a real one). New `_remapMain` walks the pages and carries the constant gaps across; `_remapCross` is the closed form of the cross-axis centring.

`PdfViewerController.setZoom` had the same class of bug — it passed the raw viewport centre as a list-space focal point, so a zoomed, panned viewer zoomed around whatever sat at the untransformed centre. It now maps that centre back through the transform.

### 2. The scale path (`PointerScaleEvent` — **this is web ctrl+wheel**)

On the web the wheel path never runs. The browser reports ctrl+wheel as a pinch, so Flutter delivers a `PointerScaleEvent`; `_onPointerSignal` ignores it (`event is! PointerScrollEvent`) and InteractiveViewer handles it — correctly, around the pointer. Then `_settleZoomGesture` folded IV's transform into the page layout with `_setLayoutZoom(total)` and **no focal point**, re-anchoring the whole document on the viewport centre.

A fold is a pure scale, so holding one viewport point holds every other: the settle now measures which content sits under the main axis' centre *through the transform it is about to drop*, and pins that. Scaling about the viewport centre is already right for the cross axis (the layout centres every page there), so only the main axis needed its leftover translation computed against the — possibly clamped — scroll jump.

The settle folds the other way too, packing the layout zoom into the transform once a gesture clears fit-width, and that fold carries the focal point by the same argument.

### Deliberately still not anchored

The **cross axis at the seam itself**. Holding that point on the first notch out of `PdfViewerFit.page` would need canvas beside the page, which `_clampedTransform` refuses once zoom lives in the transform (and below the seam it is the layout that centres the page, with no offset to give). That notch grows the page about the viewport's cross centre — what Chrome's viewer does too — and every notch after it anchors exactly. The scroll axis anchors in every case.

Rationale, the measurement method, and the test-only `jumpToPage` deadlock gotcha are written up in `doc/dev-log/2026-09-04-ctrl-wheel-zoom-cursor-anchor.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — no issues found
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2541 passed, 27 skipped
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test — driven for real in Chromium, see below

If any relevant check was not run, explain why: the change is confined to the viewer's gesture/zoom math in `dart_pdf_editor`, so the pure-Dart package suites and the corpus render sweeps cannot be affected — nothing in the parse or render pipeline is touched.

### Measured in a real browser

The web half cannot be seen from a widget test, so it was measured end to end: build the example for web, serve `build/web`, drive Chromium through Playwright (`keyboard.down('Control')` + `mouse.wheel`), then cross-correlate the image patch under the cursor from the before frame — scaled by the known `e^(120/200)` notch — against the after frame. Drift of the content under the cursor, in device pixels:

| Case (example app, default fit-page open) | Before | After |
| --- | ---: | ---: |
| One notch at (620, 400), from a fresh open | `(-83, -84)` | `(-83, 0)` |
| A notch above the seam, at (500, 300) | `(-1, -1)` | `(-1, 0)` |

The remaining -83 is the cross-axis limit described above: that notch makes the page exactly fill the viewport width, so there is no offset left to give. The second row is why the bug reads as "only the first notch is wrong" on a document opened at fit-page.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered — no new states; scroll-extent and transform clamps are unchanged, and a clamp still legitimately wins over the anchor at the document's edges.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked — `_zoomTo` is shared by ctrl+wheel, touch pinch, trackpad pinch and `setZoom`; `_settleZoomGesture` additionally covers InteractiveViewer-owned pinches and the web scale signal. All are exercised by the existing suite plus the new cases.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable — not applicable, no document mutation.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out — ruled out: the added work is a few arithmetic operations per zoom event plus a bounded page walk that runs only when the layout zoom actually changes. Nothing per-frame or per-render changed, so no perf sweep applies.

## PDF fixtures and screenshots

New widget test `packages/dart_pdf_editor/test/ctrl_wheel_zoom_focus_test.dart` measures the drift directly: it locates the page under the cursor, applies the gesture, and asserts the same document point is still under the cursor. Eleven cases across both zoom regimes, both seam crossings and both folds, and both event types. Five of them fail on the pre-fix code — 37 px and 94 px on the wheel path, 60 px, 15 px and 60 px on the scale path.

Note on reading those cases: the seam is a **fit multiple**, not a px/pt zoom. On this fixture fit-width is about 1.3 px/pt, so a 1.6x scale signal from fit-page reports `zoom` 1.21 and still settles *below* the seam — which is why the case that exercises the fold into the transform takes 2.2x and asserts a zoom past fit-width.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The one behavioural judgement call worth a second opinion is the cross axis at the seam (see above). Anchoring it would mean letting `_clampedTransform` show canvas beside the page just past fit, which is a broader policy change than this fix.
- `_settleZoomGesture` still clamps only the main axis after a fold, leaving the cross axis for `_springBackCross` — unchanged.
- Test gotcha found on the way: `await controller.jumpToPage(3)` deadlocks a widget test — the jump is close enough to animate and nothing pumps frames while the test awaits it. `jumpToPage(4)` in the same fixture snaps instead and looks fine, which is what makes it confusing.
- Two gotchas for anyone repeating the browser measurement: point the loader at the local `canvaskit/` (no network in a sandbox), and pass a locale, or the engine throws `Incorrect locale information provided` before the app boots — which is why CI's Patrol invocation carries `--web-locale en-US`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01911aWoDp97PzxeB6EsLFJQ