### PR TITLE
Warm pages ahead during slow scrolling

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.1.0
 
+- Keep nearby pages sharp during slow scrolling by using spare GPU capacity,
+  while fast scrolling continues to prioritize responsiveness.
 - Save and manage named handwritten signatures, and reuse saved annotations
   across documents from a searchable library.
 - Add cursor guides, a visible page grid, and optional grid snapping for

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -128,14 +128,14 @@ class AppDevTools extends ChangeNotifier {
   final ValueNotifier<PdfPageRasterCachePolicy> pageRasterCachePolicy =
       ValueNotifier(const PdfPageRasterCachePolicy());
 
-  /// Whether idle viewer time is spent baking exact page rasters ahead of
+  /// Whether spare viewer time is spent baking exact page rasters ahead of
   /// navigation (#614). The product warms only the nearby working set by
-  /// default: it removes the blurry first-arrival pause without committing to
-  /// a whole-document raster pass. The work remains preemptible and bounded by
-  /// [pageRasterCachePolicy]; Developer tools can disable or expand it. Kept
-  /// as its own notifier for the same reason as [pageRasterCachePolicy] - a
-  /// policy change must reach the mounted document without waiting for the
-  /// log-traffic rebuild.
+  /// default: idle time covers both directions, while sustained slow scrolling
+  /// uses a bounded accelerated window in the travel direction. The work stays
+  /// preemptible and bounded by [pageRasterCachePolicy]; Developer tools can
+  /// disable or expand it. Kept as its own notifier for the same reason as
+  /// [pageRasterCachePolicy] - a policy change must reach the mounted document
+  /// without waiting for the log-traffic rebuild.
   final ValueNotifier<PdfPageRasterWarmPolicy> pageRasterWarmPolicy =
       ValueNotifier(const PdfPageRasterWarmPolicy.nearby());
 
@@ -564,14 +564,16 @@ class AppDevTools extends ChangeNotifier {
         '${policy.maxEntryBytes >> 20}MB/page');
   }
 
-  /// Applies an idle full-raster warm policy to every mounted viewer.
+  /// Applies a full-raster warm policy to every mounted viewer.
   void setPageRasterWarmPolicy(PdfPageRasterWarmPolicy policy) {
     if (pageRasterWarmPolicy.value == policy) return;
     pageRasterWarmPolicy.value = policy;
     PdfPerfLog.log('raster-warm policy mode=${policy.mode.name} '
-        'window=${policy.window} idleMs=${policy.idleDelay.inMilliseconds}');
-    addLog('devtools: idle raster warm \u2192 ${policy.mode.name}'
-        '${policy.mode == PdfPageRasterWarmMode.nearby ? ' (\u00b1${policy.window})' : ''}');
+        'window=${policy.window} slowWindow=${policy.slowScrollWindow} '
+        'idleMs=${policy.idleDelay.inMilliseconds}');
+    addLog('devtools: page raster warm \u2192 ${policy.mode.name}'
+        '${policy.mode == PdfPageRasterWarmMode.nearby ? ' (\u00b1${policy.window})' : ''}, '
+        'slow-scroll \u2192${policy.slowScrollWindow}');
   }
 
   /// Returns the visited-page raster cache to adaptive machine-headroom mode.
@@ -707,9 +709,18 @@ class AppDevTools extends ChangeNotifier {
           final int v when v > 0 => v,
           _ => 3,
         };
+        final slowWindow = switch (map['pageRasterWarmSlowScrollWindow']) {
+          final int v when v >= 0 => v,
+          _ => 3,
+        };
         setPageRasterWarmPolicy(switch (mode) {
-          'nearby' => PdfPageRasterWarmPolicy.nearby(window: window),
-          'document' => const PdfPageRasterWarmPolicy.document(),
+          'nearby' => PdfPageRasterWarmPolicy.nearby(
+              window: window,
+              slowScrollWindow: slowWindow,
+            ),
+          'document' => PdfPageRasterWarmPolicy.document(
+              slowScrollWindow: slowWindow,
+            ),
           _ => const PdfPageRasterWarmPolicy.disabled(),
         });
       }
@@ -754,6 +765,8 @@ class AppDevTools extends ChangeNotifier {
               _fixedPageRasterCachePolicy.maxEntryBytes,
           'pageRasterWarmMode': pageRasterWarmPolicy.value.mode.name,
           'pageRasterWarmWindow': pageRasterWarmPolicy.value.window,
+          'pageRasterWarmSlowScrollWindow':
+              pageRasterWarmPolicy.value.slowScrollWindow,
         }),
       );
     } catch (e) {

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -698,8 +698,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   ];
   static const _fixedEntrySeedBytes = 256 << 20;
 
-  // Idle full-raster warm (#614) as a single selector. -1 is off, 0 is the
-  // whole document, a positive value is that many pages either side.
+  // Full-raster warm (#614) as a single selector. -1 is off, 0 is the whole
+  // document, a positive value is that many pages either side. Enabled modes
+  // also use their bounded directional window during slow scrolling.
   static const _rasterWarmChoices = <(int, String)>[
     (-1, 'Off'),
     (2, 'Nearby +/-2'),
@@ -707,12 +708,16 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
     (0, 'Whole document'),
   ];
 
