### PR TITLE
Add annotation alignment guides and page rulers

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -669,6 +669,24 @@ typedef _ShapeResize = ({
   double opacity,
 });
 
+/// One transient smart-guide line in view space. Vertical guides carry an
+/// x [position] and y [from]/[to]; horizontal guides carry a y [position]
+/// and x [from]/[to].
+typedef _AlignmentGuide = ({
+  Axis axis,
+  double position,
+  double from,
+  double to,
+});
+
+/// One edge/centre another annotation (or the page) can align to.
+typedef _AlignmentTarget = ({
+  double position,
+  double from,
+  double to,
+  int role,
+});
+
 /// Which sides of the selection a resize handle moves: -1 left/top edge,
 /// +1 right/bottom edge, 0 leaves that axis alone. (View space, y down.)
 // Resize-handle geometry lives in handle_layout.dart as a pure, unit-testable
@@ -965,6 +983,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   // the painter spins by _resizeAngle), not page-axis view rects.
   Offset? _moveStart;
   Offset? _moveCurrent;
+
+  /// Smart guides currently holding a move/resize on an annotation edge or
+  /// centre. They exist only for the live drag and never enter the PDF.
+  List<_AlignmentGuide> _alignmentGuides = const [];
 
   /// The global position of the annotation or content move's current point -
   /// captured so a drop over another page can be resolved to a page point
@@ -1319,6 +1341,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         preferences.gridSpacing > 0;
   }
 
+  /// Smart alignment uses the same temporary Alt bypass as the grid. Its
+  /// tolerance is converted from screen pixels to this overlay's view space,
+  /// so it feels equally magnetic at every transform zoom.
+  bool get _smartAlignmentSnapping =>
+      _controller.preferences.smartAlignmentGuides &&
+      !HardwareKeyboard.instance.isAltPressed;
+
+  static const double _alignmentTolerance = 6;
+
   /// Snaps a view-space point to the nearest page-space grid intersection.
   /// The grid begins at the crop box's lower-left corner, so it is stable
   /// across layout zoom, transform zoom, and /Rotate.
@@ -1334,15 +1365,238 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     return _geometry.toViewOffset(snappedX, snappedY);
   }
 
