### PR TITLE
Bound the web PDF cache by bytes and add storage controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Test DartPDF app
         working-directory: app
         run: flutter test --coverage
+      - name: Test browser PDF snapshot cache
+        working-directory: app
+        run: flutter test --platform chrome test/web/pdf_cache_web_test.dart
       - name: Upload app coverage
         uses: codecov/codecov-action@v7
         with:

--- a/app/README.md
+++ b/app/README.md
@@ -96,6 +96,17 @@ initialization. This applies to debug, release, and Store builds, so dialogs
 and regular windows cannot end up on incompatible engine modes. See
 [the implementation notes](../doc/dev-log/2026-08-14-flutter-347-multi-window.md).
 
+Web Recent documents use disposable IndexedDB snapshots with a **256 MiB total
+budget** and a **64 MiB per-file limit**. Opening or reopening a cached document
+refreshes its recency; older snapshots are evicted as needed. New snapshots are
+skipped when they would consume the last 10% of the browser's estimated origin
+quota. If the estimate is unavailable, the app's own limits still apply.
+Settings → **Cached documents** shows the stored PDF size and offers **Clear
+cached documents**. Evicted or cleared documents stay in Recents and need to be
+picked again. Clearing leaves open documents and unsaved-change recovery intact.
+Existing caches are brought under the limits on startup. These limits currently
+apply to the web snapshot store; native snapshot storage is unchanged.
+
 On web, `dart_pdf_editor` uses its bundled page-render worker asset
 automatically. If the browser cannot load it, rendering falls back to the main
 thread.

--- a/app/lib/cached_documents_settings.dart
+++ b/app/lib/cached_documents_settings.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'l10n/app_l10n.dart';
+import 'pdf_cache.dart';
+import 'recents.dart';
+
+/// Settings for disposable web snapshots, separate from Recents and recovery.
+class CachedDocumentsSettings extends StatefulWidget {
+  const CachedDocumentsSettings(
+      {super.key,
+      required this.recents,
+      this.readUsage = cachedPdfUsage,
+      this.clearCache = clearCachedPdfs});
+
+  final RecentsStore recents;
+  final Future<PdfCacheUsage?> Function() readUsage;
+  final Future<bool> Function() clearCache;
+
+  @override
+  State<CachedDocumentsSettings> createState() =>
+      _CachedDocumentsSettingsState();
+}
+
+class _CachedDocumentsSettingsState extends State<CachedDocumentsSettings> {
+  late Future<PdfCacheUsage?> _usage;
+  bool _clearing = false;
+  bool _failed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _usage = widget.readUsage();
+    widget.recents.addListener(_refresh);
+  }
+
+  @override
+  void dispose() {
+    widget.recents.removeListener(_refresh);
+    super.dispose();
+  }
+
+  void _refresh() => setState(() {
+        _usage = widget.readUsage();
+      });
+
+  Future<void> _clear() async {
+    final checked = {
+      for (final entry in widget.recents.items)
+        if (entry.cachePath != null) entry.cachePath!,
+    };
+    setState(() {
+      _clearing = true;
+      _failed = false;
+    });
+    var cleared = false;
+    try {
+      cleared = await widget.clearCache();
+    } catch (_) {
+      // Keep the size and Recent availability when storage rejects the clear.
+    }
+    if (cleared) await widget.recents.updateCachedAvailability(checked, {});
+    if (!mounted) return;
+    setState(() {
+      _clearing = false;
+      _failed = !cleared;
+      _usage = widget.readUsage();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = appL10n(context);
+    final style = Theme.of(context).textTheme;
+    final number =
+        NumberFormat.decimalPattern(Localizations.localeOf(context).toString())
+          ..minimumFractionDigits = 1
+          ..maximumFractionDigits = 1;
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+      Text(l10n.settingsCachedDocuments, style: style.titleSmall),
+      const SizedBox(height: 8),
+      FutureBuilder<PdfCacheUsage?>(
+          future: _usage,
+          builder: (context, snapshot) {
+            final usage = snapshot.data;
+            return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (snapshot.connectionState != ConnectionState.done)
+                    const LinearProgressIndicator()
+                  else
+                    Text(
+                        usage == null
+                            ? l10n.settingsCacheUnavailable
+                            : l10n.settingsCacheUsage(
+                                number.format(usage.bytes / (1024 * 1024)),
+                                '${pdfCacheMaxBytes ~/ (1024 * 1024)}'),
+                        key: const ValueKey('settings-cache-usage'),
+                        style: style.bodySmall),
+                  Text(
+                      l10n.settingsCacheExplanation(
+                          '${pdfCacheMaxFileBytes ~/ (1024 * 1024)}'),
+                      style: style.bodySmall),
+                  TextButton.icon(
+                    key: const ValueKey('settings-clear-cache'),
+                    onPressed: _clearing ||
+                            usage?.documents == 0 ||
+                            snapshot.connectionState != ConnectionState.done
+                        ? null
+                        : _clear,
+                    icon: const Icon(Icons.delete_outline),
+                    label: Text(l10n.settingsClearCachedDocuments),
+                  ),
+                ]);
+          }),
+      if (_failed)
+        Text(l10n.settingsCacheClearFailed,
+            style: style.bodySmall
+                ?.copyWith(color: Theme.of(context).colorScheme.error)),
+    ]);
+  }
+}

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -840,15 +840,25 @@ class _EditorScreenState extends State<EditorScreen>
     await _session.save(documents);
   }
 
-  /// Deletes private PDF snapshots and first-page thumbnails that no Recent
-  /// entry still references, so local caches cannot grow without bound as
-  /// entries roll off the list.
+  /// Serializes snapshot writes plus their Recent updates against pruning.
+  Future<void> _recentCacheWork = Future<void>.value();
+
+  /// Prunes unreferenced snapshots/thumbnails and enforces the web byte budget.
   void _pruneRecentCache() {
+    _recentCacheWork = _recentCacheWork.then((_) => _pruneRecentCacheNow());
+  }
+
+  Future<void> _pruneRecentCacheNow() async {
+    if (!mounted) return;
     final keep = {
       for (final entry in _recents.items)
         if (entry.cachePath != null) entry.cachePath!,
     };
-    unawaited(pruneCachedPdfs(keep));
+    final available = await pruneCachedPdfs(keep);
+    if (!mounted) return;
+    if (available != null) {
+      await _recents.updateCachedAvailability(keep, available);
+    }
     unawaited(_recentThumbnails.retain(_recents.items));
   }
 
@@ -1191,16 +1201,26 @@ class _EditorScreenState extends State<EditorScreen>
   /// pick, then records the recent (and re-persists the session) once the
   /// snapshot is on disk. Runs off the open hot path - the tab is already
   /// visible - so a slow disk write never blocks the loading placeholder.
