### PR TITLE
Preserve sparse PDF ranges across render-worker boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,10 +646,15 @@ jobs:
             exit 1
           fi
       - run: flutter pub get
-      - name: Compile the bundled web render worker (output discarded)
+      - name: Compile the bundled web render worker for browser integration
         run: |
           dart run dart_pdf_editor:build_web_worker \
-            --out "${RUNNER_TEMP}/pdf_render_worker.dart.js"
+            --out packages/dart_pdf_editor/lib/src/sparse_test_worker.js
+      - name: Test sparse buffers in web workers
+        working-directory: packages/dart_pdf_editor
+        run: >-
+          flutter test --platform chrome --no-cross-origin-isolation
+          test/render_worker_sparse_web_test.dart --reporter expanded
 
   # Build the Linux desktop target and validate its desktop-integration files.
   # Mirrors the release-app.yml linux job's build deps (GTK + libsecret for

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js.deps
 packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js.map
 packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js.deps
 
+# Compiled worker served by the browser integration test (never published).
+packages/dart_pdf_editor/lib/src/sparse_test_worker.js
+packages/dart_pdf_editor/lib/src/sparse_test_worker.js.map
+packages/dart_pdf_editor/lib/src/sparse_test_worker.js.deps
+
 # Generated workers used by the standalone performance harness. The harness
 # build compiles these beside its source index before copying the complete web
 # bundle to app/build/web; running the builder from the workspace root can also

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Preserve sparse-buffer ranges across native and web render workers, pooled
+  and urgent workers, and overprint retries, including edit/undo/redo updates.
+
 ## 4.2.0
 
 - Add `textMenuBuilder`, the text-selection counterpart to

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:pdf_cos/pdf_cos.dart' show cosSparseBufferRanges;
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart' show StripPlan;
@@ -10,6 +11,7 @@ import 'budgeted_cache.dart';
 import 'perf_log.dart';
 import 'region_replay_index.dart';
 import 'render_trace.dart';
+import 'render_worker_ranges.dart';
 import 'render_worker_transcript_cache.dart' show retainedCommandGraphWeight;
 import 'render_worker_stub.dart'
     if (dart.library.io) 'render_worker_isolate.dart'
@@ -239,16 +241,19 @@ const int pdfRenderWorkerPoolMinPages = 12;
 /// the edit session's grow-only buffer, which is replaced rather than mutated).
 /// Skipping the pool's defensive snapshot saves a full-document allocation per
 /// worker generation - the single-worker branch never copied either.
+/// [populatedRanges] follows [PdfDocument.open]'s sparse-buffer contract.
 PdfRenderWorker startPdfRenderWorker(
   Uint8List bytes, {
   required int pageCount,
   int? workerCount,
   bool copySource = false,
+  List<int>? populatedRanges,
 }) {
   final count = math.max(1, workerCount ?? pdfRenderWorkerPoolSize);
   final backend = count > 1 && pageCount >= pdfRenderWorkerPoolMinPages
-      ? PdfPooledRenderWorker(bytes, count, copySource: copySource)
-      : startRenderWorker(bytes);
+      ? PdfPooledRenderWorker(bytes, count,
+          copySource: copySource, populatedRanges: populatedRanges)
+      : startRenderWorker(bytes, populatedRanges: populatedRanges);
   return PdfCachingRenderWorker(backend);
 }
 
