### PR TITLE
fix(viewer): avoid blurry text under multi-line highlights

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1160,6 +1160,16 @@ class PdfViewer extends StatefulWidget {
     int rotation,
   )? debugAnnotationAppearanceRendererOverride;
 
+  /// List-returning counterpart used to exercise one annotation owning several
+  /// tightly bounded appearance pictures. Takes precedence over
+  /// [debugAnnotationAppearanceRendererOverride].
+  @visibleForTesting
+  static Future<List<ui.Picture>> Function(
+    PdfPage page,
+    PdfAnnotation annotation,
+    int rotation,
+  )? debugAnnotationAppearancePicturesRendererOverride;
+
   /// Test observer called immediately before an annotation appearance picture
   /// is disposed. Production ownership and disposal remain unchanged.
   @visibleForTesting
@@ -8639,7 +8649,7 @@ class _AnnotationAppearanceLayerState
   /// The stream half is typed `Object` because `CosStream` is not exported
   /// into this library; it uses identity equality, so the key mixes stream
   /// identity with the [PdfRect]'s value equality - exactly the intent.
-  final Map<(Object, PdfRect), ui.Picture> _cache = {};
+  final Map<(Object, PdfRect), List<ui.Picture>> _cache = {};
   int? _cacheRotation;
   Size? _cacheSize;
 
@@ -8714,7 +8724,7 @@ class _AnnotationAppearanceLayerState
     // normally disjoint, but overlapping render generations must still never
     // dispose the same native handle twice.
     final owned = Set<ui.Picture>.identity()
-      ..addAll(_cache.values)
+      ..addAll(_cache.values.expand((pictures) => pictures))
       ..addAll(_retired);
     _cache.clear();
     _cacheRotation = null;
