### PR TITLE
Accelerate document raster warming with Flutter GPU

### DIFF
--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -899,7 +899,10 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           title: 'Idle raster warm',
           help: 'Spends genuine viewer idle time rasterizing pages ahead of '
               'navigation, so arriving on them paints instantly instead of '
-              'interpreting and reading back first. Warming stands down the '
+              'rendering first. With the Flutter GPU backend selected, '
+              'accepted pages are produced as GPU-resident exact images; '
+              'unsupported pages retain the exact Canvas fallback. Warming '
+              'stands down the '
               'moment anything scrolls, zooms, edits, or renders, and never '
               'stores more than the visited-page raster budget above allows - '
               'so a whole-document warm on a large file settles into a moving '

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3475,6 +3475,7 @@ class _PdfViewerState extends State<PdfViewer>
           signature: target.signature,
           pixelRatio: target.ratio,
           worker: _effectiveRenderWorker,
+          rasterBackend: widget.tileRasterBackend,
           // the least urgent thing in the worker's queue, so a visible page
           // always wins it and can preempt a warm already running
           priority: _rasterWarmWorkerPriority,

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -15,6 +15,7 @@ import 'raster_warm.dart';
 import 'render_worker.dart';
 import 'retained_scene.dart';
 import 'renderer.dart';
+import 'tile_raster_backend.dart';
 
 /// Memory policy for full-resolution rasters of pages the user has visited.
 ///