@@ -299,8 +304,11 @@ abstract class PdfRenderWorker {
   /// from scratch (see that class), and concurrent requests for one page share a
   /// single decode. The cache wraps the whole pool, so it is shared across every
   /// worker and is fresh for each document.
-  static PdfRenderWorker start(Uint8List bytes) =>
-      PdfCachingRenderWorker(_backend(bytes));
+  ///
+  /// [populatedRanges] follows [PdfDocument.open]'s sparse-buffer contract;
+  /// omitted ranges are inherited from the source buffer before it is copied.
+  static PdfRenderWorker start(Uint8List bytes, {List<int>? populatedRanges}) =>
+      PdfCachingRenderWorker(_backend(bytes, populatedRanges));
 
   /// Builds the uncached backend: a single platform worker, or - when
   /// [pdfRenderWorkerPoolSize] asks for more than one - a pool of them.
@@ -310,10 +318,12 @@ abstract class PdfRenderWorker {
   /// first paint's sparse buffer - both immutable under the worker), so a
   /// full-document snapshot here is pure waste on the big files #359 makes
   /// common.
-  static PdfRenderWorker _backend(Uint8List bytes) => pdfRenderWorkerPoolSize >
-          1
-      ? PdfPooledRenderWorker(bytes, pdfRenderWorkerPoolSize, copySource: false)
-      : startRenderWorker(bytes);
+  static PdfRenderWorker _backend(
+          Uint8List bytes, List<int>? populatedRanges) =>
+      pdfRenderWorkerPoolSize > 1
+          ? PdfPooledRenderWorker(bytes, pdfRenderWorkerPoolSize,
+              copySource: false, populatedRanges: populatedRanges)
+          : startRenderWorker(bytes, populatedRanges: populatedRanges);
 
   /// The raw platform worker, NOT wrapped in [PdfCachingRenderWorker]. Test-
   /// only: for exercising the inner queue/cancel/priority contract, which the
@@ -321,8 +331,9 @@ abstract class PdfRenderWorker {
   /// queue). Production code uses [start]. (No `@visibleForTesting` annotation
   /// because this library stays Flutter-free so the web worker can compile via
   /// `dart compile js` without pulling in Flutter.)
-  static PdfRenderWorker startUncached(Uint8List bytes) =>
-      startRenderWorker(bytes);
+  static PdfRenderWorker startUncached(Uint8List bytes,
+          {List<int>? populatedRanges}) =>
+      startRenderWorker(bytes, populatedRanges: populatedRanges);
 
   /// Warms the platform render worker ahead of a document, so its startup cost
   /// overlaps whatever the user is doing (choosing or loading a file) instead of
@@ -670,10 +681,12 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
   /// from [bytes], saving a full-document-sized allocation on every (re)start -
   /// worth ~one document copy per worker generation on the big files #359 makes
   /// common.
+  /// [populatedRanges] is copied with the shared snapshot; if omitted, the map
+  /// attached to [bytes] is inherited.
   factory PdfPooledRenderWorker(Uint8List bytes, int size,
-          {bool copySource = true}) =>
+          {bool copySource = true, List<int>? populatedRanges}) =>
       PdfPooledRenderWorker._shared(
-        copySource ? Uint8List.fromList(bytes) : bytes,
+        _prepareSource(bytes, copySource, populatedRanges),
         size,
         startRenderWorker,
       );
@@ -688,9 +701,20 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
     int size,
     PdfRenderWorker Function(Uint8List) spawn, {
     bool copySource = true,
+    List<int>? populatedRanges,
   }) =>
       PdfPooledRenderWorker._shared(
-          copySource ? Uint8List.fromList(bytes) : bytes, size, spawn);
+          _prepareSource(bytes, copySource, populatedRanges), size, spawn);
+
+  static Uint8List _prepareSource(
+      Uint8List bytes, bool copySource, List<int>? populatedRanges) {
+    final ranges = renderWorkerPopulatedRanges(bytes, populatedRanges);
+    final shared = copySource ? Uint8List.fromList(bytes) : bytes;
+    // Every lane (including the lazy urgent lane) inherits this one snapshot's
+    // map when startRenderWorker constructs its platform init payload.
+    if (ranges != null) cosSparseBufferRanges[shared] = ranges;
+    return shared;
+  }
 
   /// Seeds every worker and the urgent lane from the already-owned [shared]
   /// snapshot (the factories above copy the caller's bytes once into it).
@@ -1100,6 +1124,9 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
       final next = Uint8List(newLength);
       next.setRange(0, baseLength, urgentBytes);
       next.setRange(baseLength, newLength, appendedBytes);
+      final ranges = renderWorkerRevisionRanges(
+          cosSparseBufferRanges[urgentBytes], baseLength, newLength);
+      if (ranges != null) cosSparseBufferRanges[next] = ranges;
       _urgentBytes = next;
     }
     _urgentWorker?.dispose();

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -17,6 +17,7 @@ import 'package:pdf_graphics/raster.dart'
 import 'region_replay_index.dart';
 import 'jpeg_accelerator.dart';
 import 'render_worker.dart';
+import 'render_worker_ranges.dart';
 import 'render_worker_transcript_cache.dart'
     show compactTranscriptSourceCommands, retainedCommandGraphsWeight;
 
@@ -65,8 +66,10 @@ int debugPdfRenderWorkerIgnoredStaleCancels = 0;
 /// kill this long-lived pooled worker. See
 /// `packages/pdf_graphics/tool/bench_render_seam.dart` and
 /// `doc/dev-log/2026-07-17-seam-transfer-measurement.md`.
-PdfRenderWorker startRenderWorker(Uint8List bytes) =>
-    _IsolateRenderWorker(bytes);
+PdfRenderWorker startRenderWorker(Uint8List bytes,
+        {List<int>? populatedRanges}) =>
+    _IsolateRenderWorker(
+        bytes, renderWorkerPopulatedRanges(bytes, populatedRanges));
 
 /// No-op on native: spawning a background isolate carries no fetch/compile cost
 /// (the ~1.45 s #450 warm-up is dart2js-on-the-web specific), so there is