@@ -8762,7 +8772,7 @@ class _AnnotationAppearanceLayerState
     // still references these until the next publish, and a frame can paint
     // in between.
     if (_cacheRotation != widget.rotation || _cacheSize != pageSize) {
-      _retire(_cache.values);
+      _retire(_cache.values.expand((pictures) => pictures));
       _cache.clear();
       _cacheRotation = widget.rotation;
       _cacheSize = pageSize;
@@ -8786,7 +8796,7 @@ class _AnnotationAppearanceLayerState
       for (final annotation in annotations) _appearanceKey(annotation),
     };
     for (final source in _cache.keys.toList()) {
-      if (!live.contains(source)) _retire([_cache.remove(source)!]);
+      if (!live.contains(source)) _retire(_cache.remove(source)!);
     }
 
     final missing = [
@@ -8846,19 +8856,19 @@ class _AnnotationAppearanceLayerState
       final annotation = missing[i];
       final source = _appearanceKey(annotation);
       if (!_cache.containsKey(source)) {
-        final picture = await _renderAnnotation(page, annotation, rotation);
+        final pictures = await _renderAnnotation(page, annotation, rotation);
         if (!mounted || generation != _generation || !widget.active) {
-          if (picture != null) _disposePicture(picture);
+          _disposePictureList(pictures);
           return;
         }
-        if (picture != null) {
+        if (pictures.isNotEmpty) {
           // A newer overlapping generation may have filled this slot while
-          // the decoder was awaiting. Keep one owner of the native picture.
+          // the decoder was awaiting. Keep one owner of the native pictures.
           final existing = _cache[source];
           if (existing != null) {
-            _disposePicture(picture);
+            _disposePictureList(pictures);
           } else {
-            _cache[source] = picture;
+            _cache[source] = pictures;
           }
         }
       }
@@ -8879,7 +8889,7 @@ class _AnnotationAppearanceLayerState
     if (!mounted || generation != _generation) return;
     final next = [
       for (final annotation in annotations)
-        if (_cache[_appearanceKey(annotation)] case final picture?) picture,
+        ...?_cache[_appearanceKey(annotation)],
     ];
     setState(() {
       _pictures = next;
@@ -8910,15 +8920,32 @@ class _AnnotationAppearanceLayerState
     _retired.clear();
   }
 
-  Future<ui.Picture?> _renderAnnotation(
+  Future<List<ui.Picture>> _renderAnnotation(
       PdfPage page, PdfAnnotation annotation, int rotation) async {
     try {
+      final picturesOverride =
+          PdfViewer.debugAnnotationAppearancePicturesRendererOverride;
+      if (picturesOverride != null) {
+        return await picturesOverride(page, annotation, rotation);
+      }
       final override = PdfViewer.debugAnnotationAppearanceRendererOverride;
-      if (override != null) return await override(page, annotation, rotation);
-      return await PdfPageRenderer.renderAnnotationPicture(page, annotation,
-          rotation: rotation);
+      if (override != null) {
+        final picture = await override(page, annotation, rotation);
+        return picture == null ? const [] : [picture];
+      }
+      return await PdfPageRenderer.renderAnnotationPictures(
+        page,
+        annotation,
+        rotation: rotation,
+      );
     } catch (_) {
-      return null;
+      return const [];
+    }
+  }
+
+  void _disposePictureList(Iterable<ui.Picture> pictures) {
+    for (final picture in pictures) {
+      _disposePicture(picture);
     }
   }
 

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -9,6 +9,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'canvas_device.dart';
 import 'image_decoder.dart';
+import 'page_geometry.dart';
 import 'render_worker.dart';
 import 'strips/strip_device.dart';
 
@@ -550,7 +551,40 @@ class PdfPageRenderer {
   static Future<ui.Picture?> renderAnnotationPicture(
       PdfPage page, PdfAnnotation annotation,
       {int? rotation}) async {
-    if (annotation.normalAppearance == null) return null;
+    final pictures = await _renderAnnotationPictures(
+      page,
+      annotation,
+      rotation: rotation,
+      splitWrappedHighlight: false,
+    );
+    return pictures.isEmpty ? null : pictures.single;
+  }
+
+  /// Renders an annotation for the viewer's resting appearance layer.
+  ///
+  /// A Highlight whose axis-aligned `/QuadPoints` span several lines is
+  /// recorded as one tightly clipped picture per quad. Keeping the advanced
+  /// Multiply blend out of the annotation's much larger union `/Rect` avoids
+  /// an intermediate Windows compositor surface covering both text lines.
+  /// Other annotations retain the single-picture behavior of
+  /// [renderAnnotationPicture].
+  static Future<List<ui.Picture>> renderAnnotationPictures(
+          PdfPage page, PdfAnnotation annotation,
+          {int? rotation}) =>
+      _renderAnnotationPictures(
+        page,
+        annotation,
+        rotation: rotation,
+        splitWrappedHighlight: true,
+      );
+
+  static Future<List<ui.Picture>> _renderAnnotationPictures(
+    PdfPage page,
+    PdfAnnotation annotation, {
+    required bool splitWrappedHighlight,
+    int? rotation,
+  }) async {
+    if (annotation.normalAppearance == null) return const [];
     final cos = page.document.cos;
 
     final collector = ImageCollector();
@@ -560,32 +594,62 @@ class PdfPageRenderer {
         cache: PdfImageCache.instance);
 
     final box = page.cropBox;
-    final size = pageSize(page, rotation: rotation);
-    final recorder = ui.PictureRecorder();
-    final canvas = Canvas(recorder);
-    _applyPageTransform(canvas, page, size, box, rotation: rotation);
+    final effectiveRotation = rotation ?? page.rotation;
+    final size = pageSize(page, rotation: effectiveRotation);
+    final quads = annotation.behavior.markupQuads;
+    final splitQuads = splitWrappedHighlight &&
+            annotation.subtype == 'Highlight' &&
+            quads != null &&
+            quads.length > 1 &&
+            quads.every((quad) =>
+                quad.left.isFinite &&
+                quad.bottom.isFinite &&
+                quad.right.isFinite &&
+                quad.top.isFinite &&
+                quad.width > 0 &&
+                quad.height > 0)
+        ? quads
+        : null;
+    final clips = splitQuads ?? const <PdfRect?>[null];
+    final geometry = PdfPageGeometry(
+      cropBox: box,
+      rotation: effectiveRotation,
+      viewSize: size,
+    );
+    final pictures = <ui.Picture>[];
+    try {
+      for (final clip in clips) {
+        final recorder = ui.PictureRecorder();
+        final rasterClip = clip == null ? null : geometry.toViewRect(clip);
+        final canvas = Canvas(recorder, rasterClip);
+        _applyPageTransform(canvas, page, size, box,
+            rotation: effectiveRotation);
+        if (clip != null) {
+          canvas.clipRect(
+            Rect.fromLTRB(clip.left, clip.bottom, clip.right, clip.top),
+          );
+        }
 
-    // pixelRatio 0 turns the one-device-pixel stroke floor off (#660). This
-    // picture is scale-independent - the appearance layer replays it at
-    // whatever page-to-view scale the viewer is at - so flooring here would
-    // bake a scale-dependent choice in: every positive width under 1 pt
-    // would become a Skia hairline that stays one pixel at 333% zoom. A
-    // pressure-sensitive ink stroke is exactly that case (a 1.5 pt pen at
-    // zero pressure draws 0.6 pt), and it visibly snapped from its live
-    // width to a hairline the moment this picture replaced the overlay.
-    // A genuine `0 w` stroke arrives here as 0 and still paints as Skia's
-    // hairline, which is what §8.4.3.2 asks for. The raster paths that do
-    // know their output scale keep their positive ratio, so #426's
-    // CAD-linework floor is untouched.
-    PdfInterpreter(
-            cos: cos,
-            device: CanvasPdfDevice(canvas, images: images, pixelRatio: 0))
-        .drawAnnotation(page, annotation);
-    final picture = recorder.endRecording();
-    for (final image in images.values) {
-      disposePdfDecodedImage(image);
+        // pixelRatio 0 turns the one-device-pixel stroke floor off (#660).
+        // The pictures are scale-independent; flooring here would bake a
+        // scale-dependent choice into every later replay.
+        PdfInterpreter(
+          cos: cos,
+          device: CanvasPdfDevice(canvas, images: images, pixelRatio: 0),
+        ).drawAnnotation(page, annotation);
+        pictures.add(recorder.endRecording());
+      }
+      return List.unmodifiable(pictures);
+    } catch (_) {
+      for (final picture in pictures) {
+        picture.dispose();
+      }
+      rethrow;
+    } finally {
+      for (final image in images.values) {
+        disposePdfDecodedImage(image);
+      }
     }
-    return picture;
   }
 
   /// Renders [page] to a bitmap. [pixelRatio] of 2 doubles the resolution.

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -562,12 +562,14 @@ class PdfPageRenderer {
 
   /// Renders an annotation for the viewer's resting appearance layer.
   ///
-  /// A Highlight whose axis-aligned `/QuadPoints` span several lines is
-  /// recorded as one tightly clipped picture per quad. Keeping the advanced
-  /// Multiply blend out of the annotation's much larger union `/Rect` avoids
-  /// an intermediate Windows compositor surface covering both text lines.
-  /// Other annotations retain the single-picture behavior of
-  /// [renderAnnotationPicture].
+  /// A Highlight with a small set of pairwise-disjoint, axis-aligned
+  /// `/QuadPoints` is recorded as one tightly clipped picture per quad.
+  /// Keeping the advanced Multiply blend out of the annotation's much larger
+  /// union `/Rect` avoids an intermediate Windows compositor surface covering
+  /// several text lines. Overlapping or long quad lists retain the
+  /// single-picture behavior of [renderAnnotationPicture]: overlap must not
+  /// composite the full appearance repeatedly, and split replay must stay
+  /// bounded rather than becoming quadratic in the quad count.
   static Future<List<ui.Picture>> renderAnnotationPictures(
           PdfPage page, PdfAnnotation annotation,
           {int? rotation}) =>
@@ -601,13 +603,15 @@ class PdfPageRenderer {
             annotation.subtype == 'Highlight' &&
             quads != null &&
             quads.length > 1 &&
+            quads.length <= _maxSplitHighlightQuads &&
             quads.every((quad) =>
                 quad.left.isFinite &&
                 quad.bottom.isFinite &&
                 quad.right.isFinite &&
                 quad.top.isFinite &&
                 quad.width > 0 &&
-                quad.height > 0)
+                quad.height > 0) &&
+            _arePairwiseDisjoint(quads)
         ? quads
         : null;
     final clips = splitQuads ?? const <PdfRect?>[null];
@@ -650,6 +654,26 @@ class PdfPageRenderer {
         disposePdfDecodedImage(image);
       }
     }
+  }
+
+  /// Bounds interpreter replay for the split path. Each clipped picture still
+  /// replays the complete appearance, so an unbounded list would do O(q²)
+  /// command work. Longer highlights take the legacy one-picture path.
+  static const int _maxSplitHighlightQuads = 8;
+
+  static bool _arePairwiseDisjoint(List<PdfRect> quads) {
+    for (var i = 0; i < quads.length; i++) {
+      final a = quads[i];
+      for (var j = i + 1; j < quads.length; j++) {
+        final b = quads[j];
+        final overlaps = a.left < b.right &&
+            a.right > b.left &&
+            a.bottom < b.top &&
+            a.top > b.bottom;
+        if (overlaps) return false;
+      }
+    }
+    return true;
   }
 
   /// Renders [page] to a bitmap. [pixelRatio] of 2 doubles the resolution.

--- a/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
+++ b/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
@@ -112,6 +112,51 @@ void main() {
     expect(renders, 6);
   });
 
+  testWidgets('one annotation can own and dispose several appearance pictures',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    editing.addRectangle(0, const PdfRect(100, 600, 250, 640));
+
+    final rendered = <ui.Picture>[];
+    final disposals = Map<ui.Picture, int>.identity();
+    PdfViewer.debugAnnotationAppearancePicturesRendererOverride =
+        (_, __, ___) async {
+      for (var i = 0; i < 2; i++) {
+        final recorder = ui.PictureRecorder();
+        Canvas(recorder).drawRect(
+          Rect.fromLTWH(i.toDouble(), 0, 1, 1),
+          Paint()..color = const Color(0xFF000000),
+        );
+        rendered.add(recorder.endRecording());
+      }
+      return List.unmodifiable(rendered);
+    };
+    PdfViewer.debugAnnotationAppearanceDisposeObserver = (picture) {
+      disposals.update(picture, (count) => count + 1, ifAbsent: () => 1);
+    };
+    addTearDown(() {
+      PdfViewer.debugAnnotationAppearancePicturesRendererOverride = null;
+      PdfViewer.debugAnnotationAppearanceDisposeObserver = null;
+    });
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: PdfViewerFit.width,
+          document: editing.document,
+          editing: editing,
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(rendered, hasLength(2));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(disposals.keys, unorderedEquals(rendered));
+    expect(disposals.values, everyElement(1));
+  });
+
   testWidgets('restyling one annotation keeps the other on screen',
       (tester) async {
     final editing = await pumpViewer(tester);

--- a/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
+++ b/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
@@ -134,6 +134,72 @@ void main() {
     expect(pictures, hasLength(1));
   });
 
+  test('overlapping Highlight quads keep one compositing pass', () async {
+    final editing = PdfEditingController(buildTextLinesPdf(const ['Overlap']));
+    addTearDown(editing.dispose);
+    editing.apply(
+      (editor) => editor.addHighlight(
+        0,
+        const [
+          PdfRect(36, 716, 140, 732),
+          PdfRect(100, 716, 205, 732),
+        ],
+        opacity: 0.5,
+      ),
+    );
+
+    final page = editing.document.page(0);
+    final annotation = page.annotations.single;
+    final pictures = await PdfPageRenderer.renderAnnotationPictures(
+      page,
+      annotation,
+    );
+    addTearDown(() => _disposeAll(pictures));
+    expect(pictures, hasLength(1),
+        reason: 'replaying the complete appearance per overlapping clip '
+            'would darken their intersection repeatedly');
+
+    final legacy = await PdfPageRenderer.renderAnnotationPicture(
+      page,
+      annotation,
+    );
+    addTearDown(legacy!.dispose);
+    const union = ui.Rect.fromLTRB(34, 58, 207, 80);
+    expect(
+      await _rgbaRegion(pictures.single, union),
+      await _rgbaRegion(legacy, union),
+      reason: 'overlap must preserve the legacy single-pass pixels',
+    );
+  });
+
+  test('long Highlights keep bounded single-picture rendering', () async {
+    final editing = PdfEditingController(
+      buildTextLinesPdf(List.generate(9, (i) => 'Highlighted line $i')),
+    );
+    addTearDown(editing.dispose);
+    editing.apply(
+      (editor) => editor.addHighlight(
+        0,
+        [
+          for (var i = 0; i < 9; i++)
+            PdfRect(36, 716.0 - i * 20, 180, 732.0 - i * 20),
+        ],
+        opacity: 1,
+      ),
+    );
+
+    final page = editing.document.page(0);
+    final pictures = await PdfPageRenderer.renderAnnotationPictures(
+      page,
+      page.annotations.single,
+    );
+    addTearDown(() => _disposeAll(pictures));
+
+    expect(pictures, hasLength(1),
+        reason: 'nine full appearance replays would already do 81 quad '
+            'draws; long lists must use one bounded replay');
+  });
+
   test('multi-quad non-Highlight markup keeps the one-picture path', () async {
     final editing = PdfEditingController(buildTextLinesPdf(const ['A', 'B']));
     addTearDown(editing.dispose);

--- a/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
+++ b/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
@@ -1,0 +1,159 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<int> _alphaAt(ui.Picture picture, ui.Offset point) async {
+  final image = await PdfPageRenderer.rasterizeRegion(
+    picture,
+    ui.Rect.fromCenter(center: point, width: 1, height: 1),
+    2,
+  );
+  try {
+    final bytes = (await image.toByteData())!;
+    return bytes.getUint8(3);
+  } finally {
+    image.dispose();
+  }
+}
+
+Future<Uint8List> _rgbaRegion(
+  ui.Picture picture,
+  ui.Rect region,
+) async {
+  final image = await PdfPageRenderer.rasterizeRegion(picture, region, 2);
+  try {
+    final bytes = (await image.toByteData())!;
+    return Uint8List.fromList(bytes.buffer.asUint8List());
+  } finally {
+    image.dispose();
+  }
+}
+
+ui.Picture _combine(Iterable<ui.Picture> pictures) {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder);
+  for (final picture in pictures) {
+    canvas.drawPicture(picture);
+  }
+  return recorder.endRecording();
+}
+
+void _disposeAll(Iterable<ui.Picture> pictures) {
+  for (final picture in pictures) {
+    picture.dispose();
+  }
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('a wrapped Highlight records one clipped picture per markup quad',
+      () async {
+    final editing = PdfEditingController(
+      buildTextLinesPdf(
+        const ['First highlighted line', 'Second highlighted line'],
+        size: 12,
+      ),
+    );
+    addTearDown(editing.dispose);
+    editing.apply(
+      (editor) => editor.addHighlight(
+        0,
+        const [
+          PdfRect(36, 716, 180, 732),
+          PdfRect(36, 692, 205, 708),
+        ],
+        color: 0xFFFF00,
+        opacity: 1,
+      ),
+    );
+
+    final page = editing.document.page(0);
+    final annotation = page.annotations.single;
+    final pictures = await PdfPageRenderer.renderAnnotationPictures(
+      page,
+      annotation,
+    );
+    addTearDown(() => _disposeAll(pictures));
+
+    expect(pictures, hasLength(2));
+
+    // Annotation pictures use rotated page-raster space (y down). For a
+    // 792-point page these are the centres of the first quad, second quad,
+    // and the vertical gap between them.
+    const first = ui.Offset(80, 68);
+    const second = ui.Offset(80, 92);
+    const gap = ui.Offset(80, 80);
+
+    expect(await _alphaAt(pictures[0], first), greaterThan(0));
+    expect(await _alphaAt(pictures[0], second), 0);
+    expect(await _alphaAt(pictures[0], gap), 0);
+
+    expect(await _alphaAt(pictures[1], first), 0);
+    expect(await _alphaAt(pictures[1], second), greaterThan(0));
+    expect(await _alphaAt(pictures[1], gap), 0);
+
+    final legacy = await PdfPageRenderer.renderAnnotationPicture(
+      page,
+      annotation,
+    );
+    final combined = _combine(pictures);
+    addTearDown(legacy!.dispose);
+    addTearDown(combined.dispose);
+    const union = ui.Rect.fromLTRB(34, 58, 207, 102);
+    expect(
+      await _rgbaRegion(combined, union),
+      await _rgbaRegion(legacy, union),
+      reason: 'splitting must not alter colour, alpha, or Multiply pixels',
+    );
+  });
+
+  test('a single-quad Highlight keeps the one-picture path', () async {
+    final editing = PdfEditingController(buildTextLinesPdf(const ['One line']));
+    addTearDown(editing.dispose);
+    editing.apply(
+      (editor) => editor.addHighlight(
+        0,
+        const [PdfRect(36, 716, 120, 732)],
+        opacity: 1,
+      ),
+    );
+
+    final page = editing.document.page(0);
+    final pictures = await PdfPageRenderer.renderAnnotationPictures(
+      page,
+      page.annotations.single,
+    );
+    addTearDown(() => _disposeAll(pictures));
+
+    expect(pictures, hasLength(1));
+  });
+
+  test('multi-quad non-Highlight markup keeps the one-picture path', () async {
+    final editing = PdfEditingController(buildTextLinesPdf(const ['A', 'B']));
+    addTearDown(editing.dispose);
+    editing.apply(
+      (editor) => editor.addUnderline(
+        0,
+        const [
+          PdfRect(36, 716, 80, 732),
+          PdfRect(36, 692, 80, 708),
+        ],
+      ),
+    );
+
+    final page = editing.document.page(0);
+    final pictures = await PdfPageRenderer.renderAnnotationPictures(
+      page,
+      page.annotations.single,
+    );
+    addTearDown(() => _disposeAll(pictures));
+
+    expect(pictures, hasLength(1));
+  });
+}


### PR DESCRIPTION
## Summary

Fixes blurry text beneath multi-line Highlight annotations, most noticeable on Windows at fractional zoom levels such as 165%.

## Root Cause

Multi-line Highlight annotations were previously rendered as a single `ui.Picture` covering the union of their `/QuadPoints`.

Because Highlights use the `Multiply` blend mode, the Windows GPU compositor could create and resample a large intermediate surface covering multiple text lines. At fractional zoom levels, this caused the text within that area to appear blurred.

## Changes

- Render multi-line Highlights as one tightly clipped `ui.Picture` per `/QuadPoints` region.
- Update the annotation appearance cache to support multiple pictures per annotation.
- Preserve the existing single-picture path for:
  - Single-line Highlights
  - Underline, StrikeOut, and Squiggly annotations
  - All other annotation types
- Preserve the original color, opacity, appearance stream, and `Multiply` blending behavior.
- Avoid page raster invalidation and re-rendering.

## Performance Impact

The change only affects multi-line Highlight annotations.

A two-line Highlight now replays two small pictures instead of one large picture. This adds a small number of draw calls but reduces the intermediate compositing area. It does not trigger page raster refreshes, so the expected performance impact is negligible.

## Issue
<img width="1785" height="1368" alt="image" src="https://github.com/user-attachments/assets/4d235fcf-8e3e-4ffe-bb38-9efccdbfbe76" />

## Result
<img width="1166" height="945" alt="image" src="https://github.com/user-attachments/assets/ab212a17-359b-45bc-bb0c-154f575efd2a" />


<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [ ] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [x] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
