### PR TITLE
Prefer Flutter GPU by default in DartPDF

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -47,12 +47,13 @@ AppImage and portable tarball builds remain available from
 - Progressive rendering reveals complex pages top-down, while faithful
   overprint and spot-color handling keeps print-oriented PDFs visually
   accurate.
-- Developer tools (F12) can switch deep-zoom tiles live between Canvas and the
-  optional flutter_gpu backend, tune the GPU texture/geometry ceilings, inspect
-  actual GPU/fallback routes and resource pressure, and export those metrics as
-  JSON. Web keeps Canvas through the companion's compile-time stub; pull-request
-  web previews provide macOS, Windows, and Linux download buttons in this
-  section for testing the native backend.
+- Native builds prefer the bundled flutter_gpu backend by default; unsupported
+  pages and runtime failures replay exactly through Canvas. Developer tools
+  (F12) can switch the preference live, tune the GPU texture/geometry ceilings,
+  inspect actual GPU/fallback routes and resource pressure, and export those
+  metrics as JSON. Web keeps Canvas through the companion's compile-time stub;
+  pull-request web previews provide macOS, Windows, and Linux download buttons
+  in this section for testing the native backend.
 - Desktop builds include the native `dartpdf` CLI and stdio MCP server for
   bounded inspection, text extraction, form listing, and annotation listing.
   See [`dart_pdf_cli`](../packages/dart_pdf_cli) for installed paths and agent

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -143,11 +143,15 @@ class AppDevTools extends ChangeNotifier {
   /// old scene sessions without reopening the PDF; the base raster stays
   /// visible while the selected backend repopulates the invalidated LoD.
   ///
-  /// The custom flutter_gpu backend is experimental. Keep Canvas as the safe
-  /// default even on supported platforms; developers can opt into flutter_gpu
-  /// from the panel when they are deliberately testing it.
+  /// DartPDF prefers flutter_gpu wherever the compiled backend is available.
+  /// The preference remains switchable at runtime, and unsupported scenes or
+  /// raster failures still replay exactly through Canvas.
   late final ValueNotifier<TileRasterBackendMode> tileRasterBackendMode =
-      ValueNotifier(TileRasterBackendMode.canvas);
+      ValueNotifier(
+    flutterGpuTileRasterBackend.isPlatformSupported
+        ? TileRasterBackendMode.flutterGpu
+        : TileRasterBackendMode.canvas,
+  );
 
   /// Changes when the selected backend instance is replaced without changing
   /// its mode (for example after editing a GPU byte ceiling).
@@ -159,7 +163,6 @@ class AppDevTools extends ChangeNotifier {
   int _gpuTextureBytes = 256 << 20;
   int _gpuGeometryBytes = 256 << 20;
   bool _gpuOverprintApproximation = false;
-  bool _flutterGpuOptIn = false;
 
   bool get gpuOverprintApproximation => _gpuOverprintApproximation;
 
@@ -179,13 +182,7 @@ class AppDevTools extends ChangeNotifier {
           ? flutterGpuTileRasterBackend
           : _canvasTileRasterBackend;
 
-  void setTileRasterBackendMode(
-    TileRasterBackendMode mode, {
-    bool recordOptIn = true,
-  }) {
-    if (recordOptIn) {
-      _flutterGpuOptIn = mode == TileRasterBackendMode.flutterGpu;
-    }
+  void setTileRasterBackendMode(TileRasterBackendMode mode) {
     if (tileRasterBackendMode.value == mode) return;
     tileRasterBackendMode.value = mode;
     // A backend A/B switch must not keep serving already-rendered slabs from
@@ -657,20 +654,17 @@ class AppDevTools extends ChangeNotifier {
             .where((value) => value.name == mode)
             .firstOrNull;
         if (restored != null) {
-          // Older releases selected flutter_gpu automatically on supported
-          // Macs and then persisted that choice. Requiring this new marker
-          // migrates those installs back to Canvas while preserving a
-          // deliberate Developer Tools opt-in made after this change.
+          // Keep an explicit stored preference. A stored flutter_gpu choice
+          // falls back to Canvas only when this build cannot provide it; the
+          // old opt-in marker is intentionally no longer required now that
+          // flutter_gpu is DartPDF's supported-platform default.
           final restoreFlutterGpu =
               restored == TileRasterBackendMode.flutterGpu &&
-                  map['flutterGpuOptIn'] == true &&
                   flutterGpuTileRasterBackend.isPlatformSupported;
-          _flutterGpuOptIn = restoreFlutterGpu;
           setTileRasterBackendMode(
             restoreFlutterGpu
                 ? TileRasterBackendMode.flutterGpu
                 : TileRasterBackendMode.canvas,
-            recordOptIn: false,
           );
         }
       }
@@ -737,7 +731,10 @@ class AppDevTools extends ChangeNotifier {
         jsonEncode({
           'deepZoomMode': deepZoomMode,
           'tileRasterBackend': tileRasterBackendMode.value.name,
-          'flutterGpuOptIn': _flutterGpuOptIn,
+          // Retain the marker for backwards compatibility with builds that
+          // predate flutter_gpu becoming the default.
+          'flutterGpuOptIn':
+              tileRasterBackendMode.value == TileRasterBackendMode.flutterGpu,
           'gpuTextureBytes': flutterGpuTileRasterBackend.maxTextureBytes,
           'gpuGeometryBytes': flutterGpuTileRasterBackend.maxGeometryBytes,
           'gpuOverprintApproximation': _gpuOverprintApproximation,

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -34,16 +34,17 @@ void main() {
       maxGeometryBytes: 256 << 20,
     );
     AppDevTools.instance.setGpuOverprintApproximation(false);
-    AppDevTools.instance.setTileRasterBackendMode(TileRasterBackendMode.canvas);
+    AppDevTools.instance
+        .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
     AppDevTools.instance.flutterGpuTileRasterBackend.stats.reset();
     PdfPerfLog.enabled = false;
     pdfRenderWorkerPoolSize = defaultPdfRenderWorkerPoolSize;
   });
 
-  test('Canvas is the default tile raster backend', () {
+  test('flutter_gpu is the default tile raster backend', () {
     expect(
       AppDevTools.instance.tileRasterBackendMode.value,
-      TileRasterBackendMode.canvas,
+      TileRasterBackendMode.flutterGpu,
     );
   });
 
@@ -160,7 +161,8 @@ void main() {
   test('restore with nothing persisted leaves the defaults alone', () async {
     SharedPreferences.setMockInitialValues({});
     pdfRenderWorkerPoolSize = 3;
-    AppDevTools.instance.setTileRasterBackendMode(TileRasterBackendMode.canvas);
+    AppDevTools.instance
+        .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
     AppDevTools.instance.setPageRasterCachePolicy(
       const PdfPageRasterCachePolicy(),
     );
@@ -173,7 +175,7 @@ void main() {
     expect(AppDevTools.instance.deepZoomMode, AppDevTools.modePatch);
     expect(
       AppDevTools.instance.tileRasterBackendMode.value,
-      TileRasterBackendMode.canvas,
+      TileRasterBackendMode.flutterGpu,
     );
     expect(pdfRenderWorkerPoolSize, 3);
     expect(
@@ -183,7 +185,8 @@ void main() {
     expect(AppDevTools.instance.pageRasterWarmPolicy.value.enabled, isFalse);
   });
 
-  test('legacy automatic flutter_gpu selection migrates to Canvas', () async {
+  test('legacy flutter_gpu selection remains selected without marker',
+      () async {
     SharedPreferences.setMockInitialValues({
       'flutter.devtools.options': jsonEncode({
         'tileRasterBackend': TileRasterBackendMode.flutterGpu.name,
@@ -194,12 +197,26 @@ void main() {
 
     await tools.restoreOptions();
 
-    expect(tools.tileRasterBackendMode.value, TileRasterBackendMode.canvas);
+    expect(tools.tileRasterBackendMode.value, TileRasterBackendMode.flutterGpu);
 
     await tools.persistOptions();
     final stored =
         (await SharedPreferences.getInstance()).getString('devtools.options');
-    expect(jsonDecode(stored!)['flutterGpuOptIn'], isFalse);
+    expect(jsonDecode(stored!)['flutterGpuOptIn'], isTrue);
+  });
+
+  test('an explicit persisted Canvas preference remains selected', () async {
+    SharedPreferences.setMockInitialValues({
+      'flutter.devtools.options': jsonEncode({
+        'tileRasterBackend': TileRasterBackendMode.canvas.name,
+      }),
+    });
+    final tools = AppDevTools.instance;
+    tools.setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
+
+    await tools.restoreOptions();
+
+    expect(tools.tileRasterBackendMode.value, TileRasterBackendMode.canvas);
   });
 
   test('a corrupt payload is logged, not thrown', () async {


### PR DESCRIPTION
## Summary

- prefer the bundled flutter_gpu backend on supported native DartPDF builds
- preserve an explicit saved Canvas preference and legacy saved GPU selections
- keep web and unsupported or failed scenes on the exact Canvas fallback

## Testing

- fvm flutter test --reporter compact test/devtools_options_test.dart test/devtools_panel_test.dart
- fvm dart analyze
- fvm flutter build web --debug --no-pub