-  /// Applies grid snapping to a move without making the result depend on
-  /// where inside the annotation the user grabbed it. The primary box's
-  /// top-left corner is the anchor that lands on the grid; the pointer keeps
-  /// its original grab offset from that box.
-  Offset _snapMovePosition(Offset start, Offset current, Rect? anchorRect) {
-    if (!_gridSnapping || anchorRect == null) return current;
+  /// The visible bounds of the whole annotation selection on this page.
+  /// Multi-selection snapping treats the group as one object, like design
+  /// tools do, instead of pulling whichever annotation happened to be last.
+  Rect? get _selectedGroupViewRect {
+    final rects = _selectedViewRects;
+    if (rects.isEmpty) return null;
+    var bounds = rects.first;
+    for (final rect in rects.skip(1)) {
+      bounds = bounds.expandToInclude(rect);
+    }
+    return bounds;
+  }
+
+  /// Edges and centres on this page that a dragged annotation can meet.
+  /// Hidden annotations and the current selection are omitted. The page's
+  /// outside edges and centre are always candidates, which makes centering a
+  /// box possible even on an otherwise empty page.
+  List<_AlignmentTarget> _alignmentTargetsFor(Axis axis) {
+    final pageSize = _geometry.viewSize;
+    final targets = <_AlignmentTarget>[];
+    void addRect(Rect rect) {
+      if (rect.isEmpty || !rect.isFinite) return;
+      if (axis == Axis.vertical) {
+        for (final (x, role) in [
+          (rect.center.dx, 0),
+          (rect.left, -1),
+          (rect.right, 1),
+        ]) {
+          targets
+              .add((position: x, from: rect.top, to: rect.bottom, role: role));
+        }
+      } else {
+        for (final (y, role) in [
+          (rect.center.dy, 0),
+          (rect.top, -1),
+          (rect.bottom, 1),
+        ]) {
+          targets
+              .add((position: y, from: rect.left, to: rect.right, role: role));
+        }
+      }
+    }
+
+    // The page frame is a full-span target, so a page-centre snap draws a
+    // reassuring page-height/width line instead of a tiny unexplained mark.
+    if (axis == Axis.vertical) {
+      for (final (x, role) in [
+        (pageSize.width / 2, 0),
+        (0.0, -1),
+        (pageSize.width, 1),
+      ]) {
+        targets.add((position: x, from: 0, to: pageSize.height, role: role));
+      }
+    } else {
+      for (final (y, role) in [
+        (pageSize.height / 2, 0),
+        (0.0, -1),
+        (pageSize.height, 1),
+      ]) {
+        targets.add((position: y, from: 0, to: pageSize.width, role: role));
+      }
+    }
+
+    final selected = <int>{
+      for (final slot in _controller.selectedAnnotationSlots)
+        if (slot.$1 == widget.pageIndex) slot.$2,
+    };
+    final annotations = _controller.pageAt(widget.pageIndex).annotations;
+    for (var i = 0; i < annotations.length; i++) {
+      if (selected.contains(i)) continue;
+      final annotation = annotations[i];
+      if (annotation.isHidden ||
+          annotation.isNoView ||
+          annotation.subtype == 'Popup') {
+        continue;
+      }
+      addRect(_geometry.toViewRect(annotation.calloutBox ?? annotation.rect));
+    }
+    return targets;
+  }
+
+  /// Finds the closest x and y alignment independently. The returned delta
+  /// shifts [moving] onto those targets; the guides span both objects (or the
+  /// whole page for page targets). Only one winner per axis is used, avoiding
+  /// the noisy thicket of lines produced by showing every near match.
+  ({double? dx, double? dy, List<_AlignmentGuide> guides})
+      _alignmentSnapForRect(
+    Rect moving, {
+    bool horizontal = true,
+    bool vertical = true,
+    List<(double, int)>? xAnchors,
+    List<(double, int)>? yAnchors,
+  }) {
+    if (!_smartAlignmentSnapping || moving.isEmpty) {
+      return (dx: null, dy: null, guides: const []);
+    }
+    final tolerance = _alignmentTolerance * _chromeScale;
+
+    ({double delta, _AlignmentTarget target})? best(
+      Axis axis,
+      List<(double, int)> anchors,
+      List<_AlignmentTarget> targets,
+    ) {
+      ({double delta, _AlignmentTarget target})? winner;
+      for (final target in targets) {
+        for (final (anchor, role) in anchors) {
+          // Centres meet centres. Outside edges may meet either outside edge
+          // (aligned or touching), but never an unrelated centre line.
+          if (role == 0 ? target.role != 0 : target.role == 0) continue;
+          final delta = target.position - anchor;
+          // Once caught, release a little farther out than the acquire
+          // radius. That small hysteresis stops a slow drag flickering on and
+          // off the line when pointer samples straddle the threshold.
+          final held = _alignmentGuides.any((guide) =>
+              guide.axis == axis &&
+              (guide.position - target.position).abs() <
+                  precisionErrorTolerance);
+          if (delta.abs() > tolerance * (held ? 1.5 : 1)) continue;
+          if (winner == null ||
+              delta.abs() < winner.delta.abs() - precisionErrorTolerance) {
+            winner = (delta: delta, target: target);
+          }
+        }
+      }
+      return winner;
+    }
+
+    final x = vertical
+        ? best(
+            Axis.vertical,
+            xAnchors ??
+                [
+                  (moving.center.dx, 0),
+                  (moving.left, -1),
+                  (moving.right, 1),
+                ],
+            _alignmentTargetsFor(Axis.vertical))
+        : null;
+    final y = horizontal
+        ? best(
+            Axis.horizontal,
+            yAnchors ??
+                [
+                  (moving.center.dy, 0),
+                  (moving.top, -1),
+                  (moving.bottom, 1),
+                ],
+            _alignmentTargetsFor(Axis.horizontal))
+        : null;
+    final padding = 5 * _chromeScale;
+    return (
+      dx: x?.delta,
+      dy: y?.delta,
+      guides: [
+        if (x case final match?)
+          (
+            axis: Axis.vertical,
+            position: match.target.position,
+            from: math.min(moving.top, match.target.from) - padding,
+            to: math.max(moving.bottom, match.target.to) + padding,
+          ),
+        if (y case final match?)
+          (
+            axis: Axis.horizontal,
+            position: match.target.position,
+            from: math.min(moving.left, match.target.from) - padding,
+            to: math.max(moving.right, match.target.to) + padding,
+          ),
+      ],
+    );
+  }
+
+  /// Applies smart alignment and grid snapping to a move without making the
+  /// result depend on where inside the annotation the user grabbed it. Smart
+  /// targets win on an axis while they are within the six-pixel magnetic
+  /// range; the grid remains the fallback on the other axis.
+  Offset _snapMovePosition(Offset start, Offset current, Rect? anchorRect,
+      {bool alignAnnotations = true}) {
+    if (anchorRect == null) {
+      _alignmentGuides = const [];
+      return current;
+    }
     final delta = current - start;
-    final target = anchorRect.topLeft + delta;
-    return current + (_snapPointToGrid(target) - target);
+    final group = (_selectedGroupViewRect ?? anchorRect).shift(delta);
+    final alignment = alignAnnotations
+        ? _alignmentSnapForRect(group)
+        : (dx: null, dy: null, guides: const <_AlignmentGuide>[]);
+    _alignmentGuides = alignment.guides;
+
+    Offset gridDelta = Offset.zero;
+    if (_gridSnapping) {
+      final target = anchorRect.topLeft + delta;
+      gridDelta = _snapPointToGrid(target) - target;
+    }
+    return current +
+        Offset(
+          alignment.dx ?? gridDelta.dx,
+          alignment.dy ?? gridDelta.dy,
+        );
+  }
+
+  /// Snaps an unrotated resize handle to annotation/page alignments, with the
+  /// grid as the per-axis fallback. A rotated box keeps grid snapping only:
+  /// matching its local axes to page axes would make the handle shear away
+  /// from the pointer and is more surprising than helpful.
+  Offset _snapResizePosition(Offset position, {double? aspectRatio}) {
+    final handle = _resizeHandle;
+    final from = _resizeFrom;
+    if (handle == null || from == null || _resizeAngle != 0) {
+      _alignmentGuides = const [];
+      return _snapPointToGrid(position);
+    }
+    final raw = _resizedRect(from, handle, position - _moveStart!,
+            aspectRatio: aspectRatio)
+        .$1;
+    final alignment = _alignmentSnapForRect(
+      raw,
+      vertical: handle.dx != 0,
+      horizontal: handle.dy != 0,
+      xAnchors: handle.dx == 0
+          ? null
+          : [(handle.dx < 0 ? raw.left : raw.right, handle.dx)],
+      yAnchors: handle.dy == 0
+          ? null
+          : [(handle.dy < 0 ? raw.top : raw.bottom, handle.dy)],
+    );
+    _alignmentGuides = alignment.guides;
+    final grid = _snapPointToGrid(position);
+    return Offset(
+      alignment.dx == null ? grid.dx : position.dx + alignment.dx!,
+      alignment.dy == null ? grid.dy : position.dy + alignment.dy!,
+    );
   }
 
   /// Constrains [point] to the nearest 45° direction from [anchor] while
@@ -1577,6 +1831,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _dragCurrent = null;
       _moveStart = null;
       _moveCurrent = null;
+      _alignmentGuides = const [];
       _moveCurrentGlobal = null;
       _elementMoveStart = null;
       _elementMoveCurrent = null;
@@ -3901,16 +4156,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       });
     } else if (_resizeHandle != null) {
       setState(() {
-        final snapped = _snapPointToGrid(position);
-        _moveCurrent = snapped;
-        // a rotated selection's handles move along its own axes, so the
-        // pointer delta rotates into the local frame
-        final delta = snapped - _moveStart!;
         // holding Shift locks the original aspect ratio
         final aspectRatio =
             HardwareKeyboard.instance.isShiftPressed && _resizeFrom!.height > 0
                 ? _resizeFrom!.width / _resizeFrom!.height
                 : null;
+        final snapped = _snapResizePosition(position, aspectRatio: aspectRatio);
+        _moveCurrent = snapped;
+        // a rotated selection's handles move along its own axes, so the
+        // pointer delta rotates into the local frame
+        final delta = snapped - _moveStart!;
         final (resized, flipX, flipY) = _resizedRect(
             _resizeFrom!,
             _resizeHandle!,
@@ -3925,7 +4180,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     } else if (_elementMoveStart != null) {
       _moveCurrentGlobal = _autoScrollGlobal;
       setState(() => _elementMoveCurrent = _snapMovePosition(
-          _elementMoveStart!, position, _selectedElementRestRect));
+          _elementMoveStart!, position, _selectedElementRestRect,
+          alignAnnotations: false));
       _reportElementMovePreview();
     } else if (_moveStart != null) {
       _moveCurrentGlobal = _autoScrollGlobal;
@@ -4052,6 +4308,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _dragCurrent = null;
       _moveStart = null;
       _moveCurrent = null;
+      _alignmentGuides = const [];
       _moveCurrentGlobal = null;
       _elementMoveStart = null;
       _elementMoveCurrent = null;
@@ -5732,10 +5989,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final cropping = _controller.isCroppingImage &&
         _controller.selectedPage == widget.pageIndex;
     final picking = _controller.isPickingColor;
-    // Cursor guides also mount this overlay in ordinary reader/hand mode.
-    // In that passive state the MouseRegion paints the guides, but no gesture
-    // recognizer may enter the arena and steal scrolling or text selection
-    // from the viewer underneath.
+    // Cursor guides and rulers also mount this overlay in ordinary reader/
+    // hand mode. In that passive state the MouseRegion paints them, but no
+    // gesture recognizer may enter the arena and steal scrolling or text
+    // selection from the viewer underneath.
     final acceptsEditingGestures = _tool != null ||
         _selectMode ||
         _controller.activeSavedAnnotation != null;
@@ -6093,6 +6350,21 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   size: Size.infinite,
                 ),
               ),
