### PR TITLE
Prevent editing notifications from disrupting viewer rebuilds

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -465,8 +466,41 @@ class PdfEditingController extends ChangeNotifier {
   /// across sessions). See [PdfThumbnailCache].
   final PdfThumbnailCache thumbnailCache = PdfThumbnailCache();
 
+  bool _notificationPending = false;
+  bool _disposed = false;
+
+  /// Page lifecycle callbacks can change editing state while the lazy viewer
+  /// is building or laying out (for example, closing an off-screen editor).
+  /// Keep the state change immediate, but deliver its UI notification after
+  /// that frame so listeners cannot dirty a partially rebuilt page subtree.
+  /// Normal input and headless controller use retain synchronous delivery.
+  @override
+  void notifyListeners() {
+    SchedulerBinding? scheduler;
+    try {
+      scheduler = SchedulerBinding.instance;
+    } catch (_) {
+      // A controller can be used without installing a Flutter binding.
+    }
+    if (!_disposed &&
+        scheduler?.schedulerPhase == SchedulerPhase.persistentCallbacks) {
+      if (_notificationPending) return;
+      _notificationPending = true;
+      scheduler!.addPostFrameCallback((_) {
+        if (_disposed || !_notificationPending) return;
+        _notificationPending = false;
+        super.notifyListeners();
+      });
+      return;
+    }
+    _notificationPending = false;
+    super.notifyListeners();
+  }
+
   @override
   void dispose() {
+    _disposed = true;
+    _notificationPending = false;
     _settlePick(null);
     _inkTimer?.cancel();
     _flashTimer?.cancel();

--- a/packages/dart_pdf_editor/test/viewer_scroll_lifecycle_test.dart
+++ b/packages/dart_pdf_editor/test/viewer_scroll_lifecycle_test.dart
@@ -1,0 +1,138 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Exercise a controller update from inside the page's nested build scope.
+// This models the text-session cleanup a page lifecycle callback can publish;
+// without deferral it dirties the viewer and the page's listening ancestors.
+class _CloseEditingOnUpdate extends StatefulWidget {
+  const _CloseEditingOnUpdate(this.editing);
+  final PdfEditingController editing;
+  @override
+  State<_CloseEditingOnUpdate> createState() => _CloseEditingOnUpdateState();
+}
+
+class _CloseEditingOnUpdateState extends State<_CloseEditingOnUpdate> {
+  @override
+  void didUpdateWidget(_CloseEditingOnUpdate oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    widget.editing.setEditingText(false);
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  testWidgets('frame notifications coalesce while input stays synchronous',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    await editing.preferences.ready;
+    final phases = <SchedulerPhase>[];
+    editing.addListener(() => phases.add(tester.binding.schedulerPhase));
+    editing.setEditingText(true);
+    expect(phases, [SchedulerPhase.idle]);
+    phases.clear();
+    await tester.pumpWidget(Builder(builder: (context) {
+      editing.setEditingText(false);
+      editing.setEditingText(true);
+      expect(editing.isEditingText, isTrue);
+      expect(phases, isEmpty);
+      return const SizedBox.shrink();
+    }));
+    expect(phases, [SchedulerPhase.postFrameCallbacks]);
+  });
+
+  testWidgets('a pending notification cannot outlive its controller',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    await editing.preferences.ready;
+    var notifications = 0;
+    editing.addListener(() => notifications++);
+    await tester.pumpWidget(Builder(builder: (context) {
+      editing.setEditingText(true);
+      editing.dispose();
+      return const SizedBox.shrink();
+    }));
+    expect(notifications, 0);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('page lifecycle notifications do not dirty a rebuilding viewer',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(57));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: PdfViewer(
+      document: editing.document,
+      editing: editing,
+      controller: viewer,
+      pagePreviews: false,
+      pageOverlayBuilder: (context, index, geometry) => [
+        _CloseEditingOnUpdate(editing),
+      ],
+    ))));
+    await tester.pump();
+    editing.setEditingText(true);
+    viewer.setZoom(0.22);
+    await tester.pump();
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+    expect(editing.isEditingText, isFalse);
+    expect(find.byType(PdfPageView), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+  testWidgets('scrolling past a focused inline editor preserves navigation',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildMultiPagePdf(57));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    editing.addFreeText(0, const PdfRect(100, 600, 300, 700), 'Note');
+    editing.selectAnnotation(0, 0);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            document: editing.document,
+            editing: editing,
+            controller: viewer,
+            pagePreviews: false,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    editing.requestEditSelectedTextInline();
+    await tester.pump();
+    expect(editing.isEditingText, isTrue);
+    viewer.jumpToPage(44);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(tester.takeException(), isNull);
+    expect(viewer.currentPage, 44);
+    // Flutter keeps the focused editor alive off-screen. It must not block
+    // touch navigation or corrupt the lazy list while other pages rebuild.
+    await tester.drag(find.byType(PdfViewer), const Offset(0, -500));
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(tester.takeException(), isNull);
+    expect(viewer.currentPage, greaterThan(44));
+    expect(find.byType(PdfPageView), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+}


### PR DESCRIPTION
## Summary

Editing-state notifications raised during a page lifecycle callback can dirty the viewer and its listening ancestors while Flutter is rebuilding or laying out the lazy page list. This can break subsequent builds and leave the main viewer blank while thumbnails remain visible.

Defer and coalesce `PdfEditingController` notifications raised during persistent frame callbacks until the frame ends. State changes remain immediate; normal input and controller use without a Flutter binding retain synchronous notifications. Disposing the controller cancels pending delivery.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Bug fix

## Validation

- [x] `fvm dart analyze` — no issues.
- [x] Repository formatter check for both changed files.
- [x] Full `dart_pdf_editor` Flutter suite — 2,578 passed, 27 skipped.
- [x] Targeted Flutter suites: viewer lifecycle, viewer navigation, iPad input, off-page reach, text editing, annotation sync, preferences, clipboard, and forms.

The new regression fails before the fix when a lifecycle callback updates editing state inside a page's nested build scope. Additional tests cover notification coalescing, synchronous input delivery, disposal, and continued touch navigation past a focused inline editor in a 57-page document.

All applicable CI checks passed, including the full repository test job, iOS/Android/macOS Patrol, browser functional and performance scenarios, GPU checks, coverage, and preview deployments. The first browser attempt timed out during Playwright page setup before its first test; rerunning the failed job passed without code changes or weakened checks.

No PDF interpreter or rasterization changes; corpus baselines are unchanged.

## User experience

- [x] The affected journey and expected behavior are described above.
- [x] Disposal and normal input notification behavior are covered.
- [x] Touch navigation and text focus are covered by targeted tests.

## PDF fixtures and screenshots

Uses programmatically generated fixtures; no user PDF is uploaded.

## Compatibility checklist

- [x] Flutter imports remain confined to `dart_pdf_editor`.
- [x] No `dart:io` imports added.
- [x] Package layering is preserved.
- [x] Tests use programmatically generated PDFs.

## Notes for reviewers

This addresses a reproducible lifecycle-notification failure consistent with the reported viewer exception. The exact scrolling sequence with the user's PDF on iPad has not been reproduced or device-verified.
