### PR TITLE
fix(viewer): allow panning between text lines

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5790,7 +5790,29 @@ class _PdfViewerState extends State<PdfViewer>
     if (point == null) return null;
     final (i, x, y) = point;
     final text = _pageText(i);
-    var isOnTextLine = false;
+    final offset = _textPositionOnLine(
+      text,
+      x,
+      y,
+      alongTolerance: alongTolerance,
+    );
+    return offset == null ? null : (i, offset);
+  }
+
+  /// The text offset at ([x], [y]) when the point lies within a run's line
+  /// box, allowing [alongTolerance] only before or after its baseline span.
+  ///
+  /// Taking an already-extracted [text] lets hover use this same hit rule
+  /// without forcing extraction for a heavy page whose cache is still cold.
+  int? _textPositionOnLine(
+    PdfPageText text,
+    double x,
+    double y, {
+    required double alongTolerance,
+  }) {
+    PdfExtractedRun? best;
+    var bestEx = 0.0;
+    var bestDistance = double.infinity;
     for (final run in text.runs) {
       if (run.text.isEmpty) continue;
       final inverse = run.transform.inverted();
@@ -5807,13 +5829,44 @@ class _PdfViewerState extends State<PdfViewer>
           ex <= run.width + padding &&
           ey >= -0.25 &&
           ey <= 0.75) {
-        isOnTextLine = true;
-        break;
+        final outside = ex < 0
+            ? -ex
+            : ex > run.width
+                ? ex - run.width
+                : 0.0;
+        final distance = outside * baselineScale;
+        if (distance < bestDistance) {
+          best = run;
+          bestEx = ex;
+          bestDistance = distance;
+        }
       }
     }
-    if (!isOnTextLine) return null;
-    final offset = text.positionNear(x, y, tolerance: alongTolerance);
-    return offset < 0 ? null : (i, offset);
+    return best == null ? null : _textOffsetInRun(best, bestEx);
+  }
+
+  /// Maps an em-space baseline position to the nearest character boundary in
+  /// [run]. Kept local to the matched run so hover remains a single pass over
+  /// dense pages and overlapping rotated run bounds cannot steal the hit.
+  int _textOffsetInRun(PdfExtractedRun run, double ex) {
+    final offsets = run.isRightToLeft ? null : run.charOffsets;
+    if (offsets != null) {
+      var lo = 0;
+      var hi = offsets.length - 1;
+      while (lo < hi) {
+        final mid = (lo + hi) >> 1;
+        if (offsets[mid] < ex) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      if (lo > 0 && ex - offsets[lo - 1] <= offsets[lo] - ex) lo--;
+      return run.startIndex + lo;
+    }
+    final fraction = run.width > 0 ? (ex / run.width).clamp(0.0, 1.0) : 0.0;
+    final logicalFraction = run.isRightToLeft ? 1 - fraction : fraction;
+    return run.startIndex + (logicalFraction * run.text.length).round();
   }
 
   /// Whether the hover cursor over [local] should be the text I-beam.
@@ -5839,7 +5892,7 @@ class _PdfViewerState extends State<PdfViewer>
     } else {
       text = _pageText(i);
     }
-    return text.positionNear(x, y, tolerance: 8) >= 0;
+    return _textPositionOnLine(text, x, y, alongTolerance: 8) != null;
   }
 
   /// Visible annotations with an action on a page, cached.
@@ -6083,7 +6136,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// text menu (and its host-takeover counterpart) depend on so that Copy
   /// has something to act on.
   void _prepareTextSelectionAt(Offset local) {
-    final position = _textPositionAt(local, tolerance: 14);
+    final position = _textSelectionStartAt(local, alongTolerance: 14);
     if (!(position != null && _selectionContains(position))) {
       _selectWordAt(local);
     }
@@ -7510,7 +7563,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// The whitespace-delimited word range at a point (list coordinates).
   ((int, int), (int, int))? _wordRangeAt(Offset local,
       {double tolerance = 14}) {
-    final position = _textPositionAt(local, tolerance: tolerance);
+    final position = _textSelectionStartAt(local, alongTolerance: tolerance);
     if (position == null) return null;
     final text = _pageText(position.$1).text;
     var start = position.$2.clamp(0, text.length);

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5780,6 +5780,42 @@ class _PdfViewerState extends State<PdfViewer>
     return offset < 0 ? null : (i, offset);
   }
 
+  /// Maps a selection press to text while keeping inter-line whitespace out
+  /// of the text gesture. The ordinary nearest-position tolerance is useful
+  /// just before or after a run, but applying it perpendicular to the
+  /// baseline makes narrow gaps between lines impossible to grab-pan.
+  (int, int)? _textSelectionStartAt(Offset local,
+      {required double alongTolerance}) {
+    final point = _pagePointAt(local);
+    if (point == null) return null;
+    final (i, x, y) = point;
+    final text = _pageText(i);
+    var isOnTextLine = false;
+    for (final run in text.runs) {
+      if (run.text.isEmpty) continue;
+      final inverse = run.transform.inverted();
+      if (inverse == null) continue;
+      final ex = inverse.transformX(x, y);
+      final ey = inverse.transformY(x, y);
+      final baselineScale = math.sqrt(run.transform.a * run.transform.a +
+          run.transform.b * run.transform.b);
+      if (baselineScale <= 1e-12) continue;
+      final padding = alongTolerance / baselineScale;
+      // Text extraction uses this conventional em-space ascent/descent for
+      // run bounds and selection quads (text_extraction.dart::_quadOf).
+      if (ex >= -padding &&
+          ex <= run.width + padding &&
+          ey >= -0.25 &&
+          ey <= 0.75) {
+        isOnTextLine = true;
+        break;
+      }
+    }
+    if (!isOnTextLine) return null;
+    final offset = text.positionNear(x, y, tolerance: alongTolerance);
+    return offset < 0 ? null : (i, offset);
+  }
+
   /// Whether the hover cursor over [local] should be the text I-beam.
   ///
   /// For an ordinary page this extracts synchronously (fast) so the I-beam
@@ -6885,7 +6921,11 @@ class _PdfViewerState extends State<PdfViewer>
       return;
     }
     _wordAnchor = null;