+              if (_controller.preferences.smartAlignmentGuides &&
+                  _alignmentGuides.isNotEmpty)
+                Positioned.fill(
+                  child: RepaintBoundary(
+                    child: CustomPaint(
+                      key: const ValueKey('pdf-alignment-guides'),
+                      painter: _AlignmentGuidePainter(
+                        guides: _alignmentGuides,
+                        chromeScale: _chromeScale,
+                        color: const Color(0xFFE91E63),
+                      ),
+                      size: Size.infinite,
+                    ),
+                  ),
+                ),
               // The in-progress pencil/mouse stroke, isolated on its own
               // RepaintBoundary and repainted via _activeStrokeRepaint. While
               // a stroke is live nothing above rebuilds, so only this layer
@@ -6105,10 +6377,26 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   ),
                 ),
               ),
-              // The pointer-tracking cursors, on their own RepaintBoundary
-              // above the ink: a hover moves them by ticking _cursorRepaint,
-              // which repaints this layer alone (#403). Topmost of the
-              // painted layers, so a cursor is never buried under a preview.
+              if (_controller.preferences.showPageRulers)
+                Positioned.fill(
+                  child: RepaintBoundary(
+                    child: CustomPaint(
+                      key: const ValueKey('pdf-page-rulers'),
+                      painter: _PageRulerPainter(
+                        this,
+                        surfaceColor: Theme.of(context).colorScheme.surface,
+                        textColor: Theme.of(context).colorScheme.onSurface,
+                        accentColor:
+                            PdfViewerTheme.of(context).annotationChromeColor ??
+                                Theme.of(context).colorScheme.primary,
+                      ),
+                      size: Size.infinite,
+                    ),
+                  ),
+                ),
+              // The pointer-tracking cursors, on their own RepaintBoundary,
+              // stay above the ink, rulers, and guides. Hover ticks only
+              // _cursorRepaint, so moving a cursor never rebuilds the page.
               Positioned.fill(
                 child: RepaintBoundary(
                   child: CustomPaint(
@@ -6641,6 +6929,180 @@ void _paintPenCursor(
         ..color = const Color(0xB3FFFFFF)
         ..style = PaintingStyle.stroke
         ..strokeWidth = 1 * chromeScale);
+}
+
+/// Paints the temporary object/page alignment lines that appear only while a
+/// move or resize is magnetically held. A dark halo keeps the one-pixel pink
+/// line legible over both paper and dense drawings.
+class _AlignmentGuidePainter extends CustomPainter {
+  const _AlignmentGuidePainter({
+    required this.guides,
+    required this.chromeScale,
+    required this.color,
+  });
+
+  @visibleForTesting
+  final List<_AlignmentGuide> guides;
+  final double chromeScale;
+  final Color color;
+
+  @visibleForTesting
+  double get strokeWidth => 1 * chromeScale;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.clipRect(Offset.zero & size);
+    final halo = Paint()
+      ..color = const Color(0xA6FFFFFF)
+      ..strokeWidth = 3 * chromeScale;
+    final line = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth;
+    for (final guide in guides) {
+      final (from, to) = guide.axis == Axis.vertical
+          ? (
+              Offset(guide.position, guide.from),
+              Offset(guide.position, guide.to),
+            )
+          : (
+              Offset(guide.from, guide.position),
+              Offset(guide.to, guide.position),
+            );
+      canvas
+        ..drawLine(from, to, halo)
+        ..drawLine(from, to, line);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_AlignmentGuidePainter oldDelegate) =>
+      oldDelegate.guides != guides ||
+      oldDelegate.chromeScale != chromeScale ||
+      oldDelegate.color != color;
+}
+
+/// Adaptive rulers inset along the page's top and left edges. Values are
+/// distances in PDF points from the visible top-left corner; the major step
+/// follows a 1/2/5 progression so labels never crowd as the page zooms.
+class _PageRulerPainter extends CustomPainter {
+  _PageRulerPainter(
+    this._state, {
+    required this.surfaceColor,
+    required this.textColor,
+    required this.accentColor,
+  }) : super(repaint: _state._cursorRepaint);
+
+  final _EditingPageOverlayState _state;
+  final Color surfaceColor;
+  final Color textColor;
+  final Color accentColor;
+
+  @visibleForTesting
+  double get bandWidth => 24 * _state._chromeScale;
+
+  @visibleForTesting
+  Offset? get cursor => _state._guideCursor;
+
+  @visibleForTesting
+  double majorStepFor(Size size) {
+    final pointsForLabel = 64 * _state._chromeScale / _state._geometry.scale;
+    if (!pointsForLabel.isFinite || pointsForLabel <= 0) return 100;
+    final power =
+        math.pow(10, (math.log(pointsForLabel) / math.ln10).floor()).toDouble();
+    for (final multiplier in const [1.0, 2.0, 5.0, 10.0]) {
+      final step = multiplier * power;
+      if (step >= pointsForLabel) return step;
+    }
+    return 10 * power;
+  }
+
+  void _paintLabel(Canvas canvas, String label, Offset at, double fontSize) {
+    final painter = TextPainter(
+      text: TextSpan(
+        text: label,
+        style: TextStyle(
+          color: textColor.withValues(alpha: 0.82),
+          fontSize: fontSize,
+          height: 1,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+    painter.paint(canvas, at);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+    final s = _state._chromeScale;
+    final band = bandWidth;
+    final scale = _state._geometry.scale;
+    final major = majorStepFor(size);
+    final minor = major / 5;
+    final ruleFill = Paint()..color = surfaceColor.withValues(alpha: 0.90);
+    final hairline = Paint()
+      ..color = textColor.withValues(alpha: 0.34)
+      ..strokeWidth = 0.75 * s;
+    final ticks = Paint()
+      ..color = textColor.withValues(alpha: 0.62)
+      ..strokeWidth = 0.75 * s;
+
+    canvas
+      ..drawRect(Rect.fromLTWH(0, 0, size.width, band), ruleFill)
+      ..drawRect(Rect.fromLTWH(0, 0, band, size.height), ruleFill)
+      ..drawLine(Offset(0, band), Offset(size.width, band), hairline)
+      ..drawLine(Offset(band, 0), Offset(band, size.height), hairline);
+
+    final widthPoints = size.width / scale;
+    final heightPoints = size.height / scale;
+    final tickCountX = (widthPoints / minor).floor();
+    for (var i = 0; i <= tickCountX; i++) {
+      final value = i * minor;
+      final x = value * scale;
+      final isMajor = i % 5 == 0;
+      final length = (isMajor ? 8 : 4) * s;
+      canvas.drawLine(Offset(x, band), Offset(x, band - length), ticks);
+      if (isMajor && x >= band + 2 * s) {
+        _paintLabel(canvas, value.round().toString(), Offset(x + 2 * s, 3 * s),
+            8.5 * s);
+      }
+    }
+    final tickCountY = (heightPoints / minor).floor();
+    for (var i = 0; i <= tickCountY; i++) {
+      final value = i * minor;
+      final y = value * scale;
+      final isMajor = i % 5 == 0;
+      final length = (isMajor ? 8 : 4) * s;
+      canvas.drawLine(Offset(band, y), Offset(band - length, y), ticks);
+      if (isMajor && y >= band + 2 * s) {
+        _paintLabel(canvas, value.round().toString(), Offset(2 * s, y + 2 * s),
+            8.5 * s);
+      }
+    }
+
+    // Mouse position readouts: a short accent slash in each ruler gives the
+    // precision benefit of crosshairs without drawing full cursor guides.
+    final cursor = this.cursor;
+    if (cursor != null) {
+      final marker = Paint()
+        ..color = accentColor
+        ..strokeWidth = 1.5 * s;
+      canvas
+        ..drawLine(Offset(cursor.dx, 0), Offset(cursor.dx, band), marker)
+        ..drawLine(Offset(0, cursor.dy), Offset(band, cursor.dy), marker);
+    }
+
+    // The shared corner hides tick/label fragments from both axes and makes
+    // the two strips read as one instrument.
+    canvas.drawRect(Rect.fromLTWH(0, 0, band, band), ruleFill);
+    canvas
+      ..drawLine(Offset(0, band), Offset(band, band), hairline)
+      ..drawLine(Offset(band, 0), Offset(band, band), hairline);
+  }
+
+  @override
+  bool shouldRepaint(_PageRulerPainter oldDelegate) => true;
 }
 
 /// The pointer-tracking cursors and hover previews, on their own

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -57,6 +57,8 @@ class PdfEditingPreferences extends ChangeNotifier {
   double _eraserRadius = 8;
   bool _showVerticalCursorGuide = false;
   bool _showHorizontalCursorGuide = false;
+  bool _smartAlignmentGuides = true;
+  bool _showPageRulers = false;
   bool _showSnapGrid = false;
   bool _snapToGrid = false;
   double _gridSpacing = 10;
@@ -184,6 +186,10 @@ class PdfEditingPreferences extends ChangeNotifier {
       _showHorizontalCursorGuide =
           store.getBool('${_prefix}showHorizontalCursorGuide') ??
               _showHorizontalCursorGuide;
+      _smartAlignmentGuides = store.getBool('${_prefix}smartAlignmentGuides') ??
+          _smartAlignmentGuides;
+      _showPageRulers =
+          store.getBool('${_prefix}showPageRulers') ?? _showPageRulers;
       _showSnapGrid = store.getBool('${_prefix}showSnapGrid') ?? _showSnapGrid;
       _snapToGrid = store.getBool('${_prefix}snapToGrid') ?? _snapToGrid;
       final gridSpacing = store.getDouble('${_prefix}gridSpacing');
@@ -739,6 +745,29 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _showHorizontalCursorGuide) return;
     _showHorizontalCursorGuide = value;
     _write((s) => s.setBool('${_prefix}showHorizontalCursorGuide', value));
+    notifyListeners();
+  }
+
+  /// Whether moving and resizing annotations snaps their outside edges and
+  /// centres to the page and to other visible annotations. A transient guide
+  /// marks every active snap. Hold Alt during a gesture to bypass it.
+  bool get smartAlignmentGuides => _smartAlignmentGuides;
+
+  set smartAlignmentGuides(bool value) {
+    if (value == _smartAlignmentGuides) return;
+    _smartAlignmentGuides = value;
+    _write((s) => s.setBool('${_prefix}smartAlignmentGuides', value));
+    notifyListeners();
+  }
+
+  /// Whether adaptive point rulers are drawn along the top and left edges of
+  /// every page. Rulers are display-only and are not written into the PDF.
+  bool get showPageRulers => _showPageRulers;
+
+  set showPageRulers(bool value) {
+    if (value == _showPageRulers) return;
+    _showPageRulers = value;
+    _write((s) => s.setBool('${_prefix}showPageRulers', value));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -47,7 +47,7 @@ typedef PdfEditingToolbarWidgetBuilder = Widget Function(
   PdfViewerController viewerController,
 );
 
-/// Opens the stock cursor-guide and grid-snap settings.
+/// Opens the stock guide, snapping, grid, and ruler settings.
 ///
 /// The switches update [preferences] live and persist through
 /// [PdfEditingPreferences]. They are display/interaction settings only; no
@@ -63,73 +63,94 @@ Future<void> showPdfEditingGuidesDialog(
   await showPdfDialog<void>(
     context: context,
     builder: (context) => AlertDialog(
-      title: const Text('Cursor guides and grid'),
+      title: const Text('Guides, snapping and rulers'),
       contentPadding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
       content: SizedBox(
         width: 360,
         child: ListenableBuilder(
           listenable: preferences,
-          builder: (context, _) => Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SwitchListTile(
-                key: const ValueKey('pdf-cursor-guide-vertical'),
-                secondary: const Icon(Icons.vertical_align_center),
-                title: const Text('Vertical cursor line'),
-                value: preferences.showVerticalCursorGuide,
-                onChanged: (value) =>
-                    preferences.showVerticalCursorGuide = value,
-              ),
-              SwitchListTile(
-                key: const ValueKey('pdf-cursor-guide-horizontal'),
-                secondary: const Icon(Icons.horizontal_rule),
-                title: const Text('Horizontal cursor line'),
-                value: preferences.showHorizontalCursorGuide,
-                onChanged: (value) =>
-                    preferences.showHorizontalCursorGuide = value,
-              ),
-              const Divider(height: 1),
-              SwitchListTile(
-                key: const ValueKey('pdf-grid-snap'),
-                secondary: const Icon(Icons.grid_4x4),
-                title: const Text('Snap to grid'),
-                subtitle: const Text('Hold Alt to bypass snapping'),
-                value: preferences.snapToGrid,
-                onChanged: (value) => preferences.snapToGrid = value,
-              ),
-              SwitchListTile(
-                key: const ValueKey('pdf-grid-visible'),
-                secondary: const Icon(Icons.grid_on_outlined),
-                title: const Text('Show grid lines'),
-                subtitle: const Text('Display only; not added to the PDF'),
-                value: preferences.showSnapGrid,
-                onChanged: (value) => preferences.showSnapGrid = value,
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-                child: Row(children: [
-                  const Text('Grid spacing'),
-                  Expanded(
-                    child: Slider(
-                      key: const ValueKey('pdf-grid-spacing'),
-                      value: preferences.gridSpacing.clamp(1, 144),
-                      min: 1,
-                      max: 144,
-                      divisions: 143,
-                      label: '${spacingLabel(preferences.gridSpacing)} pt',
-                      onChanged: (value) => preferences.gridSpacing = value,
+          builder: (context, _) => SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SwitchListTile(
+                  key: const ValueKey('pdf-smart-alignment-guides'),
+                  secondary: const Icon(Icons.align_horizontal_center),
+                  title: const Text('Smart alignment guides'),
+                  subtitle: const Text(
+                      'Snap annotation edges and centres • Hold Alt to bypass'),
+                  value: preferences.smartAlignmentGuides,
+                  onChanged: (value) =>
+                      preferences.smartAlignmentGuides = value,
+                ),
+                SwitchListTile(
+                  key: const ValueKey('pdf-page-rulers'),
+                  secondary: const Icon(Icons.straighten),
+                  title: const Text('Page rulers'),
+                  subtitle: const Text('Show point measurements at page edges'),
+                  value: preferences.showPageRulers,
+                  onChanged: (value) => preferences.showPageRulers = value,
+                ),
+                const Divider(height: 1),
+                SwitchListTile(
+                  key: const ValueKey('pdf-cursor-guide-vertical'),
+                  secondary: const Icon(Icons.vertical_align_center),
+                  title: const Text('Vertical cursor line'),
+                  value: preferences.showVerticalCursorGuide,
+                  onChanged: (value) =>
+                      preferences.showVerticalCursorGuide = value,
+                ),
+                SwitchListTile(
+                  key: const ValueKey('pdf-cursor-guide-horizontal'),
+                  secondary: const Icon(Icons.horizontal_rule),
+                  title: const Text('Horizontal cursor line'),
+                  value: preferences.showHorizontalCursorGuide,
+                  onChanged: (value) =>
+                      preferences.showHorizontalCursorGuide = value,
+                ),
+                const Divider(height: 1),
+                SwitchListTile(
+                  key: const ValueKey('pdf-grid-snap'),
+                  secondary: const Icon(Icons.grid_4x4),
+                  title: const Text('Snap to grid'),
+                  subtitle: const Text('Hold Alt to bypass snapping'),
+                  value: preferences.snapToGrid,
+                  onChanged: (value) => preferences.snapToGrid = value,
+                ),
+                SwitchListTile(
+                  key: const ValueKey('pdf-grid-visible'),
+                  secondary: const Icon(Icons.grid_on_outlined),
+                  title: const Text('Show grid lines'),
+                  subtitle: const Text('Display only; not added to the PDF'),
+                  value: preferences.showSnapGrid,
+                  onChanged: (value) => preferences.showSnapGrid = value,
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+                  child: Row(children: [
+                    const Text('Grid spacing'),
+                    Expanded(
+                      child: Slider(
+                        key: const ValueKey('pdf-grid-spacing'),
+                        value: preferences.gridSpacing.clamp(1, 144),
+                        min: 1,
+                        max: 144,
+                        divisions: 143,
+                        label: '${spacingLabel(preferences.gridSpacing)} pt',
+                        onChanged: (value) => preferences.gridSpacing = value,
+                      ),
                     ),
-                  ),
-                  SizedBox(
-                    width: 48,
-                    child: Text(
-                      '${spacingLabel(preferences.gridSpacing)} pt',
-                      textAlign: TextAlign.end,
+                    SizedBox(
+                      width: 48,
+                      child: Text(
+                        '${spacingLabel(preferences.gridSpacing)} pt',
+                        textAlign: TextAlign.end,
+                      ),
                     ),
-                  ),
-                ]),
-              ),
-            ],
+                  ]),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -9382,8 +9382,9 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                   // default-mode (mouse click) annotation selection, or
                   // a pending attention flash (the sidebar's zoom-to -
                   // links and form fields flash without a selection). Cursor
-                  // guides mount the same low-latency hover layer even in
-                  // ordinary reader/hand mode.
+                  // cursor guides and rulers mount the same passive,
+                  // low-latency hover layer even in ordinary reader/hand
+                  // mode.
                   builder: (context, _) {
                     final rasterCurrent = _rastered &&
                         _annotationLayerCurrent &&
@@ -9401,6 +9402,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                             editing.pendingFlash == null &&
                             !editing.preferences.showVerticalCursorGuide &&
                             !editing.preferences.showHorizontalCursorGuide &&
+                            !editing.preferences.showPageRulers &&
                             !editing.preferences.showSnapGrid &&
                             (rasterCurrent ||
                                 editing.committedInkOn(widget.index) == null)

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -2024,7 +2024,7 @@ class PdfShellViewOptionsButton extends StatelessWidget {
             value: _ViewOption.editingGuides,
             child: ListTile(
               leading: Icon(Icons.grid_4x4),
-              title: Text('Cursor guides and grid'),
+              title: Text('Guides, snapping and rulers'),
               trailing: Icon(Icons.chevron_right),
               contentPadding: EdgeInsets.zero,
             ),

--- a/packages/dart_pdf_editor/test/editing_drag_preview_test.dart
+++ b/packages/dart_pdf_editor/test/editing_drag_preview_test.dart
@@ -134,6 +134,7 @@ void main() {
     testWidgets('a move drag shows the annotation at the dragged position',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
+      editing.preferences.smartAlignmentGuides = false;
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);
@@ -205,6 +206,7 @@ void main() {
     testWidgets('a moved stamp keeps its afterimage while host rebuilds',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.smartAlignmentGuides = false
         ..color = const Color(0xFFFF0000)
         ..addStamp(0, const PdfRect(100, 650, 250, 750), 'PAID')
         ..tool = PdfEditTool.select
@@ -252,6 +254,7 @@ void main() {
       // paint above every page.
       PdfMoveDragPreview? reported;
       final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..preferences.smartAlignmentGuides = false
         ..color = const Color(0xFFFF0000)
         ..addRectangle(0, const PdfRect(100, 550, 300, 650))
         ..tool = PdfEditTool.select
@@ -326,6 +329,7 @@ void main() {
           Offset(x * scale, (pageHeight - y) * scale);
 
       final editing = PdfEditingController(buildShortTwoPagePdf(pageHeight));
+      editing.preferences.smartAlignmentGuides = false;
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);

--- a/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
+++ b/packages/dart_pdf_editor/test/editing_guides_grid_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/editing/editing_overlay.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -26,6 +27,18 @@ dynamic gridPainter(WidgetTester tester) => tester
     .singleWhere(
       (painter) => painter.runtimeType.toString() == '_SnapGridPainter',
     );
+
+dynamic alignmentPainter(WidgetTester tester) => tester
+    .widget<CustomPaint>(find.byKey(
+      const ValueKey('pdf-alignment-guides'),
+    ))
+    .painter;
+
+dynamic rulerPainter(WidgetTester tester) => tester
+    .widget<CustomPaint>(find.byKey(
+      const ValueKey('pdf-page-rulers'),
+    ))
+    .painter;
 
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
@@ -186,6 +199,109 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 400));
   });
 
+  testWidgets('smart guides snap annotation edges and centres while moving',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing
+      ..addRectangle(0, const PdfRect(100, 650, 200, 750))
+      ..addRectangle(0, const PdfRect(300, 500, 400, 600))
+      ..tool = PdfEditTool.select
+      ..selectAnnotation(0, 0);
+    await tester.pump();
+
+    final gesture = await tester.startGesture(view(150, 700),
+        kind: PointerDeviceKind.mouse);
+    // Raw placement is two points shy on x; y is already aligned. The smart
+    // guide should magnetize both axes to the second annotation.
+    await gesture.moveTo(view(348, 550));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('pdf-alignment-guides')), findsOneWidget);
+    final painter = alignmentPainter(tester);
+    final guides = List<dynamic>.from(painter.guides as Iterable);
+    expect(guides.length, 2);
+    expect(
+        guides.any((g) =>
+            g.axis == Axis.vertical &&
+            (g.position - view(350, 0).dx).abs() < 0.1),
+        isTrue,
+        reason: guides.toString());
+    expect(
+        guides.any((g) =>
+            g.axis == Axis.horizontal &&
+            (g.position - view(0, 550).dy).abs() < 0.1),
+        isTrue);
+
+    await gesture.up();
+    await tester.pump();
+    final moved = editing.document.page(0).annotations[0].rect;
+    expect(moved.left, closeTo(300, 0.01));
+    expect(moved.bottom, closeTo(500, 0.01));
+    expect(moved.right, closeTo(400, 0.01));
+    expect(moved.top, closeTo(600, 0.01));
+    expect(find.byKey(const ValueKey('pdf-alignment-guides')), findsNothing);
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('smart guides snap resize axes and Alt bypasses them',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing
+      ..addRectangle(0, const PdfRect(100, 600, 200, 700))
+      ..addRectangle(0, const PdfRect(300, 500, 400, 600))
+      ..tool = PdfEditTool.select
+      ..selectAnnotation(0, 0);
+    await tester.pump();
+
+    // Bottom-right is (200, 600) in page space. Land both dragged edges two
+    // points from the reference box; they should snap exactly onto it.
+    await dragMouse(tester, view(200, 600), view(298, 502));
+    var resized = editing.document.page(0).annotations[0].rect;
+    expect(resized.right, closeTo(300, 0.01));
+    expect(resized.bottom, closeTo(500, 0.01),
+        reason: 'target=${editing.document.page(0).annotations[1].rect}');
+
+    // Undo, then make the same drag with Alt down: the raw off-guide values
+    // survive and no alignment line is mounted.
+    editing.undo();
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+    final gesture = await tester.startGesture(view(200, 600),
+        kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(view(298, 502));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('pdf-alignment-guides')), findsNothing);
+    await gesture.up();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+    await tester.pump();
+    resized = editing.document.page(0).annotations[0].rect;
+    expect(resized.right, closeTo(298, 0.5));
+    expect(resized.bottom, closeTo(502, 0.5));
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('optional page rulers use adaptive point ticks and hover marks',
+      (tester) async {
+    final editing = await pumpEditor(tester);
+    editing.preferences.showPageRulers = true;
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('pdf-page-rulers')), findsOneWidget);
+    var painter = rulerPainter(tester);
+    expect(painter.bandWidth, 24);
+    expect(painter.majorStepFor(const Size(800, 1035)), 50);
+    expect(painter.cursor, isNull);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(5, 5));
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(view(220, 700));
+    await tester.pump();
+    painter = rulerPainter(tester);
+    expect(painter.cursor.dx, closeTo(view(220, 700).dx, 0.1));
+    expect(painter.cursor.dy, closeTo(view(220, 700).dy, 0.1));
+  });
+
   testWidgets('editor settings exposes persistent guide and grid controls',
       (tester) async {
     final preferences = PdfEditingPreferences();
@@ -207,11 +323,15 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('pdf-shell-editing-guides')),
         kind: PointerDeviceKind.mouse);
     await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-smart-alignment-guides')));
+    await tester.tap(find.byKey(const ValueKey('pdf-page-rulers')));
     await tester.tap(find.byKey(const ValueKey('pdf-cursor-guide-vertical')));
     await tester.tap(find.byKey(const ValueKey('pdf-grid-snap')));
     await tester.tap(find.byKey(const ValueKey('pdf-grid-visible')));
     await tester.pump();
 
+    expect(preferences.smartAlignmentGuides, isFalse);
+    expect(preferences.showPageRulers, isTrue);
     expect(preferences.showVerticalCursorGuide, isTrue);
     expect(preferences.snapToGrid, isTrue);
     expect(preferences.showSnapGrid, isTrue);
@@ -224,6 +344,8 @@ void main() {
     final first = PdfEditingPreferences();
     await first.ready;
     first
+      ..smartAlignmentGuides = false
+      ..showPageRulers = true
       ..showVerticalCursorGuide = true
       ..showHorizontalCursorGuide = true
       ..showSnapGrid = true
@@ -233,6 +355,8 @@ void main() {
 
     final second = PdfEditingPreferences();
     await second.ready;
+    expect(second.smartAlignmentGuides, isFalse);
+    expect(second.showPageRulers, isTrue);
     expect(second.showVerticalCursorGuide, isTrue);
     expect(second.showHorizontalCursorGuide, isTrue);
     expect(second.showSnapGrid, isTrue);


### PR DESCRIPTION
## Summary

- add zoom-independent smart snapping for annotation moves, grouped moves, and unrotated resizes
- align annotation edges and centers to page and peer-annotation targets with transient visual guides
- keep grid snapping as a fallback and allow temporary Alt bypass
- add optional adaptive point rulers along page edges
- persist both controls in the editor settings popup

## UX rationale

The interaction follows established design/PDF editor patterns: center and outer-edge targets, visible feedback only while a snap is active, stable screen-space sensitivity, release hysteresis, and a temporary modifier override. Smart guides default on; rulers remain opt-in and display-only.

## Verification

- fvm dart analyze
- 285 focused Flutter regression tests across editing, selection, resize, text, forms, shells, and preferences
- git diff --check