### PR TITLE
Sharpen pages during slow scrolling

### DIFF
--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -129,12 +129,15 @@ class AppDevTools extends ChangeNotifier {
       ValueNotifier(const PdfPageRasterCachePolicy());
 
   /// Whether idle viewer time is spent baking exact page rasters ahead of
-  /// navigation (#614). Off by default; the panel's presets turn it on. Kept
+  /// navigation (#614). The product warms only the nearby working set by
+  /// default: it removes the blurry first-arrival pause without committing to
+  /// a whole-document raster pass. The work remains preemptible and bounded by
+  /// [pageRasterCachePolicy]; Developer tools can disable or expand it. Kept
   /// as its own notifier for the same reason as [pageRasterCachePolicy] - a
   /// policy change must reach the mounted document without waiting for the
   /// log-traffic rebuild.
   final ValueNotifier<PdfPageRasterWarmPolicy> pageRasterWarmPolicy =
-      ValueNotifier(const PdfPageRasterWarmPolicy.disabled());
+      ValueNotifier(const PdfPageRasterWarmPolicy.nearby());
 
   /// Runtime tile-backend selection exposed by Developer tools.
   ///

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -28,7 +28,7 @@ void main() {
     );
     AppDevTools.instance.useAutoPageRasterCache();
     AppDevTools.instance
-        .setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.disabled());
+        .setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.nearby());
     AppDevTools.instance.setGpuTileBudgets(
       maxTextureBytes: 256 << 20,
       maxGeometryBytes: 256 << 20,
@@ -138,8 +138,9 @@ void main() {
   test('the idle raster warm policy round-trips', () async {
     SharedPreferences.setMockInitialValues({});
     final tools = AppDevTools.instance;
-    expect(tools.pageRasterWarmPolicy.value.enabled, isFalse,
-        reason: 'warming is off until a host asks for it');
+    expect(tools.pageRasterWarmPolicy.value,
+        const PdfPageRasterWarmPolicy.nearby(),
+        reason: 'the app proactively warms only its nearby working set');
 
     tools.setPageRasterWarmPolicy(
         const PdfPageRasterWarmPolicy.nearby(window: 5));
@@ -182,7 +183,8 @@ void main() {
       AppDevTools.instance.pageRasterCachePolicy.value,
       const PdfPageRasterCachePolicy(),
     );
-    expect(AppDevTools.instance.pageRasterWarmPolicy.value.enabled, isFalse);
+    expect(AppDevTools.instance.pageRasterWarmPolicy.value,
+        const PdfPageRasterWarmPolicy.nearby());
   });
 
   test('legacy flutter_gpu selection remains selected without marker',

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -290,15 +290,15 @@ void main() {
   testWidgets('the idle raster warm selector applies live', (tester) async {
     await pumpWithDoc(tester);
     addTearDown(() => AppDevTools.instance
-        .setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.disabled()));
+        .setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.nearby()));
     await tester.sendKeyEvent(LogicalKeyboardKey.f12);
     await tester.pump();
 
     final warm = find.byKey(const ValueKey('devtools-page-raster-warm'));
     await tester.ensureVisible(warm);
     await tester.pump();
-    expect(find.text('Off'), findsWidgets,
-        reason: 'no background full-raster work until asked for');
+    expect(find.text('Nearby +/-3'), findsWidgets,
+        reason: 'the app warms a bounded nearby working set by default');
 
     await tester.tap(warm);
     await tester.pumpAndSettle();

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -491,9 +491,11 @@ class PdfPageView extends StatefulWidget {
   /// 2. **When the record lands** - at most [motionSafeMaxCommands] commands
   ///    and no more image pixels than [motionSafeMaxImagePixels].
   ///
-  /// A page that fails either test keeps the classic behaviour: held until the
-  /// scroll settles, then one per frame. Set false to restore the old
-  /// strictly-paced scrolling everywhere.
+  /// A worker-backed page that fails either test uses the input-quiet lane:
+  /// its expensive replay stays out of live wheel/drag frames but begins as
+  /// soon as input stops, without waiting for the longer conservative settle
+  /// hold. A failing local page keeps the classic held behaviour. Set false to
+  /// restore strictly-paced scrolling everywhere.
   static bool motionSafeRenders = true;
 
   /// Content-stream ceiling for entering the motion-safe lane with **no render
@@ -2603,9 +2605,10 @@ class _PdfPageViewState extends State<PdfPageView>
   PdfRenderMotionClass _motionSafePass = PdfRenderMotionClass.held;
 
   /// This page's record has already come back too big (or image-bearing) to
-  /// replay during a scroll. The request-time verdict is a guess; this is the
-  /// answer, and it stops the page from speculatively recording again on
-  /// every hold only to be abandoned at the same gate.
+  /// replay during live input. The request-time verdict is a guess; this is
+  /// the answer, and it stops the page from speculatively taking the fully
+  /// free lane again. A worker-backed pass can still use the short quiet lane
+  /// once input stops; a local pass keeps the strict settle hold.
   bool _recordKnownHeld = false;
 
   /// Cached answer of [_xObjectsWithinMotionBudget] for [_xObjectBudgetPage].
@@ -2660,21 +2663,48 @@ class _PdfPageViewState extends State<PdfPageView>
   /// either the walk runs in a worker (free to this thread) or the page is
   /// small enough to walk here ([motionSafeLocalMaxRawContentBytes]).
   PdfRenderMotionClass _pageAllowsMotionRender() {
-    if (!PdfPageView.motionSafeRenders || _recordKnownHeld) {
+    if (!PdfPageView.motionSafeRenders) {
       return PdfRenderMotionClass.held;
+    }
+    final workerBacked = widget.renderWorker?.isActive ?? false;
+    if (_recordKnownHeld) {
+      return workerBacked
+          ? PdfRenderMotionClass.quiet
+          : PdfRenderMotionClass.held;
     }
     // A page-level XObject can hide megabytes of image behind a
     // three-operator content stream - but the dictionary says how many pixels
     // it declares, so measure rather than assume (see
-    // [PdfPageView.motionSafeMaxImagePixels]).
-    if (!_xObjectsWithinMotionBudget()) return PdfRenderMotionClass.held;
+    // [PdfPageView.motionSafeMaxImagePixels]). A worker moves the walk and
+    // decode off this thread; keep the upload/replay out of live input, but do
+    // not make the focused page wait out the full conservative settle window.
+    if (!_xObjectsWithinMotionBudget()) {
+      return workerBacked
+          ? PdfRenderMotionClass.quiet
+          : PdfRenderMotionClass.held;
+    }
     // A live worker means the walk costs this thread nothing: free.
-    if (widget.renderWorker?.isActive ?? false) {
+    if (workerBacked) {
       return PdfRenderMotionClass.free;
     }
-    // No worker, so the walk runs here. Small pages may still take the quiet
-    // window - motion has stopped by then and the hold is only insurance
-    // against it resuming - but never a live gesture.
+    return _pageAllowsLocalMotionRender();
+  }
+
+  /// The motion verdict when the page will actually walk on the UI isolate.
+  ///
+  /// This deliberately ignores whether a worker reports itself active. An
+  /// active worker may still decline an individual page; letting that status
+  /// leak into the fallback verdict would move the very large local walk this
+  /// policy protects into the short quiet lane.
+  PdfRenderMotionClass _pageAllowsLocalMotionRender() {
+    if (!PdfPageView.motionSafeRenders ||
+        _recordKnownHeld ||
+        !_xObjectsWithinMotionBudget()) {
+      return PdfRenderMotionClass.held;
+    }
+    // Small local pages may take the quiet window - motion has stopped by then
+    // and the hold is only insurance against it resuming - but never a live
+    // gesture.
     return widget.page.rawContentLength <=
             PdfPageView.motionSafeLocalMaxRawContentBytes
         ? PdfRenderMotionClass.quiet
@@ -2709,7 +2739,13 @@ class _PdfPageViewState extends State<PdfPageView>
     List<PdfRenderCommand>? commands,
   }) async {
     if (commands != null && !_recordAllowsMotionReplay(commands)) {
-      _motionSafePass = PdfRenderMotionClass.held;
+      // The worker already paid the unknown walk/decode away from the UI
+      // isolate. A large replay still must not land in a live wheel/drag
+      // frame, but waiting the remaining 500 ms settle insurance after input
+      // has stopped is pure visible latency.
+      _motionSafePass = PdfPageView.motionSafeRenders
+          ? PdfRenderMotionClass.quiet
+          : PdfRenderMotionClass.held;
       _recordKnownHeld = true;
     }
     final scheduler = widget.renderScheduler;
@@ -2850,7 +2886,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // before the lane existed.
     // This walk runs on the UI thread whatever the request thought, so the
     // pass can be no freer than the local class allows.
-    final local = _pageAllowsMotionRender();
+    final local = _pageAllowsLocalMotionRender();
     if (local == PdfRenderMotionClass.held ||
         _motionSafePass == PdfRenderMotionClass.held) {
       _motionSafePass = PdfRenderMotionClass.held;

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -491,11 +491,12 @@ class PdfPageView extends StatefulWidget {
   /// 2. **When the record lands** - at most [motionSafeMaxCommands] commands
   ///    and no more image pixels than [motionSafeMaxImagePixels].
   ///
-  /// A worker-backed page that fails either test uses the input-quiet lane:
-  /// its expensive replay stays out of live wheel/drag frames but begins as
-  /// soon as input stops, without waiting for the longer conservative settle
-  /// hold. A failing local page keeps the classic held behaviour. Set false to
-  /// restore strictly-paced scrolling everywhere.
+  /// A worker-backed page that fails either test uses the slow-motion lane:
+  /// its expensive replay stays out of fast wheel/drag frames but may sharpen
+  /// during a sustained slow scroll, or as soon as input stops, without
+  /// waiting for the longer conservative settle hold. A failing local page
+  /// keeps the classic held behaviour. Set false to restore strictly-paced
+  /// scrolling everywhere.
   static bool motionSafeRenders = true;
 
   /// Content-stream ceiling for entering the motion-safe lane with **no render
@@ -2605,10 +2606,10 @@ class _PdfPageViewState extends State<PdfPageView>
   PdfRenderMotionClass _motionSafePass = PdfRenderMotionClass.held;
 
   /// This page's record has already come back too big (or image-bearing) to
-  /// replay during live input. The request-time verdict is a guess; this is
+  /// replay during fast input. The request-time verdict is a guess; this is
   /// the answer, and it stops the page from speculatively taking the fully
-  /// free lane again. A worker-backed pass can still use the short quiet lane
-  /// once input stops; a local pass keeps the strict settle hold.
+  /// free lane again. A worker-backed pass can still use the slow-motion lane;
+  /// a local pass keeps the strict settle hold.
   bool _recordKnownHeld = false;
 
   /// Cached answer of [_xObjectsWithinMotionBudget] for [_xObjectBudgetPage].
@@ -2669,18 +2670,19 @@ class _PdfPageViewState extends State<PdfPageView>
     final workerBacked = widget.renderWorker?.isActive ?? false;
     if (_recordKnownHeld) {
       return workerBacked
-          ? PdfRenderMotionClass.quiet
+          ? PdfRenderMotionClass.slow
           : PdfRenderMotionClass.held;
     }
     // A page-level XObject can hide megabytes of image behind a
     // three-operator content stream - but the dictionary says how many pixels
     // it declares, so measure rather than assume (see
     // [PdfPageView.motionSafeMaxImagePixels]). A worker moves the walk and
-    // decode off this thread; keep the upload/replay out of live input, but do
-    // not make the focused page wait out the full conservative settle window.
+    // decode off this thread; keep the upload/replay out of fast input, but let
+    // the focused page sharpen during sustained slow motion instead of waiting
+    // out the full conservative settle window.
     if (!_xObjectsWithinMotionBudget()) {
       return workerBacked
-          ? PdfRenderMotionClass.quiet
+          ? PdfRenderMotionClass.slow
           : PdfRenderMotionClass.held;
     }
     // A live worker means the walk costs this thread nothing: free.
@@ -2740,11 +2742,12 @@ class _PdfPageViewState extends State<PdfPageView>
   }) async {
     if (commands != null && !_recordAllowsMotionReplay(commands)) {
       // The worker already paid the unknown walk/decode away from the UI
-      // isolate. A large replay still must not land in a live wheel/drag
-      // frame, but waiting the remaining 500 ms settle insurance after input
-      // has stopped is pure visible latency.
+      // isolate. A large replay still must not land in a fast wheel/drag
+      // frame, but it can sharpen during sustained slow motion; waiting the
+      // remaining 500 ms settle insurance after input has stopped is also pure
+      // visible latency.
       _motionSafePass = PdfPageView.motionSafeRenders
-          ? PdfRenderMotionClass.quiet
+          ? PdfRenderMotionClass.slow
           : PdfRenderMotionClass.held;
       _recordKnownHeld = true;
     }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -589,6 +589,12 @@ class PdfViewerController extends ChangeNotifier {
   bool get debugLiveRenderInput =>
       _state?._renderScheduler.activeGesture ?? false;
 
+  /// Test hook: whether the attached viewer currently admits bounded
+  /// worker-backed sharpening during a sustained slow scroll.
+  @visibleForTesting
+  bool get debugSlowRenderMotion =>
+      _state?._renderScheduler.slowMotion ?? false;
+
   /// Whether the attached viewer still has foreground page work in flight: a
   /// scroll holding renders back, or pages queued for their first interpret.
   /// False when no viewer is attached.
@@ -1802,16 +1808,15 @@ class _PdfViewerState extends State<PdfViewer>
   /// occupy its slot instead of painting it during a fast scroll.
   int _pageEpoch = 0;
 
-  /// Paces every page's first (UI-thread) interpret so no frame runs
-  /// more than one - [PdfPageRenderScheduler]. Its [holding] flag stands
-  /// in for the old render hold: while the list scrolls faster than
-  /// pages can usefully render, not-yet-interpreted pages keep their
-  /// preview/placeholder instead of stalling the UI thread mid-fling
-  /// (the stall is what made the scrollbar leap on heavy documents).
-  /// When scrolling settles, held pages drain one per frame, nearest the
-  /// viewport first, rather than all firing in one event-loop turn (the
-  /// burst that froze fast scrolling on iPad). Released when the velocity
-  /// estimate drops or the scroll-settle timer fires.
+  /// Paces every page's first (UI-thread) interpret so no frame runs more than
+  /// one - [PdfPageRenderScheduler]. Its strict [holding] flag stays raised
+  /// through the scroll-settle window, keeping heavyweight local work behind
+  /// a preview/placeholder instead of stalling the UI thread mid-fling (the
+  /// stall that made the scrollbar leap on heavy documents). A separate
+  /// velocity lane lets bounded worker-backed sharpening through during a
+  /// sustained slow scroll. When scrolling settles, held pages drain one per
+  /// frame, nearest the viewport first, rather than all firing in one
+  /// event-loop turn (the burst that froze fast scrolling on iPad).
   final _renderScheduler = PdfPageRenderScheduler();
 
   /// (frame timestamp, scroll pixels) samples from the last ~200ms,
@@ -1877,6 +1882,17 @@ class _PdfViewerState extends State<PdfViewer>
   /// never read as "stopped", short enough that a reader who has actually
   /// stopped is not made to wait.
   static const _gestureQuietDelay = Duration(milliseconds: 120);
+
+  /// A slow-scroll sharpening lane uses viewport-relative velocity with
+  /// hysteresis. It opens below 0.8 viewport lengths per second and remains
+  /// open until motion exceeds 1.2 viewport lengths per second. The floors
+  /// keep unusually short viewports from labelling ordinary wheel motion as
+  /// slow. The opening grace in [_trackScrollVelocity] still wins, so the lane
+  /// cannot open on the low first samples of a flick that is accelerating.
+  static const double _slowScrollEnterViewportRate = 0.8;
+  static const double _slowScrollExitViewportRate = 1.2;
+  static const double _slowScrollEnterFloor = 480;
+  static const double _slowScrollExitFloor = 640;
 
   /// Fires once the viewer has been quiet for
   /// [PdfPageRasterWarmPolicy.idleDelay]. Any scroll, zoom, edit, or queued
@@ -2098,6 +2114,7 @@ class _PdfViewerState extends State<PdfViewer>
     // A live gesture is what a UI-thread walk must not run inside; the quiet
     // window that follows one is not (see [PdfPageRenderScheduler.activeGesture]).
     _renderScheduler.activeGesture = _directMotionRenderHoldActive;
+    if (!_motionRenderHoldActive) _renderScheduler.slowMotion = false;
     _renderScheduler.parked = !widget.active;
   }
 
@@ -2123,6 +2140,7 @@ class _PdfViewerState extends State<PdfViewer>
     _cancelPreviewPrerenderSchedule();
     _motionHoldReleaseTimer?.cancel();
     _motionHoldReleaseTimer = null;
+    _renderScheduler.slowMotion = false;
     _renderScheduler.holding = true;
   }
 
@@ -3677,17 +3695,17 @@ class _PdfViewerState extends State<PdfViewer>
     );
   }
 
-  /// Estimates the scroll velocity over a ~200ms window of per-frame
-  /// samples and holds the render scheduler past ~2 viewport-heights/sec.
-  /// Frame timestamps (not wall clock) collapse the burst of listener
-  /// calls a single wheel tick produces into one sample - an instant
-  /// 100px jump must not read as infinite velocity.
+  /// Estimates the scroll velocity over a ~200ms window of per-frame samples
+  /// and opens the worker-backed sharpening lane during sustained slow motion.
+  /// Frame timestamps (not wall clock) collapse the burst of listener calls a
+  /// single wheel tick produces into one sample - an instant 100px jump must
+  /// not read as infinite velocity.
   void _trackScrollVelocity() {
     if (!_scroll.hasClients) return;
     // Mark the gesture before the first-sample early return below. Expensive
-    // worker-backed pages use the short input-quiet lane: they may sharpen
-    // while the conservative scroll hold is still up, but never in the frame
-    // that began a wheel/drag burst. Previously the first event raised only
+    // worker-backed pages use the slow-motion lane: they may sharpen while the
+    // conservative scroll hold is still up, but never in the unclassified
+    // first frame of a wheel/drag burst. Previously the first event raised only
     // [holding], so a quiet-class render could slip through before the second
     // event supplied a velocity sample.
     _markScrollGestureActive();
@@ -3719,26 +3737,43 @@ class _PdfViewerState extends State<PdfViewer>
     final velocity =
         (pixels - _scrollSamples.first.$2).abs() * 1e6 / span; // px/s
     final viewport = _scroll.position.viewportDimension;
-    // A flick ramps up: its first inter-frame deltas underread the
-    // gesture's true speed, so a velocity verdict taken in the burst's
-    // opening frames reads "slow" and releases the hold right as the
-    // scroll accelerates - a heavy page entering then interprets
-    // synchronously and drops the frame (the hitch felt a fraction of a
-    // page into a fast scroll). Hold unconditionally through the opening
-    // window, then govern by the windowed velocity (>~2 viewport-
-    // heights/sec). Held pages paint their low-res preview, not blank, so
-    // a genuinely slow scroll only shows a brief preview before the grace
-    // lapses and the page sharpens; the settle timer clears the burst.
+    // A flick ramps up: its first inter-frame deltas underread the gesture's
+    // true speed, so a velocity verdict taken in the burst's opening frames
+    // reads "slow" right as the scroll accelerates. Keep the slow lane closed
+    // through that grace, then use hysteresis around roughly one viewport per
+    // second: the lower threshold prevents a fast scroll entering the lane,
+    // while the higher exit avoids flickering it off on tiny speed changes.
+    // The strict hold remains raised through the full settle window, so local
+    // heavyweight work still cannot run here; only work explicitly classified
+    // [PdfRenderMotionClass.slow] can sharpen during slow input.
     final opening = now - _scrollBurstStart < const Duration(milliseconds: 150);
-    final activeMotion = _motionRenderHoldActive;
-    final hold =
-        activeMotion || opening || velocity > math.max(800, 2 * viewport);
-    _vectorFirstPrefetch = hold && (_effectiveRenderWorker?.isActive ?? false);
+    // A wheel event also owns the short transform-release timer, but the live
+    // scroll-settle timer identifies it as list motion whose velocity we can
+    // classify. [_previewUiMustDefer] is the existing distinction between
+    // that case and a direct pan/zoom gesture that must never enter this lane.
+    final directMotion = _previewUiMustDefer;
+    final slowEnter = math.max(
+      _slowScrollEnterFloor,
+      _slowScrollEnterViewportRate * viewport,
+    );
+    final slowExit = math.max(
+      _slowScrollExitFloor,
+      _slowScrollExitViewportRate * viewport,
+    );
+    final slowThreshold = _renderScheduler.slowMotion ? slowExit : slowEnter;
+    final slow = !opening && !directMotion && velocity <= slowThreshold;
+    _renderScheduler.slowMotion = slow;
+    final fastThreshold = math.max(800, 2 * viewport);
+    final hold = _motionRenderHoldActive || opening || velocity > fastThreshold;
+    _vectorFirstPrefetch =
+        !slow && hold && (_effectiveRenderWorker?.isActive ?? false);
     PdfPerfLog.log('scroll page=${_controller.currentPage} '
         'v=${velocity.toStringAsFixed(0)}px/s '
-        'threshold=${math.max(800, 2 * viewport).toStringAsFixed(0)} '
+        'slow=${slow ? 'ON' : 'off'} '
+        'slowThreshold=${slowThreshold.toStringAsFixed(0)} '
+        'fastThreshold=${fastThreshold.toStringAsFixed(0)} '
         'prefetch=${_vectorFirstPrefetch ? 'vector' : 'full'} '
-        'opening=$opening active=$activeMotion '
+        'opening=$opening direct=$directMotion '
         'hold=${hold ? 'ON' : 'off'}');
     // a paused viewer (overlaid by another view) holds unconditionally
     _renderScheduler.holding = hold || !widget.active;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -583,6 +583,12 @@ class PdfViewerController extends ChangeNotifier {
   @visibleForTesting
   bool get debugRenderHold => _state?._renderScheduler.holding ?? false;
 
+  /// Test hook: whether scroll input is still arriving frequently enough that
+  /// input-quiet page work must remain deferred.
+  @visibleForTesting
+  bool get debugLiveRenderInput =>
+      _state?._renderScheduler.activeGesture ?? false;
+
   /// Whether the attached viewer still has foreground page work in flight: a
   /// scroll holding renders back, or pages queued for their first interpret.
   /// False when no viewer is attached.
@@ -3678,6 +3684,13 @@ class _PdfViewerState extends State<PdfViewer>
   /// 100px jump must not read as infinite velocity.
   void _trackScrollVelocity() {
     if (!_scroll.hasClients) return;
+    // Mark the gesture before the first-sample early return below. Expensive
+    // worker-backed pages use the short input-quiet lane: they may sharpen
+    // while the conservative scroll hold is still up, but never in the frame
+    // that began a wheel/drag burst. Previously the first event raised only
+    // [holding], so a quiet-class render could slip through before the second
+    // event supplied a velocity sample.
+    _markScrollGestureActive();
     final now = WidgetsBinding.instance.currentSystemFrameTimeStamp;
     final pixels = _scroll.position.pixels;
     if (_scrollSamples.isEmpty) {
@@ -3729,11 +3742,15 @@ class _PdfViewerState extends State<PdfViewer>
         'hold=${hold ? 'ON' : 'off'}');
     // a paused viewer (overlaid by another view) holds unconditionally
     _renderScheduler.holding = hold || !widget.active;
-    // A gesture is in flight while events keep arriving (or a finger/fling
-    // genuinely owns the viewport). Deliberately NOT `activeMotion`, which
-    // includes the 500 ms quiet window: that window is the thing a cheap
-    // local walk should be allowed through.
-    // An event just arrived, so a gesture is happening by definition.
+  }
+
+  /// Restarts the short live-input boundary used by quiet-class renders.
+  ///
+  /// Deliberately independent of the longer scroll-settle hold: that hold is
+  /// insurance against an expensive background render landing if input
+  /// resumes, whereas the focused page the reader stopped on should begin
+  /// sharpening as soon as the input stream itself has gone quiet.
+  void _markScrollGestureActive() {
     _renderScheduler.activeGesture = true;
     _gestureQuietTimer?.cancel();
     _gestureQuietTimer = Timer(_gestureQuietDelay, () {

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -53,9 +53,11 @@ import 'perf_log.dart';
 /// a hold - one per frame, and only near the scroll's destination
 /// ([motionSafeHoldRadius], so a fling does not record every page it passes) -
 /// and several may start in one frame once the scroll settles. Expensive
-/// worker-backed results use the intermediate input-quiet lane: replay waits
-/// until the live input stream stops, but not for the longer settle insurance.
-/// Heavy local work keeps the old held, then one-per-frame behaviour.
+/// worker-backed results use the intermediate slow-motion lane: replay may
+/// land during a sustained slow scroll, or as soon as the live input stream
+/// stops, without waiting for the longer settle insurance. Small local walks
+/// use the input-quiet lane and still stay out of every live gesture. Heavy
+/// local work keeps the old held, then one-per-frame behaviour.
 ///
 /// On a long text document that is the difference between arriving on a page
 /// and waiting out the scroll before the render even starts (~600 ms to
@@ -72,12 +74,19 @@ enum PdfRenderMotionClass {
   /// anything whose cost is unknown or large gets.
   held,
 
-  /// Runs during the scroll-quiet window but not inside a live gesture: either
-  /// a small page whose walk is on the UI thread, or an expensive worker result
-  /// whose replay/upload must stay out of live input. In both cases waiting
-  /// out the full settle window is visible latency, while landing in a gesture
-  /// frame would be a stutter.
+  /// Runs during the scroll-quiet window but not inside a live gesture. This is
+  /// for a small page whose walk is on the UI thread, and other work that must
+  /// not compete with any pointer/wheel input. Waiting out the full settle
+  /// window is visible latency, while landing in a gesture frame would be a
+  /// stutter.
   quiet,
+
+  /// Runs during a sustained slow scroll, or once live input goes quiet, but
+  /// not during fast motion. This is for worker-backed sharpening whose walk
+  /// is off-thread but whose replay/upload is too large for a fast frame.
+  ///
+  /// Unlike [quiet], this class must never be used for a local UI-thread walk.
+  slow,
 
   /// Runs whenever, motion or not: the walk is in a worker and the replay is
   /// small, so a scrolling frame pays nothing for it.
@@ -146,6 +155,7 @@ class PdfPageRenderScheduler {
 
   bool _holding = false;
   bool _activeGesture = false;
+  bool _slowMotion = false;
 
   /// Whether work of [motion] may run right now. The whole point of the class
   /// being evaluated here, and not when the request was made.
@@ -153,6 +163,7 @@ class PdfPageRenderScheduler {
 
   bool _motionPermits(PdfRenderMotionClass motion) => switch (motion) {
         PdfRenderMotionClass.free => true,
+        PdfRenderMotionClass.slow => _slowMotion || !_activeGesture,
         PdfRenderMotionClass.quiet => !_activeGesture,
         PdfRenderMotionClass.held => !_holding,
       };
@@ -218,9 +229,25 @@ class PdfPageRenderScheduler {
     }
   }
 
-  /// True while a fast scroll is in flight: the viewer raises it from its
-  /// velocity estimate. No request is granted while held; lowering it
-  /// drains the queue.
+  /// Whether the current live input is a sustained slow scroll.
+  ///
+  /// While true, [PdfRenderMotionClass.slow] work may sharpen the focused page
+  /// through the conservative hold. The setter wakes both queues when the
+  /// velocity crosses into that lane; changing back to fast motion closes the
+  /// gate before the next scheduled grant.
+  bool get slowMotion => _slowMotion;
+  set slowMotion(bool value) {
+    if (_slowMotion == value || _disposed) return;
+    _slowMotion = value;
+    if (_slowMotion) {
+      _scheduleDrain();
+      _scheduleUiDrain();
+    }
+  }
+
+  /// True through the conservative scroll-settle window. Held-class work does
+  /// not run until it lowers; the motion-safe classes above can pass according
+  /// to the current live-input and velocity state.
   bool get holding => _holding;
   set holding(bool value) {
     if (_holding == value || _disposed) return;
@@ -462,6 +489,7 @@ class PdfPageRenderScheduler {
         'focus=$_focus cost=${next.motion.name} '
         'hold=${_holding ? 'ON' : 'off'}'
         '${_activeGesture ? ' gesture=ON' : ''} '
+        '${_slowMotion ? 'slow=ON ' : ''}'
         'remaining=${_pending.length}');
     _inFlight[next.token] = null;
     _activePriorities[next.token] = next.priority;

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -52,9 +52,10 @@ import 'perf_log.dart';
 /// (`PdfPageView.motionSafeMaxCommands`). Motion-safe work is granted **during**
 /// a hold - one per frame, and only near the scroll's destination
 /// ([motionSafeHoldRadius], so a fling does not record every page it passes) -
-/// and several may start in one frame once the scroll settles. Everything else
-/// keeps exactly the old behaviour - held, then one per frame - because those
-/// are the pages the pacing exists for.
+/// and several may start in one frame once the scroll settles. Expensive
+/// worker-backed results use the intermediate input-quiet lane: replay waits
+/// until the live input stream stops, but not for the longer settle insurance.
+/// Heavy local work keeps the old held, then one-per-frame behaviour.
 ///
 /// On a long text document that is the difference between arriving on a page
 /// and waiting out the scroll before the render even starts (~600 ms to
@@ -71,10 +72,11 @@ enum PdfRenderMotionClass {
   /// anything whose cost is unknown or large gets.
   held,
 
-  /// Runs during the scroll-quiet window but not inside a live gesture: a
-  /// small page whose walk is on the UI thread, where waiting out the full
-  /// quiet window is the delay a reader complains about, but stuttering a
-  /// gesture in progress would be worse.
+  /// Runs during the scroll-quiet window but not inside a live gesture: either
+  /// a small page whose walk is on the UI thread, or an expensive worker result
+  /// whose replay/upload must stay out of live input. In both cases waiting
+  /// out the full settle window is visible latency, while landing in a gesture
+  /// frame would be a stutter.
   quiet,
 
   /// Runs whenever, motion or not: the walk is in a worker and the replay is

--- a/packages/dart_pdf_editor/test/motion_safe_render_test.dart
+++ b/packages/dart_pdf_editor/test/motion_safe_render_test.dart
@@ -15,9 +15,10 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 /// An in-process [PdfRenderWorker] that records on the test isolate, so the
 /// worker render path runs deterministically under pump().
 class _SyncWorker extends PdfRenderWorker {
-  _SyncWorker(this._bytes);
+  _SyncWorker(this._bytes, {this.decline = false});
 
   final Uint8List _bytes;
+  final bool decline;
   late final PdfDocument _doc = PdfDocument.open(_bytes);
   bool _disposed = false;
 
@@ -34,6 +35,7 @@ class _SyncWorker extends PdfRenderWorker {
       PdfRect? imageDecodeRegion,
       PdfPartialRecordSink? onPartial}) async {
     if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
+    if (decline) return null;
     final page = _doc.page(pageIndex);
     final ops = ContentStreamParser.parse(page.contentBytes(),
         operationLimit: decodeImages ? null : commandLimit);
@@ -79,11 +81,15 @@ void main() {
     WidgetTester tester,
     Uint8List bytes, {
     required bool holding,
+    bool activeGesture = false,
+    bool workerDeclines = false,
   }) async {
     final document = PdfDocument.open(bytes);
-    final worker = _SyncWorker(bytes);
+    final worker = _SyncWorker(bytes, decline: workerDeclines);
     addTearDown(worker.dispose);
-    final scheduler = PdfPageRenderScheduler()..holding = holding;
+    final scheduler = PdfPageRenderScheduler()
+      ..holding = holding
+      ..activeGesture = activeGesture;
     addTearDown(scheduler.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Center(
@@ -178,7 +184,7 @@ void main() {
     await settle(tester);
   });
 
-  testWidgets('a page carrying a big image waits for the scroll to settle',
+  testWidgets('a worker-backed big image waits for input, not full settle',
       (tester) async {
     // A megapixel-class underlay is the decode/upload the hold exists to
     // prevent. Whichever gate catches it - the page's own /XObject
@@ -189,13 +195,48 @@ void main() {
       layers: 1,
       ops: 20,
     );
-    final scheduler = await pumpPage(tester, bytes, holding: true);
+    final scheduler =
+        await pumpPage(tester, bytes, holding: true, activeGesture: true);
     for (var i = 0; i < 6; i++) {
       await settle(tester);
     }
     expect(painted(tester), isFalse,
-        reason: 'an image decode/upload mid-fling is the hitch the hold '
-            'exists to prevent');
+        reason: 'an image decode/upload must not land during live input');
+
+    // Input stops, but the conservative 500ms scroll-settle hold remains.
+    // The focused worker-backed page should sharpen in this short quiet lane
+    // instead of making the reader stare at its preview for the whole hold.
+    scheduler.activeGesture = false;
+    for (var i = 0; i < 20 && !painted(tester); i++) {
+      await settle(tester);
+    }
+    expect(painted(tester), isTrue);
+    expect(scheduler.holding, isTrue,
+        reason: 'background/local heavy work remains protected');
+  });
+
+  testWidgets('a declined big image keeps the strict local-render hold',
+      (tester) async {
+    final bytes = buildSyntheticRasterUnderlaySheet(
+      underlays: const [PdfUnderlaySpec(width: 1200, height: 1200)],
+      layers: 1,
+      ops: 20,
+    );
+    final scheduler = await pumpPage(
+      tester,
+      bytes,
+      holding: true,
+      activeGesture: true,
+      workerDeclines: true,
+    );
+
+    scheduler.activeGesture = false;
+    for (var i = 0; i < 10; i++) {
+      await settle(tester);
+    }
+    expect(painted(tester), isFalse,
+        reason: 'a worker declaration is not enough: once it declines, the '
+            'large walk would run locally and must retain the strict hold');
 
     scheduler.holding = false;
     for (var i = 0; i < 20 && !painted(tester); i++) {
@@ -226,7 +267,7 @@ void main() {
     expect(scheduler.holding, isTrue, reason: 'still scrolling');
   });
 
-  testWidgets('the image budget is what decides, not the presence of an image',
+  testWidgets('the image budget chooses free versus input-quiet rendering',
       (tester) async {
     // The same page as above, with the budget moved under it: what governs is
     // how many pixels the page declares, not whether it declares any.
@@ -238,38 +279,43 @@ void main() {
       layers: 1,
       ops: 20,
     );
-    final scheduler = await pumpPage(tester, bytes, holding: true);
+    final scheduler =
+        await pumpPage(tester, bytes, holding: true, activeGesture: true);
     for (var i = 0; i < 8; i++) {
       await settle(tester);
     }
     expect(painted(tester), isFalse,
-        reason: 'the same page, one pixel over budget, keeps the strict hold');
+        reason: 'the same page, one pixel over budget, stays out of a live '
+            'input frame');
 
-    scheduler.holding = false;
+    scheduler.activeGesture = false;
     for (var i = 0; i < 20 && !painted(tester); i++) {
       await settle(tester);
     }
     expect(painted(tester), isTrue);
+    expect(scheduler.holding, isTrue);
   });
 
-  testWidgets('a record over the command ceiling waits for the settle',
+  testWidgets('a large worker record waits for input, not full settle',
       (tester) async {
     final previous = PdfPageView.motionSafeMaxCommands;
     PdfPageView.motionSafeMaxCommands = 0;
     addTearDown(() => PdfPageView.motionSafeMaxCommands = previous);
-    final scheduler = await pumpPage(tester, buildClassicPdf(), holding: true);
+    final scheduler = await pumpPage(tester, buildClassicPdf(),
+        holding: true, activeGesture: true);
     for (var i = 0; i < 6; i++) {
       await settle(tester);
     }
     expect(painted(tester), isFalse,
-        reason: 'replaying a large buffer inside a scrolling frame is the '
+        reason: 'replaying a large buffer inside a live input frame is the '
             'cost the ceiling bounds');
 
-    scheduler.holding = false;
+    scheduler.activeGesture = false;
     for (var i = 0; i < 10 && !painted(tester); i++) {
       await settle(tester);
     }
     expect(painted(tester), isTrue);
+    expect(scheduler.holding, isTrue);
   });
 
   testWidgets('with no worker a small page renders in the scroll-quiet window',

--- a/packages/dart_pdf_editor/test/motion_safe_render_test.dart
+++ b/packages/dart_pdf_editor/test/motion_safe_render_test.dart
@@ -184,7 +184,7 @@ void main() {
     await settle(tester);
   });
 
-  testWidgets('a worker-backed big image waits for input, not full settle',
+  testWidgets('a worker-backed big image sharpens during a slow scroll',
       (tester) async {
     // A megapixel-class underlay is the decode/upload the hold exists to
     // prevent. Whichever gate catches it - the page's own /XObject
@@ -203,14 +203,16 @@ void main() {
     expect(painted(tester), isFalse,
         reason: 'an image decode/upload must not land during live input');
 
-    // Input stops, but the conservative 500ms scroll-settle hold remains.
-    // The focused worker-backed page should sharpen in this short quiet lane
-    // instead of making the reader stare at its preview for the whole hold.
-    scheduler.activeGesture = false;
+    // The input remains live, but its measured velocity falls into the slow
+    // lane. The focused worker-backed page should sharpen now instead of
+    // making the reader stop completely; the conservative hold stays raised
+    // for local and background work.
+    scheduler.slowMotion = true;
     for (var i = 0; i < 20 && !painted(tester); i++) {
       await settle(tester);
     }
     expect(painted(tester), isTrue);
+    expect(scheduler.activeGesture, isTrue, reason: 'input is still arriving');
     expect(scheduler.holding, isTrue,
         reason: 'background/local heavy work remains protected');
   });
@@ -230,7 +232,7 @@ void main() {
       workerDeclines: true,
     );
 
-    scheduler.activeGesture = false;
+    scheduler.slowMotion = true;
     for (var i = 0; i < 10; i++) {
       await settle(tester);
     }
@@ -329,7 +331,8 @@ void main() {
     final document = PdfDocument.open(bytes);
     final scheduler = PdfPageRenderScheduler()
       ..holding = true
-      ..activeGesture = true;
+      ..activeGesture = true
+      ..slowMotion = true;
     addTearDown(scheduler.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Center(

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -106,6 +106,43 @@ void main() {
     expect(ran, ['safe', 'held']);
   });
 
+  testWidgets('slow motion admits worker sharpening but not quiet local work',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler()
+      ..holding = true
+      ..activeGesture = true
+      ..focus = 0;
+    addTearDown(scheduler.dispose);
+    final ran = <String>[];
+    scheduler.request('slow', 0, () => ran.add('slow'),
+        motion: PdfRenderMotionClass.slow);
+    scheduler.request('quiet', 0, () => ran.add('quiet'),
+        motion: PdfRenderMotionClass.quiet);
+
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(ran, isEmpty, reason: 'fast live input keeps both lanes closed');
+
+    scheduler.slowMotion = true;
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(ran, ['slow'],
+        reason: 'only off-thread worker sharpening enters a slow scroll');
+
+    scheduler
+      ..slowMotion = false
+      ..activeGesture = false;
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(ran, ['slow', 'quiet'],
+        reason: 'small local work waits until live input stops');
+    expect(scheduler.holding, isTrue,
+        reason: 'strict held work still waits for the full settle');
+  });
+
   testWidgets('a hold still paces motion-safe grants one per frame',
       (tester) async {
     final scheduler = PdfPageRenderScheduler()
@@ -311,9 +348,7 @@ void main() {
     final scheduler = PdfPageRenderScheduler()..focus = 100;
     addTearDown(scheduler.dispose);
     final order = <int>[];
-    scheduler
-        .paceUiWork('stale-index', 100, focusDistance: 2)
-        .then((ready) {
+    scheduler.paceUiWork('stale-index', 100, focusDistance: 2).then((ready) {
       if (ready) order.add(100);
     });
     scheduler.paceUiWork('visible', 5, focusDistance: 0).then((ready) {

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -656,11 +656,11 @@ void main() {
 
   testWidgets('PdfPageView defers worker replay when render hold resumes',
       (tester) async {
-    // A record big enough to matter is still held: the motion-safe lane
-    // (PdfPageView.motionSafeRenders) only lets a SMALL image-free buffer
-    // replay through a scroll, and pinning the ceiling at zero puts this
-    // fixture on the classic side of that line. The lane's own behaviour is
-    // covered in motion_safe_render_test.dart.
+    // A record big enough to matter cannot replay through live input. Pinning
+    // the ceiling at zero puts this fixture on the input-quiet side of that
+    // line; this test raises the hold without separately ending the gesture,
+    // so the result remains deferred. The lane's complete behaviour is covered
+    // in motion_safe_render_test.dart.
     final previousCeiling = PdfPageView.motionSafeMaxCommands;
     PdfPageView.motionSafeMaxCommands = 0;
     addTearDown(() => PdfPageView.motionSafeMaxCommands = previousCeiling);
@@ -703,7 +703,9 @@ void main() {
     expect(worker.calls.single.$3, isTrue,
         reason: 'the fresh preview skips the vector-first pass');
 
-    scheduler.holding = true;
+    scheduler
+      ..holding = true
+      ..activeGesture = true;
     worker.completeAll();
     for (var i = 0; i < 10; i++) {
       await tester.pump(const Duration(milliseconds: 16));
@@ -712,7 +714,9 @@ void main() {
         reason: 'a worker result that arrives after motion restarts must not '
             'replay/rasterize on the UI side');
 
-    scheduler.holding = false;
+    scheduler
+      ..activeGesture = false
+      ..holding = false;
     for (var i = 0; i < 40 && rasters == 0; i++) {
       worker.completeAll();
       await tester.pump(const Duration(milliseconds: 16));

--- a/packages/dart_pdf_editor/test/wheel_scroll_test.dart
+++ b/packages/dart_pdf_editor/test/wheel_scroll_test.dart
@@ -35,11 +35,9 @@ void main() {
     await pumpViewer(tester);
     final pointer = TestPointer(101, PointerDeviceKind.trackpad);
     pointer.hover(const Offset(400, 300));
-    await tester.sendEventToBinding(
-        pointer.scroll(const Offset(0, 120)));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 120)));
     await tester.pumpAndSettle();
-    final state = tester
-        .state<ScrollableState>(find.byType(Scrollable).first);
+    final state = tester.state<ScrollableState>(find.byType(Scrollable).first);
     expect(state.position.pixels, greaterThan(0),
         reason: 'vertical trackpad scroll should scroll the list');
   });
@@ -55,8 +53,18 @@ void main() {
     await tester.sendEventToBinding(pointer.scroll(const Offset(0, 120)));
     await tester.pump();
     expect(controller.debugRenderHold, isTrue);
+    expect(controller.debugLiveRenderInput, isTrue,
+        reason: 'the very first wheel event must close the quiet render lane');
 
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 119));
+    expect(controller.debugLiveRenderInput, isTrue);
+    await tester.pump(const Duration(milliseconds: 2));
+    expect(controller.debugLiveRenderInput, isFalse,
+        reason: 'the focused worker page may sharpen after input goes quiet');
+    expect(controller.debugRenderHold, isTrue,
+        reason: 'heavy local and background work keeps the 500ms protection');
+
+    await tester.pump(const Duration(milliseconds: 179));
     expect(controller.debugRenderHold, isTrue,
         reason: 'a delayed wheel acknowledgement must not release a CAD '
             'raster into the middle of the gesture');
@@ -75,14 +83,12 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 300));
     expect(controller.zoom, greaterThan(1.01));
 
-    final state = tester
-        .state<ScrollableState>(find.byType(Scrollable).first);
+    final state = tester.state<ScrollableState>(find.byType(Scrollable).first);
     final before = state.position.pixels;
     final pointer = TestPointer(102, PointerDeviceKind.trackpad);
     pointer.hover(const Offset(400, 300));
     for (var i = 0; i < 5; i++) {
-      await tester.sendEventToBinding(
-          pointer.scroll(const Offset(0, 60)));
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 60)));
       await tester.pump(const Duration(milliseconds: 16));
     }
     await tester.pumpAndSettle();
@@ -104,8 +110,7 @@ void main() {
     // capture tx via the controller's pan state: use visiblePageRegion
     final beforeRegion = controller.visiblePageRegion(0);
     for (var i = 0; i < 5; i++) {
-      await tester.sendEventToBinding(
-          pointer.scroll(const Offset(60, 0)));
+      await tester.sendEventToBinding(pointer.scroll(const Offset(60, 0)));
       await tester.pump(const Duration(milliseconds: 16));
     }
     await tester.pumpAndSettle();

--- a/packages/dart_pdf_editor/test/wheel_scroll_test.dart
+++ b/packages/dart_pdf_editor/test/wheel_scroll_test.dart
@@ -55,6 +55,9 @@ void main() {
     expect(controller.debugRenderHold, isTrue);
     expect(controller.debugLiveRenderInput, isTrue,
         reason: 'the very first wheel event must close the quiet render lane');
+    expect(controller.debugSlowRenderMotion, isFalse,
+        reason: 'the opening sample must not misclassify an accelerating '
+            'flick as slow');
 
     await tester.pump(const Duration(milliseconds: 119));
     expect(controller.debugLiveRenderInput, isTrue);
@@ -70,6 +73,37 @@ void main() {
             'raster into the middle of the gesture');
 
     await tester.pump(const Duration(milliseconds: 250));
+    expect(controller.debugRenderHold, isFalse);
+  });
+
+  testWidgets('sustained slow scrolling opens the sharpening lane',
+      (tester) async {
+    final controller = await pumpViewer(tester);
+    await tester.pumpAndSettle();
+    final pointer = TestPointer(108, PointerDeviceKind.mouse);
+    pointer.hover(const Offset(400, 300));
+
+    // Five small steps over 200ms are well under one viewport per second.
+    // The 150ms opening grace must elapse before the lane can open.
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 8)));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    expect(controller.debugLiveRenderInput, isTrue,
+        reason: 'the wheel stream is still active');
+    expect(controller.debugSlowRenderMotion, isTrue,
+        reason: 'bounded worker-backed pages may sharpen during slow motion');
+    expect(controller.debugRenderHold, isTrue,
+        reason: 'strict local and background work remains held');
+
+    // One fast step pushes the 200ms window above the hysteresis exit. The
+    // lane closes immediately, without waiting for the settle timer.
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 300)));
+    await tester.pump(const Duration(milliseconds: 16));
+    expect(controller.debugSlowRenderMotion, isFalse);
+    expect(controller.debugRenderHold, isTrue);
+
+    await tester.pump(const Duration(milliseconds: 550));
     expect(controller.debugRenderHold, isFalse);
   });
 

--- a/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/gpu_benchmark_test.dart
@@ -58,6 +58,18 @@ Future<void> _waitForGpuIdle(FlutterGpuTileRasterBackend backend) async {
   );
 }
 
+Future<int> _timeSerialGpuImage(
+  FlutterGpuTileRasterBackend backend,
+  Future<ui.Image> Function() render,
+) async {
+  final elapsed = await _timeSettledImage(render);
+  // Pixel readback can resolve just before Flutter delivers the command-buffer
+  // completion callback. Wait for that callback too so the next sample sees
+  // the just-used transient resources back in their pools.
+  await _waitForGpuIdle(backend);
+  return elapsed;
+}
+
 Future<(int, Uint8List)> _timePixels(Future<ui.Image> Function() render) async {
   final clock = Stopwatch()..start();
   final image = await render();
@@ -194,7 +206,8 @@ void main() {
       backend.stats.reset();
       final settled = <int>[];
       for (var index = 0; index < 15; index++) {
-        settled.add(await _timeSettledImage(
+        settled.add(await _timeSerialGpuImage(
+          backend,
           () => session.rasterizeRegion(region, pixelRatio: 0.5),
         ));
       }
@@ -303,7 +316,8 @@ void main() {
       backend.stats.reset();
       final settled = <int>[];
       for (var index = 0; index < 15; index++) {
-        settled.add(await _timeSettledImage(
+        settled.add(await _timeSerialGpuImage(
+          backend,
           () => session.rasterizeRegion(region, pixelRatio: 0.5),
         ));
       }


### PR DESCRIPTION
## Summary

- warm a bounded window of three nearby full-page rasters by default while the viewer is idle
- classify page work into settled-only, input-quiet, slow-scroll worker sharpening, and always-safe lanes
- open the slow lane after a 150 ms flick-detection grace below 0.8 viewport lengths per second; keep it open until 1.2 viewport lengths per second to avoid threshold flicker
- admit only bounded worker-backed work during slow scrolling, one result per frame and within one page of focus
- keep fast scrolling, direct pan/zoom, heavyweight local fallback, and background work on the strict hold
- preserve the 120 ms input-quiet path after motion stops and an explicit saved Off preference

## Why

This is the rendering-policy follow-up to #878. The GPU backend makes rendering faster, but the old policy could still leave scan-heavy pages blurred until scrolling stopped. The velocity lane lets the page under a careful scroll progressively sharpen without exposing fast flings to expensive UI-thread work.

The attached 30-page issue PDF uses repeated 3200 x 2133 images. Local sampling accepted the pages on the GPU path, with warm page work around 9-18 ms versus roughly 37-127 ms on Canvas. The Fedora AppImage still needs an end-to-end recording before #871 should be closed.

## Testing

- `fvm dart analyze`
- `fvm flutter test test/render_scheduler_test.dart test/motion_safe_render_test.dart test/wheel_scroll_test.dart` (47 passed)
- render-hold, worker, page-session, page-view, preview, and raster-warm regression set (202 passed)
- full package suite on the base policy change (2,554 passed; 27 skipped corpus/benchmark cases)
- full app suite (504 passed)