-    final position = _textPositionAt(details.localPosition, tolerance: 14);
+    // Decide from the actual press, not the position after the recognizer has
+    // crossed drag slop. A press in the gap between two lines must grab-pan
+    // even if that initial movement happens to finish over a line.
+    final start = _lastMouseDownLocal ?? details.localPosition;
+    final position = _textSelectionStartAt(start, alongTolerance: 14);
     if (position == null) {
       // nothing to select under the press: the drag grabs the document
       // instead (mouse drags don't reach the list's scrollable)

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -344,6 +344,34 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400));
   });
 
+  testWidgets('mouse drag between text lines grab-pans the page',
+      (tester) async {
+    final controller = await pumpViewer(
+      tester,
+      bytes: buildTextLinesPdf(const ['First line', 'Second line']),
+    );
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+    // The 12pt runs occupy y=717..729 and y=693..705. A press at y=711 is
+    // visibly between them but was within the old 14pt nearest-text radius.
+    final before = controller.visiblePageRegion(0)!;
+    final gesture = await tester.startGesture(view(100, 711),
+        kind: PointerDeviceKind.mouse);
+    await gesture.moveBy(const Offset(0, -20)); // cross drag slop over line 1
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, -80));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    final after = controller.visiblePageRegion(0)!;
+    expect(after.bottom, greaterThan(before.bottom),
+        reason: 'inter-line whitespace should start grab-pan, not selection');
+    expect(controller.hasSelection, isFalse);
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
   testWidgets('explicit Hand mode pans over text instead of selecting it',
       (tester) async {
     final bytes = buildMultiPagePdf(5);

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -372,6 +372,63 @@ void main() {
     await tester.pump(const Duration(milliseconds: 400));
   });
 
+  testWidgets('inter-line gap shows the grab cursor', (tester) async {
+    await pumpViewer(
+      tester,
+      bytes: buildTextLinesPdf(const ['First line', 'Second line']),
+    );
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+    MouseRegion region() => tester.widget<MouseRegion>(find
+        .descendant(
+            of: find.byType(PdfViewer), matching: find.byType(MouseRegion))
+        .first);
+
+    final hover =
+        await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 77);
+    await hover.addPointer(location: view(100, 711));
+    await tester.pump();
+    await hover.moveTo(view(101, 711));
+    await tester.pump();
+    expect(region().cursor, SystemMouseCursors.grab);
+    await hover.removePointer();
+    await tester.pump();
+  });
+
+  testWidgets('mouse double-click between text lines does not select',
+      (tester) async {
+    final controller = await pumpViewer(
+      tester,
+      bytes: buildTextLinesPdf(const ['First line', 'Second line']),
+    );
+    const scale = 800 / 612;
+    final gap = Offset(100 * scale, (792 - 711) * scale);
+    await tester.tapAt(gap, kind: PointerDeviceKind.mouse);
+    await tester.pump(const Duration(milliseconds: 80));
+    await tester.tapAt(gap, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    expect(controller.hasSelection, isFalse);
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('right-click between text lines does not select adjacent text',
+      (tester) async {
+    final controller = await pumpViewer(
+      tester,
+      bytes: buildTextLinesPdf(const ['First line', 'Second line']),
+    );
+    const scale = 800 / 612;
+    final gap = Offset(100 * scale, (792 - 711) * scale);
+    await tester.tapAt(
+      gap,
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await tester.pumpAndSettle();
+    expect(controller.hasSelection, isFalse);
+    expect(controller.selectedText, isEmpty);
+  });
+
   testWidgets('explicit Hand mode pans over text instead of selecting it',
       (tester) async {
     final bytes = buildMultiPagePdf(5);


### PR DESCRIPTION
## Summary

Fix mouse drag handling in narrow whitespace between text lines.

Previously, the text-selection hit tolerance applied in every direction, causing inter-line whitespace to be treated as text. As a result, dragging between nearby lines started text selection instead of panning the page.

## Changes

- Determine the gesture from the original pointer-down position.
- Apply selection tolerance only along the text baseline.
- Treat whitespace perpendicular to the text line as a page-pan target.
- Preserve the existing tolerance near the beginning and end of text runs.
- Add a regression test for panning between nearby text lines.


## Issue
<img width="960" height="564" alt="pdf_viewer_example2026-09-0423-41-55_09s-18s" src="https://github.com/user-attachments/assets/3241aba0-3a25-4352-b3f9-9988a1a0d940" />

## Result
<img width="960" height="564" alt="pdf_viewer_example2026-09-0423-51-46" src="https://github.com/user-attachments/assets/71a024f8-d79f-4c97-bb84-5d84e75eadba" />


<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [ ] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [x] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [ ] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