-  static String _rasterWarmLabel(PdfPageRasterWarmPolicy policy) =>
-      switch (policy.mode) {
-        PdfPageRasterWarmMode.disabled => 'Off',
-        PdfPageRasterWarmMode.nearby => 'Nearby +/-${policy.window}',
-        PdfPageRasterWarmMode.document => 'Whole document',
-      };
+  static String _rasterWarmLabel(PdfPageRasterWarmPolicy policy) {
+    if (!policy.enabled) return 'Off';
+    final slowWindow = policy.mode == PdfPageRasterWarmMode.nearby
+        ? math.min(policy.window, policy.slowScrollWindow)
+        : policy.slowScrollWindow;
+    final idle = policy.mode == PdfPageRasterWarmMode.nearby
+        ? 'Idle ±${policy.window}'
+        : 'All idle';
+    return '$idle · slow →$slowWindow';
+  }
 
   void _setPageRasterWarm(int choice) {
     _tools.setPageRasterWarmPolicy(switch (choice) {
@@ -896,17 +901,18 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         _byteBudgetControl(
           theme,
           key: const ValueKey('devtools-page-raster-warm'),
-          title: 'Idle raster warm',
+          title: 'Page raster warm',
           help: 'Spends genuine viewer idle time rasterizing pages ahead of '
               'navigation, so arriving on them paints instantly instead of '
-              'rendering first. With the Flutter GPU backend selected, '
-              'accepted pages are produced as GPU-resident exact images; '
-              'unsupported pages retain the exact Canvas fallback. Warming '
-              'stands down the '
-              'moment anything scrolls, zooms, edits, or renders, and never '
-              'stores more than the visited-page raster budget above allows - '
-              'so a whole-document warm on a large file settles into a moving '
-              'window rather than growing without limit.',
+              'rendering first. During sustained slow scrolling, an '
+              'accelerated backend also keeps up to three pages sharp in the '
+              'travel direction, one GPU submission at a time; fast motion, '
+              'foreground work, and direction changes stop further work. '
+              'Unsupported pages use the exact Canvas fallback only after '
+              'scrolling is idle. Both paths stay inside the visited-page '
+              'raster budget, '
+              'so a large file settles into a moving window rather than '
+              'growing without limit.',
           value: _tools.pageRasterWarmPolicy.value.mode ==
                   PdfPageRasterWarmMode.disabled
               ? -1

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -135,28 +135,38 @@ void main() {
     );
   });
 
-  test('the idle raster warm policy round-trips', () async {
+  test('the page raster warm policy round-trips', () async {
     SharedPreferences.setMockInitialValues({});
     final tools = AppDevTools.instance;
     expect(tools.pageRasterWarmPolicy.value,
         const PdfPageRasterWarmPolicy.nearby(),
         reason: 'the app proactively warms only its nearby working set');
 
-    tools.setPageRasterWarmPolicy(
-        const PdfPageRasterWarmPolicy.nearby(window: 5));
+    tools.setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.nearby(
+      window: 5,
+      slowScrollWindow: 4,
+    ));
     await tools.persistOptions();
 
     tools.setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.disabled());
     await tools.restoreOptions();
-    expect(tools.pageRasterWarmPolicy.value,
-        const PdfPageRasterWarmPolicy.nearby(window: 5));
+    expect(
+      tools.pageRasterWarmPolicy.value,
+      const PdfPageRasterWarmPolicy.nearby(
+        window: 5,
+        slowScrollWindow: 4,
+      ),
+    );
 
-    tools.setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.document());
+    tools.setPageRasterWarmPolicy(
+        const PdfPageRasterWarmPolicy.document(slowScrollWindow: 2));
     await tools.persistOptions();
     tools.setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.disabled());
     await tools.restoreOptions();
     expect(
-        tools.pageRasterWarmPolicy.value.mode, PdfPageRasterWarmMode.document);
+      tools.pageRasterWarmPolicy.value,
+      const PdfPageRasterWarmPolicy.document(slowScrollWindow: 2),
+    );
   });
 
   test('restore with nothing persisted leaves the defaults alone', () async {

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -287,7 +287,7 @@ void main() {
     expect(PdfPageView.debugTileStoreOverride, isNull);
   });
 
-  testWidgets('the idle raster warm selector applies live', (tester) async {
+  testWidgets('the page raster warm selector applies live', (tester) async {
     await pumpWithDoc(tester);
     addTearDown(() => AppDevTools.instance
         .setPageRasterWarmPolicy(const PdfPageRasterWarmPolicy.nearby()));
@@ -297,7 +297,7 @@ void main() {
     final warm = find.byKey(const ValueKey('devtools-page-raster-warm'));
     await tester.ensureVisible(warm);
     await tester.pump();
-    expect(find.text('Nearby +/-3'), findsWidgets,
+    expect(find.text('Idle ±3 · slow →3'), findsWidgets,
         reason: 'the app warms a bounded nearby working set by default');
 
     await tester.tap(warm);

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.1.0
 
+- Sharpen pages directionally during sustained slow scrolling with a bounded
+  accelerated look-ahead, while preserving fast-scroll preemption and strict
+  worker, raster-cache, and Canvas-fallback safeguards.
 - Add a persistent named handwritten-signature library with previews,
   selection, rename/redraw/delete management, and automatic migration from the
   previous single saved signature.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -625,11 +625,12 @@ class PdfViewerController extends ChangeNotifier {
   final _PdfForwardingListenable _pageRenderActivity =
       _PdfForwardingListenable();
 
-  /// What the idle full-raster warm ([PdfViewer.pageRasterWarmPolicy]) and the
-  /// exact-raster cache ([PdfViewer.pageRasterCachePolicy]) have actually done:
-  /// attempts, completions, hits, bytes, and evictions. Null when no viewer is
-  /// attached. Useful for a diagnostics panel or a benchmark assertion; the
-  /// same numbers appear in the [PdfPerfLog] trace as `raster-warm` and
+  /// What full-raster warming ([PdfViewer.pageRasterWarmPolicy]) and the exact-
+  /// raster cache ([PdfViewer.pageRasterCachePolicy]) have actually done:
+  /// attempts, completions, hits, bytes, and evictions. This includes both
+  /// idle warming and accelerated slow-scroll look-ahead. Null when no viewer
+  /// is attached. Useful for a diagnostics panel or a benchmark assertion;
+  /// the same numbers appear in the [PdfPerfLog] trace as `raster-warm` and
   /// `page-raster` lines.
   PdfPageRasterWarmStats? get pageRasterWarmStats =>
       _state?._previews.warmStats;
@@ -638,6 +639,12 @@ class PdfViewerController extends ChangeNotifier {
   /// raster.
   @visibleForTesting
   bool get debugRasterWarming => _state?._warmingRasters ?? false;
+
+  /// Whether the attached viewer is currently producing an accelerated exact
+  /// raster ahead of a sustained slow scroll.
+  @visibleForTesting
+  bool get debugSlowScrollRasterWarming =>
+      _state?._warmingSlowScrollRasters ?? false;
 
   /// Runs the idle full-raster warm now, without waiting out
   /// [PdfPageRasterWarmPolicy.idleDelay] - the seam tests use to exercise the
@@ -1367,15 +1374,18 @@ class PdfViewer extends StatefulWidget {
   /// shared in-memory cache.
   final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
-  /// Whether genuine viewer idle time is spent baking exact, display-sized
-  /// rasters for pages the user has not visited, so they paint immediately on
-  /// arrival instead of interpreting and reading back first.
+  /// Whether spare viewer time is spent baking exact, display-sized rasters
+  /// for pages the user has not visited, so they paint immediately on arrival
+  /// instead of interpreting and reading back first.
   ///
-  /// Disabled by default: warming trades CPU, GPU, and memory for navigation
-  /// latency. [pageRasterCachePolicy] bounds what the result is allowed to
-  /// occupy - a warm policy without a matching cache budget warms a handful of
-  /// pages and then declines the rest. Requires [pagePreviews], which owns the
-  /// shared cache. See [PdfPageRasterWarmPolicy].
+  /// The ordinary pass runs at idle. An enabled policy may also use an
+  /// accelerated backend for bounded directional look-ahead during sustained
+  /// slow scrolling; see [PdfPageRasterWarmPolicy.slowScrollWindow]. Disabled
+  /// by default: warming trades CPU, GPU, and memory for navigation latency.
+  /// [pageRasterCachePolicy] bounds what the result is allowed to occupy - a
+  /// warm policy without a matching cache budget warms a handful of pages and
+  /// then declines the rest. Requires [pagePreviews], which owns the shared
+  /// cache. See [PdfPageRasterWarmPolicy].
   final PdfPageRasterWarmPolicy pageRasterWarmPolicy;
 
   /// Persistent on-disk text cache (see [PdfPageTextCache]). When set with
@@ -1879,6 +1889,20 @@ class _PdfViewerState extends State<PdfViewer>
   final _rasterWarmAttempts = Set<PdfPage>.identity();
   bool _warmingRasters = false;
 
+  /// Pages offered to the accelerated slow-scroll look-ahead. Kept separate
+  /// from [_rasterWarmAttempts]: a page the GPU declines during live motion is
+  /// still eligible for the exact Canvas fallback when the viewer later idles.
+  final _slowScrollRasterWarmAttempts = Set<PdfPage>.identity();
+  bool _warmingSlowScrollRasters = false;
+  int _slowScrollRasterWarmDirection = 0;
+  int _slowScrollRasterWarmGeneration = 0;
+
+  /// At most this fraction of the exact-raster LRU is allowed to describe the
+  /// directional look-ahead window. The nearest admissible page always gets
+  /// one chance even when its raster is larger than the fraction; the cache's
+  /// hard per-entry and total limits still win.
+  static const double _slowScrollRasterBudgetFraction = 1 / 3;
+
   /// Lowers [PdfPageRenderScheduler.activeGesture] once the reader has stopped
   /// moving for [_gestureQuietDelay] - far shorter than the 500 ms scroll-quiet
   /// window, because it answers a different question. The quiet window asks
@@ -2124,7 +2148,10 @@ class _PdfViewerState extends State<PdfViewer>
     // A live gesture is what a UI-thread walk must not run inside; the quiet
     // window that follows one is not (see [PdfPageRenderScheduler.activeGesture]).
     _renderScheduler.activeGesture = _directMotionRenderHoldActive;
-    if (!_motionRenderHoldActive) _renderScheduler.slowMotion = false;
+    if (!_motionRenderHoldActive) {
+      _renderScheduler.slowMotion = false;
+      _setSlowScrollRasterWarmDirection(0);
+    }
     _renderScheduler.parked = !widget.active;
   }
 
@@ -2151,6 +2178,7 @@ class _PdfViewerState extends State<PdfViewer>
     _motionHoldReleaseTimer?.cancel();
     _motionHoldReleaseTimer = null;
     _renderScheduler.slowMotion = false;
+    _setSlowScrollRasterWarmDirection(0);
     _renderScheduler.holding = true;
   }
 
@@ -2488,6 +2516,8 @@ class _PdfViewerState extends State<PdfViewer>
     _previewAttempts.clear();
     _previewVectorAttempts.clear();
     _intermediatePreviewAttempts.clear();
+    _slowScrollRasterWarmAttempts.clear();
+    _setSlowScrollRasterWarmDirection(0);
   }
 
   void _onPerformanceChanged() {
@@ -2511,6 +2541,7 @@ class _PdfViewerState extends State<PdfViewer>
       _tileBackendWarmUpTimer?.cancel();
       _tileBackendWarmUpTimer = null;
     } else {
+      _startSlowScrollRasterWarm();
       _schedulePreviewPrerender();
       if (_pendingTileBackendWarmUp != null) _armTileBackendWarmUp();
     }
@@ -2892,6 +2923,7 @@ class _PdfViewerState extends State<PdfViewer>
           : const Duration(milliseconds: 500),
       _settleScrollChange,
     );
+    _startSlowScrollRasterWarm();
     if (_vectorFirstPrefetch) {
       // A high-velocity scroll can hold on-screen renders long enough that
       // newly-visible pages would otherwise stay blank. Let the worker warm a
@@ -2905,6 +2937,8 @@ class _PdfViewerState extends State<PdfViewer>
     _scrollSettleTimer = null;
     _scrollSamples.clear();
     _vectorFirstPrefetch = false;
+    _renderScheduler.slowMotion = false;
+    _setSlowScrollRasterWarmDirection(0);
     // A programmatic jump may have reached its scroll offset before the
     // destination page has produced a full raster. Keep that explicit target
     // as the render/warm focus until its pixels arrive; otherwise the
@@ -3581,7 +3615,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// finishing it on top of the frame the user is waiting for. Whatever it
   /// abandons is retried after the next settle.
   Future<void> _warmFullRasters() async {
-    if (_warmingRasters || !_rasterWarmIdle) return;
+    if (_warmingRasters || _warmingSlowScrollRasters || !_rasterWarmIdle) {
+      return;
+    }
     _warmingRasters = true;
     try {
       while (_rasterWarmIdle) {
@@ -3618,7 +3654,154 @@ class _PdfViewerState extends State<PdfViewer>
       }
     } finally {
       _warmingRasters = false;
+      _startSlowScrollRasterWarm();
     }
+  }
+
+  /// Whether a directional exact-raster warm may use spare accelerated
+  /// capacity while slow scroll input is still arriving.
+  ///
+  /// This is intentionally stricter than the visible page's slow-motion lane:
+  /// look-ahead is optional, so it requires a real accelerated full-page
+  /// backend and a spare worker lane. A serial worker, Canvas fallback, zoom,
+  /// edit, direct pan, or foreground render leaves all capacity to the page the
+  /// reader can already see.
+  bool _slowScrollRasterWarmAllowed(int generation, int direction) {
+    final policy = widget.pageRasterWarmPolicy;
+    final worker = _effectiveRenderWorker;
+    return mounted &&
+        generation == _slowScrollRasterWarmGeneration &&
+        direction != 0 &&
+        direction == _slowScrollRasterWarmDirection &&
+        widget.active &&
+        widget.pagePreviews &&
+        policy.enabled &&
+        policy.slowScrollWindow > 0 &&
+        widget.tileRasterBackend.supportsFullPageRasterWarmUp &&
+        worker != null &&
+        worker.isActive &&
+        worker.concurrentRecordCapacity >= 2 &&
+        _renderScheduler.slowMotion &&
+        !_renderScheduler.hasForegroundWork &&
+        !_previewUiMustDefer &&
+        !_zoomed &&
+        _renderScale <= 1.01 &&
+        widget.editing?.tool == null;
+  }
+
+  /// Starts the serial GPU look-ahead after the current callback/frame has
+  /// released foreground scheduling state. Repeated scroll events are cheap:
+  /// the in-flight flag coalesces them and the loop re-aims from currentPage
+  /// before choosing every page.
+  void _startSlowScrollRasterWarm() {
+    if (_warmingRasters || _warmingSlowScrollRasters) return;
+    final generation = _slowScrollRasterWarmGeneration;
+    final direction = _slowScrollRasterWarmDirection;
+    if (!_slowScrollRasterWarmAllowed(generation, direction)) return;
+    unawaited(_warmSlowScrollRasters(generation, direction));
+  }
+
+  /// Produces exact rasters ahead of a sustained slow scroll, nearest first.
+  ///
+  /// Only one page is submitted at a time. The worker moves interpretation and
+  /// image decoding off-thread; the accelerated backend owns the raster. A
+  /// fast step or direction reversal invalidates [generation] and is observed
+  /// around every await by [PdfPagePreviewCache.warmFullRaster].
+  Future<void> _warmSlowScrollRasters(int generation, int direction) async {
+    if (_warmingRasters ||
+        _warmingSlowScrollRasters ||
+        !_slowScrollRasterWarmAllowed(generation, direction)) {
+      return;
+    }
+    _warmingSlowScrollRasters = true;
+    try {
+      while (_slowScrollRasterWarmAllowed(generation, direction)) {
+        final pages = _pages;
+        final index = _nextSlowScrollRasterWarmIndex(pages, direction);
+        if (index == null) return;
+        final page = pages[index];
+        final target = _rasterWarmTarget(index, page);
+        if (target == null) return;
+        _slowScrollRasterWarmAttempts.add(page);
+        final stored = await _previews.warmFullRaster(
+          index,
+          page,
+          signature: target.signature,
+          pixelRatio: target.ratio,
+          worker: _effectiveRenderWorker,
+          rasterBackend: widget.tileRasterBackend,
+          // Foreground pages are 0; fast-scroll previews are 1. Exact
+          // look-ahead outranks idle command/raster warming (3/4) but never
+          // something the reader is already waiting to see.
+          priority: 2,
+          shouldStop: () =>
+              !_slowScrollRasterWarmAllowed(generation, direction),
+          acceleratedOnly: true,
+        );
+        if (!mounted) return;
+        if (!stored && !_slowScrollRasterWarmAllowed(generation, direction)) {
+          // Preemption is temporary. A later slow stretch should be allowed to
+          // offer the same page again; a genuine GPU rejection stays attempted
+          // for this document and the idle Canvas path remains independent.
+          _slowScrollRasterWarmAttempts.remove(page);
+          return;
+        }
+        await SchedulerBinding.instance.endOfFrame;
+      }
+    } finally {
+      _warmingSlowScrollRasters = false;
+    }
+  }
+
+  /// Chooses the nearest not-yet-visible page in the scroll direction.
+  ///
+  /// Page count is the user-facing cap. Bytes are the real greed governor: at
+  /// most one third of the exact-raster cache describes this look-ahead, with
+  /// a one-page floor so the conservative default cache can still help. Both
+  /// the cache's total and per-entry hard limits are checked again by
+  /// [PdfPagePreviewCache.warmFullRaster] before any interpretation begins.
+  int? _nextSlowScrollRasterWarmIndex(List<PdfPage> pages, int direction) {
+    if (pages.isEmpty || direction == 0) return null;
+    final policy = widget.pageRasterWarmPolicy;
+    var window = policy.slowScrollWindow;
+    if (policy.mode == PdfPageRasterWarmMode.nearby) {
+      window = math.min(window, policy.window);
+    }
+    if (window <= 0) return null;
+
+    final totalBudget = _previews.maxFullRasterBytes;
+    if (totalBudget <= 0) return null;
+    final byteWindow = math.min(
+      totalBudget,
+      math.max(
+        _previews.maxFullRasterEntryBytes,
+        (totalBudget * _slowScrollRasterBudgetFraction).floor(),
+      ),
+    );
+    final current = _controller.currentPage.clamp(0, pages.length - 1);
+    var plannedBytes = 0;
+    for (var distance = 1; distance <= window; distance++) {
+      final index = current + direction * distance;
+      if (index < 0 || index >= pages.length) break;
+      if (_onScreenSpan.contains(index)) continue;
+      final page = pages[index];
+      final target = _rasterWarmTarget(index, page);
+      if (target == null) continue;
+      final nextBytes = plannedBytes + target.signature.bytes;
+      if (plannedBytes > 0 && nextBytes > byteWindow) break;
+      plannedBytes = nextBytes;
+      if (_slowScrollRasterWarmAttempts.contains(page)) continue;
+      if (_previews.hasFullRaster(target.signature, page)) continue;
+      return index;
+    }
+    return null;
+  }
+
+  void _setSlowScrollRasterWarmDirection(int direction) {
+    final normalized = direction.sign;
+    if (_slowScrollRasterWarmDirection == normalized) return;
+    _slowScrollRasterWarmDirection = normalized;
+    _slowScrollRasterWarmGeneration++;
   }
 
   /// Worker priority for warm records. The worker ranks *low* numbers first,
@@ -3744,8 +3927,8 @@ class _PdfViewerState extends State<PdfViewer>
     }
     final span = (now - _scrollSamples.first.$1).inMicroseconds;
     if (span <= 0) return; // all samples this frame: keep the verdict
-    final velocity =
-        (pixels - _scrollSamples.first.$2).abs() * 1e6 / span; // px/s
+    final displacement = pixels - _scrollSamples.first.$2;
+    final velocity = displacement.abs() * 1e6 / span; // px/s
     final viewport = _scroll.position.viewportDimension;
     // A flick ramps up: its first inter-frame deltas underread the gesture's
     // true speed, so a velocity verdict taken in the burst's opening frames
@@ -3773,6 +3956,9 @@ class _PdfViewerState extends State<PdfViewer>
     final slowThreshold = _renderScheduler.slowMotion ? slowExit : slowEnter;
     final slow = !opening && !directMotion && velocity <= slowThreshold;
     _renderScheduler.slowMotion = slow;
+    _setSlowScrollRasterWarmDirection(
+      slow && displacement != 0 ? displacement.sign.toInt() : 0,
+    );
     final fastThreshold = math.max(800, 2 * viewport);
     final hold = _motionRenderHoldActive || opening || velocity > fastThreshold;
     _vectorFirstPrefetch =
@@ -3849,11 +4035,14 @@ class _PdfViewerState extends State<PdfViewer>
           widget.pageRasterCachePolicy.maxEntryBytes >
               oldWidget.pageRasterCachePolicy.maxEntryBytes) {
         _rasterWarmAttempts.clear();
+        _slowScrollRasterWarmAttempts.clear();
       }
       _scheduleRasterWarm();
     }
     if (oldWidget.pageRasterWarmPolicy != widget.pageRasterWarmPolicy) {
       _rasterWarmAttempts.clear();
+      _slowScrollRasterWarmAttempts.clear();
+      _slowScrollRasterWarmGeneration++;
       _scheduleRasterWarm();
     }
     if (oldWidget.pagePreviews != widget.pagePreviews ||
@@ -3892,6 +4081,8 @@ class _PdfViewerState extends State<PdfViewer>
       // paper color and annotation visibility are part of the raster
       // signature, so every warmed raster just became unreachable
       _rasterWarmAttempts.clear();
+      _slowScrollRasterWarmAttempts.clear();
+      _slowScrollRasterWarmGeneration++;
       _commandWarmAttempts.clear();
       _commandWarmAnchor = null;
       _commandHeavyWarmStarted = false;
@@ -3929,6 +4120,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (oldWidget.active != widget.active) {
       _renderScheduler.parked = !widget.active;
       if (!widget.active) {
+        _setSlowScrollRasterWarmDirection(0);
         _pendingTileBackendWarmUp = null;
         _tileBackendWarmUpTimer?.cancel();
         _tileBackendWarmUpTimer = null;
@@ -3947,6 +4139,8 @@ class _PdfViewerState extends State<PdfViewer>
     }
     if (!identical(oldWidget.tileRasterBackend, widget.tileRasterBackend) &&
         oldWidget.active == widget.active) {
+      _slowScrollRasterWarmAttempts.clear();
+      _slowScrollRasterWarmGeneration++;
       _scheduleTileBackendWarmUp();
     }
   }
@@ -4097,6 +4291,8 @@ class _PdfViewerState extends State<PdfViewer>
     // page objects changed, so every warmed raster is either rebound (content
     // unchanged) or gone; re-arm the pass over the new revision's pages
     _rasterWarmAttempts.clear();
+    _slowScrollRasterWarmAttempts.clear();
+    _slowScrollRasterWarmGeneration++;
     _schedulePreviewPrerender();
     _scheduleRasterWarm();
     if (!sameGeometry && remappedViewport == null) {
@@ -4256,6 +4452,7 @@ class _PdfViewerState extends State<PdfViewer>
         attempted.remove(oldPage);
       }
       _rasterWarmAttempts.remove(oldPage);
+      _slowScrollRasterWarmAttempts.remove(oldPage);
       _commandWarmAttempts.remove(oldPage);
       _pages[entry.key] = entry.value;
       final nextGeometry = geometry[entry.key]!;
@@ -4713,6 +4910,8 @@ class _PdfViewerState extends State<PdfViewer>
     // rotation is part of the raster signature (and changes the page's
     // physical size): nothing warmed under the old one can be reused
     _rasterWarmAttempts.clear();
+    _slowScrollRasterWarmAttempts.clear();
+    _slowScrollRasterWarmGeneration++;
     _commandWarmAttempts.clear();
     _commandWarmAnchor = null;
     _commandHeavyWarmStarted = false;
@@ -4770,6 +4969,7 @@ class _PdfViewerState extends State<PdfViewer>
   @override
   void dispose() {
     _commandWarmGeneration++;
+    _slowScrollRasterWarmGeneration++;
     // A namespace is private to this State and cannot be reused after dispose.
     // Retire it explicitly so the process-wide store neither lands an old
     // asynchronous raster nor retains an unreachable viewer token.

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -1595,7 +1595,13 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// a visible page always wins the worker's queue. When [rasterBackend]
   /// supports full-page warming, its retained-scene session produces the
   /// exact image directly; a rejection or failure falls back to Canvas for
-  /// this page. Returns whether a raster was stored.
+  /// this page.
+  ///
+  /// [acceleratedOnly] requires both an active worker and an accelerated
+  /// full-page backend. It declines the page when the worker cannot provide a
+  /// command buffer or the backend cannot produce the image: live-motion
+  /// look-ahead must never record or raster through Canvas on the platform
+  /// thread. Returns whether a raster was stored.
   Future<bool> warmFullRaster(
     int index,
     PdfPage page, {
@@ -1605,6 +1611,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
     PdfTileRasterBackend? rasterBackend,
     int priority = 4,
     bool Function()? shouldStop,
+    bool acceleratedOnly = false,
   }) async {
     if (_disposed) return false;
     if (hasFullRaster(signature, page)) {
@@ -1620,12 +1627,23 @@ class PdfPagePreviewCache extends ChangeNotifier {
       return false;
     }
     if (shouldStop?.call() ?? false) return false;
+    final backend = rasterBackend;
+    final accelerated = backend != null && backend.supportsFullPageRasterWarmUp;
+    final activeWorker = worker != null && worker.isActive;
+    if (acceleratedOnly && (!accelerated || !activeWorker)) {
+      _warmRejections++;
+      PdfPerfLog.log(
+        'raster-warm accelerated-only decline page=$index '
+        'reason=${!activeWorker ? 'no-worker' : 'no-backend'}',
+      );
+      return false;
+    }
     _warmAttempts++;
     final sw = Stopwatch()..start();
     var stored = false;
     try {
       final size = PdfPageRenderer.pageSize(page, rotation: signature.rotation);
-      final commands = worker != null && worker.isActive
+      final commands = activeWorker
           ? await worker.record(index,
               annotations: signature.annotations,
               priority: priority,
@@ -1636,6 +1654,13 @@ class PdfPagePreviewCache extends ChangeNotifier {
         return false;
       }
       if (_disposed || hasFullRaster(signature, page)) return false;
+      if (acceleratedOnly && commands == null) {
+        PdfPerfLog.log(
+          'raster-warm accelerated-only decline page=$index '
+          'reason=worker-declined',
+        );
+        return false;
+      }
       ui.Picture? picture;
       ui.Image? image;
       var route = 'canvas';
@@ -1644,8 +1669,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
         annotations: signature.annotations,
         rotation: signature.rotation,
       );
-      final backend = rasterBackend;
-      if (backend != null && backend.supportsFullPageRasterWarmUp) {
+      if (backend != null && accelerated) {
         PdfRetainedScene? scene;
         PdfTileRasterSession? session;
         try {
@@ -1699,12 +1723,15 @@ class PdfPagePreviewCache extends ChangeNotifier {
             route = backend.debugLabel;
             // The exact raster is the important result. Keep a page-space
             // picture only to seed the tiny navigation preview without a
-            // second interpretation; failure here must not discard paid-for
-            // accelerated pixels.
-            try {
-              picture = scene.replay(pixelRatio: 1);
-            } catch (_) {
-              picture = null;
+            // second interpretation during idle warming; accelerated-only
+            // live motion must not replay the retained scene through Canvas.
+            // Failure here must not discard paid-for accelerated pixels.
+            if (!acceleratedOnly) {
+              try {
+                picture = scene.replay(pixelRatio: 1);
+              } catch (_) {
+                picture = null;
+              }
             }
           }
         } catch (error) {
@@ -1714,11 +1741,14 @@ class PdfPagePreviewCache extends ChangeNotifier {
           picture = null;
           // The accelerated route can reject a perfectly valid retained
           // scene. Replaying that already-recorded scene gives Canvas its
-          // exact fallback without interpreting and decoding the page again.
-          try {
-            picture = scene?.replay(pixelRatio: 1);
-          } catch (_) {
-            picture = null;
+          // exact idle fallback without interpreting and decoding the page
+          // again. Live-motion warming deliberately skips the replay.
+          if (!acceleratedOnly) {
+            try {
+              picture = scene?.replay(pixelRatio: 1);
+            } catch (_) {
+              picture = null;
+            }
           }
           PdfPerfLog.log(
             'raster-warm gpu fallback page=$index '
@@ -1728,6 +1758,14 @@ class PdfPagePreviewCache extends ChangeNotifier {
           session?.dispose();
           scene?.dispose();
         }
+      }
+      if (image == null && acceleratedOnly) {
+        picture?.dispose();
+        PdfPerfLog.log(
+          'raster-warm accelerated-only decline page=$index '
+          'backend=${backend?.debugLabel ?? 'none'}',
+        );
+        return false;
       }
       if (image == null) {
         if (shouldStop?.call() ?? false) {

--- a/packages/dart_pdf_editor/lib/src/raster_warm.dart
+++ b/packages/dart_pdf_editor/lib/src/raster_warm.dart
@@ -15,20 +15,27 @@ enum PdfPageRasterWarmMode {
   document,
 }
 
-/// Whether - and how far ahead - the viewer spends idle time baking exact,
-/// display-sized page rasters for pages the user has not visited.
+/// Whether - and how far ahead - the viewer bakes exact, display-sized page
+/// rasters for pages the user has not visited.
 ///
 /// [PdfPageRasterCachePolicy] governs how much of that result is *retained*.
 /// This governs whether it is ever *produced*: without it the exact-raster
 /// cache fills only as pages render on screen, so the first arrival on a page
 /// always pays for its own interpretation and readback.
 ///
-/// The warm is idle work in the strict sense. It starts only after the viewer
-/// has been quiet for [idleDelay], stands down the instant a scroll, zoom,
+/// The ordinary warm is idle work in the strict sense. It starts only after
+/// the viewer has been quiet for [idleDelay], stands down the instant a zoom,
 /// edit, or foreground page render needs the platform thread, and paces itself
-/// to one page at a time with a frame yielded between pages. It targets the
-/// settled fit-size raster only - deep zoom stays region/tile driven - and
-/// never renders a page whose raster the cache policy could not admit.
+/// to one page at a time with a frame yielded between pages. During a sustained
+/// slow scroll, [slowScrollWindow] additionally admits a directional look-ahead
+/// through an accelerated full-page backend. That lane remains serial,
+/// requires a spare render-worker lane, and never falls back to Canvas while
+/// input is live. Fast motion immediately prevents another submission and
+/// preempts work that has not yet reached the GPU.
+///
+/// Both paths target the settled fit-size raster only - deep zoom stays
+/// region/tile driven - and never render a page whose raster the cache policy
+/// could not admit.
 ///
 /// When the selected [PdfTileRasterBackend] advertises full-page warm support,
 /// the viewer records a retained scene and produces the resident image through
@@ -56,6 +63,7 @@ class PdfPageRasterWarmPolicy {
   const PdfPageRasterWarmPolicy.disabled()
       : mode = PdfPageRasterWarmMode.disabled,
         window = 0,
+        slowScrollWindow = 0,
         idleDelay = const Duration(milliseconds: 750);
 
   /// Warms up to [window] pages either side of the viewport - a conservative
@@ -63,18 +71,22 @@ class PdfPageRasterWarmPolicy {
   /// committing the memory a whole document would.
   const PdfPageRasterWarmPolicy.nearby({
     this.window = 3,
+    this.slowScrollWindow = 3,
     this.idleDelay = const Duration(milliseconds: 750),
   })  : mode = PdfPageRasterWarmMode.nearby,
-        assert(window > 0);
+        assert(window > 0),
+        assert(slowScrollWindow >= 0);
 
   /// Warms every page, nearest the viewport first. Bounded in practice by
   /// [PdfPageRasterCachePolicy.maxBytes]: pages past the budget evict the
   /// least-recently-used rasters, so a document larger than the budget settles
   /// into a moving window rather than growing without limit.
   const PdfPageRasterWarmPolicy.document({
+    this.slowScrollWindow = 3,
     this.idleDelay = const Duration(milliseconds: 750),
   })  : mode = PdfPageRasterWarmMode.document,
-        window = 0;
+        window = 0,
+        assert(slowScrollWindow >= 0);
 
   /// How far the warm reaches.
   final PdfPageRasterWarmMode mode;
@@ -82,6 +94,14 @@ class PdfPageRasterWarmPolicy {
   /// Pages either side of the viewport warmed under
   /// [PdfPageRasterWarmMode.nearby]. Unused by the other modes.
   final int window;
+
+  /// Maximum number of not-yet-visible pages to keep sharp ahead of a
+  /// sustained slow scroll.
+  ///
+  /// The effective count is also bounded by the exact-raster byte budget. In
+  /// [PdfPageRasterWarmMode.nearby] it cannot exceed [window]. Set to zero to
+  /// retain idle warming while disabling live directional look-ahead.
+  final int slowScrollWindow;
 
   /// How long the viewer must be quiet - no scroll, zoom, edit, or queued
   /// page render - before warming starts or resumes.
@@ -99,17 +119,20 @@ class PdfPageRasterWarmPolicy {
       other is PdfPageRasterWarmPolicy &&
       mode == other.mode &&
       window == other.window &&
+      slowScrollWindow == other.slowScrollWindow &&
       idleDelay == other.idleDelay;
 
   @override
-  int get hashCode => Object.hash(mode, window, idleDelay);
+  int get hashCode => Object.hash(mode, window, slowScrollWindow, idleDelay);
 
   @override
   String toString() => switch (mode) {
         PdfPageRasterWarmMode.disabled => 'PdfPageRasterWarmPolicy.disabled()',
         PdfPageRasterWarmMode.nearby =>
-          'PdfPageRasterWarmPolicy.nearby(window: $window)',
-        PdfPageRasterWarmMode.document => 'PdfPageRasterWarmPolicy.document()',
+          'PdfPageRasterWarmPolicy.nearby(window: $window, '
+              'slowScrollWindow: $slowScrollWindow)',
+        PdfPageRasterWarmMode.document => 'PdfPageRasterWarmPolicy.document('
+            'slowScrollWindow: $slowScrollWindow)',
       };
 }
 

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -195,6 +195,16 @@ class PdfPageRenderScheduler {
   bool get busy =>
       !_parked && (_holding || _pending.isNotEmpty || _inFlight.isNotEmpty);
 
+  /// Whether page work the reader is waiting for is queued or running.
+  ///
+  /// Unlike [busy], this deliberately excludes [holding]. A slow scroll keeps
+  /// that conservative hold raised even after every visible page is sharp;
+  /// accelerated look-ahead may use a spare worker/GPU lane in that state,
+  /// but must still stand down the instant real foreground work appears.
+  bool get hasForegroundWork =>
+      !_parked &&
+      (_pending.isNotEmpty || _inFlight.isNotEmpty || _uiPending.isNotEmpty);
+
   bool _parked = false;
 
   /// True while the viewer is overlaid by another view and renders nothing

--- a/packages/dart_pdf_editor/test/raster_warm_test.dart
+++ b/packages/dart_pdf_editor/test/raster_warm_test.dart
@@ -4,9 +4,11 @@
 // reading back first.
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -21,6 +23,7 @@ class _FullPageWarmBackend extends PdfTileRasterBackend {
   int sessions = 0;
   int rasters = 0;
   int disposals = 0;
+  final List<int> pages = [];
 
   @override
   bool get supportsFullPageRasterWarmUp => true;
@@ -55,6 +58,7 @@ class _FullPageWarmSession implements PdfTileRasterSession {
     int? tracePage,
   }) {
     backend.rasters++;
+    if (tracePage != null) backend.pages.add(tracePage);
     if (backend.failRaster) {
       throw StateError('test accelerated raster failure');
     }
@@ -102,6 +106,7 @@ void main() {
     PdfViewerController controller, {
     required PdfPageRasterWarmPolicy warm,
     PdfTileRasterBackend tileRasterBackend = const PdfCanvasTileRasterBackend(),
+    PdfRenderWorker? renderWorker,
     PdfPageRasterCachePolicy cache = const PdfPageRasterCachePolicy(
       maxBytes: 512 * 1024 * 1024,
       maxEntryBytes: 64 * 1024 * 1024,
@@ -116,6 +121,7 @@ void main() {
             pageRasterCachePolicy: cache,
             pageRasterWarmPolicy: warm,
             tileRasterBackend: tileRasterBackend,
+            renderWorker: renderWorker,
           ),
         ),
       );
@@ -281,6 +287,214 @@ void main() {
         tester, () => controller.pageRasterWarmStats!.completions > during);
     expect(controller.pageRasterWarmStats!.completions, greaterThan(during),
         reason: 'the settle restarts the pass');
+  });
+
+  testWidgets('slow scrolling warms exact rasters in the travel direction',
+      (tester) async {
+    final bytes = buildMultiPagePdf(12);
+    final document = PdfDocument.open(bytes);
+    final controller = PdfViewerController();
+    final backend = _FullPageWarmBackend();
+    final worker = _MultiPageRecordingWorker(bytes, capacity: 2);
+    addTearDown(controller.dispose);
+    addTearDown(worker.dispose);
+    await tester.pumpWidget(viewer(
+      document,
+      controller,
+      warm: const PdfPageRasterWarmPolicy.nearby(
+        window: 3,
+        idleDelay: Duration(seconds: 5),
+      ),
+      tileRasterBackend: backend,
+      renderWorker: worker,
+    ));
+    await tester.pump();
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+
+    // Put both directions in range without giving the ordinary idle warm its
+    // five-second quiet window.
+    unawaited(controller.jumpToPage(6));
+    for (var i = 0; i < 18; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(6) && !controller.isPageRenderBusy,
+        rounds: 30);
+    expect(controller.currentPage, 6);
+    backend.pages.clear();
+    final completionsBefore = controller.pageRasterWarmStats!.completions;
+
+    final pointer = TestPointer(301, PointerDeviceKind.mouse)
+      ..hover(const Offset(400, 300));
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 8)));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    expect(controller.debugSlowRenderMotion, isTrue);
+    await pumpUntil(
+      tester,
+      () => controller.pageRasterWarmStats!.completions > completionsBefore,
+      rounds: 8,
+    );
+    expect(backend.pages, isNotEmpty);
+    expect(backend.pages.every((page) => page > 6 && page <= 9), isTrue,
+        reason: 'only the next three pages may consume the GPU look-ahead');
+
+    // Let the first gesture settle, then reverse. The generation fence must
+    // re-aim the next pass behind the same current page rather than continuing
+    // to fill the stale forward queue.
+    await tester.pump(const Duration(milliseconds: 550));
+    backend.pages.clear();
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, -8)));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await pumpUntil(tester, () => backend.pages.isNotEmpty, rounds: 8);
+    expect(backend.pages, isNotEmpty);
+    expect(backend.pages.every((page) => page < 6 && page >= 3), isTrue,
+        reason: 'reversing scroll direction re-aims the exact-raster warm');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('fast scrolling never starts exact GPU look-ahead',
+      (tester) async {
+    final bytes = buildMultiPagePdf(12);
+    final document = PdfDocument.open(bytes);
+    final controller = PdfViewerController();
+    final backend = _FullPageWarmBackend();
+    final worker = _MultiPageRecordingWorker(bytes, capacity: 2);
+    addTearDown(controller.dispose);
+    addTearDown(worker.dispose);
+    await tester.pumpWidget(viewer(
+      document,
+      controller,
+      warm: const PdfPageRasterWarmPolicy.nearby(
+        idleDelay: Duration(seconds: 5),
+      ),
+      tileRasterBackend: backend,
+      renderWorker: worker,
+    ));
+    await tester.pump();
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+    backend.pages.clear();
+    final completionsBefore = controller.pageRasterWarmStats!.completions;
+
+    final pointer = TestPointer(302, PointerDeviceKind.mouse)
+      ..hover(const Offset(400, 300));
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 300)));
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+    expect(controller.debugSlowRenderMotion, isFalse);
+    expect(controller.debugSlowScrollRasterWarming, isFalse);
+    expect(controller.pageRasterWarmStats!.completions, completionsBefore,
+        reason: 'fast motion keeps exact off-screen GPU work fully preempted');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('a serial worker keeps its only lane for visible pages',
+      (tester) async {
+    final bytes = buildMultiPagePdf(12);
+    final document = PdfDocument.open(bytes);
+    final controller = PdfViewerController();
+    final backend = _FullPageWarmBackend();
+    final worker = _MultiPageRecordingWorker(bytes, capacity: 1);
+    addTearDown(controller.dispose);
+    addTearDown(worker.dispose);
+    await tester.pumpWidget(viewer(
+      document,
+      controller,
+      warm: const PdfPageRasterWarmPolicy.nearby(
+        idleDelay: Duration(seconds: 5),
+      ),
+      tileRasterBackend: backend,
+      renderWorker: worker,
+    ));
+    await tester.pump();
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+    backend.pages.clear();
+    final completionsBefore = controller.pageRasterWarmStats!.completions;
+
+    final pointer = TestPointer(303, PointerDeviceKind.mouse)
+      ..hover(const Offset(400, 300));
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 8)));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    expect(controller.debugSlowRenderMotion, isTrue,
+        reason: 'the motion itself is eligible; worker capacity is the gate');
+    await pumpUntil(tester, () => backend.pages.isNotEmpty, rounds: 12);
+    final offscreenPages = backend.pages.where((page) => page != 0).toList();
+    final completionsAfter = controller.pageRasterWarmStats!.completions;
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(offscreenPages, isEmpty);
+    expect(completionsAfter, completionsBefore,
+        reason: 'speculation must not strand a visible page behind the only '
+            'record lane');
+  });
+
+  testWidgets('slow look-ahead cannot consume more than its byte share',
+      (tester) async {
+    final bytes = buildMultiPagePdf(12);
+    final document = PdfDocument.open(bytes);
+    final controller = PdfViewerController();
+    final backend = _FullPageWarmBackend();
+    final worker = _MultiPageRecordingWorker(bytes, capacity: 2);
+    addTearDown(controller.dispose);
+    addTearDown(worker.dispose);
+    await tester.pumpWidget(viewer(
+      document,
+      controller,
+      warm: const PdfPageRasterWarmPolicy.nearby(
+        window: 5,
+        slowScrollWindow: 5,
+        idleDelay: Duration(seconds: 5),
+      ),
+      cache: const PdfPageRasterCachePolicy(
+        maxBytes: 64 * 1024 * 1024,
+        maxEntryBytes: 20 * 1024 * 1024,
+      ),
+      tileRasterBackend: backend,
+      renderWorker: worker,
+    ));
+    await tester.pump();
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+    backend.pages.clear();
+    final completionsBefore = controller.pageRasterWarmStats!.completions;
+
+    final pointer = TestPointer(304, PointerDeviceKind.mouse)
+      ..hover(const Offset(400, 300));
+    for (var i = 0; i < 5; i++) {
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, 8)));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await pumpUntil(
+      tester,
+      () => controller.pageRasterWarmStats!.completions > completionsBefore,
+      rounds: 20,
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    final warmedPages = backend.pages.where((page) => page != 0).toSet();
+    final completionsAfter = controller.pageRasterWarmStats!.completions;
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(warmedPages, hasLength(1),
+        reason: 'the one-third look-ahead share fits one 17 MB exact raster, '
+            'not the five-page policy window');
+    expect(completionsAfter, completionsBefore + 1);
   });
 
   testWidgets('changing either policy on a mounted viewer re-arms the pass',
@@ -555,6 +769,57 @@ void main() {
       });
     });
 
+    testWidgets('accelerated-only rejection does not replay through Canvas',
+        (tester) async {
+      final t = target();
+      final backend = _FullPageWarmBackend(reject: true);
+      final worker = _RecordingWorker(page);
+      await tester.runAsync(() async {
+        expect(
+          await cache.warmFullRaster(
+            0,
+            page,
+            signature: t.signature,
+            pixelRatio: t.ratio,
+            rasterBackend: backend,
+            worker: worker,
+            acceleratedOnly: true,
+          ),
+          isFalse,
+        );
+        expect(backend.sessions, 1);
+        expect(backend.rasters, 0);
+        expect(cache.hasFullRaster(t.signature, page), isFalse,
+            reason: 'live motion must leave an unsupported page soft instead '
+                'of paying for a synchronous Canvas fallback');
+      });
+    });
+
+    testWidgets('accelerated-only worker rejection never records locally',
+        (tester) async {
+      final t = target();
+      final backend = _FullPageWarmBackend();
+      final worker = _DecliningWorker();
+      await tester.runAsync(() async {
+        expect(
+          await cache.warmFullRaster(
+            0,
+            page,
+            signature: t.signature,
+            pixelRatio: t.ratio,
+            rasterBackend: backend,
+            worker: worker,
+            acceleratedOnly: true,
+          ),
+          isFalse,
+        );
+        expect(backend.sessions, 0,
+            reason: 'a declined worker record must not be rebuilt on the UI '
+                'thread just to reach the backend');
+        expect(cache.hasFullRaster(t.signature, page), isFalse);
+      });
+    });
+
     testWidgets('a preempt after the picture is built still stores nothing',
         (tester) async {
       final t = target();
@@ -779,6 +1044,8 @@ void main() {
         const PdfPageRasterWarmPolicy.nearby(window: 3));
     expect(const PdfPageRasterWarmPolicy.nearby(window: 3),
         isNot(const PdfPageRasterWarmPolicy.nearby(window: 4)));
+    expect(const PdfPageRasterWarmPolicy.nearby(slowScrollWindow: 2),
+        isNot(const PdfPageRasterWarmPolicy.nearby(slowScrollWindow: 3)));
     expect(const PdfPageRasterWarmPolicy.nearby(window: 3).hashCode,
         const PdfPageRasterWarmPolicy.nearby(window: 3).hashCode);
     expect('${const PdfPageRasterWarmPolicy.document()}', contains('document'));
@@ -858,6 +1125,50 @@ class _RecordingWorker extends PdfRenderWorker {
 
   @override
   void dispose() {}
+}
+
+/// Multi-page worker with a spare lane, matching the desktop app's pool shape.
+/// Work still executes deterministically on the test isolate; the capacity is
+/// the scheduling contract the slow-scroll warm requires before speculating.
+class _MultiPageRecordingWorker extends PdfRenderWorker {
+  _MultiPageRecordingWorker(Uint8List bytes, {required this.capacity})
+      : _document = PdfDocument.open(bytes);
+
+  final PdfDocument _document;
+  final int capacity;
+  bool _disposed = false;
+
+  @override
+  int get concurrentRecordCapacity => capacity;
+
+  @override
+  bool get isActive => !_disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async {
+    if (_disposed || pageIndex < 0 || pageIndex >= _document.pageCount) {
+      return null;
+    }
+    final page = _document.page(pageIndex);
+    final device = RecordingPdfDevice();
+    PdfInterpreter(cos: _document.cos, device: device).drawPage(page);
+    return device.commands;
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _disposed = true;
 }
 
 /// Active, but declines every record - the real worker's behaviour when a page


### PR DESCRIPTION
## Summary

- warm exact page rasters directionally during sustained slow scrolling
- keep the live path accelerated-only, serial, preemptible, and behind visible work
- bound look-ahead by both page count and a fraction of the exact-raster cache
- expose and persist the policy in Developer Tools

## Policy

- up to 3 pages ahead by default
- one speculative GPU submission at a time
- requires at least 2 render-worker lanes
- stops for fast motion, reversal, zoom, editing, or foreground rendering
- never falls back to platform-thread Canvas work while scrolling
- uses at most one-third of the exact-raster cache, with normal total and per-page admission limits still enforced

## Validation

- fvm dart analyze
- full dart_pdf_editor suite: 2,573 passed, 27 skipped
- raster_warm_test.dart: 36 passed
- app Developer Tools tests: 22 passed