-  Future<void> _snapshotOpenedDocument(DocumentTab tab, Uint8List bytes) async {
+  Future<void> _snapshotOpenedDocument(DocumentTab tab, Uint8List bytes) {
+    // A prune must not delete a snapshot between its write and its Recent add.
+    return _recentCacheWork = _recentCacheWork.then((_) async {
+      await _snapshotOpenedDocumentNow(tab, bytes);
+      await _pruneRecentCacheNow();
+    });
+  }
+
+  Future<void> _snapshotOpenedDocumentNow(
+      DocumentTab tab, Uint8List bytes) async {
+    if (!mounted || !_tabs.contains(tab)) return;
     final cachePath = await cacheOpenedPdf(bytes);
     if (!mounted || !_tabs.contains(tab)) return;
     if (cachePath == null) {
       // The snapshot failed: still record a (non-reopenable) recent.
-      _recents.add(title: tab.title, bookmark: tab.originBookmark);
+      await _recents.add(title: tab.title, bookmark: tab.originBookmark);
       return;
     }
     tab.cachePath = cachePath;
-    _recents.add(
+    await _recents.add(
         title: tab.title, cachePath: cachePath, bookmark: tab.originBookmark);
     unawaited(_persistSession());
   }
@@ -2121,7 +2141,11 @@ class _EditorScreenState extends State<EditorScreen>
             bookmark: entry.bookmark);
       }
     } catch (e) {
-      await _recents.remove(entry.id);
+      if (originPath == null && entry.cachePath != null) {
+        await _recents.updateCachedAvailability({entry.cachePath!}, {});
+      } else {
+        await _recents.remove(entry.id);
+      }
       _pruneRecentCache();
       if (!mounted) return;
       AppDevTools.instance.addLog(

--- a/app/lib/idb_web.dart
+++ b/app/lib/idb_web.dart
@@ -18,15 +18,17 @@ import 'package:web/web.dart' as web;
 /// same version never fires `onupgradeneeded`, so every transaction against the
 /// missing store would throw "object store not found". We detect that and
 /// reopen at the next version to add it.
-Future<web.IDBDatabase> openIdb(String name, List<String> stores) async {
-  var db = await _openAt(name, stores, null);
+Future<web.IDBDatabase> openIdb(String name, List<String> stores,
+    {void Function(web.IDBDatabase, web.IDBTransaction)? onUpgrade}) async {
+  var db = await _openAt(name, stores, null, onUpgrade);
   if (stores.every((s) => db.objectStoreNames.contains(s))) return db;
   final next = db.version + 1;
   db.close();
-  return _openAt(name, stores, next);
+  return _openAt(name, stores, next, onUpgrade);
 }
 
-Future<web.IDBDatabase> _openAt(String name, List<String> stores, int? version) {
+Future<web.IDBDatabase> _openAt(String name, List<String> stores, int? version,
+    void Function(web.IDBDatabase, web.IDBTransaction)? onUpgrade) {
   final completer = Completer<web.IDBDatabase>();
   final request = version == null
       ? web.window.indexedDB.open(name)
@@ -36,13 +38,27 @@ Future<web.IDBDatabase> _openAt(String name, List<String> stores, int? version) 
     for (final store in stores) {
       if (!db.objectStoreNames.contains(store)) db.createObjectStore(store);
     }
+    onUpgrade?.call(db, request.transaction!);
   }.toJS;
   request.onsuccess = (web.Event _) {
-    completer.complete(request.result as web.IDBDatabase);
+    final db = request.result as web.IDBDatabase;
+    if (completer.isCompleted) {
+      db.close();
+      return;
+    }
+    completer.complete(db);
   }.toJS;
   request.onerror = (web.Event _) {
+    if (completer.isCompleted) return;
     completer.completeError(
         StateError('IndexedDB open failed: ${request.error?.message}'));
+  }.toJS;
+  request.onblocked = (web.Event _) {
+    if (completer.isCompleted) return;
+    // An older app tab may hold a connection without a versionchange handler.
+    // Optional storage must fail promptly instead of waiting forever for it.
+    completer
+        .completeError(StateError('IndexedDB upgrade blocked by another tab'));
   }.toJS;
   return completer.future;
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -264,5 +264,11 @@
   "updateFailed": "فشل التحديث: {error}",
   "imageSourceTakePhoto": "التقاط صورة",
   "imageSourceChooseFile": "اختيار ملف",
-  "imageSourceCameraFailed": "تعذّر التقاط صورة"
+  "imageSourceCameraFailed": "تعذّر التقاط صورة",
+  "settingsCachedDocuments": "المستندات المخزنة مؤقتًا",
+  "settingsCacheUsage": "تم استخدام {used} MiB من {limit} MiB",
+  "settingsCacheExplanation": "لا تُخزّن الملفات التي تتجاوز {limit} MiB مؤقتًا. يحتفظ المسح بقائمة الملفات الأخيرة والمستندات المفتوحة والتغييرات غير المحفوظة؛ يجب اختيار الملفات المخزنة مؤقتًا مجددًا لإعادة فتحها.",
+  "settingsClearCachedDocuments": "مسح المستندات المخزنة مؤقتًا",
+  "settingsCacheUnavailable": "حجم التخزين المؤقت غير متاح",
+  "settingsCacheClearFailed": "تعذر مسح المستندات المخزنة مؤقتًا. حاول مجددًا."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Update fehlgeschlagen: {error}",
   "imageSourceTakePhoto": "Foto aufnehmen",
   "imageSourceChooseFile": "Datei auswählen",
-  "imageSourceCameraFailed": "Foto konnte nicht aufgenommen werden"
+  "imageSourceCameraFailed": "Foto konnte nicht aufgenommen werden",
+  "settingsCachedDocuments": "Zwischengespeicherte Dokumente",
+  "settingsCacheUsage": "{used} MiB von {limit} MiB belegt",
+  "settingsCacheExplanation": "Dateien über {limit} MiB werden nicht zwischengespeichert. Beim Leeren bleiben die Liste zuletzt geöffneter Dateien, offene Dokumente und ungespeicherte Änderungen erhalten; zwischengespeicherte Dateien müssen zum Öffnen erneut ausgewählt werden.",
+  "settingsClearCachedDocuments": "Zwischengespeicherte Dokumente löschen",
+  "settingsCacheUnavailable": "Cache-Größe nicht verfügbar",
+  "settingsCacheClearFailed": "Zwischengespeicherte Dokumente konnten nicht gelöscht werden. Erneut versuchen."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1398,5 +1398,42 @@
   "imageSourceCameraFailed": "Couldn't take a photo",
   "@imageSourceCameraFailed":   {
       "description": "Toast shown when the camera cannot be opened - no camera on the device, or access refused."
+  },
+  "settingsCachedDocuments": "Cached documents",
+  "settingsCacheUsage": "{used} MiB of {limit} MiB used",
+  "settingsCacheExplanation": "Files over {limit} MiB are not cached. Clearing keeps your Recent list, open documents and unsaved changes; cached files must be picked again to reopen.",
+  "settingsClearCachedDocuments": "Clear cached documents",
+  "settingsCacheUnavailable": "Cache size unavailable",
+  "settingsCacheClearFailed": "Could not clear cached documents. Try again.",
+  "@settingsCachedDocuments": {
+    "description": "Opened PDF snapshot cache settings: settingsCachedDocuments"
+  },
+  "@settingsCacheUsage": {
+    "description": "Opened PDF snapshot cache settings: settingsCacheUsage",
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "@settingsCacheExplanation": {
+    "description": "Opened PDF snapshot cache settings: settingsCacheExplanation",
+    "placeholders": {
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "@settingsClearCachedDocuments": {
+    "description": "Opened PDF snapshot cache settings: settingsClearCachedDocuments"
+  },
+  "@settingsCacheUnavailable": {
+    "description": "Opened PDF snapshot cache settings: settingsCacheUnavailable"
+  },
+  "@settingsCacheClearFailed": {
+    "description": "Opened PDF snapshot cache settings: settingsCacheClearFailed"
   }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Error en la actualización: {error}",
   "imageSourceTakePhoto": "Hacer foto",
   "imageSourceChooseFile": "Elegir archivo",
-  "imageSourceCameraFailed": "No se pudo hacer la foto"
+  "imageSourceCameraFailed": "No se pudo hacer la foto",
+  "settingsCachedDocuments": "Documentos en caché",
+  "settingsCacheUsage": "{used} MiB de {limit} MiB usados",
+  "settingsCacheExplanation": "Los archivos de más de {limit} MiB no se guardan en caché. Al borrar se conservan la lista de recientes, los documentos abiertos y los cambios sin guardar; tendrás que seleccionar de nuevo los archivos para abrirlos.",
+  "settingsClearCachedDocuments": "Borrar documentos en caché",
+  "settingsCacheUnavailable": "Tamaño de caché no disponible",
+  "settingsCacheClearFailed": "No se pudieron borrar los documentos en caché. Inténtalo de nuevo."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Échec de la mise à jour : {error}",
   "imageSourceTakePhoto": "Prendre une photo",
   "imageSourceChooseFile": "Choisir un fichier",
-  "imageSourceCameraFailed": "Impossible de prendre une photo"
+  "imageSourceCameraFailed": "Impossible de prendre une photo",
+  "settingsCachedDocuments": "Documents en cache",
+  "settingsCacheUsage": "{used} MiB utilisés sur {limit} MiB",
+  "settingsCacheExplanation": "Les fichiers de plus de {limit} MiB ne sont pas mis en cache. La suppression conserve les fichiers récents, les documents ouverts et les modifications non enregistrées ; les fichiers en cache devront être sélectionnés à nouveau pour les rouvrir.",
+  "settingsClearCachedDocuments": "Effacer les documents en cache",
+  "settingsCacheUnavailable": "Taille du cache indisponible",
+  "settingsCacheClearFailed": "Impossible d’effacer les documents en cache. Réessayez."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -264,5 +264,11 @@
   "updateFailed": "अपडेट विफल: {error}",
   "imageSourceTakePhoto": "फ़ोटो लें",
   "imageSourceChooseFile": "फ़ाइल चुनें",
-  "imageSourceCameraFailed": "फ़ोटो नहीं ली जा सकी"
+  "imageSourceCameraFailed": "फ़ोटो नहीं ली जा सकी",
+  "settingsCachedDocuments": "कैश किए गए दस्तावेज़",
+  "settingsCacheUsage": "{limit} MiB में से {used} MiB उपयोग में",
+  "settingsCacheExplanation": "{limit} MiB से बड़ी फ़ाइलें कैश नहीं की जातीं। साफ़ करने पर हाल की फ़ाइलों की सूची, खुले दस्तावेज़ और बिना सहेजे बदलाव बने रहते हैं; कैश की गई फ़ाइलों को फिर से खोलने के लिए दोबारा चुनना होगा।",
+  "settingsClearCachedDocuments": "कैश किए गए दस्तावेज़ साफ़ करें",
+  "settingsCacheUnavailable": "कैश का आकार उपलब्ध नहीं है",
+  "settingsCacheClearFailed": "कैश किए गए दस्तावेज़ साफ़ नहीं किए जा सके। फिर से कोशिश करें।"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Pembaruan gagal: {error}",
   "imageSourceTakePhoto": "Ambil foto",
   "imageSourceChooseFile": "Pilih berkas",
-  "imageSourceCameraFailed": "Tidak dapat mengambil foto"
+  "imageSourceCameraFailed": "Tidak dapat mengambil foto",
+  "settingsCachedDocuments": "Dokumen dalam cache",
+  "settingsCacheUsage": "{used} MiB dari {limit} MiB digunakan",
+  "settingsCacheExplanation": "File di atas {limit} MiB tidak disimpan dalam cache. Menghapus cache tetap menyimpan daftar terbaru, dokumen terbuka, dan perubahan yang belum disimpan; file dalam cache harus dipilih lagi untuk dibuka kembali.",
+  "settingsClearCachedDocuments": "Hapus dokumen dalam cache",
+  "settingsCacheUnavailable": "Ukuran cache tidak tersedia",
+  "settingsCacheClearFailed": "Tidak dapat menghapus dokumen dalam cache. Coba lagi."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Aggiornamento non riuscito: {error}",
   "imageSourceTakePhoto": "Scatta foto",
   "imageSourceChooseFile": "Scegli file",
-  "imageSourceCameraFailed": "Impossibile scattare la foto"
+  "imageSourceCameraFailed": "Impossibile scattare la foto",
+  "settingsCachedDocuments": "Documenti nella cache",
+  "settingsCacheUsage": "{used} MiB utilizzati su {limit} MiB",
+  "settingsCacheExplanation": "I file oltre {limit} MiB non vengono memorizzati nella cache. La pulizia conserva i recenti, i documenti aperti e le modifiche non salvate; per riaprire i file nella cache dovrai selezionarli di nuovo.",
+  "settingsClearCachedDocuments": "Svuota la cache dei documenti",
+  "settingsCacheUnavailable": "Dimensione della cache non disponibile",
+  "settingsCacheClearFailed": "Impossibile svuotare la cache dei documenti. Riprova."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -264,5 +264,11 @@
   "updateFailed": "更新に失敗しました: {error}",
   "imageSourceTakePhoto": "写真を撮る",
   "imageSourceChooseFile": "ファイルを選択",
-  "imageSourceCameraFailed": "写真を撮影できませんでした"
+  "imageSourceCameraFailed": "写真を撮影できませんでした",
+  "settingsCachedDocuments": "キャッシュされたドキュメント",
+  "settingsCacheUsage": "{limit} MiB 中 {used} MiB 使用",
+  "settingsCacheExplanation": "{limit} MiB を超えるファイルはキャッシュされません。削除しても最近使ったファイルの一覧、開いているドキュメント、未保存の変更は保持されます。キャッシュされたファイルを再度開くには、ファイルを選び直す必要があります。",
+  "settingsClearCachedDocuments": "ドキュメントのキャッシュを削除",
+  "settingsCacheUnavailable": "キャッシュサイズを取得できません",
+  "settingsCacheClearFailed": "ドキュメントのキャッシュを削除できませんでした。再試行してください。"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -264,5 +264,11 @@
   "updateFailed": "업데이트 실패: {error}",
   "imageSourceTakePhoto": "사진 촬영",
   "imageSourceChooseFile": "파일 선택",
-  "imageSourceCameraFailed": "사진을 촬영하지 못했습니다"
+  "imageSourceCameraFailed": "사진을 촬영하지 못했습니다",
+  "settingsCachedDocuments": "캐시된 문서",
+  "settingsCacheUsage": "{limit} MiB 중 {used} MiB 사용",
+  "settingsCacheExplanation": "{limit} MiB를 초과하는 파일은 캐시되지 않습니다. 삭제해도 최근 파일 목록, 열린 문서 및 저장하지 않은 변경 사항은 유지됩니다. 캐시된 파일을 다시 열려면 파일을 다시 선택해야 합니다.",
+  "settingsClearCachedDocuments": "캐시된 문서 삭제",
+  "settingsCacheUnavailable": "캐시 크기를 확인할 수 없음",
+  "settingsCacheClearFailed": "캐시된 문서를 삭제하지 못했습니다. 다시 시도하세요."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1722,6 +1722,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Couldn\'t take a photo'**
   String get imageSourceCameraFailed;
+
+  /// Opened PDF snapshot cache settings: settingsCachedDocuments
+  ///
+  /// In en, this message translates to:
+  /// **'Cached documents'**
+  String get settingsCachedDocuments;
+
+  /// Opened PDF snapshot cache settings: settingsCacheUsage
+  ///
+  /// In en, this message translates to:
+  /// **'{used} MiB of {limit} MiB used'**
+  String settingsCacheUsage(String used, String limit);
+
+  /// Opened PDF snapshot cache settings: settingsCacheExplanation
+  ///
+  /// In en, this message translates to:
+  /// **'Files over {limit} MiB are not cached. Clearing keeps your Recent list, open documents and unsaved changes; cached files must be picked again to reopen.'**
+  String settingsCacheExplanation(String limit);
+
+  /// Opened PDF snapshot cache settings: settingsClearCachedDocuments
+  ///
+  /// In en, this message translates to:
+  /// **'Clear cached documents'**
+  String get settingsClearCachedDocuments;
+
+  /// Opened PDF snapshot cache settings: settingsCacheUnavailable
+  ///
+  /// In en, this message translates to:
+  /// **'Cache size unavailable'**
+  String get settingsCacheUnavailable;
+
+  /// Opened PDF snapshot cache settings: settingsCacheClearFailed
+  ///
+  /// In en, this message translates to:
+  /// **'Could not clear cached documents. Try again.'**
+  String get settingsCacheClearFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -1078,4 +1078,27 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'تعذّر التقاط صورة';
+
+  @override
+  String get settingsCachedDocuments => 'المستندات المخزنة مؤقتًا';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'تم استخدام $used MiB من $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'لا تُخزّن الملفات التي تتجاوز $limit MiB مؤقتًا. يحتفظ المسح بقائمة الملفات الأخيرة والمستندات المفتوحة والتغييرات غير المحفوظة؛ يجب اختيار الملفات المخزنة مؤقتًا مجددًا لإعادة فتحها.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'مسح المستندات المخزنة مؤقتًا';
+
+  @override
+  String get settingsCacheUnavailable => 'حجم التخزين المؤقت غير متاح';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'تعذر مسح المستندات المخزنة مؤقتًا. حاول مجددًا.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1072,4 +1072,28 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Foto konnte nicht aufgenommen werden';
+
+  @override
+  String get settingsCachedDocuments => 'Zwischengespeicherte Dokumente';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB von $limit MiB belegt';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Dateien über $limit MiB werden nicht zwischengespeichert. Beim Leeren bleiben die Liste zuletzt geöffneter Dateien, offene Dokumente und ungespeicherte Änderungen erhalten; zwischengespeicherte Dateien müssen zum Öffnen erneut ausgewählt werden.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments =>
+      'Zwischengespeicherte Dokumente löschen';
+
+  @override
+  String get settingsCacheUnavailable => 'Cache-Größe nicht verfügbar';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Zwischengespeicherte Dokumente konnten nicht gelöscht werden. Erneut versuchen.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1051,4 +1051,27 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Couldn\'t take a photo';
+
+  @override
+  String get settingsCachedDocuments => 'Cached documents';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB of $limit MiB used';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Files over $limit MiB are not cached. Clearing keeps your Recent list, open documents and unsaved changes; cached files must be picked again to reopen.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Clear cached documents';
+
+  @override
+  String get settingsCacheUnavailable => 'Cache size unavailable';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Could not clear cached documents. Try again.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1067,4 +1067,27 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'No se pudo hacer la foto';
+
+  @override
+  String get settingsCachedDocuments => 'Documentos en caché';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB de $limit MiB usados';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Los archivos de más de $limit MiB no se guardan en caché. Al borrar se conservan la lista de recientes, los documentos abiertos y los cambios sin guardar; tendrás que seleccionar de nuevo los archivos para abrirlos.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Borrar documentos en caché';
+
+  @override
+  String get settingsCacheUnavailable => 'Tamaño de caché no disponible';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'No se pudieron borrar los documentos en caché. Inténtalo de nuevo.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1069,4 +1069,27 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Impossible de prendre une photo';
+
+  @override
+  String get settingsCachedDocuments => 'Documents en cache';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB utilisés sur $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Les fichiers de plus de $limit MiB ne sont pas mis en cache. La suppression conserve les fichiers récents, les documents ouverts et les modifications non enregistrées ; les fichiers en cache devront être sélectionnés à nouveau pour les rouvrir.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Effacer les documents en cache';
+
+  @override
+  String get settingsCacheUnavailable => 'Taille du cache indisponible';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Impossible d’effacer les documents en cache. Réessayez.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -1053,4 +1053,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'फ़ोटो नहीं ली जा सकी';
+
+  @override
+  String get settingsCachedDocuments => 'कैश किए गए दस्तावेज़';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$limit MiB में से $used MiB उपयोग में';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '$limit MiB से बड़ी फ़ाइलें कैश नहीं की जातीं। साफ़ करने पर हाल की फ़ाइलों की सूची, खुले दस्तावेज़ और बिना सहेजे बदलाव बने रहते हैं; कैश की गई फ़ाइलों को फिर से खोलने के लिए दोबारा चुनना होगा।';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'कैश किए गए दस्तावेज़ साफ़ करें';
+
+  @override
+  String get settingsCacheUnavailable => 'कैश का आकार उपलब्ध नहीं है';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'कैश किए गए दस्तावेज़ साफ़ नहीं किए जा सके। फिर से कोशिश करें।';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -1057,4 +1057,27 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Tidak dapat mengambil foto';
+
+  @override
+  String get settingsCachedDocuments => 'Dokumen dalam cache';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB dari $limit MiB digunakan';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'File di atas $limit MiB tidak disimpan dalam cache. Menghapus cache tetap menyimpan daftar terbaru, dokumen terbuka, dan perubahan yang belum disimpan; file dalam cache harus dipilih lagi untuk dibuka kembali.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Hapus dokumen dalam cache';
+
+  @override
+  String get settingsCacheUnavailable => 'Ukuran cache tidak tersedia';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Tidak dapat menghapus dokumen dalam cache. Coba lagi.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -1064,4 +1064,28 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Impossibile scattare la foto';
+
+  @override
+  String get settingsCachedDocuments => 'Documenti nella cache';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB utilizzati su $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'I file oltre $limit MiB non vengono memorizzati nella cache. La pulizia conserva i recenti, i documenti aperti e le modifiche non salvate; per riaprire i file nella cache dovrai selezionarli di nuovo.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Svuota la cache dei documenti';
+
+  @override
+  String get settingsCacheUnavailable =>
+      'Dimensione della cache non disponibile';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Impossibile svuotare la cache dei documenti. Riprova.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -1034,4 +1034,26 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => '写真を撮影できませんでした';
+
+  @override
+  String get settingsCachedDocuments => 'キャッシュされたドキュメント';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$limit MiB 中 $used MiB 使用';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '$limit MiB を超えるファイルはキャッシュされません。削除しても最近使ったファイルの一覧、開いているドキュメント、未保存の変更は保持されます。キャッシュされたファイルを再度開くには、ファイルを選び直す必要があります。';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'ドキュメントのキャッシュを削除';
+
+  @override
+  String get settingsCacheUnavailable => 'キャッシュサイズを取得できません';
+
+  @override
+  String get settingsCacheClearFailed => 'ドキュメントのキャッシュを削除できませんでした。再試行してください。';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1032,4 +1032,26 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => '사진을 촬영하지 못했습니다';
+
+  @override
+  String get settingsCachedDocuments => '캐시된 문서';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$limit MiB 중 $used MiB 사용';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '$limit MiB를 초과하는 파일은 캐시되지 않습니다. 삭제해도 최근 파일 목록, 열린 문서 및 저장하지 않은 변경 사항은 유지됩니다. 캐시된 파일을 다시 열려면 파일을 다시 선택해야 합니다.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => '캐시된 문서 삭제';
+
+  @override
+  String get settingsCacheUnavailable => '캐시 크기를 확인할 수 없음';
+
+  @override
+  String get settingsCacheClearFailed => '캐시된 문서를 삭제하지 못했습니다. 다시 시도하세요.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -1065,4 +1065,27 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Kan geen foto maken';
+
+  @override
+  String get settingsCachedDocuments => 'Documenten in cache';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB van $limit MiB gebruikt';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Bestanden groter dan $limit MiB worden niet gecachet. Wissen behoudt de lijst met recente bestanden, geopende documenten en niet-opgeslagen wijzigingen; gecachete bestanden moeten opnieuw worden gekozen om ze te openen.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Documentcache wissen';
+
+  @override
+  String get settingsCacheUnavailable => 'Cachegrootte niet beschikbaar';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Kan documentcache niet wissen. Probeer het opnieuw.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -1088,4 +1088,29 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Nie udało się zrobić zdjęcia';
+
+  @override
+  String get settingsCachedDocuments => 'Dokumenty w pamięci podręcznej';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'Wykorzystano $used MiB z $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Pliki większe niż $limit MiB nie są buforowane. Czyszczenie zachowuje listę ostatnich plików, otwarte dokumenty i niezapisane zmiany; pliki z pamięci podręcznej trzeba ponownie wybrać, aby je otworzyć.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments =>
+      'Wyczyść dokumenty z pamięci podręcznej';
+
+  @override
+  String get settingsCacheUnavailable =>
+      'Rozmiar pamięci podręcznej niedostępny';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Nie udało się wyczyścić pamięci podręcznej dokumentów. Spróbuj ponownie.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1064,4 +1064,27 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Não foi possível tirar a foto';
+
+  @override
+  String get settingsCachedDocuments => 'Documentos em cache';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$used MiB de $limit MiB usados';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Arquivos maiores que $limit MiB não são armazenados em cache. A limpeza mantém a lista de recentes, os documentos abertos e as alterações não salvas; os arquivos em cache devem ser selecionados novamente para reabrir.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Limpar documentos em cache';
+
+  @override
+  String get settingsCacheUnavailable => 'Tamanho do cache indisponível';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Não foi possível limpar os documentos em cache. Tente novamente.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -1070,4 +1070,27 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Не удалось сделать снимок';
+
+  @override
+  String get settingsCachedDocuments => 'Кэшированные документы';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'Использовано $used МиБ из $limit МиБ';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Файлы больше $limit МиБ не кэшируются. Очистка сохраняет список недавних файлов, открытые документы и несохранённые изменения; для открытия кэшированных файлов потребуется выбрать их заново.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Очистить кэш документов';
+
+  @override
+  String get settingsCacheUnavailable => 'Размер кэша недоступен';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Не удалось очистить кэш документов. Повторите попытку.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -1047,4 +1047,27 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'ถ่ายภาพไม่สำเร็จ';
+
+  @override
+  String get settingsCachedDocuments => 'เอกสารที่แคชไว้';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'ใช้ไป $used MiB จาก $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'ไฟล์ที่ใหญ่กว่า $limit MiB จะไม่ถูกแคช การล้างจะเก็บรายการล่าสุด เอกสารที่เปิดอยู่ และการเปลี่ยนแปลงที่ยังไม่ได้บันทึกไว้ โดยต้องเลือกไฟล์ที่เคยแคชอีกครั้งเพื่อเปิดใหม่';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'ล้างเอกสารที่แคชไว้';
+
+  @override
+  String get settingsCacheUnavailable => 'ไม่สามารถดูขนาดแคชได้';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'ไม่สามารถล้างเอกสารที่แคชไว้ได้ โปรดลองอีกครั้ง';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -1053,4 +1053,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Fotoğraf çekilemedi';
+
+  @override
+  String get settingsCachedDocuments => 'Önbelleğe alınan belgeler';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '$limit MiB alanın $used MiB kadarı kullanılıyor';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '$limit MiB üzerindeki dosyalar önbelleğe alınmaz. Temizleme, son dosyalar listesini, açık belgeleri ve kaydedilmemiş değişiklikleri korur; önbellekteki dosyaları yeniden açmak için tekrar seçmeniz gerekir.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Önbellekteki belgeleri temizle';
+
+  @override
+  String get settingsCacheUnavailable => 'Önbellek boyutu kullanılamıyor';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Önbellekteki belgeler temizlenemedi. Tekrar deneyin.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -1073,4 +1073,27 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Не вдалося зробити знімок';
+
+  @override
+  String get settingsCachedDocuments => 'Кешовані документи';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'Використано $used МіБ із $limit МіБ';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Файли понад $limit МіБ не кешуються. Очищення зберігає список нещодавніх файлів, відкриті документи та незбережені зміни; для відкриття кешованих файлів їх потрібно вибрати знову.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Очистити кеш документів';
+
+  @override
+  String get settingsCacheUnavailable => 'Розмір кешу недоступний';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Не вдалося очистити кеш документів. Спробуйте ще раз.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -1054,4 +1054,28 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => 'Không thể chụp ảnh';
+
+  @override
+  String get settingsCachedDocuments => 'Tài liệu đã lưu vào bộ nhớ đệm';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return 'Đã dùng $used MiB trên $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return 'Tệp lớn hơn $limit MiB không được lưu vào bộ nhớ đệm. Việc xóa vẫn giữ danh sách gần đây, tài liệu đang mở và thay đổi chưa lưu; bạn cần chọn lại tệp đã lưu trong bộ nhớ đệm để mở lại.';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => 'Xóa tài liệu trong bộ nhớ đệm';
+
+  @override
+  String get settingsCacheUnavailable =>
+      'Không có thông tin kích thước bộ nhớ đệm';
+
+  @override
+  String get settingsCacheClearFailed =>
+      'Không thể xóa tài liệu trong bộ nhớ đệm. Hãy thử lại.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -1027,6 +1027,28 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get imageSourceCameraFailed => '无法拍照';
+
+  @override
+  String get settingsCachedDocuments => '缓存的文档';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '已使用 $used MiB，共 $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '超过 $limit MiB 的文件不会缓存。清除后会保留最近文件列表、打开的文档和未保存的更改；要重新打开缓存的文件，需要再次选择文件。';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => '清除缓存的文档';
+
+  @override
+  String get settingsCacheUnavailable => '无法获取缓存大小';
+
+  @override
+  String get settingsCacheClearFailed => '无法清除缓存的文档。请重试。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -2053,4 +2075,26 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get imageSourceCameraFailed => '無法拍照';
+
+  @override
+  String get settingsCachedDocuments => '快取的文件';
+
+  @override
+  String settingsCacheUsage(String used, String limit) {
+    return '已使用 $used MiB，共 $limit MiB';
+  }
+
+  @override
+  String settingsCacheExplanation(String limit) {
+    return '超過 $limit MiB 的檔案不會快取。清除後會保留最近使用的檔案清單、開啟的文件和未儲存的變更；若要重新開啟快取的檔案，需再次選取檔案。';
+  }
+
+  @override
+  String get settingsClearCachedDocuments => '清除快取的文件';
+
+  @override
+  String get settingsCacheUnavailable => '無法取得快取大小';
+
+  @override
+  String get settingsCacheClearFailed => '無法清除快取的文件。請重試。';
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Bijwerken mislukt: {error}",
   "imageSourceTakePhoto": "Foto maken",
   "imageSourceChooseFile": "Bestand kiezen",
-  "imageSourceCameraFailed": "Kan geen foto maken"
+  "imageSourceCameraFailed": "Kan geen foto maken",
+  "settingsCachedDocuments": "Documenten in cache",
+  "settingsCacheUsage": "{used} MiB van {limit} MiB gebruikt",
+  "settingsCacheExplanation": "Bestanden groter dan {limit} MiB worden niet gecachet. Wissen behoudt de lijst met recente bestanden, geopende documenten en niet-opgeslagen wijzigingen; gecachete bestanden moeten opnieuw worden gekozen om ze te openen.",
+  "settingsClearCachedDocuments": "Documentcache wissen",
+  "settingsCacheUnavailable": "Cachegrootte niet beschikbaar",
+  "settingsCacheClearFailed": "Kan documentcache niet wissen. Probeer het opnieuw."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Aktualizacja nie powiodła się: {error}",
   "imageSourceTakePhoto": "Zrób zdjęcie",
   "imageSourceChooseFile": "Wybierz plik",
-  "imageSourceCameraFailed": "Nie udało się zrobić zdjęcia"
+  "imageSourceCameraFailed": "Nie udało się zrobić zdjęcia",
+  "settingsCachedDocuments": "Dokumenty w pamięci podręcznej",
+  "settingsCacheUsage": "Wykorzystano {used} MiB z {limit} MiB",
+  "settingsCacheExplanation": "Pliki większe niż {limit} MiB nie są buforowane. Czyszczenie zachowuje listę ostatnich plików, otwarte dokumenty i niezapisane zmiany; pliki z pamięci podręcznej trzeba ponownie wybrać, aby je otworzyć.",
+  "settingsClearCachedDocuments": "Wyczyść dokumenty z pamięci podręcznej",
+  "settingsCacheUnavailable": "Rozmiar pamięci podręcznej niedostępny",
+  "settingsCacheClearFailed": "Nie udało się wyczyścić pamięci podręcznej dokumentów. Spróbuj ponownie."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Falha na atualização: {error}",
   "imageSourceTakePhoto": "Tirar foto",
   "imageSourceChooseFile": "Escolher arquivo",
-  "imageSourceCameraFailed": "Não foi possível tirar a foto"
+  "imageSourceCameraFailed": "Não foi possível tirar a foto",
+  "settingsCachedDocuments": "Documentos em cache",
+  "settingsCacheUsage": "{used} MiB de {limit} MiB usados",
+  "settingsCacheExplanation": "Arquivos maiores que {limit} MiB não são armazenados em cache. A limpeza mantém a lista de recentes, os documentos abertos e as alterações não salvas; os arquivos em cache devem ser selecionados novamente para reabrir.",
+  "settingsClearCachedDocuments": "Limpar documentos em cache",
+  "settingsCacheUnavailable": "Tamanho do cache indisponível",
+  "settingsCacheClearFailed": "Não foi possível limpar os documentos em cache. Tente novamente."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Не удалось обновить: {error}",
   "imageSourceTakePhoto": "Сделать снимок",
   "imageSourceChooseFile": "Выбрать файл",
-  "imageSourceCameraFailed": "Не удалось сделать снимок"
+  "imageSourceCameraFailed": "Не удалось сделать снимок",
+  "settingsCachedDocuments": "Кэшированные документы",
+  "settingsCacheUsage": "Использовано {used} МиБ из {limit} МиБ",
+  "settingsCacheExplanation": "Файлы больше {limit} МиБ не кэшируются. Очистка сохраняет список недавних файлов, открытые документы и несохранённые изменения; для открытия кэшированных файлов потребуется выбрать их заново.",
+  "settingsClearCachedDocuments": "Очистить кэш документов",
+  "settingsCacheUnavailable": "Размер кэша недоступен",
+  "settingsCacheClearFailed": "Не удалось очистить кэш документов. Повторите попытку."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -264,5 +264,11 @@
   "updateFailed": "การอัปเดตล้มเหลว: {error}",
   "imageSourceTakePhoto": "ถ่ายภาพ",
   "imageSourceChooseFile": "เลือกไฟล์",
-  "imageSourceCameraFailed": "ถ่ายภาพไม่สำเร็จ"
+  "imageSourceCameraFailed": "ถ่ายภาพไม่สำเร็จ",
+  "settingsCachedDocuments": "เอกสารที่แคชไว้",
+  "settingsCacheUsage": "ใช้ไป {used} MiB จาก {limit} MiB",
+  "settingsCacheExplanation": "ไฟล์ที่ใหญ่กว่า {limit} MiB จะไม่ถูกแคช การล้างจะเก็บรายการล่าสุด เอกสารที่เปิดอยู่ และการเปลี่ยนแปลงที่ยังไม่ได้บันทึกไว้ โดยต้องเลือกไฟล์ที่เคยแคชอีกครั้งเพื่อเปิดใหม่",
+  "settingsClearCachedDocuments": "ล้างเอกสารที่แคชไว้",
+  "settingsCacheUnavailable": "ไม่สามารถดูขนาดแคชได้",
+  "settingsCacheClearFailed": "ไม่สามารถล้างเอกสารที่แคชไว้ได้ โปรดลองอีกครั้ง"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Güncelleme başarısız: {error}",
   "imageSourceTakePhoto": "Fotoğraf çek",
   "imageSourceChooseFile": "Dosya seç",
-  "imageSourceCameraFailed": "Fotoğraf çekilemedi"
+  "imageSourceCameraFailed": "Fotoğraf çekilemedi",
+  "settingsCachedDocuments": "Önbelleğe alınan belgeler",
+  "settingsCacheUsage": "{limit} MiB alanın {used} MiB kadarı kullanılıyor",
+  "settingsCacheExplanation": "{limit} MiB üzerindeki dosyalar önbelleğe alınmaz. Temizleme, son dosyalar listesini, açık belgeleri ve kaydedilmemiş değişiklikleri korur; önbellekteki dosyaları yeniden açmak için tekrar seçmeniz gerekir.",
+  "settingsClearCachedDocuments": "Önbellekteki belgeleri temizle",
+  "settingsCacheUnavailable": "Önbellek boyutu kullanılamıyor",
+  "settingsCacheClearFailed": "Önbellekteki belgeler temizlenemedi. Tekrar deneyin."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Не вдалося оновити: {error}",
   "imageSourceTakePhoto": "Зробити знімок",
   "imageSourceChooseFile": "Вибрати файл",
-  "imageSourceCameraFailed": "Не вдалося зробити знімок"
+  "imageSourceCameraFailed": "Не вдалося зробити знімок",
+  "settingsCachedDocuments": "Кешовані документи",
+  "settingsCacheUsage": "Використано {used} МіБ із {limit} МіБ",
+  "settingsCacheExplanation": "Файли понад {limit} МіБ не кешуються. Очищення зберігає список нещодавніх файлів, відкриті документи та незбережені зміни; для відкриття кешованих файлів їх потрібно вибрати знову.",
+  "settingsClearCachedDocuments": "Очистити кеш документів",
+  "settingsCacheUnavailable": "Розмір кешу недоступний",
+  "settingsCacheClearFailed": "Не вдалося очистити кеш документів. Спробуйте ще раз."
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -264,5 +264,11 @@
   "updateFailed": "Cập nhật thất bại: {error}",
   "imageSourceTakePhoto": "Chụp ảnh",
   "imageSourceChooseFile": "Chọn tệp",
-  "imageSourceCameraFailed": "Không thể chụp ảnh"
+  "imageSourceCameraFailed": "Không thể chụp ảnh",
+  "settingsCachedDocuments": "Tài liệu đã lưu vào bộ nhớ đệm",
+  "settingsCacheUsage": "Đã dùng {used} MiB trên {limit} MiB",
+  "settingsCacheExplanation": "Tệp lớn hơn {limit} MiB không được lưu vào bộ nhớ đệm. Việc xóa vẫn giữ danh sách gần đây, tài liệu đang mở và thay đổi chưa lưu; bạn cần chọn lại tệp đã lưu trong bộ nhớ đệm để mở lại.",
+  "settingsClearCachedDocuments": "Xóa tài liệu trong bộ nhớ đệm",
+  "settingsCacheUnavailable": "Không có thông tin kích thước bộ nhớ đệm",
+  "settingsCacheClearFailed": "Không thể xóa tài liệu trong bộ nhớ đệm. Hãy thử lại."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -264,5 +264,11 @@
   "updateFailed": "更新失败：{error}",
   "imageSourceTakePhoto": "拍照",
   "imageSourceChooseFile": "选择文件",
-  "imageSourceCameraFailed": "无法拍照"
+  "imageSourceCameraFailed": "无法拍照",
+  "settingsCachedDocuments": "缓存的文档",
+  "settingsCacheUsage": "已使用 {used} MiB，共 {limit} MiB",
+  "settingsCacheExplanation": "超过 {limit} MiB 的文件不会缓存。清除后会保留最近文件列表、打开的文档和未保存的更改；要重新打开缓存的文件，需要再次选择文件。",
+  "settingsClearCachedDocuments": "清除缓存的文档",
+  "settingsCacheUnavailable": "无法获取缓存大小",
+  "settingsCacheClearFailed": "无法清除缓存的文档。请重试。"
 }

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -264,5 +264,11 @@
   "updateFailed": "更新失敗：{error}",
   "imageSourceTakePhoto": "拍照",
   "imageSourceChooseFile": "選擇檔案",
-  "imageSourceCameraFailed": "無法拍照"
+  "imageSourceCameraFailed": "無法拍照",
+  "settingsCachedDocuments": "快取的文件",
+  "settingsCacheUsage": "已使用 {used} MiB，共 {limit} MiB",
+  "settingsCacheExplanation": "超過 {limit} MiB 的檔案不會快取。清除後會保留最近使用的檔案清單、開啟的文件和未儲存的變更；若要重新開啟快取的檔案，需再次選取檔案。",
+  "settingsClearCachedDocuments": "清除快取的文件",
+  "settingsCacheUnavailable": "無法取得快取大小",
+  "settingsCacheClearFailed": "無法清除快取的文件。請重試。"
 }

--- a/app/lib/pdf_cache.dart
+++ b/app/lib/pdf_cache.dart
@@ -15,6 +15,7 @@
 //
 // Conditions are evaluated in order, first match wins: native targets have
 // dart:io, web targets have dart:js_interop (and not dart:io).
+export 'pdf_cache_policy.dart';
 export 'pdf_cache_stub.dart'
     if (dart.library.io) 'pdf_cache_io.dart'
     if (dart.library.js_interop) 'pdf_cache_web.dart';

--- a/app/lib/pdf_cache_io.dart
+++ b/app/lib/pdf_cache_io.dart
@@ -4,6 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'pdf_cache_key.dart';
+import 'pdf_cache_policy.dart';
+
+bool get canManageCachedPdfs => false;
+Future<PdfCacheUsage?> cachedPdfUsage() async => null;
+Future<bool> clearCachedPdfs() async => false;
 
 /// Whether opened PDFs should be snapshotted for later reopening on this
 /// platform. Only mobile needs it: desktop keeps the picked file's real path,
@@ -50,11 +55,11 @@ Future<Uint8List?> readCachedPdf(String cacheKey) async => null;
 /// Deletes cached copies no longer referenced by [keep] (the cache paths still
 /// held by Recent entries), so the store can't grow without bound as entries
 /// roll off the capped list.
-Future<void> pruneCachedPdfs(Set<String> keep) async {
-  if (!canCacheRecentPdfs) return;
+Future<Set<String>?> pruneCachedPdfs(Set<String> keep) async {
+  if (!canCacheRecentPdfs) return null;
   try {
     final dir = await _cacheDir();
-    if (!await dir.exists()) return;
+    if (!await dir.exists()) return null;
     await for (final entry in dir.list()) {
       if (entry is File && !keep.contains(entry.path)) {
         try {
@@ -67,4 +72,5 @@ Future<void> pruneCachedPdfs(Set<String> keep) async {
   } catch (_) {
     // No writable store - nothing to prune.
   }
+  return null;
 }

--- a/app/lib/pdf_cache_policy.dart
+++ b/app/lib/pdf_cache_policy.dart
@@ -1,0 +1,20 @@
+/// Limits apply to disposable opened-document snapshots, never crash recovery.
+const pdfCacheMaxBytes = 256 * 1024 * 1024;
+const pdfCacheMaxFileBytes = 64 * 1024 * 1024;
+
+/// PDF payload bytes only; browser bookkeeping is included in its quota estimate.
+class PdfCacheUsage {
+  const PdfCacheUsage(this.bytes, this.documents);
+
+  final int bytes;
+  final int documents;
+}
+
+/// Leave 10% of the origin quota free for preferences, recovery and overhead.
+/// An unavailable estimate still permits caching within our own byte budget.
+bool pdfCacheFitsQuota(int addedBytes, {num? usage, num? quota}) {
+  if (usage == null || quota == null || !usage.isFinite || !quota.isFinite) {
+    return true;
+  }
+  return usage >= 0 && quota > 0 && usage + addedBytes <= quota * 0.9;
+}

--- a/app/lib/pdf_cache_stub.dart
+++ b/app/lib/pdf_cache_stub.dart
@@ -1,4 +1,9 @@
 import 'dart:typed_data';
+import 'pdf_cache_policy.dart';
+
+bool get canManageCachedPdfs => false;
+Future<PdfCacheUsage?> cachedPdfUsage() async => null;
+Future<bool> clearCachedPdfs() async => false;
 
 /// A target with neither `dart:io` nor JS interop can't snapshot opened bytes,
 /// so Recent entries there still need a fresh pick to reopen.
@@ -8,4 +13,4 @@ Future<String?> cacheOpenedPdf(Uint8List bytes) async => null;
 
 Future<Uint8List?> readCachedPdf(String cacheKey) async => null;
 
-Future<void> pruneCachedPdfs(Set<String> keep) async {}
+Future<Set<String>?> pruneCachedPdfs(Set<String> keep) async => null;

--- a/app/lib/pdf_cache_web.dart
+++ b/app/lib/pdf_cache_web.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
@@ -5,96 +7,289 @@ import 'package:web/web.dart' as web;
 
 import 'idb_web.dart';
 import 'pdf_cache_key.dart';
+import 'pdf_cache_policy.dart';
 
-/// Web byte-snapshot store for opened PDFs, backed by IndexedDB.
-///
-/// The browser file picker hands back only bytes - no reusable path - so
-/// without a store a web Recent entry could never reopen ("Pick again to
-/// reopen"). We keep the opened bytes in IndexedDB (`localStorage` is ~5 MB,
-/// synchronous and string-only; IndexedDB stores binary blobs) keyed by a
-/// content hash, and reopening reads them straight back. One object store maps
-/// the content hash to the raw `Uint8List`.
-///
-/// Every operation degrades to a miss on failure - a blocked or unavailable
-/// IndexedDB (private-mode quotas, disabled storage) just leaves the Recent
-/// entry non-reopenable, exactly as before, and never breaks the app.
-
-/// Web keeps opened bytes in IndexedDB, so Recent entries reopen without a
-/// fresh pick.
 bool get canCacheRecentPdfs => true;
+bool get canManageCachedPdfs => true;
 
-const String _dbName = 'dart_pdf_editor_app.recent_pdfs';
-const String _storeName = 'pdfs';
+final _cache = WebPdfCache();
 
-/// Snapshots [bytes] into IndexedDB and returns the content-hash key, or null
-/// when the store is unavailable or the write fails.
-///
-/// The key is a content key ([pdfContentKey]), so reopening or re-picking the
-/// same document reuses one entry instead of piling up copies - and the same
-/// bytes always map to the same Recent identity, matching the native
-/// filesystem store.
-///
-/// The first `await` is load-bearing and must stay first. An `async` body runs
-/// synchronously up to its initial await, so computing the key before one
-/// would run it inside the caller's frame - and `unawaited(...)` at the call
-/// site would not help, because that defers only the *future*, never the
-/// synchronous prefix. Yielding first pushes the whole snapshot off the frame
-/// that opened the document, which is the one the user is waiting on.
-Future<String?> cacheOpenedPdf(Uint8List bytes) async {
-  try {
-    await null;
-    final key = pdfContentKey(bytes);
-    final store = await _store('readwrite');
-    await idbRequest<void>(store.put(bytes.toJS, key.toJS), (_) {});
-    return key;
-  } catch (_) {
-    return null;
-  }
+Future<String?> cacheOpenedPdf(Uint8List bytes) => _cache.put(bytes);
+Future<Uint8List?> readCachedPdf(String key) => _cache.read(key);
+Future<Set<String>?> pruneCachedPdfs(Set<String> keep) => _cache.prune(keep);
+Future<PdfCacheUsage?> cachedPdfUsage() => _cache.usage();
+Future<bool> clearCachedPdfs() => _cache.clear();
+
+typedef PdfStorageEstimate = ({num? usage, num? quota});
+
+Future<PdfStorageEstimate> _estimateStorage() async {
+  final estimate = await web.window.navigator.storage.estimate().toDart;
+  return (usage: estimate.usage, quota: estimate.quota);
 }
 
-/// Reads a snapshot back by its content-hash [cacheKey]. Throws when it's gone
-/// or IndexedDB is unavailable - the web has no filesystem to fall back to, so
-/// `readPdfAtPath` must not treat a miss as "read it off disk instead"; the
-/// throw drops the stale Recent entry, exactly as a gone file does on native.
-Future<Uint8List?> readCachedPdf(String cacheKey) async {
-  final store = await _store('readonly');
-  final bytes = await idbRequest<Uint8List?>(store.get(cacheKey.toJS), (result) {
-    if (result == null) return null;
-    return (result as JSUint8Array).toDart;
-  });
-  if (bytes == null) throw StateError('No cached PDF for $cacheKey');
-  return bytes;
-}
+/// Disposable PDF snapshots. Metadata and bytes change in one transaction, so
+/// concurrent tabs cannot overspend the budget or leave orphaned byte records.
+/// Limits and the estimate provider are injectable for real-browser tests.
+class WebPdfCache {
+  WebPdfCache({
+    this.databaseName = 'dart_pdf_editor_app.recent_pdfs',
+    this.maxBytes = pdfCacheMaxBytes,
+    this.maxFileBytes = pdfCacheMaxFileBytes,
+    Future<PdfStorageEstimate> Function()? estimateStorage,
+  }) : _estimate = estimateStorage ?? _estimateStorage;
 
-/// Deletes snapshots no longer referenced by [keep] (the cache keys still held
-/// by Recent entries), so the store can't grow without bound as entries roll
-/// off the capped list.
-Future<void> pruneCachedPdfs(Set<String> keep) async {
-  try {
-    final readStore = await _store('readonly');
-    final keys = await idbRequest<List<String>>(readStore.getAllKeys(), (result) {
-      if (result == null) return const [];
-      return [
-        for (final key in (result as JSArray<JSAny?>).toDart)
-          (key! as JSString).toDart,
-      ];
-    });
-    for (final key in keys) {
-      if (keep.contains(key)) continue;
-      // A fresh transaction per delete: an IndexedDB transaction auto-commits
-      // once it goes idle, so it would already be inactive if we reused one
-      // read store across these awaited deletes.
-      final store = await _store('readwrite');
-      await idbRequest<void>(store.delete(key.toJS), (_) {});
+  final String databaseName;
+  final int maxBytes;
+  final int maxFileBytes;
+  final Future<PdfStorageEstimate> Function() _estimate;
+  Future<web.IDBDatabase>? _db;
+  static const _pdfs = 'pdfs';
+  static const _meta = 'metadata';
+
+  Future<web.IDBDatabase> _database() async {
+    try {
+      final db = await (_db ??= openIdb(databaseName, const [_pdfs, _meta],
+          onUpgrade: (_, transaction) {
+        // Upgrade the old raw-byte store one PDF at a time: getAll() here
+        // would clone the entire, potentially multi-GB legacy cache into RAM.
+        final metadata = transaction.objectStore(_meta);
+        final request = transaction.objectStore(_pdfs).openCursor();
+        request.onsuccess = (web.Event _) {
+          try {
+            if (request.result == null) return;
+            final cursor = request.result as web.IDBCursorWithValue;
+            final key = (cursor.key as JSString).toDart;
+            final size = (cursor.value as JSUint8Array).toDart.length;
+            if (size > maxFileBytes || size > maxBytes) {
+              cursor.delete();
+              metadata.delete(cursor.key);
+            } else {
+              // Historical access times aren't available. Legacy snapshots are
+              // oldest until first reopened; content keys and bytes stay intact.
+              metadata.put(_Entry(key, size, 0).encode().toJS, cursor.key);
+            }
+            cursor.continue_();
+          } catch (_) {
+            transaction.abort();
+          }
+        }.toJS;
+      }));
+      db.onversionchange = (web.Event _) {
+        db.close();
+        _db = null;
+      }.toJS;
+      return db;
+    } catch (_) {
+      _db = null; // A transient open failure must not poison the next attempt.
+      rethrow;
     }
-  } catch (_) {
-    // No writable store - nothing to prune.
+  }
+
+  /// Yields before hashing, preserving #438's open-frame latency fix. A skipped
+  /// or failed snapshot is just a Recent that needs a fresh file pick.
+  Future<String?> put(Uint8List bytes) async {
+    await null;
+    if (bytes.length > maxFileBytes || bytes.length > maxBytes) return null;
+    try {
+      final key = pdfContentKey(bytes);
+      PdfStorageEstimate estimate;
+      try {
+        estimate = await _estimate();
+      } catch (_) {
+        estimate = (usage: null, quota: null);
+      }
+      return await _withEntries((transaction, entries) {
+        final existing = entries.any((entry) => entry.key == key);
+        if (!existing &&
+            !pdfCacheFitsQuota(bytes.length,
+                usage: estimate.usage, quota: estimate.quota)) {
+          _trim(transaction, entries);
+          return null;
+        }
+        final entry = _Entry(key, bytes.length, _nextAccess(entries));
+        entries.removeWhere((entry) => entry.key == key);
+        _trim(transaction, entries, reserve: bytes.length);
+        transaction.objectStore(_meta).put(entry.encode().toJS, key.toJS);
+        if (!existing) {
+          transaction.objectStore(_pdfs).put(bytes.toJS, key.toJS);
+        }
+        return key;
+      });
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<Uint8List?> read(String key) async {
+    final db = await _database();
+    final bytes = await _transaction<Uint8List?>(db, (transaction, result) {
+      final request = transaction.objectStore(_pdfs).get(key.toJS);
+      request.onsuccess = (web.Event _) {
+        try {
+          final raw = request.result;
+          if (raw == null) {
+            result(null);
+            return;
+          }
+          final bytes = (raw as JSUint8Array).toDart;
+          final metadata = transaction.objectStore(_meta);
+          final all = metadata.getAll();
+          all.onsuccess = (web.Event _) {
+            try {
+              metadata.put(
+                  _Entry(key, bytes.length, _nextAccess(_entries(all.result)))
+                      .encode()
+                      .toJS,
+                  key.toJS);
+              result(bytes);
+            } catch (_) {
+              transaction.abort();
+            }
+          }.toJS;
+        } catch (_) {
+          transaction.abort();
+        }
+      }.toJS;
+    });
+    if (bytes == null) throw StateError('No cached PDF for $key');
+    return bytes;
+  }
+
+  /// Also enforces the byte limits on startup, including a legacy store that
+  /// already exceeds them. Returns null on failure, never a false empty store.
+  Future<Set<String>?> prune(Set<String> keep) async {
+    try {
+      return await _withEntries((transaction, entries) {
+        for (final entry in entries.toList()) {
+          if (!keep.contains(entry.key)) {
+            _delete(transaction, entry.key);
+            entries.remove(entry);
+          }
+        }
+        _trim(transaction, entries);
+        return entries.map((entry) => entry.key).toSet();
+      });
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<PdfCacheUsage?> usage() async {
+    try {
+      return await _withEntries((transaction, entries) {
+        _trim(transaction, entries);
+        return PdfCacheUsage(
+            entries.fold(0, (sum, entry) => sum + entry.size), entries.length);
+      });
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> clear() async {
+    try {
+      final db = await _database();
+      await _transaction<void>(db, (transaction, result) {
+        transaction.objectStore(_pdfs).clear();
+        transaction.objectStore(_meta).clear();
+        result(null);
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<void> close() async {
+    (await _db)?.close();
+    _db = null;
+  }
+
+  int _nextAccess(List<_Entry> entries) => entries.fold(
+      DateTime.now().millisecondsSinceEpoch,
+      (time, entry) => time > entry.used ? time : entry.used + 1);
+
+  void _trim(web.IDBTransaction transaction, List<_Entry> entries,
+      {int reserve = 0}) {
+    entries.sort((a, b) {
+      final order = a.used.compareTo(b.used);
+      return order == 0 ? a.key.compareTo(b.key) : order;
+    });
+    var total = entries.fold(reserve, (sum, entry) => sum + entry.size);
+    for (final entry in entries.toList()) {
+      if (entry.size > maxFileBytes || total > maxBytes) {
+        _delete(transaction, entry.key);
+        total -= entry.size;
+        entries.remove(entry);
+      }
+    }
+  }
+
+  void _delete(web.IDBTransaction transaction, String key) {
+    transaction.objectStore(_pdfs).delete(key.toJS);
+    transaction.objectStore(_meta).delete(key.toJS);
+  }
+
+  Future<T> _withEntries<T>(
+      T Function(web.IDBTransaction, List<_Entry>) edit) async {
+    final db = await _database();
+    return _transaction<T>(db, (transaction, result) {
+      final request = transaction.objectStore(_meta).getAll();
+      request.onsuccess = (web.Event _) {
+        try {
+          // Issue all dependent requests in the event callback, before the
+          // transaction goes idle. An await here can auto-commit underneath us.
+          result(edit(transaction, _entries(request.result)));
+        } catch (_) {
+          transaction.abort();
+        }
+      }.toJS;
+    });
+  }
+
+  List<_Entry> _entries(JSAny? raw) => [
+        for (final value in (raw as JSArray<JSString>).toDart)
+          _Entry.decode(value.toDart),
+      ];
+
+  Future<T> _transaction<T>(web.IDBDatabase db,
+      void Function(web.IDBTransaction, void Function(T)) start) {
+    final done = Completer<T>();
+    final transaction =
+        db.transaction([_pdfs.toJS, _meta.toJS].toJS, 'readwrite');
+    late T value;
+    transaction.oncomplete = (web.Event _) {
+      try {
+        done.complete(value);
+      } catch (error, stack) {
+        done.completeError(error, stack);
+      }
+    }.toJS;
+    transaction.onabort = (web.Event _) {
+      done.completeError(StateError('PDF cache transaction aborted: '
+          '${transaction.error?.message}'));
+    }.toJS;
+    try {
+      start(transaction, (result) {
+        value = result;
+      });
+    } catch (_) {
+      transaction.abort();
+    }
+    // Request success alone is insufficient: quota errors can abort at commit.
+    return done.future;
   }
 }
 
-Future<web.IDBDatabase>? _db;
+class _Entry {
+  const _Entry(this.key, this.size, this.used);
+  final String key;
+  final int size;
+  final int used;
 
-Future<web.IDBObjectStore> _store(String mode) async {
-  final db = await (_db ??= openIdb(_dbName, const [_storeName]));
-  return db.transaction(_storeName.toJS, mode).objectStore(_storeName);
+  String encode() => jsonEncode([key, size, used]);
+  factory _Entry.decode(String value) {
+    final fields = jsonDecode(value) as List;
+    return _Entry(fields[0] as String, fields[1] as int, fields[2] as int);
+  }
 }

--- a/app/lib/recents.dart
+++ b/app/lib/recents.dart
@@ -12,6 +12,7 @@ class RecentFile {
     required this.title,
     this.path,
     this.cachePath,
+    this.cacheAvailable = true,
     this.bookmark,
     required this.openedAt,
   });
@@ -30,6 +31,9 @@ class RecentFile {
   /// saves still go through save-as.
   final String? cachePath;
 
+  /// Evicted snapshots retain their identity/title in Recents, but need a pick.
+  final bool cacheAvailable;
+
   /// macOS security-scoped bookmark for [path], when available.
   final String? bookmark;
 
@@ -45,7 +49,9 @@ class RecentFile {
   /// otherwise the private snapshot. Null when neither is available (web).
   String? get readPath {
     if (path != null && path!.isNotEmpty) return path;
-    if (cachePath != null && cachePath!.isNotEmpty) return cachePath;
+    if (cacheAvailable && cachePath != null && cachePath!.isNotEmpty) {
+      return cachePath;
+    }
     return null;
   }
 
@@ -56,6 +62,7 @@ class RecentFile {
         't': title,
         if (path != null) 'p': path,
         if (cachePath != null) 'c': cachePath,
+        if (!cacheAvailable) 'a': false,
         if (bookmark != null) 'b': bookmark,
         'o': openedAt,
       };
@@ -64,6 +71,7 @@ class RecentFile {
         title: (j['t'] as String?) ?? 'Untitled',
         path: j['p'] as String?,
         cachePath: j['c'] as String?,
+        cacheAvailable: j['a'] != false,
         bookmark: j['b'] as String?,
         openedAt: (j['o'] as num?)?.toInt() ?? 0,
       );
@@ -79,6 +87,13 @@ class RecentsStore extends ChangeNotifier {
 
   final List<RecentFile> _items = [];
   bool _loaded = false;
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
 
   List<RecentFile> get items => List.unmodifiable(_items);
   bool get isEmpty => _items.isEmpty;
@@ -136,6 +151,31 @@ class RecentsStore extends ChangeNotifier {
 
   Future<void> clear() async {
     _items.clear();
+    notifyListeners();
+    await _persist();
+  }
+
+  /// Reconciles only the keys inspected by the caller, so a concurrent add
+  /// isn't marked missing using an older inventory. Keeps ordering/identity.
+  Future<void> updateCachedAvailability(
+      Set<String> checked, Set<String> available) async {
+    if (_disposed) return;
+    var changed = false;
+    for (var i = 0; i < _items.length; i++) {
+      final entry = _items[i];
+      if (!checked.contains(entry.cachePath)) continue;
+      final exists = available.contains(entry.cachePath);
+      if (entry.cacheAvailable == exists) continue;
+      _items[i] = RecentFile(
+          title: entry.title,
+          path: entry.path,
+          cachePath: entry.cachePath,
+          cacheAvailable: exists,
+          bookmark: entry.bookmark,
+          openedAt: entry.openedAt);
+      changed = true;
+    }
+    if (!changed) return;
     notifyListeners();
     await _persist();
   }

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'app_info.dart';
+import 'cached_documents_settings.dart';
 import 'l10n/app_l10n.dart';
 import 'l10n/app_localizations.dart';
 import 'language_names.dart';
+import 'pdf_cache.dart';
 import 'recents.dart';
 import 'update.dart';
 import 'update_install_flow.dart';
@@ -232,6 +234,10 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                       .settingsRecentCount(widget.recents.items.length),
                   style: theme.textTheme.bodySmall,
                 ),
+                if (canManageCachedPdfs) ...[
+                  const Divider(height: 32),
+                  CachedDocumentsSettings(recents: widget.recents),
+                ],
                 const Divider(height: 32),
                 Text(appL10n(context).settingsSystem,
                     style: theme.textTheme.titleSmall),

--- a/app/test/cached_documents_settings_test.dart
+++ b/app/test/cached_documents_settings_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:dart_pdf_editor_app/cached_documents_settings.dart';
+import 'package:dart_pdf_editor_app/pdf_cache.dart';
+import 'package:dart_pdf_editor_app/recents.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('shows usage and clears snapshots while preserving Recents',
+      (tester) async {
+    final recents = RecentsStore();
+    addTearDown(recents.dispose);
+    await recents.add(title: 'cached.pdf', cachePath: 'key');
+    await recents.add(title: 'local.pdf', path: '/local.pdf');
+    var usage = const PdfCacheUsage(12 * 1024 * 1024, 1);
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: CachedDocumentsSettings(
+      recents: recents,
+      readUsage: () async => usage,
+      clearCache: () async {
+        usage = const PdfCacheUsage(0, 0);
+        return true;
+      },
+    ))));
+    await tester.pumpAndSettle();
+    expect(find.text('12.0 MiB of 256 MiB used'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('settings-clear-cache')));
+    await tester.pumpAndSettle();
+    expect(find.text('0.0 MiB of 256 MiB used'), findsOneWidget);
+    expect(recents.items.map((entry) => entry.id), ['/local.pdf', 'key']);
+    expect(recents.items.first.isReopenable, isTrue);
+    expect(recents.items.last.isReopenable, isFalse);
+    final reloaded = RecentsStore();
+    addTearDown(reloaded.dispose);
+    await reloaded.load();
+    expect(reloaded.items.last.cacheAvailable, isFalse);
+  });
+
+  testWidgets('failed clear retains reopenability and reports failure',
+      (tester) async {
+    final recents = RecentsStore();
+    addTearDown(recents.dispose);
+    await recents.add(title: 'cached.pdf', cachePath: 'key');
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: CachedDocumentsSettings(
+      recents: recents,
+      readUsage: () async => const PdfCacheUsage(1024, 1),
+      clearCache: () async => false,
+    ))));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-clear-cache')));
+    await tester.pumpAndSettle();
+    expect(recents.items.single.isReopenable, isTrue);
+    expect(find.text('Could not clear cached documents. Try again.'),
+        findsOneWidget);
+  });
+
+  testWidgets('unavailable usage does not pretend the cache is empty',
+      (tester) async {
+    final recents = RecentsStore();
+    addTearDown(recents.dispose);
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: CachedDocumentsSettings(
+      recents: recents,
+      readUsage: () async => null,
+    ))));
+    await tester.pumpAndSettle();
+    expect(find.text('Cache size unavailable'), findsOneWidget);
+    expect(
+        tester
+            .widget<TextButton>(
+                find.byKey(const ValueKey('settings-clear-cache')))
+            .onPressed,
+        isNotNull);
+  });
+
+  testWidgets('dismissing settings during clear still updates Recents',
+      (tester) async {
+    final recents = RecentsStore();
+    addTearDown(recents.dispose);
+    await recents.add(title: 'cached.pdf', cachePath: 'key');
+    final cleared = Completer<bool>();
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: CachedDocumentsSettings(
+      recents: recents,
+      readUsage: () async => const PdfCacheUsage(1024, 1),
+      clearCache: () => cleared.future,
+    ))));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('settings-clear-cache')));
+    await tester.pumpWidget(const SizedBox());
+    cleared.complete(true);
+    await tester.pumpAndSettle();
+    expect(recents.items.single.isReopenable, isFalse);
+  });
+}

--- a/app/test/pdf_cache_policy_test.dart
+++ b/app/test/pdf_cache_policy_test.dart
@@ -1,0 +1,17 @@
+import 'package:dart_pdf_editor_app/pdf_cache_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('quota reserve accounts for the incoming PDF and accepts the boundary',
+      () {
+    expect(pdfCacheFitsQuota(10, usage: 80, quota: 100), isTrue);
+    expect(pdfCacheFitsQuota(11, usage: 80, quota: 100), isFalse);
+    expect(pdfCacheFitsQuota(1, usage: 91, quota: 100), isFalse);
+    expect(pdfCacheFitsQuota(1, usage: 0, quota: 0), isFalse);
+  });
+  test('unavailable estimates permit the independently budgeted cache', () {
+    expect(pdfCacheFitsQuota(4), isTrue);
+    expect(pdfCacheFitsQuota(4, usage: 10), isTrue);
+    expect(pdfCacheFitsQuota(4, quota: double.nan), isTrue);
+  });
+}

--- a/app/test/recents_test.dart
+++ b/app/test/recents_test.dart
@@ -62,4 +62,21 @@ void main() {
     await store.clear();
     expect(store.isEmpty, isTrue);
   });
+
+  test('eviction preserves identity, order and a usable original path',
+      () async {
+    final store = RecentsStore();
+    await store.add(title: 'a.pdf', cachePath: 'a');
+    await store.add(title: 'b.pdf', cachePath: 'b', path: '/b.pdf');
+    await store.add(title: 'new.pdf', cachePath: 'new');
+    final ids = store.items.map((entry) => entry.id).toList();
+    final times = store.items.map((entry) => entry.openedAt).toList();
+    await store.updateCachedAvailability({'a', 'b'}, {});
+    expect(store.items.map((entry) => entry.id), ids);
+    expect(store.items.map((entry) => entry.openedAt), times);
+    expect(store.items.map((entry) => entry.isReopenable), [true, true, false]);
+    await store.add(title: 'a.pdf', cachePath: 'a');
+    expect(store.items.length, 3);
+    expect(store.items.first.isReopenable, isTrue);
+  });
 }

--- a/app/test/settings_menu_test.dart
+++ b/app/test/settings_menu_test.dart
@@ -48,7 +48,10 @@ void main() {
     expect(find.byKey(const ValueKey('settings-default-app')), findsOneWidget);
     expect(find.text('Set up as default application'), findsOneWidget);
 
-    await tester.tap(find.byKey(const ValueKey('settings-default-app')));
+    final tile = find.byKey(const ValueKey('settings-default-app'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    await tester.tap(tile);
     await tester.pumpAndSettle();
 
     expect(find.text('Set up as default application'), findsWidgets);

--- a/app/test/web/pdf_cache_web_test.dart
+++ b/app/test/web/pdf_cache_web_test.dart
@@ -1,0 +1,205 @@
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor_app/idb_web.dart';
+import 'package:dart_pdf_editor_app/pdf_cache_web.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  var serial = 0;
+  late String name;
+  late WebPdfCache cache;
+  final clients = <WebPdfCache>[];
+
+  Uint8List bytes(int marker, [int size = 4]) =>
+      Uint8List(size)..fillRange(0, size, marker);
+  WebPdfCache client(
+      {int budget = 10,
+      int fileLimit = 8,
+      Future<PdfStorageEstimate> Function()? estimate}) {
+    final result = WebPdfCache(
+        databaseName: name,
+        maxBytes: budget,
+        maxFileBytes: fileLimit,
+        estimateStorage: estimate ?? () async => (usage: 0, quota: 1000));
+    clients.add(result);
+    return result;
+  }
+
+  setUp(() {
+    name =
+        'pdf-cache-test-${DateTime.now().microsecondsSinceEpoch}-${serial++}';
+    cache = client();
+  });
+  tearDown(() async {
+    for (final client in clients) {
+      await client.close();
+    }
+    clients.clear();
+    await idbRequest<void>(web.window.indexedDB.deleteDatabase(name), (_) {});
+  });
+
+  Future<void> legacy(Map<String, Uint8List> files) async {
+    final db = await openIdb(name, const ['pdfs']);
+    final store = db.transaction('pdfs'.toJS, 'readwrite').objectStore('pdfs');
+    await Future.wait([
+      for (final entry in files.entries)
+        idbRequest<void>(store.put(entry.value.toJS, entry.key.toJS), (_) {}),
+    ]);
+    db.close();
+  }
+
+  test('evicts by bytes and keeps recently read snapshots across clients',
+      () async {
+    final a = (await cache.put(bytes(1)))!;
+    final b = (await cache.put(bytes(2)))!;
+    expect(await cache.read(a), bytes(1));
+    final other = client();
+    final c = (await other.put(bytes(3)))!;
+    expect(await other.read(a), bytes(1));
+    expect(await other.read(c), bytes(3));
+    await expectLater(other.read(b), throwsStateError);
+    final usage = (await other.usage())!;
+    expect(usage.bytes, 8);
+    expect(usage.documents, 2);
+  });
+
+  test('duplicate picks touch the LRU without spending bytes again', () async {
+    final a = await cache.put(bytes(1));
+    final b = await cache.put(bytes(2));
+    expect(await cache.put(bytes(1)), a);
+    await cache.put(bytes(3));
+    expect((await cache.usage())!.bytes, 8);
+    await expectLater(cache.read(b!), throwsStateError);
+    expect(await cache.read(a!), bytes(1));
+  });
+
+  test('oversized picks skip without evicting existing snapshots', () async {
+    final a = (await cache.put(bytes(1)))!;
+    expect(await cache.put(bytes(2, 9)), isNull);
+    expect(await cache.read(a), bytes(1));
+    expect((await cache.usage())!.bytes, 4);
+    expect(await cache.put(bytes(3, 8)), isNotNull); // inclusive per-file limit
+    expect((await cache.usage())!.bytes, 8);
+  });
+
+  test('quota pressure skips a new snapshot but reuses an existing one',
+      () async {
+    final a = (await cache.put(bytes(1)))!;
+    final pressured = client(estimate: () async => (usage: 88, quota: 100));
+    expect(await pressured.put(bytes(2)), isNull);
+    expect(await pressured.put(bytes(1)), a);
+    expect(await pressured.read(a), bytes(1));
+    expect((await cache.usage())!.bytes, 4);
+  });
+
+  test('missing or failing estimates still obey the app budget', () async {
+    for (final estimate in <Future<PdfStorageEstimate> Function()>[
+      () async => (usage: null, quota: null),
+      () async => throw StateError('estimate unavailable'),
+    ]) {
+      final fallback = client(estimate: estimate);
+      expect(await fallback.put(bytes(1)), isNotNull);
+      expect(await fallback.put(bytes(2)), isNotNull);
+      expect(await fallback.put(bytes(3)), isNotNull);
+      expect((await fallback.usage())!.bytes, 8);
+      await fallback.clear();
+    }
+  });
+
+  test('concurrent tabs share one transactionally enforced budget', () async {
+    final other = client();
+    final keys = await Future.wait([
+      cache.put(bytes(1)),
+      other.put(bytes(2)),
+      cache.put(bytes(3)),
+      other.put(bytes(4)),
+    ]);
+    expect(keys, everyElement(isNotNull));
+    final kept = (await cache.prune(keys.cast<String>().toSet()))!;
+    expect(kept.length, 2);
+    expect((await cache.usage())!.bytes, 8);
+    for (final key in kept) {
+      expect(await cache.read(key), hasLength(4));
+    }
+  });
+
+  test('legacy migration preserves small snapshots and drops oversized files',
+      () async {
+    await legacy({'old-a': bytes(1), 'old-big': bytes(2, 20)});
+    final kept = await cache.prune({'old-a', 'old-big'});
+    expect(kept, {'old-a'});
+    expect(await cache.read('old-a'), bytes(1));
+    expect((await cache.usage())!.bytes, 4);
+    await expectLater(cache.read('old-big'), throwsStateError);
+  });
+
+  test('startup trims a legacy cache even without opening another file',
+      () async {
+    await legacy({'a': bytes(1), 'b': bytes(2), 'c': bytes(3)});
+    final kept = (await cache.prune({'a', 'b', 'c'}))!;
+    expect(kept, {'b', 'c'});
+    expect((await cache.usage())!.bytes, 8);
+    await expectLater(cache.read('a'), throwsStateError);
+  });
+
+  test('a legacy tab blocking upgrade fails promptly and permits retry',
+      () async {
+    final oldTab = await openIdb(name, const ['pdfs']);
+    expect(
+        await cache.put(bytes(1)).timeout(const Duration(seconds: 5)), isNull);
+    oldTab.close();
+    // The formerly blocked upgrade finishes, then this connection can open.
+    final key = await cache.put(bytes(1));
+    expect(key, isNotNull);
+    expect(await cache.read(key!), bytes(1));
+  });
+
+  test('a schema upgrade releases and refreshes an existing connection',
+      () async {
+    final key = (await cache.put(bytes(1)))!;
+    final upgraded =
+        await openIdb(name, const ['pdfs', 'metadata', 'future-store']);
+    upgraded.close();
+    expect(await cache.read(key), bytes(1));
+  });
+
+  test('prune removes unreferenced snapshots and returns the live inventory',
+      () async {
+    final a = (await cache.put(bytes(1)))!;
+    final b = (await cache.put(bytes(2)))!;
+    expect(await cache.prune({a, 'already-evicted'}), {a});
+    await expectLater(cache.read(b), throwsStateError);
+    expect((await cache.usage())!.documents, 1);
+  });
+
+  test('clear deletes payloads and metadata and allows caching again',
+      () async {
+    final key = (await cache.put(bytes(1)))!;
+    expect(await cache.clear(), isTrue);
+    expect((await cache.usage())!.bytes, 0);
+    expect((await cache.usage())!.documents, 0);
+    await expectLater(cache.read(key), throwsStateError);
+    expect(await cache.put(bytes(1)), key);
+    expect(await cache.read(key), bytes(1));
+  });
+
+  test('failed transactions return failure and can recover on clear', () async {
+    final key = (await cache.put(bytes(1)))!;
+    final db = await openIdb(name, const ['pdfs', 'metadata']);
+    final store =
+        db.transaction('metadata'.toJS, 'readwrite').objectStore('metadata');
+    await idbRequest<void>(store.put('broken metadata'.toJS, key.toJS), (_) {});
+    db.close();
+    expect(await cache.put(bytes(2)), isNull);
+    await expectLater(cache.read(key), throwsStateError);
+    expect(await cache.prune({key}), isNull); // must not report an empty cache
+    expect(await cache.usage(), isNull);
+    expect(await cache.clear(), isTrue);
+    expect(await cache.put(bytes(2)), isNotNull);
+  });
+}


### PR DESCRIPTION
Opened PDFs could silently accumulate gigabytes in IndexedDB because the snapshot store was bounded only by the 20-entry Recent list. The web cache now has a 256 MiB payload budget, evicts least-recently-used snapshots, skips files over 64 MiB, and checks `navigator.storage.estimate()` before accepting new snapshots, leaving 10% quota headroom.

Settings now shows cached PDF usage and can clear snapshots while keeping Recents, open documents, and unsaved-change recovery. Evicted entries retain their identity and become “Pick again to reopen.” All 20 app locales include the new settings strings. Native snapshot storage is unchanged.

Byte records and size/access metadata change in one IndexedDB transaction, including eviction, so concurrent browser tabs share the budget. Startup migrates legacy snapshots one file at a time and trims the existing store. Writes are acknowledged only after transaction commit; blocked upgrades and failed storage operations degrade gracefully.

Validation:
- Full app suite: 510 tests passed; final Settings/Recents follow-up: 11 passed.
- Real Chrome IndexedDB suite: 13 tests passed, including migration, LRU, quota pressure, concurrent clients, blocked upgrades, clear, and failed transactions. Added to CI.
- Repository-wide `dart analyze --fatal-infos` and ARB coverage passed.
- Release web build passed.

Fixes #436.