@@ -77,8 +80,8 @@ void prewarmRenderWorkers(int count) {}
 void disposePrewarmedRenderWorkers() {}
 
 class _IsolateRenderWorker extends PdfRenderWorker {
-  _IsolateRenderWorker(Uint8List bytes) {
-    unawaited(_spawn(bytes));
+  _IsolateRenderWorker(Uint8List bytes, List<int>? populatedRanges) {
+    unawaited(_spawn(bytes, populatedRanges));
   }
 
   Isolate? _isolate;
@@ -126,9 +129,9 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     _pump();
   }
 
-  Future<void> _spawn(Uint8List bytes) async {
+  Future<void> _spawn(Uint8List bytes, List<int>? populatedRanges) async {
     try {
-      await _spawnInner(bytes);
+      await _spawnInner(bytes, populatedRanges);
     } catch (error, stack) {
       // isolates unsupported / spawn threw: behave like the null worker -
       // every queued and future record() resolves to null (local render).
@@ -150,7 +153,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     }
   }
 
-  Future<void> _spawnInner(Uint8List bytes) async {
+  Future<void> _spawnInner(Uint8List bytes, List<int>? populatedRanges) async {
     final handshake = Completer<List<SendPort>>();
     _fromWorker.listen((message) {
       if (message is List<SendPort>) {
@@ -219,6 +222,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     final isolate = await Isolate.spawn(
       _workerMain,
       _WorkerInit(_fromWorker.sendPort, TransferableTypedData.fromList([bytes]),
+          populatedRanges: populatedRanges,
           perfEnabled: PdfPerfLog.enabled,
           deferStaleCancel: debugDeferPdfRenderWorkerCancelUntilNextRequest),
       debugName: 'pdf-render-worker',
@@ -743,7 +747,12 @@ class _PendingRequest {
 
 class _WorkerInit {
   _WorkerInit(this.reply, this.bytes,
-      {this.perfEnabled = false, this.deferStaleCancel = false});
+      {this.populatedRanges,
+      this.perfEnabled = false,
+      this.deferStaleCancel = false});
+
+  /// Populated byte pairs; unlike the buffer's Expando, these cross isolates.
+  final List<int>? populatedRanges;
 
   /// The port the worker sends its own command port (and every response) on.
   final SendPort reply;
@@ -782,6 +791,7 @@ void _workerMain(_WorkerInit init) {
   // append-only revisions arrive ('update' messages), so the buffer the open
   // document parses from stays valid across edits.
   var workerBytes = init.bytes.materialize().asUint8List();
+  var populatedRanges = init.populatedRanges;
   PdfDocument? document;
   // One decoded-image cache per open document, mirroring the web backend: a
   // page recorded several times in a scroll reuses its image decodes instead of
@@ -789,7 +799,7 @@ void _workerMain(_WorkerInit init) {
   // cannot change what a record renders.
   var imageCache = PdfImageDecodeCache();
   try {
-    document = PdfDocument.open(workerBytes);
+    document = PdfDocument.open(workerBytes, populatedRanges: populatedRanges);
   } catch (_) {
     document = null; // a broken document fails every page → all local renders
   }
@@ -846,14 +856,19 @@ void _workerMain(_WorkerInit init) {
         final appended =
             (request[3] as TransferableTypedData).materialize().asUint8List();
         final newLength = request[4] as int;
+        if (newLength != baseLength + appended.length) {
+          throw ArgumentError('inconsistent revision length');
+        }
         final changed = (request[5] as List?)?.cast<int>().toSet();
         final rebuilt = Uint8List(baseLength + appended.length)
           ..setRange(0, baseLength, workerBytes)
           ..setRange(baseLength, baseLength + appended.length, appended);
         final live = Uint8List.sublistView(rebuilt, 0, newLength);
+        final nextRanges =
+            renderWorkerRevisionRanges(populatedRanges, baseLength, newLength);
         var incremental = false;
         final doc = document;
-        if (doc != null) {
+        if (doc != null && baseLength == doc.cos.bytes.length) {
           try {
             doc.applyIncrementalUpdate(live);
             incremental = true;
@@ -864,7 +879,7 @@ void _workerMain(_WorkerInit init) {
         }
         if (!incremental) {
           try {
-            document = PdfDocument.open(live);
+            document = PdfDocument.open(live, populatedRanges: nextRanges);
             imageCache = PdfImageDecodeCache(); // new document, new streams
           } catch (_) {
             document = null;
@@ -872,6 +887,7 @@ void _workerMain(_WorkerInit init) {
         }
         // Commit the grown buffer only once the document reflects it.
         workerBytes = rebuilt;
+        populatedRanges = nextRanges;
         // On the in-place fast path only the changed pages' cached commands are
         // stale; a re-open makes a fresh document, so every cached command
         // (which referenced the old one) must go. A suspended record walks the

--- a/packages/dart_pdf_editor/lib/src/render_worker_ranges.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_ranges.dart
@@ -1,0 +1,31 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+
+/// Captures metadata before a worker copies/transfers the source bytes.
+List<int>? renderWorkerPopulatedRanges(Uint8List bytes,
+    [List<int>? populatedRanges]) {
+  final ranges = populatedRanges ?? cosSparseBufferRanges[bytes];
+  return ranges == null ? null : List<int>.unmodifiable(ranges);
+}
+
+/// Keeps the shared prefix's holes and marks the appended revision populated.
+/// An undo has no append; clipping also drops ranges beyond its shorter EOF.
+List<int>? renderWorkerRevisionRanges(
+    List<int>? ranges, int baseLength, int newLength) {
+  if (ranges == null) return null;
+  final result = <int>[];
+  for (var i = 0; i < ranges.length; i += 2) {
+    if (ranges[i] >= baseLength) break;
+    result.addAll([ranges[i], math.min(ranges[i + 1], baseLength)]);
+  }
+  if (newLength > baseLength) {
+    if (result.isNotEmpty && result.last == baseLength) {
+      result[result.length - 1] = newLength;
+    } else {
+      result.addAll([baseLength, newLength]);
+    }
+  }
+  return List<int>.unmodifiable(result);
+}

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -8,7 +8,9 @@ import 'render_worker.dart';
 /// Fallback used where `dart:isolate` is unavailable (the web) until a Web
 /// Worker backend lands: a worker that never offloads, so every page renders
 /// locally exactly as it did before the worker existed.
-PdfRenderWorker startRenderWorker(Uint8List bytes) => const _NullRenderWorker();
+PdfRenderWorker startRenderWorker(Uint8List bytes,
+        {List<int>? populatedRanges}) =>
+    const _NullRenderWorker();
 
 /// No-op: there is no worker to prewarm on this platform (#450 is web-specific).
 void prewarmRenderWorkers(int count) {}

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -16,6 +16,7 @@ import 'perf_log.dart';
 import 'region_replay_index.dart';
 import 'render_trace.dart';
 import 'render_worker.dart';
+import 'render_worker_ranges.dart';
 
 // Worker lifecycle diagnostics, routed through PdfPerfLog so they ride the same
 // zero-overhead toggle as the rest of the perf trace (a single bool branch when
@@ -71,7 +72,8 @@ bool pdfRenderWorkerUseSharedArrayBuffer = true;
 /// [web.Worker] fails to construct - this degrades to a null worker
 /// ([isActive] false), so hosts can force local rendering. See
 /// `doc/render_worker_web.md`.
-PdfRenderWorker startRenderWorker(Uint8List bytes) {
+PdfRenderWorker startRenderWorker(Uint8List bytes,
+    {List<int>? populatedRanges}) {
   final url = pdfRenderWorkerScriptUrl;
   _wlog('startRenderWorker url=$url bytes=${bytes.length}');
   if (url == null) {
@@ -79,7 +81,8 @@ PdfRenderWorker startRenderWorker(Uint8List bytes) {
     return _WebRenderWorker.disabled();
   }
   try {
-    return _WebRenderWorker(bytes, url);
+    return _WebRenderWorker(
+        bytes, url, renderWorkerPopulatedRanges(bytes, populatedRanges));
   } catch (e) {
     // Worker construction can throw (bad URL, blocked by CSP): fall back.
     _wlog('construction threw: $e - falling back to local');
@@ -164,7 +167,8 @@ void disposePrewarmedRenderWorkers() {
 }
 
 class _WebRenderWorker extends PdfRenderWorker {
-  _WebRenderWorker(Uint8List bytes, String scriptUrl) {
+  _WebRenderWorker(
+      Uint8List bytes, String scriptUrl, List<int>? populatedRanges) {
     // Adopt a pre-booted worker (its fetch/compile/boot already overlapped the
     // file pick) when one is available, else construct on demand as before.
     final worker = _prewarmedWorkers.isNotEmpty
@@ -181,6 +185,10 @@ class _WebRenderWorker extends PdfRenderWorker {
     _wlog('worker constructed from $scriptUrl');
 
     final init = JSObject()..setProperty('kind'.toJS, 'init'.toJS);
+    if (populatedRanges != null) {
+      init.setProperty('populatedRanges'.toJS,
+          populatedRanges.map((value) => value.toJS).toList().toJS);
+    }
     init.setProperty('timings'.toJS, (_perfClock != null).toJS);
     init.setProperty(
       'reuseTranscripts'.toJS,

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -157,7 +157,7 @@ bool _presentPageSurfaceBitmap(
 /// full wiring.
 ///
 /// Protocol (mirrors the native isolate backend):
-/// - `{kind:'init', bytes:ArrayBuffer|SharedArrayBuffer, shared}` → opens the
+/// - `{kind:'init', bytes:ArrayBuffer|SharedArrayBuffer, shared, populatedRanges?}` → opens the
 ///   document, replies `{kind:'ready', shared}`.
 /// - `{kind:'record', id, page, annotations}` → replies `{kind:'result', id,
 ///   buffer:ArrayBuffer|null}` (null = the page can't be offloaded; the main
@@ -225,7 +225,12 @@ void runPdfRenderWorker() {
         final bytes = shared
             ? _jsUint8View(buffer).toDart
             : (buffer as JSArrayBuffer).toDart.asUint8List();
-        document = PdfDocument.open(bytes);
+        final populatedRanges =
+            (data.getProperty('populatedRanges'.toJS) as JSArray<JSNumber>?)
+                ?.toDart
+                .map((value) => value.toDartInt)
+                .toList();
+        document = PdfDocument.open(bytes, populatedRanges: populatedRanges);
         imageCache = PdfImageDecodeCache(); // new document, new streams
         flateSampleCache = _BrowserFlateSampleCache();
         flatePredecoder = _BrowserFlatePredecoder(flateSampleCache);

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -461,12 +461,14 @@ class PdfRetainedScene {
     ({double? maxImagePixelRatio, double imageDecodeHeadroom}) options,
   ) async {
     final source = TransferableTypedData.fromList([page.document.cos.bytes]);
+    final populatedRanges = page.document.cos.populatedRanges;
     final annotations = plan.annotations;
     final decodeRatio = options.maxImagePixelRatio == null
         ? null
         : options.maxImagePixelRatio! * options.imageDecodeHeadroom;
     final encoded = await Isolate.run(() {
-      final document = PdfDocument.open(source.materialize().asUint8List());
+      final document = PdfDocument.open(source.materialize().asUint8List(),
+          populatedRanges: populatedRanges);
       if (pageIndex >= document.pageCount) return null;
       final retryPage = document.page(pageIndex);
       final recorder = RecordingPdfDevice();

--- a/packages/dart_pdf_editor/test/fixtures/sparse_worker_pdf.dart
+++ b/packages/dart_pdf_editor/test/fixtures/sparse_worker_pdf.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+/// Real objects deliberately sit inside the declared holes: losing the map
+/// makes them render, so the regression needs neither a large file nor a timer.
+({Uint8List bytes, List<int> ranges}) sparseWorkerPdf() {
+  final editor = PdfEditor(PdfDocument.open(_threePages()))
+    // Stamps have no synthesized fallback when their appearance is unfetched.
+    ..addStamp(0, const PdfRect(20, 20, 120, 120), 'FETCHED');
+  final bytes = editor.save();
+  final whole = PdfDocument.open(bytes);
+  final appearance = whole.page(0).annotations.single.normalAppearance!;
+  final refs = [
+    whole.page(1).dict['Contents'] as CosReference,
+    whole.cos.referenceTo(appearance)!,
+  ];
+  final text = latin1.decode(bytes);
+  final holes = refs.map((ref) {
+    final start = text.indexOf('${ref.objectNumber} ${ref.generation} obj');
+    if (start < 0) throw StateError('fixture object header missing');
+    final end = text.indexOf('endobj', start) + 'endobj'.length;
+    return (start, end);
+  }).toList()
+    ..sort((a, b) => a.$1.compareTo(b.$1));
+  return (
+    bytes: bytes,
+    ranges: [
+      0,
+      for (final hole in holes) ...[hole.$1, hole.$2],
+      bytes.length
+    ],
+  );
+}
+
+// Keep the fixture browser-safe; the general fixture package exports native
+// performance generators whose 64-bit integer literals cannot compile to JS.
+Uint8List _threePages() {
+  final builder = CosDocumentBuilder();
+  final pages = CosDictionary({
+    'Type': CosName('Pages'),
+    'Count': CosInteger(3),
+  });
+  final pagesRef = builder.add(pages);
+  final font = builder.add(CosDictionary({
+    'Type': CosName('Font'),
+    'Subtype': CosName('Type1'),
+    'BaseFont': CosName('Helvetica'),
+  }));
+  pages['Kids'] = CosArray([
+    for (var i = 0; i < 3; i++)
+      builder.add(CosDictionary({
+        'Type': CosName('Page'),
+        'Parent': pagesRef,
+        'MediaBox': CosArray([0, 0, 612, 792].map(CosInteger.new).toList()),
+        'Resources': CosDictionary({
+          'Font': CosDictionary({'F1': font})
+        }),
+        'Contents': builder.add(CosStream(
+          CosDictionary(),
+          Uint8List.fromList(
+              ascii.encode('BT /F1 24 Tf 72 720 Td (Page ${i + 1}) Tj ET')),
+        )),
+      })),
+  ]);
+  return builder.build(
+      root: builder.add(CosDictionary({
+    'Type': CosName('Catalog'),
+    'Pages': pagesRef,
+  })));
+}

--- a/packages/dart_pdf_editor/test/render_worker_sparse_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_sparse_test.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'fixtures/sparse_worker_pdf.dart';
+
+List<PdfRenderCommand> _record(PdfDocument document, int index) {
+  final page = document.page(index);
+  final device = RecordingPdfDevice();
+  PdfInterpreter(cos: document.cos, device: device)
+    ..drawPageContent(page, page.contentBytes())
+    ..drawAnnotations(page);
+  return device.commands;
+}
+
+Future<void> _expectSparse(PdfRenderWorker worker, PdfDocument local,
+    {int priority = 0}) async {
+  final commands = await worker.record(0, priority: priority);
+  expect(commands, isNotNull);
+  expect(commands!.whereType<PdfStrokePathCommand>().length,
+      _record(local, 0).whereType<PdfStrokePathCommand>().length,
+      reason: 'the unfetched annotation appearance must stay missing');
+  final text = await worker.extractText(1, priority: priority);
+  expect(text, isNotNull);
+  expect(text!.text, isEmpty,
+      reason: 'unfetched page content must not be extracted');
+  expect((await worker.extractText(2, priority: priority))!.text,
+      contains('Page 3'),
+      reason: 'populated neighbours still resolve');
+}
+
+void main() {
+  for (final mode in ['uncached', 'cached', 'single', 'pool', 'shared pool']) {
+    testWidgets('$mode worker carries inherited holes across the byte copy',
+        (tester) async {
+      await tester.runAsync(() async {
+        final fixture = sparseWorkerPdf();
+        final whole = PdfDocument.open(Uint8List.fromList(fixture.bytes));
+        final local =
+            PdfDocument.open(fixture.bytes, populatedRanges: fixture.ranges);
+        expect(_record(whole, 0).length, greaterThan(_record(local, 0).length));
+        expect(PdfTextExtractor.extract(whole, 1).text, isNotEmpty);
+        final worker = switch (mode) {
+          'uncached' => PdfRenderWorker.startUncached(fixture.bytes),
+          'cached' => PdfRenderWorker.start(fixture.bytes),
+          'single' =>
+            startPdfRenderWorker(fixture.bytes, pageCount: 3, workerCount: 1),
+          _ =>
+            PdfPooledRenderWorker(fixture.bytes, 2, copySource: mode == 'pool'),
+        };
+        addTearDown(worker.dispose);
+        await _expectSparse(worker, local);
+        if (worker is PdfPooledRenderWorker) {
+          await _expectSparse(worker, local, priority: -2000);
+        }
+      });
+    });
+  }
+
+  for (final pooled in [false, true]) {
+    testWidgets('explicit holes survive edit, undo, redo (pooled=$pooled)',
+        (tester) async {
+      await tester.runAsync(() async {
+        final fixture = sparseWorkerPdf();
+        final worker = pooled
+            ? PdfPooledRenderWorker(fixture.bytes, 2,
+                populatedRanges: fixture.ranges)
+            : PdfRenderWorker.startUncached(fixture.bytes,
+                populatedRanges: fixture.ranges);
+        addTearDown(worker.dispose);
+        final local = PdfDocument.open(Uint8List.fromList(fixture.bytes),
+            populatedRanges: fixture.ranges);
+        await _expectSparse(worker, local);
+        final edited = (PdfEditor(local)
+              ..addSquare(0, const PdfRect(150, 20, 250, 120)))
+            .save();
+        local.applyIncrementalUpdate(edited);
+        final append = Uint8List.sublistView(edited, fixture.bytes.length);
+        worker.updateRevision(fixture.bytes.length, append, edited.length, {0});
+        await _expectSparse(worker, local);
+        if (pooled) await _expectSparse(worker, local, priority: -2000);
+
+        // Undo forces a full reopen; redo extends the sparse map again.
+        worker.updateRevision(
+            fixture.bytes.length, Uint8List(0), fixture.bytes.length, {0});
+        final original = PdfDocument.open(Uint8List.fromList(fixture.bytes),
+            populatedRanges: fixture.ranges);
+        await _expectSparse(worker, original);
+        if (pooled) await _expectSparse(worker, original, priority: -2000);
+        worker.updateRevision(fixture.bytes.length, append, edited.length, {0});
+        await _expectSparse(worker, local);
+        if (pooled) await _expectSparse(worker, local, priority: -2000);
+      });
+    });
+  }
+
+  testWidgets('overprint retry inherits the document map after an edit',
+      (tester) async {
+    await tester.runAsync(() async {
+      final fixture = sparseWorkerPdf();
+      final document =
+          PdfDocument.open(fixture.bytes, populatedRanges: fixture.ranges);
+      final edited = (PdfEditor(document)
+            ..addSquare(0, const PdfRect(150, 20, 250, 120)))
+          .save();
+      document.applyIncrementalUpdate(edited);
+      final source = await PdfRetainedScene.record(document.page(0));
+      addTearDown(source.dispose);
+      final retry = await source.rerecordWithOverprintMaxDimension(768)!;
+      addTearDown(retry.dispose);
+      expect(retry.commands.length, source.commands.length);
+      expect(retry.commands.length, _record(document, 0).length);
+    });
+  });
+
+  test('range snapshots cannot mutate a document or an earlier revision', () {
+    final fixture = sparseWorkerPdf();
+    final document =
+        PdfDocument.open(fixture.bytes, populatedRanges: fixture.ranges);
+    final before = document.cos.populatedRanges!;
+    expect(() => before.clear(), throwsUnsupportedError);
+    fixture.ranges.clear();
+    expect(document.cos.populatedRanges, before);
+    final edited = (PdfEditor(document)
+          ..addSquare(0, const PdfRect(150, 20, 250, 120)))
+        .save();
+    document.applyIncrementalUpdate(edited);
+    expect(document.cos.populatedRanges!.last, edited.length);
+    expect(before.last, fixture.bytes.length);
+    expect(CosDocument.open(fixture.bytes).populatedRanges, before);
+    expect(PdfDocument.open(edited).cos.populatedRanges,
+        document.cos.populatedRanges);
+    final copy = PdfDocument.open(Uint8List.fromList(edited),
+        populatedRanges: document.cos.populatedRanges);
+    expect(PdfTextExtractor.extract(copy, 1).text, isEmpty);
+  });
+}

--- a/packages/dart_pdf_editor/test/render_worker_sparse_web_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_sparse_web_test.dart
@@ -1,0 +1,66 @@
+// Build the real worker before running this browser-only integration test:
+// dart run dart_pdf_editor:build_web_worker --out lib/src/sparse_test_worker.js
+// flutter test --platform chrome --no-cross-origin-isolation \
+//   test/render_worker_sparse_web_test.dart
+// Delete the generated lib/src/sparse_test_worker.js after the run.
+// The shared-buffer case also runs when hosted with isolation headers. Flutter
+// 3.47's test server omits COEP on the generated suite iframe, so its isolation
+// flag blocks that iframe; CI exercises transferable buffers until that is fixed.
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/render_worker_web.dart' as platform;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:web/web.dart' as web;
+
+import 'fixtures/sparse_worker_pdf.dart';
+
+void main() {
+  for (final shared in [false, true]) {
+    test('web worker preserves sparse ranges (shared=$shared)', () async {
+      final oldUrl = pdfRenderWorkerScriptUrl;
+      final oldShared = platform.pdfRenderWorkerUseSharedArrayBuffer;
+      pdfRenderWorkerScriptUrl = '${Uri.base.origin}'
+          '/packages/dart_pdf_editor/src/sparse_test_worker.js';
+      platform.pdfRenderWorkerUseSharedArrayBuffer = shared;
+      addTearDown(() {
+        pdfRenderWorkerScriptUrl = oldUrl;
+        platform.pdfRenderWorkerUseSharedArrayBuffer = oldShared;
+      });
+      final fixture = sparseWorkerPdf();
+      final whole =
+          PdfRenderWorker.startUncached(Uint8List.fromList(fixture.bytes));
+      addTearDown(whole.dispose);
+      final wholeCommands = await whole.record(0);
+      expect(wholeCommands, isNotNull);
+      expect(wholeCommands!.whereType<PdfStrokePathCommand>(), isNotEmpty);
+      expect((await whole.extractText(1))!.text, contains('Page 2'));
+
+      final explicit = PdfRenderWorker.startUncached(fixture.bytes,
+          populatedRanges: fixture.ranges);
+      addTearDown(explicit.dispose);
+      PdfDocument.open(fixture.bytes, populatedRanges: fixture.ranges);
+      final inherited = PdfPooledRenderWorker(fixture.bytes, 2);
+      addTearDown(inherited.dispose);
+      for (final worker in [explicit, inherited]) {
+        for (final priority in [0, -2000]) {
+          final commands = await worker.record(0, priority: priority);
+          expect(commands, isNotNull);
+          expect(commands!.whereType<PdfStrokePathCommand>(), isEmpty,
+              reason: 'worker=${worker.runtimeType}, priority=$priority');
+          expect(
+              (await worker.extractText(1, priority: priority))!.text, isEmpty);
+          expect((await worker.extractText(2, priority: priority))!.text,
+              contains('Page 3'));
+        }
+      }
+    },
+        skip: shared && !web.window.crossOriginIsolated
+            ? 'SharedArrayBuffer requires an isolated test page'
+            : false);
+  }
+}

--- a/packages/pdf_cos/CHANGELOG.md
+++ b/packages/pdf_cos/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Expose immutable populated-range snapshots for transferring sparse buffers,
+  and retain their metadata when reopening or appending a revision.
+
 ## 4.2.0
 
 - Lockstep minor release aligned with `dart_pdf_editor` 4.2.0. No public COS

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -49,6 +49,14 @@ class CosDocument {
   /// dangles the same way a not-yet-fetched compressed object already does.
   final List<int>? _populated;
 
+  /// Snapshot of the populated `[start, end)` byte pairs, or null for a
+  /// complete buffer. Pass this alongside a copy of [bytes] when reopening
+  /// across an isolate boundary: the buffer's identity-keyed map cannot travel
+  /// with the copy. Missing objects in a sparse document may be unfetched,
+  /// rather than absent from the original file.
+  List<int>? get populatedRanges =>
+      _populated == null ? null : List<int>.unmodifiable(_populated);
+
   /// The document image the xref offsets refer to. Grows in place when an
   /// append-only incremental revision is fed through [applyIncrementalUpdate];
   /// the prefix is always byte-identical, so objects cached against the old
@@ -163,6 +171,9 @@ class CosDocument {
     // caller's literal may be neither.
     final declared = populatedRanges ?? cosSparseBufferRanges[bytes];
     final populated = declared == null ? null : List<int>.of(declared);
+    if (populated != null) {
+      cosSparseBufferRanges[bytes] = List<int>.unmodifiable(populated);
+    }
     if (PdfPerf.enabled) {
       PdfPerf.sink?.call('cos open bytes=${bytes.length} '
           '${populated == null ? 'whole-file' : 'sparse spans=${populated.length >> 1}'}');
@@ -237,6 +248,7 @@ class CosDocument {
       } else {
         populated.addAll([bytes.length, newBytes.length]);
       }
+      cosSparseBufferRanges[newBytes] = List<int>.unmodifiable(populated);
     }
     bytes = newBytes;
     startXref = newStartXref;

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Accept `populatedRanges` in `PdfDocument.open` so copied progressive buffers
+  keep treating unfetched objects as missing.
+
 ## 4.2.0
 
 - Add `PdfAnnotation.appearanceRotation`, the rotation an annotation's normal

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -24,8 +24,15 @@ class PdfDocument {
   /// the user and then as the owner password (the empty default is what
   /// most owner-locked business documents expect); a wrong password
   /// throws [CosPasswordException].
-  static PdfDocument open(Uint8List bytes, {String password = ''}) =>
-      PdfDocument._(CosDocument.open(bytes, password: password));
+  ///
+  /// [populatedRanges] carries a sparse buffer's populated `[start, end)` byte
+  /// pairs when [bytes] has been copied (including across isolates). Omit it
+  /// to inherit the map attached to this exact buffer, or treat an unmarked
+  /// buffer as complete. See [CosDocument.populatedRanges].
+  static PdfDocument open(Uint8List bytes,
+          {String password = '', List<int>? populatedRanges}) =>
+      PdfDocument._(CosDocument.open(bytes,
+          password: password, populatedRanges: populatedRanges));
 
   /// Opens a document from an asynchronous, random-access [source] - a remote
   /// file over HTTP Range requests, a local file read on demand, or any other


### PR DESCRIPTION
Progressive PDF buffers now retain their populated byte ranges when copied into native isolates, web workers, pooled snapshots, and overprint retry isolates. Unfetched page content and annotation appearances remain missing instead of triggering scans through buffer holes.

The ranges follow explicit worker startup arguments or the source buffer's existing map. Native revision updates extend the populated tail, clip it on undo, and preserve it when reopening or starting an urgent worker. `PdfDocument.open(populatedRanges:)` and immutable `CosDocument.populatedRanges` snapshots let callers transfer the same metadata; the latter also exposes whether missing objects may be unfetched.

Validation:
- 128 worker/retained-scene tests, 35 COS source/update tests, and 11 document source/update tests passed.
- All nine new native regressions pass; disabling boundary propagation makes eight fail.
- The compiled web worker passes Chrome integration for explicit/inherited ranges, pooled workers, urgent workers, unfetched text, and appearance streams. This test now runs in CI.
- Workspace analysis and formatting checks pass.

The browser suite includes a SharedArrayBuffer case, skipped under Flutter 3.47's test server because its generated iframe lacks the isolation headers. The transferable-buffer case runs in CI; shared-buffer startup uses the same range payload.

Fixes #857.