@@ -1591,14 +1592,17 @@ class PdfPagePreviewCache extends ChangeNotifier {
   ///
   /// [worker] moves the interpreter walk off the platform thread when the
   /// backend offloads; [priority] should stay above any foreground request so
-  /// a visible page always wins the worker's queue. Returns whether a raster
-  /// was stored.
+  /// a visible page always wins the worker's queue. When [rasterBackend]
+  /// supports full-page warming, its retained-scene session produces the
+  /// exact image directly; a rejection or failure falls back to Canvas for
+  /// this page. Returns whether a raster was stored.
   Future<bool> warmFullRaster(
     int index,
     PdfPage page, {
     required PdfPageRasterSignature signature,
     required double pixelRatio,
     PdfRenderWorker? worker,
+    PdfTileRasterBackend? rasterBackend,
     int priority = 4,
     bool Function()? shouldStop,
   }) async {
@@ -1633,41 +1637,138 @@ class PdfPagePreviewCache extends ChangeNotifier {
       }
       if (_disposed || hasFullRaster(signature, page)) return false;
       ui.Picture? picture;
-      final ui.Image image;
-      if (commands != null) {
-        picture = await PdfPageRenderer.pictureFromCommands(page, commands,
-            pageColor: signature.pageColor,
-            rotation: signature.rotation,
-            maxImagePixelRatio: pixelRatio);
-      } else {
-        // No worker (or it declined): the walk runs here, exactly as it would
-        // when the page arrives on screen. That is the cost being moved into
-        // idle time, so it is worth paying - but only while nothing else
-        // wants the thread.
-        picture = await PdfPageRenderer.renderPictureRecordedWithPlan(
-          page,
-          PdfPageRenderPlan(
-            pageColor: signature.pageColor,
-            annotations: signature.annotations,
-            rotation: signature.rotation,
-          ),
-          maxImagePixelRatio: pixelRatio,
-        );
+      ui.Image? image;
+      var route = 'canvas';
+      final plan = PdfPageRenderPlan(
+        pageColor: signature.pageColor,
+        annotations: signature.annotations,
+        rotation: signature.rotation,
+      );
+      final backend = rasterBackend;
+      if (backend != null && backend.supportsFullPageRasterWarmUp) {
+        PdfRetainedScene? scene;
+        PdfTileRasterSession? session;
+        try {
+          scene = commands == null
+              ? await PdfRetainedScene.record(
+                  page,
+                  plan: plan,
+                  maxImagePixelRatio: pixelRatio,
+                  imageDecodeHeadroom: 1,
+                  retainDecodedPixelsForCommands:
+                      backend.shouldRetainLocallyDecodedImagePixels,
+                )
+              : await PdfRetainedScene.fromCommands(
+                  page,
+                  commands,
+                  plan: plan,
+                  maxImagePixelRatio: pixelRatio,
+                  retainDecodedPixels: backend.prefersDirectDecodedImageUploads,
+                  retainLocallyDecodedPixels:
+                      backend.shouldRetainLocallyDecodedImagePixels(commands),
+                  allowOverprintRerecord: true,
+                );
+          if ((shouldStop?.call() ?? false) || _disposed) {
+            if (!_disposed) _warmPreemptions++;
+            return false;
+          }
+          session = backend.createSession(scene);
+          if (session == null && backend is PdfTileRasterRetryBackend) {
+            final retry =
+                (backend as PdfTileRasterRetryBackend).retrySession(scene);
+            if (retry != null) session = await retry;
+          }
+          if ((shouldStop?.call() ?? false) || _disposed) {
+            if (!_disposed) _warmPreemptions++;
+            return false;
+          }
+          if (session != null) {
+            image = await session.rasterizeRegion(
+              Offset.zero & size,
+              pixelRatio: pixelRatio,
+              tracePage: index,
+            );
+            if (image.width != signature.width ||
+                image.height != signature.height) {
+              throw StateError(
+                '${backend.debugLabel} full-page warm returned '
+                '${image.width}x${image.height}; expected '
+                '${signature.width}x${signature.height}',
+              );
+            }
+            route = backend.debugLabel;
+            // The exact raster is the important result. Keep a page-space
+            // picture only to seed the tiny navigation preview without a
+            // second interpretation; failure here must not discard paid-for
+            // accelerated pixels.
+            try {
+              picture = scene.replay(pixelRatio: 1);
+            } catch (_) {
+              picture = null;
+            }
+          }
+        } catch (error) {
+          image?.dispose();
+          image = null;
+          picture?.dispose();
+          picture = null;
+          // The accelerated route can reject a perfectly valid retained
+          // scene. Replaying that already-recorded scene gives Canvas its
+          // exact fallback without interpreting and decoding the page again.
+          try {
+            picture = scene?.replay(pixelRatio: 1);
+          } catch (_) {
+            picture = null;
+          }
+          PdfPerfLog.log(
+            'raster-warm gpu fallback page=$index '
+            'backend=${backend.debugLabel} error=$error',
+          );
+        } finally {
+          session?.dispose();
+          scene?.dispose();
+        }
       }
-      if ((shouldStop?.call() ?? false) || _disposed) {
-        picture.dispose();
-        if (!_disposed) _warmPreemptions++;
-        return false;
-      }
-      try {
-        image = await PdfPageRenderer.rasterize(picture, size, pixelRatio);
-      } catch (_) {
-        picture.dispose();
-        rethrow;
+      if (image == null) {
+        if (shouldStop?.call() ?? false) {
+          _warmPreemptions++;
+          return false;
+        }
+        if (picture == null) {
+          if (commands != null) {
+            picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
+              page,
+              commands,
+              plan,
+              maxImagePixelRatio: pixelRatio,
+            );
+          } else {
+            // No worker (or it declined): the walk runs here, exactly as it
+            // would when the page arrives on screen. That is the cost being
+            // moved into idle time, so it is worth paying - but only while
+            // nothing else wants the thread.
+            picture = await PdfPageRenderer.renderPictureRecordedWithPlan(
+              page,
+              plan,
+              maxImagePixelRatio: pixelRatio,
+            );
+          }
+        }
+        if ((shouldStop?.call() ?? false) || _disposed) {
+          picture.dispose();
+          if (!_disposed) _warmPreemptions++;
+          return false;
+        }
+        try {
+          image = await PdfPageRenderer.rasterize(picture, size, pixelRatio);
+        } catch (_) {
+          picture.dispose();
+          rethrow;
+        }
       }
       if (_disposed) {
         image.dispose();
-        picture.dispose();
+        picture?.dispose();
         return false;
       }
       try {
@@ -1690,17 +1791,18 @@ class PdfPagePreviewCache extends ChangeNotifier {
         // The interpretation is already in hand, so the low-resolution
         // navigation preview comes free - no second walk when the background
         // prerender reaches this page.
-        if (!isFresh(index, page, requireImages: true)) {
+        if (picture != null && !isFresh(index, page, requireImages: true)) {
           await putFromPicture(index, page, picture,
               rotation: signature.rotation);
         }
       } finally {
         image.dispose();
-        picture.dispose();
+        picture?.dispose();
       }
       PdfPerfLog.log(
         'raster-warm page=$index ${signature.width}x${signature.height} '
         '${commands != null ? 'worker ' : 'local '}'
+        'backend=$route '
         'stored=$stored '
         'warm=${(sw.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms '
         '${_fullRasterState()}',

--- a/packages/dart_pdf_editor/lib/src/raster_warm.dart
+++ b/packages/dart_pdf_editor/lib/src/raster_warm.dart
@@ -30,6 +30,12 @@ enum PdfPageRasterWarmMode {
 /// settled fit-size raster only - deep zoom stays region/tile driven - and
 /// never renders a page whose raster the cache policy could not admit.
 ///
+/// When the selected [PdfTileRasterBackend] advertises full-page warm support,
+/// the viewer records a retained scene and produces the resident image through
+/// that backend. The temporary scene session is then released; the exact image
+/// remains in the same byte-budgeted LRU used for visited pages. A backend that
+/// rejects or fails one page falls back to the exact Canvas path for that page.
+///
 /// The default is [PdfPageRasterWarmMode.disabled]: warming trades CPU, GPU,
 /// and memory for navigation latency, and only the host knows whether that
 /// trade is wanted. A desktop reader with room to spare might use:

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -65,6 +65,20 @@ abstract class PdfTileRasterBackend {
   /// for backends that have no scene-specific preparation.
   bool get supportsSessionWarmUp => false;
 
+  /// Whether idle full-page raster warming may render through this backend.
+  ///
+  /// The resulting [ui.Image] is retained by the viewer's exact-raster LRU,
+  /// not by the short-lived session. This lets a host make a budgeted set (or
+  /// an entire modest document) immediately sharp on navigation without
+  /// keeping every page widget and tile session alive. Returning false keeps
+  /// the universal Canvas warm path.
+  ///
+  /// Implementations should opt in only when a full-page request has the same
+  /// exactness and ownership guarantees as an ordinary tile request. Returning
+  /// null from [createSession], or throwing during the raster, still falls back
+  /// to Canvas for that page.
+  bool get supportsFullPageRasterWarmUp => false;
+
   /// Prepares process- or view-scoped resources before the first tile.
   ///
   /// [PdfViewer] calls this after useful pixels and a quiet window, never while

--- a/packages/dart_pdf_editor/test/raster_warm_test.dart
+++ b/packages/dart_pdf_editor/test/raster_warm_test.dart
@@ -13,6 +13,65 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
+class _FullPageWarmBackend extends PdfTileRasterBackend {
+  _FullPageWarmBackend({this.reject = false, this.failRaster = false});
+
+  final bool reject;
+  final bool failRaster;
+  int sessions = 0;
+  int rasters = 0;
+  int disposals = 0;
+
+  @override
+  bool get supportsFullPageRasterWarmUp => true;
+
+  @override
+  String get debugLabel => 'test-accelerated';
+
+  @override
+  PdfTileRasterSession? createSession(PdfRetainedScene scene) {
+    sessions++;
+    if (reject) return null;
+    return _FullPageWarmSession(
+      this,
+      const PdfCanvasTileRasterBackend().createSession(scene),
+    );
+  }
+}
+
+class _FullPageWarmSession implements PdfTileRasterSession {
+  _FullPageWarmSession(this.backend, this.delegate);
+
+  final _FullPageWarmBackend backend;
+  final PdfTileRasterSession delegate;
+
+  @override
+  PdfRetainedScene get scene => delegate.scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) {
+    backend.rasters++;
+    if (backend.failRaster) {
+      throw StateError('test accelerated raster failure');
+    }
+    return delegate.rasterizeRegion(
+      region,
+      pixelRatio: pixelRatio,
+      tracePage: tracePage,
+    );
+  }
+
+  @override
+  void dispose() {
+    backend.disposals++;
+    delegate.dispose();
+  }
+}
+
 void main() {
   /// Lets the real async renderer make progress, then pumps a frame with the
   /// clock advanced - the warm's idle countdown is a [Timer], so a zero-length
@@ -42,6 +101,7 @@ void main() {
     PdfDocument document,
     PdfViewerController controller, {
     required PdfPageRasterWarmPolicy warm,
+    PdfTileRasterBackend tileRasterBackend = const PdfCanvasTileRasterBackend(),
     PdfPageRasterCachePolicy cache = const PdfPageRasterCachePolicy(
       maxBytes: 512 * 1024 * 1024,
       maxEntryBytes: 64 * 1024 * 1024,
@@ -55,6 +115,7 @@ void main() {
             initialFit: PdfViewerFit.width,
             pageRasterCachePolicy: cache,
             pageRasterWarmPolicy: warm,
+            tileRasterBackend: tileRasterBackend,
           ),
         ),
       );
@@ -71,11 +132,13 @@ void main() {
       (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(6));
     final controller = PdfViewerController();
+    final backend = _FullPageWarmBackend();
     addTearDown(controller.dispose);
     await tester.pumpWidget(viewer(
       document,
       controller,
       warm: const PdfPageRasterWarmPolicy.document(idleDelay: eager),
+      tileRasterBackend: backend,
     ));
     await tester.pump();
 
@@ -89,6 +152,11 @@ void main() {
         reason: 'the warm reaches off-screen pages while the viewer idles');
     expect(warmed.warmedBytes, greaterThan(0));
     expect(warmed.retainedBytes, greaterThan(0));
+    expect(backend.rasters, greaterThan(0),
+        reason: 'the viewer routes off-screen warm rasters through the '
+            'accelerated backend');
+    expect(backend.disposals, greaterThanOrEqualTo(warmed.completions),
+        reason: 'the exact image, not a live page session, owns residency');
 
     // Arrive on a warmed page. A cache hit is served synchronously by
     // _restoreFullRaster, ahead of the render scheduler; a fresh render is a
@@ -421,6 +489,69 @@ void main() {
           reason: 'the local walk is the cost being moved into idle time, so '
               'a declined record must not abandon the warm',
         );
+      });
+    });
+
+    testWidgets('an accelerated backend produces the resident exact raster',
+        (tester) async {
+      final t = target();
+      final backend = _FullPageWarmBackend();
+      await tester.runAsync(() async {
+        expect(
+          await cache.warmFullRaster(
+            0,
+            page,
+            signature: t.signature,
+            pixelRatio: t.ratio,
+            rasterBackend: backend,
+          ),
+          isTrue,
+        );
+        expect(backend.sessions, 1);
+        expect(backend.rasters, 1);
+        expect(backend.disposals, 1);
+        expect(cache.hasFullRaster(t.signature, page), isTrue);
+      });
+    });
+
+    testWidgets('backend rejection falls back to the exact Canvas raster',
+        (tester) async {
+      final t = target();
+      final backend = _FullPageWarmBackend(reject: true);
+      await tester.runAsync(() async {
+        expect(
+          await cache.warmFullRaster(
+            0,
+            page,
+            signature: t.signature,
+            pixelRatio: t.ratio,
+            rasterBackend: backend,
+          ),
+          isTrue,
+        );
+        expect(backend.sessions, 1);
+        expect(backend.rasters, 0);
+        expect(cache.hasFullRaster(t.signature, page), isTrue);
+      });
+    });
+
+    testWidgets('backend raster failure falls back to Canvas', (tester) async {
+      final t = target();
+      final backend = _FullPageWarmBackend(failRaster: true);
+      await tester.runAsync(() async {
+        expect(
+          await cache.warmFullRaster(
+            0,
+            page,
+            signature: t.signature,
+            pixelRatio: t.ratio,
+            rasterBackend: backend,
+          ),
+          isTrue,
+        );
+        expect(backend.rasters, 1);
+        expect(backend.disposals, 1);
+        expect(cache.hasFullRaster(t.signature, page), isTrue);
       });
     });
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -207,6 +207,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend
   @override
   bool get supportsSessionWarmUp => _proactiveWarmUpEnabled;
 
+  @override
+  bool get supportsFullPageRasterWarmUp => _proactiveWarmUpEnabled;
+
   /// Drops reusable texture ownership. Active compiled scenes retain the
   /// resources they are currently drawing.
   void clearImageCache() => _imageCache.clear(stats);

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -51,6 +51,9 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   Future<void> warmUp() async {}
 
   @override
+  bool get supportsFullPageRasterWarmUp => false;
+
+  @override
   String get debugLabel => 'flutter_gpu-unavailable';
 
   @override

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -71,11 +71,13 @@ void main() {
       final mobile = FlutterGpuTileRasterBackend();
       expect(mobile.supportsWarmUp, isFalse);
       expect(mobile.supportsSessionWarmUp, isFalse);
+      expect(mobile.supportsFullPageRasterWarmUp, isFalse);
 
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       final desktop = FlutterGpuTileRasterBackend();
       expect(desktop.supportsWarmUp, isTrue);
       expect(desktop.supportsSessionWarmUp, isTrue);
+      expect(desktop.supportsFullPageRasterWarmUp, isTrue);
       expect(desktop.overprintRetryMaxDimension, 512);
       expect(desktop.overprintRetryMaxCommands, 768);
       expect(desktop.maxTransientAttachmentBytes, 64 << 20);
@@ -98,10 +100,12 @@ void main() {
       final optedIn = FlutterGpuTileRasterBackend(enableProactiveWarmUp: true);
       expect(optedIn.supportsWarmUp, isTrue);
       expect(optedIn.supportsSessionWarmUp, isTrue);
+      expect(optedIn.supportsFullPageRasterWarmUp, isTrue);
       final optedOut =
           FlutterGpuTileRasterBackend(enableProactiveWarmUp: false);
       expect(optedOut.supportsWarmUp, isFalse);
       expect(optedOut.supportsSessionWarmUp, isFalse);
+      expect(optedOut.supportsFullPageRasterWarmUp, isFalse);
     } finally {
       debugDefaultTargetPlatformOverride = previous;
     }


### PR DESCRIPTION
## Summary

- route idle full-page raster warming through accelerated tile backends when supported
- retain the exact GPU-produced image in the existing byte-budgeted LRU after releasing temporary scene sessions
- preserve exact Canvas fallback for rejected or failed pages without repeating the page interpretation
- document the behavior and extend viewer/backend coverage for success, rejection, failure, preemption, invalidation, and eviction

## Validation

- fvm flutter test test/raster_warm_test.dart (30 tests)
- fvm flutter test test/backend_stats_test.dart (5 tests)
- fvm dart analyze
- native macOS run: 16 pages resident, 48 of 48 GPU submissions completed, 0 failures, 0 raster fallbacks