### PR TITLE
Add batch PDF splitting and result tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,28 @@ simplest web/server path: point it at a CORS-enabled OCR service. Both write the
 same invisible text layer, so scanned pages become selectable, searchable, and
 copyable without changing how the PDF looks.
 
+## Splitting PDFs
+
+`pdf_document` can generate multiple standalone PDFs directly from bytes:
+
+```dart
+final parts = PdfSplitter.splitExpression(bytes, '1-3, 7, 10-12');
+// Three outputs: pages 1–3, page 7, and pages 10–12.
+final firstThree = PdfSplitter.splitRange(bytes, 0, 2); // zero-based, inclusive
+```
+
+`PdfEditorView(onSplitPages: ...)` adds a validated **Split PDF…** dialog to the
+thumbnail page-actions menu. The example opens each result in a new editable tab.
+Existing single-range and thumbnail-selection exports remain available.
+
+Page annotations/resources and document information are retained; bookmarks,
+the document-level AcroForm field list, and named destinations are omitted.
+Links between pages retained in one output are remapped. Copied widgets are not
+registered in an AcroForm. Resources remain shared within an output where
+possible; each output owns its copies. Encrypted sources yield **unencrypted
+outputs**. See the [splitting guide](packages/pdf_document/README.md#splitting-and-extracting-pages)
+for indexing, password handling, validation, and extraction semantics.
+
 ## Roadmap
 
 1. ✅ COS reader: lexer, parser, FlateDecode + predictors, xref tables,

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add `PdfEditingController.exportPageRanges`, `showPdfSplitDialog`, and the
+  `onSplitPages` host callback on the editor shell and both thumbnail layouts.
+  The Split PDF action accepts comma-separated ranges and generates one PDF
+  per range in a single batch. The example opens extracted results in new tabs.
+
 ## 4.2.0
 
 - Add `textMenuBuilder`, the text-selection counterpart to

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -277,6 +277,46 @@ are byte prefixes of one buffer.
   remote apply is a non-crossable undo checkpoint; later local edits remain
   undoable without removing the remote state.
 
+## Splitting and exporting pages
+
+Provide `onSplitPages` to enable **Split PDF…** in the thumbnail sidebar/grid's
+page-actions menu. Enter `1-3, 7, 10-12` to create three separate PDFs; the host
+receives the complete batch in range order. `onExportPages` enables the existing
+single-range export and exporting a thumbnail selection into one PDF.
+
+```dart
+PdfEditorView(
+  bytes: bytes,
+  onSplitPages: (documents) {
+    for (final output in documents) {
+      // Save/share output, upload it, or open it in another editor tab.
+    }
+  },
+  onExportPages: (output) {
+    // Handle a single extracted PDF.
+  },
+)
+```
+
+For custom chrome, use `showPdfSplitDialog`, then
+`controller.exportPageRanges(ranges)`. The controller also provides
+`exportPages(indices)`, `exportPageRange(start, end)`, and `exportSelectedPages()`.
+Programmatic ranges are zero-based and inclusive; dialog page numbers start at
+1. Exports leave the source, selection, and undo history unchanged.
+
+The [example app](example/lib/main.dart) opens each split result in its own
+editable tab and opens single-file exports in a new tab too. Use the normal Save
+action on a result tab to save, download, or share that PDF.
+
+Extraction deep-copies page annotations and reachable resources, remaps links
+between retained pages in each output, and retains the document information
+dictionary. It omits document-level outlines/bookmarks, the AcroForm field list,
+and named destinations; copied widgets are not registered in an output AcroForm.
+Resources can remain shared within one output; separate outputs own their copies.
+Encrypted sources produce **unencrypted outputs**. See the
+[core splitting API](../pdf_document/README.md#splitting-and-extracting-pages)
+for the bytes-only `PdfSplitter` facade and full extraction semantics.
+
 ## Composing your own UI
 
 `PdfEditorView` and `PdfReader` are assembled from public parts:

--- a/packages/dart_pdf_editor/example/lib/l10n/app_ar.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_ar.arb
@@ -119,5 +119,6 @@
   "undo": "تراجع",
   "exFileTypePdf": "مستندات PDF",
   "exFileTypeImages": "الصور",
-  "exFileTypeFonts": "الخطوط"
+  "exFileTypeFonts": "الخطوط",
+  "exExtractedTitle": "{title} - الجزء {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_de.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_de.arb
@@ -119,5 +119,6 @@
   "undo": "Rückgängig",
   "exFileTypePdf": "PDF-Dokumente",
   "exFileTypeImages": "Bilder",
-  "exFileTypeFonts": "Schriftarten"
+  "exFileTypeFonts": "Schriftarten",
+  "exExtractedTitle": "{title} - Teil {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_en.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_en.arb
@@ -635,5 +635,17 @@
   "exFileTypeFonts": "Fonts",
   "@exFileTypeFonts":   {
       "description": "File-picker filter label for TrueType/OpenType font files."
+  },
+  "exExtractedTitle": "{title} - part {part}.pdf",
+  "@exExtractedTitle": {
+    "description": "Tab and suggested file name for extracted PDF pages.",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "part": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_es.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_es.arb
@@ -119,5 +119,6 @@
   "undo": "Deshacer",
   "exFileTypePdf": "Documentos PDF",
   "exFileTypeImages": "Imágenes",
-  "exFileTypeFonts": "Fuentes"
+  "exFileTypeFonts": "Fuentes",
+  "exExtractedTitle": "{title} - parte {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_fr.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_fr.arb
@@ -119,5 +119,6 @@
   "undo": "Annuler",
   "exFileTypePdf": "Documents PDF",
   "exFileTypeImages": "Images",
-  "exFileTypeFonts": "Polices"
+  "exFileTypeFonts": "Polices",
+  "exExtractedTitle": "{title} - partie {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_hi.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_hi.arb
@@ -119,5 +119,6 @@
   "undo": "पूर्ववत करें",
   "exFileTypePdf": "PDF दस्तावेज़",
   "exFileTypeImages": "छवियाँ",
-  "exFileTypeFonts": "फ़ॉन्ट"
+  "exFileTypeFonts": "फ़ॉन्ट",
+  "exExtractedTitle": "{title} - भाग {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_id.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_id.arb
@@ -119,5 +119,6 @@
   "undo": "Urungkan",
   "exFileTypePdf": "Dokumen PDF",
   "exFileTypeImages": "Gambar",
-  "exFileTypeFonts": "Font"
+  "exFileTypeFonts": "Font",
+  "exExtractedTitle": "{title} - bagian {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_it.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_it.arb
@@ -119,5 +119,6 @@
   "undo": "Annulla",
   "exFileTypePdf": "Documenti PDF",
   "exFileTypeImages": "Immagini",
-  "exFileTypeFonts": "Caratteri"
+  "exFileTypeFonts": "Caratteri",
+  "exExtractedTitle": "{title} - parte {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_ja.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_ja.arb
@@ -119,5 +119,6 @@
   "undo": "元に戻す",
   "exFileTypePdf": "PDF ドキュメント",
   "exFileTypeImages": "画像",
-  "exFileTypeFonts": "フォント"
+  "exFileTypeFonts": "フォント",
+  "exExtractedTitle": "{title} - パート{part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_ko.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_ko.arb
@@ -119,5 +119,6 @@
   "undo": "실행 취소",
   "exFileTypePdf": "PDF 문서",
   "exFileTypeImages": "이미지",
-  "exFileTypeFonts": "글꼴"
+  "exFileTypeFonts": "글꼴",
+  "exExtractedTitle": "{title} - 파트 {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
@@ -852,6 +852,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Fonts'**
   String get exFileTypeFonts;
+
+  /// Tab and suggested file name for extracted PDF pages.
+  ///
+  /// In en, this message translates to:
+  /// **'{title} - part {part}.pdf'**
+  String exExtractedTitle(String title, int part);
 }
 
 class _AppLocalizationsDelegate

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ar.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ar.dart
@@ -451,4 +451,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'الخطوط';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - الجزء $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_de.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_de.dart
@@ -442,4 +442,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Schriftarten';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - Teil $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_en.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_en.dart
@@ -438,4 +438,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Fonts';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - part $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_es.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_es.dart
@@ -442,4 +442,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Fuentes';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - parte $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_fr.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_fr.dart
@@ -442,4 +442,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Polices';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - partie $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_hi.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_hi.dart
@@ -439,4 +439,9 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'फ़ॉन्ट';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - भाग $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_id.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_id.dart
@@ -438,4 +438,9 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Font';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - bagian $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_it.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_it.dart
@@ -441,4 +441,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Caratteri';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - parte $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ja.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ja.dart
@@ -436,4 +436,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'フォント';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - パート$part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ko.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ko.dart
@@ -436,4 +436,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => '글꼴';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - 파트 $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_nl.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_nl.dart
@@ -443,4 +443,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Lettertypen';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - deel $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_pl.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_pl.dart
@@ -445,4 +445,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Czcionki';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - część $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_pt.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_pt.dart
@@ -443,4 +443,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Fontes';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - parte $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ru.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_ru.dart
@@ -449,4 +449,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Шрифты';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - часть $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_th.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_th.dart
@@ -437,4 +437,9 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'ฟอนต์';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - ส่วนที่ $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_tr.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_tr.dart
@@ -437,4 +437,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Yazı tipleri';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - bölüm $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_uk.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_uk.dart
@@ -456,4 +456,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Шрифти';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - частина $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_vi.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_vi.dart
@@ -440,4 +440,9 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => 'Phông chữ';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - phần $part.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_zh.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_zh.dart
@@ -436,6 +436,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get exFileTypeFonts => '字体';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - 第 $part 部分.pdf';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -870,4 +875,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get exFileTypeFonts => '字型';
+
+  @override
+  String exExtractedTitle(String title, int part) {
+    return '$title - 第 $part 部分.pdf';
+  }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_nl.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_nl.arb
@@ -119,5 +119,6 @@
   "undo": "Ongedaan maken",
   "exFileTypePdf": "PDF-documenten",
   "exFileTypeImages": "Afbeeldingen",
-  "exFileTypeFonts": "Lettertypen"
+  "exFileTypeFonts": "Lettertypen",
+  "exExtractedTitle": "{title} - deel {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_pl.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_pl.arb
@@ -119,5 +119,6 @@
   "undo": "Cofnij",
   "exFileTypePdf": "Dokumenty PDF",
   "exFileTypeImages": "Obrazy",
-  "exFileTypeFonts": "Czcionki"
+  "exFileTypeFonts": "Czcionki",
+  "exExtractedTitle": "{title} - część {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_pt.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_pt.arb
@@ -119,5 +119,6 @@
   "undo": "Desfazer",
   "exFileTypePdf": "Documentos PDF",
   "exFileTypeImages": "Imagens",
-  "exFileTypeFonts": "Fontes"
+  "exFileTypeFonts": "Fontes",
+  "exExtractedTitle": "{title} - parte {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_ru.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_ru.arb
@@ -119,5 +119,6 @@
   "undo": "Отменить",
   "exFileTypePdf": "Документы PDF",
   "exFileTypeImages": "Изображения",
-  "exFileTypeFonts": "Шрифты"
+  "exFileTypeFonts": "Шрифты",
+  "exExtractedTitle": "{title} - часть {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_th.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_th.arb
@@ -119,5 +119,6 @@
   "undo": "เลิกทำ",
   "exFileTypePdf": "เอกสาร PDF",
   "exFileTypeImages": "รูปภาพ",
-  "exFileTypeFonts": "ฟอนต์"
+  "exFileTypeFonts": "ฟอนต์",
+  "exExtractedTitle": "{title} - ส่วนที่ {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_tr.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_tr.arb
@@ -119,5 +119,6 @@
   "undo": "Geri al",
   "exFileTypePdf": "PDF belgeleri",
   "exFileTypeImages": "Görseller",
-  "exFileTypeFonts": "Yazı tipleri"
+  "exFileTypeFonts": "Yazı tipleri",
+  "exExtractedTitle": "{title} - bölüm {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_uk.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_uk.arb
@@ -119,5 +119,6 @@
   "undo": "Відмінити",
   "exFileTypePdf": "Документи PDF",
   "exFileTypeImages": "Зображення",
-  "exFileTypeFonts": "Шрифти"
+  "exFileTypeFonts": "Шрифти",
+  "exExtractedTitle": "{title} - частина {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_vi.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_vi.arb
@@ -119,5 +119,6 @@
   "undo": "Hoàn tác",
   "exFileTypePdf": "Tài liệu PDF",
   "exFileTypeImages": "Hình ảnh",
-  "exFileTypeFonts": "Phông chữ"
+  "exFileTypeFonts": "Phông chữ",
+  "exExtractedTitle": "{title} - phần {part}.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_zh.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_zh.arb
@@ -119,5 +119,6 @@
   "undo": "撤销",
   "exFileTypePdf": "PDF 文档",
   "exFileTypeImages": "图像",
-  "exFileTypeFonts": "字体"
+  "exFileTypeFonts": "字体",
+  "exExtractedTitle": "{title} - 第 {part} 部分.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_zh_Hant.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_zh_Hant.arb
@@ -119,5 +119,6 @@
   "undo": "復原",
   "exFileTypePdf": "PDF 文件",
   "exFileTypeImages": "影像",
-  "exFileTypeFonts": "字型"
+  "exFileTypeFonts": "字型",
+  "exExtractedTitle": "{title} - 第 {part} 部分.pdf"
 }

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -935,13 +935,30 @@ class _ViewerScreenState extends State<ViewerScreen> {
   }
 
   /// Opens [bytes] in a brand-new tab and makes it the active one.
-  void _openBytes(Uint8List bytes, String title, {bool isDemo = false}) {
+  void _openBytes(Uint8List bytes, String title,
+      {bool isDemo = false, bool isExtracted = false}) {
     _addTab(_DocumentTab.document(
       title: title,
       bytes: bytes,
       preferences: _prefs,
       isDemo: isDemo,
+      isExtracted: isExtracted,
     ));
+  }
+
+  void _openExtracted(List<Uint8List> outputs, String sourceTitle) {
+    final l10n = appL10n(context);
+    final stem =
+        sourceTitle.replaceFirst(RegExp(r'\.pdf$', caseSensitive: false), '');
+    final titles = {for (final tab in _tabs) tab.title};
+    var part = 1;
+    for (final output in outputs) {
+      var title = l10n.exExtractedTitle(stem, part++);
+      while (!titles.add(title)) {
+        title = l10n.exExtractedTitle(stem, part++);
+      }
+      _openBytes(output, title, isExtracted: true);
+    }
   }
 
   /// Adds a tab that just reports an open failure.
@@ -1752,9 +1769,12 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 textCache: _textCache,
                                 pageLayout: _pageLayout,
                                 onSave: (saved) => unawaited(_saveAs(saved)),
+                                alwaysAllowSave: tab.isExtracted,
                                 onPickPdfToInsert: _pickPdfBytes,
                                 onExportPages: (bytes) =>
-                                    unawaited(_saveAs(bytes)),
+                                    _openExtracted([bytes], tab.title),
+                                onSplitPages: (outputs) =>
+                                    _openExtracted(outputs, tab.title),
                                 onAction: _onAction,
                                 pageOverlayBuilder:
                                     tab.isDemo ? _demoOverlays : null,
@@ -1987,6 +2007,7 @@ class _DocumentTab {
       : session = null,
         viewer = null,
         isDemo = false,
+        isExtracted = false,
         error = null,
         compareBefore = null,
         compareAfter = null,
@@ -1997,6 +2018,7 @@ class _DocumentTab {
     required Uint8List bytes,
     required PdfEditingPreferences preferences,
     this.isDemo = false,
+    this.isExtracted = false,
   })  : session = PdfEditingController(bytes, preferences: preferences),
         viewer = PdfViewerController(),
         error = null,
@@ -2009,6 +2031,7 @@ class _DocumentTab {
       : session = null,
         viewer = null,
         isDemo = false,
+        isExtracted = false,
         compareBefore = null,
         compareAfter = null,
         loadingProgress = null,
@@ -2023,6 +2046,7 @@ class _DocumentTab {
   })  : session = null,
         viewer = null,
         isDemo = false,
+        isExtracted = false,
         error = null,
         compareBefore = before,
         compareAfter = after,
@@ -2032,6 +2056,8 @@ class _DocumentTab {
   final String title;
   final String? error;
   final bool isDemo;
+  // A new extraction has no saved file yet, even without any edits.
+  final bool isExtracted;
   final bool isLoading;
 
   /// Download progress (0..1) for a remote-load ([_openFromUrl]) loading tab,

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -23,6 +23,87 @@ void main() {
     expect(find.byType(PdfViewer), findsOneWidget);
   });
 
+  testWidgets('splitting opens every result in a tab and retains the source',
+      (tester) async {
+    await openDemo(tester);
+    final source =
+        tester.widget<PdfEditorView>(find.byType(PdfEditorView)).controller!;
+    final sourceDocument = source.document;
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-split-pages')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-split-ranges')), '1-2, 4');
+    await tester.tap(find.byKey(const ValueKey('pdf-split-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(closeButtons(), findsNWidgets(3));
+    final result =
+        tester.widget<PdfEditorView>(find.byType(PdfEditorView)).controller!;
+    expect(result.document.pageCount, 1);
+    expect(
+        tester
+            .widget<FilledButton>(find.byKey(const ValueKey('pdf-shell-save')))
+            .onPressed,
+        isNotNull);
+    expect(source.document, same(sourceDocument));
+    expect(find.text('Feature showcase - part 2.pdf'), findsOneWidget);
+    await tester.tap(find.text('Feature showcase - part 1.pdf'));
+    await tester.pumpAndSettle();
+    expect(
+        tester
+            .widget<PdfEditorView>(find.byType(PdfEditorView))
+            .controller!
+            .document
+            .pageCount,
+        2);
+  });
+
+  testWidgets('single-range export opens an editable result tab',
+      (tester) async {
+    await openDemo(tester);
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-export-pages')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-page-range-from')), '2');
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-page-range-to')), '3');
+    await tester.tap(find.byKey(const ValueKey('pdf-page-range-confirm')));
+    await tester.pumpAndSettle();
+    expect(closeButtons(), findsNWidgets(2));
+    final session =
+        tester.widget<PdfEditorView>(find.byType(PdfEditorView)).controller!;
+    expect(session.document.pageCount, 2);
+    expect(
+        tester
+            .widget<FilledButton>(find.byKey(const ValueKey('pdf-shell-save')))
+            .onPressed,
+        isNotNull);
+    session.removePage(0);
+    await tester.pumpAndSettle();
+    expect(session.document.pageCount, 1);
+    session.undo();
+    await tester.pumpAndSettle();
+    expect(session.document.pageCount, 2);
+  });
+
+  testWidgets('repeated exports get distinct tab and save names',
+      (tester) async {
+    await openDemo(tester);
+    final source = tester.widget<PdfEditorView>(find.byType(PdfEditorView));
+    final output = source.controller!.exportPageRange(0, 0);
+    source.onExportPages!(output);
+    await tester.pumpAndSettle();
+    source.onExportPages!(output);
+    await tester.pumpAndSettle();
+    expect(closeButtons(), findsNWidgets(3));
+    expect(find.text('Feature showcase - part 1.pdf'), findsOneWidget);
+    expect(find.text('Feature showcase - part 2.pdf'), findsOneWidget);
+  });
+
   testWidgets('tab strip is left aligned and app logo is compact',
       (tester) async {
     await openDemo(tester);

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -4,6 +4,8 @@ library;
 export 'package:pdf_document/pdf_document.dart'
     show
         PdfDocument,
+        PdfPageRange,
+        PdfSplitter,
         PdfAnnotationSnapshot,
         PdfStampTemplate,
         PdfStampTemplateComponent,
@@ -79,6 +81,7 @@ export 'src/page_number_field.dart';
 export 'src/page_render_session.dart';
 export 'src/perf_log.dart';
 export 'src/page_range_dialog.dart';
+export 'src/split_dialog.dart';
 export 'src/pdf_editor_view.dart';
 export 'src/pdf_page_view.dart';
 export 'src/pdf_reader.dart';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "أختام مخصصة…",
   "signatureLibraryManage": "إدارة التوقيعات",
   "signatureLibraryRenameTitle": "إعادة تسمية التوقيع",
-  "signatureLibraryEmpty": "لا توجد توقيعات محفوظة."
+  "signatureLibraryEmpty": "لا توجد توقيعات محفوظة.",
+  "splitTitle": "تقسيم PDF…",
+  "splitHelp": "أدخل نطاقات الصفحات مفصولة بفواصل. ينشئ كل نطاق ملف PDF منفصلاً.",
+  "splitRanges": "نطاقات الصفحات",
+  "splitInvalidRanges": "استخدم الصفحات من 1 إلى {count}، مفصولة بفواصل. يجب أن تكون النطاقات تصاعدية.",
+  "splitConfirm": "تقسيم",
+  "splitFailed": "تعذر تقسيم ملف PDF هذا."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Benutzerdefinierte Stempel…",
   "signatureLibraryManage": "Unterschriften verwalten",
   "signatureLibraryRenameTitle": "Unterschrift umbenennen",
-  "signatureLibraryEmpty": "Keine gespeicherten Unterschriften."
+  "signatureLibraryEmpty": "Keine gespeicherten Unterschriften.",
+  "splitTitle": "PDF aufteilen…",
+  "splitHelp": "Seitenbereiche durch Kommas trennen. Jeder Bereich wird zu einer eigenen PDF-Datei.",
+  "splitRanges": "Seitenbereiche",
+  "splitInvalidRanges": "Seiten von 1 bis {count} durch Kommas trennen. Bereiche müssen aufsteigend sein.",
+  "splitConfirm": "Aufteilen",
+  "splitFailed": "Diese PDF-Datei konnte nicht aufgeteilt werden."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -2707,5 +2707,34 @@
   "signatureLibraryEmpty": "No saved signatures.",
   "@signatureLibraryEmpty": {
     "description": "Empty-state text in the saved handwritten-signature library."
+  },
+  "splitTitle": "Split PDF…",
+  "@splitTitle": {
+    "description": "Title and menu action for splitting a PDF into multiple documents."
+  },
+  "splitHelp": "Enter page ranges separated by commas. Each range creates a separate PDF.",
+  "@splitHelp": {
+    "description": "Explains the batch split expression."
+  },
+  "splitRanges": "Page ranges",
+  "@splitRanges": {
+    "description": "Label of the split expression field."
+  },
+  "splitInvalidRanges": "Use pages 1–{count}, separated by commas. Ranges must run from first to last.",
+  "@splitInvalidRanges": {
+    "description": "Validation error for a split expression.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "splitConfirm": "Split",
+  "@splitConfirm": {
+    "description": "Confirm the batch PDF split."
+  },
+  "splitFailed": "Could not split this PDF.",
+  "@splitFailed": {
+    "description": "Shown when PDF extraction fails."
   }
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Sellos personalizados…",
   "signatureLibraryManage": "Administrar firmas",
   "signatureLibraryRenameTitle": "Cambiar nombre de la firma",
-  "signatureLibraryEmpty": "No hay firmas guardadas."
+  "signatureLibraryEmpty": "No hay firmas guardadas.",
+  "splitTitle": "Dividir PDF…",
+  "splitHelp": "Introduce intervalos de páginas separados por comas. Cada intervalo crea un PDF independiente.",
+  "splitRanges": "Intervalos de páginas",
+  "splitInvalidRanges": "Usa páginas de 1 a {count}, separadas por comas. Los intervalos deben ser ascendentes.",
+  "splitConfirm": "Dividir",
+  "splitFailed": "No se pudo dividir este PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Tampons personnalisés…",
   "signatureLibraryManage": "Gérer les signatures",
   "signatureLibraryRenameTitle": "Renommer la signature",
-  "signatureLibraryEmpty": "Aucune signature enregistrée."
+  "signatureLibraryEmpty": "Aucune signature enregistrée.",
+  "splitTitle": "Scinder le PDF…",
+  "splitHelp": "Saisissez des plages de pages séparées par des virgules. Chaque plage crée un PDF distinct.",
+  "splitRanges": "Plages de pages",
+  "splitInvalidRanges": "Utilisez les pages de 1 à {count}, séparées par des virgules. Les plages doivent être croissantes.",
+  "splitConfirm": "Scinder",
+  "splitFailed": "Impossible de scinder ce PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "कस्टम स्टैम्प…",
   "signatureLibraryManage": "हस्ताक्षर प्रबंधित करें",
   "signatureLibraryRenameTitle": "हस्ताक्षर का नाम बदलें",
-  "signatureLibraryEmpty": "कोई सहेजा गया हस्ताक्षर नहीं है।"
+  "signatureLibraryEmpty": "कोई सहेजा गया हस्ताक्षर नहीं है।",
+  "splitTitle": "PDF विभाजित करें…",
+  "splitHelp": "पृष्ठ श्रेणियाँ अल्पविराम से अलग करके दर्ज करें। हर श्रेणी से एक अलग PDF बनेगा।",
+  "splitRanges": "पृष्ठ श्रेणियाँ",
+  "splitInvalidRanges": "1 से {count} तक के पृष्ठ अल्पविराम से अलग करें। श्रेणियाँ बढ़ते क्रम में होनी चाहिए।",
+  "splitConfirm": "विभाजित करें",
+  "splitFailed": "यह PDF विभाजित नहीं किया जा सका।"
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Stempel khusus…",
   "signatureLibraryManage": "Kelola tanda tangan",
   "signatureLibraryRenameTitle": "Ganti nama tanda tangan",
-  "signatureLibraryEmpty": "Tidak ada tanda tangan tersimpan."
+  "signatureLibraryEmpty": "Tidak ada tanda tangan tersimpan.",
+  "splitTitle": "Pisahkan PDF…",
+  "splitHelp": "Masukkan rentang halaman yang dipisahkan koma. Setiap rentang menghasilkan PDF terpisah.",
+  "splitRanges": "Rentang halaman",
+  "splitInvalidRanges": "Gunakan halaman 1–{count}, dipisahkan koma. Rentang harus berurutan naik.",
+  "splitConfirm": "Pisahkan",
+  "splitFailed": "PDF ini tidak dapat dipisahkan."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Timbri personalizzati…",
   "signatureLibraryManage": "Gestisci firme",
   "signatureLibraryRenameTitle": "Rinomina firma",
-  "signatureLibraryEmpty": "Nessuna firma salvata."
+  "signatureLibraryEmpty": "Nessuna firma salvata.",
+  "splitTitle": "Dividi PDF…",
+  "splitHelp": "Inserisci intervalli di pagine separati da virgole. Ogni intervallo crea un PDF separato.",
+  "splitRanges": "Intervalli di pagine",
+  "splitInvalidRanges": "Usa pagine da 1 a {count}, separate da virgole. Gli intervalli devono essere crescenti.",
+  "splitConfirm": "Dividi",
+  "splitFailed": "Impossibile dividere questo PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "カスタムスタンプ…",
   "signatureLibraryManage": "署名を管理",
   "signatureLibraryRenameTitle": "署名の名前を変更",
-  "signatureLibraryEmpty": "保存済みの署名はありません。"
+  "signatureLibraryEmpty": "保存済みの署名はありません。",
+  "splitTitle": "PDFを分割…",
+  "splitHelp": "ページ範囲をカンマで区切って入力してください。範囲ごとに別のPDFを作成します。",
+  "splitRanges": "ページ範囲",
+  "splitInvalidRanges": "1～{count}ページをカンマで区切って指定してください。範囲は昇順で指定してください。",
+  "splitConfirm": "分割",
+  "splitFailed": "このPDFを分割できませんでした。"
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "사용자 지정 스탬프…",
   "signatureLibraryManage": "서명 관리",
   "signatureLibraryRenameTitle": "서명 이름 바꾸기",
-  "signatureLibraryEmpty": "저장된 서명이 없습니다."
+  "signatureLibraryEmpty": "저장된 서명이 없습니다.",
+  "splitTitle": "PDF 분할…",
+  "splitHelp": "페이지 범위를 쉼표로 구분하여 입력하세요. 각 범위마다 별도의 PDF가 생성됩니다.",
+  "splitRanges": "페이지 범위",
+  "splitInvalidRanges": "1~{count}페이지를 쉼표로 구분하세요. 범위는 오름차순이어야 합니다.",
+  "splitConfirm": "분할",
+  "splitFailed": "이 PDF를 분할할 수 없습니다."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -3847,6 +3847,42 @@ abstract class DartPdfEditorLocalizations {
   /// In en, this message translates to:
   /// **'No saved signatures.'**
   String get signatureLibraryEmpty;
+
+  /// Title and menu action for splitting a PDF into multiple documents.
+  ///
+  /// In en, this message translates to:
+  /// **'Split PDF…'**
+  String get splitTitle;
+
+  /// Explains the batch split expression.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter page ranges separated by commas. Each range creates a separate PDF.'**
+  String get splitHelp;
+
+  /// Label of the split expression field.
+  ///
+  /// In en, this message translates to:
+  /// **'Page ranges'**
+  String get splitRanges;
+
+  /// Validation error for a split expression.
+  ///
+  /// In en, this message translates to:
+  /// **'Use pages 1–{count}, separated by commas. Ranges must run from first to last.'**
+  String splitInvalidRanges(int count);
+
+  /// Confirm the batch PDF split.
+  ///
+  /// In en, this message translates to:
+  /// **'Split'**
+  String get splitConfirm;
+
+  /// Shown when PDF extraction fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not split this PDF.'**
+  String get splitFailed;
 }
 
 class _DartPdfEditorLocalizationsDelegate

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -2158,4 +2158,25 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'لا توجد توقيعات محفوظة.';
+
+  @override
+  String get splitTitle => 'تقسيم PDF…';
+
+  @override
+  String get splitHelp =>
+      'أدخل نطاقات الصفحات مفصولة بفواصل. ينشئ كل نطاق ملف PDF منفصلاً.';
+
+  @override
+  String get splitRanges => 'نطاقات الصفحات';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'استخدم الصفحات من 1 إلى $count، مفصولة بفواصل. يجب أن تكون النطاقات تصاعدية.';
+  }
+
+  @override
+  String get splitConfirm => 'تقسيم';
+
+  @override
+  String get splitFailed => 'تعذر تقسيم ملف PDF هذا.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -2123,4 +2123,25 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Keine gespeicherten Unterschriften.';
+
+  @override
+  String get splitTitle => 'PDF aufteilen…';
+
+  @override
+  String get splitHelp =>
+      'Seitenbereiche durch Kommas trennen. Jeder Bereich wird zu einer eigenen PDF-Datei.';
+
+  @override
+  String get splitRanges => 'Seitenbereiche';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Seiten von 1 bis $count durch Kommas trennen. Bereiche müssen aufsteigend sein.';
+  }
+
+  @override
+  String get splitConfirm => 'Aufteilen';
+
+  @override
+  String get splitFailed => 'Diese PDF-Datei konnte nicht aufgeteilt werden.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -2110,4 +2110,25 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'No saved signatures.';
+
+  @override
+  String get splitTitle => 'Split PDF…';
+
+  @override
+  String get splitHelp =>
+      'Enter page ranges separated by commas. Each range creates a separate PDF.';
+
+  @override
+  String get splitRanges => 'Page ranges';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Use pages 1–$count, separated by commas. Ranges must run from first to last.';
+  }
+
+  @override
+  String get splitConfirm => 'Split';
+
+  @override
+  String get splitFailed => 'Could not split this PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -2121,4 +2121,25 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'No hay firmas guardadas.';
+
+  @override
+  String get splitTitle => 'Dividir PDF…';
+
+  @override
+  String get splitHelp =>
+      'Introduce intervalos de páginas separados por comas. Cada intervalo crea un PDF independiente.';
+
+  @override
+  String get splitRanges => 'Intervalos de páginas';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Usa páginas de 1 a $count, separadas por comas. Los intervalos deben ser ascendentes.';
+  }
+
+  @override
+  String get splitConfirm => 'Dividir';
+
+  @override
+  String get splitFailed => 'No se pudo dividir este PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -2131,4 +2131,25 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Aucune signature enregistrée.';
+
+  @override
+  String get splitTitle => 'Scinder le PDF…';
+
+  @override
+  String get splitHelp =>
+      'Saisissez des plages de pages séparées par des virgules. Chaque plage crée un PDF distinct.';
+
+  @override
+  String get splitRanges => 'Plages de pages';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Utilisez les pages de 1 à $count, séparées par des virgules. Les plages doivent être croissantes.';
+  }
+
+  @override
+  String get splitConfirm => 'Scinder';
+
+  @override
+  String get splitFailed => 'Impossible de scinder ce PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -2114,4 +2114,25 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'कोई सहेजा गया हस्ताक्षर नहीं है।';
+
+  @override
+  String get splitTitle => 'PDF विभाजित करें…';
+
+  @override
+  String get splitHelp =>
+      'पृष्ठ श्रेणियाँ अल्पविराम से अलग करके दर्ज करें। हर श्रेणी से एक अलग PDF बनेगा।';
+
+  @override
+  String get splitRanges => 'पृष्ठ श्रेणियाँ';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '1 से $count तक के पृष्ठ अल्पविराम से अलग करें। श्रेणियाँ बढ़ते क्रम में होनी चाहिए।';
+  }
+
+  @override
+  String get splitConfirm => 'विभाजित करें';
+
+  @override
+  String get splitFailed => 'यह PDF विभाजित नहीं किया जा सका।';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -2119,4 +2119,25 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Tidak ada tanda tangan tersimpan.';
+
+  @override
+  String get splitTitle => 'Pisahkan PDF…';
+
+  @override
+  String get splitHelp =>
+      'Masukkan rentang halaman yang dipisahkan koma. Setiap rentang menghasilkan PDF terpisah.';
+
+  @override
+  String get splitRanges => 'Rentang halaman';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Gunakan halaman 1–$count, dipisahkan koma. Rentang harus berurutan naik.';
+  }
+
+  @override
+  String get splitConfirm => 'Pisahkan';
+
+  @override
+  String get splitFailed => 'PDF ini tidak dapat dipisahkan.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -2122,4 +2122,25 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Nessuna firma salvata.';
+
+  @override
+  String get splitTitle => 'Dividi PDF…';
+
+  @override
+  String get splitHelp =>
+      'Inserisci intervalli di pagine separati da virgole. Ogni intervallo crea un PDF separato.';
+
+  @override
+  String get splitRanges => 'Intervalli di pagine';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Usa pagine da 1 a $count, separate da virgole. Gli intervalli devono essere crescenti.';
+  }
+
+  @override
+  String get splitConfirm => 'Dividi';
+
+  @override
+  String get splitFailed => 'Impossibile dividere questo PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -2093,4 +2093,24 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => '保存済みの署名はありません。';
+
+  @override
+  String get splitTitle => 'PDFを分割…';
+
+  @override
+  String get splitHelp => 'ページ範囲をカンマで区切って入力してください。範囲ごとに別のPDFを作成します。';
+
+  @override
+  String get splitRanges => 'ページ範囲';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '1～$countページをカンマで区切って指定してください。範囲は昇順で指定してください。';
+  }
+
+  @override
+  String get splitConfirm => '分割';
+
+  @override
+  String get splitFailed => 'このPDFを分割できませんでした。';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -2094,4 +2094,24 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => '저장된 서명이 없습니다.';
+
+  @override
+  String get splitTitle => 'PDF 분할…';
+
+  @override
+  String get splitHelp => '페이지 범위를 쉼표로 구분하여 입력하세요. 각 범위마다 별도의 PDF가 생성됩니다.';
+
+  @override
+  String get splitRanges => '페이지 범위';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '1~$count페이지를 쉼표로 구분하세요. 범위는 오름차순이어야 합니다.';
+  }
+
+  @override
+  String get splitConfirm => '분할';
+
+  @override
+  String get splitFailed => '이 PDF를 분할할 수 없습니다.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -2119,4 +2119,25 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Geen opgeslagen handtekeningen.';
+
+  @override
+  String get splitTitle => 'PDF splitsen…';
+
+  @override
+  String get splitHelp =>
+      'Voer paginabereiken in, gescheiden door komma’s. Elk bereik wordt een afzonderlijke PDF.';
+
+  @override
+  String get splitRanges => 'Paginabereiken';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Gebruik pagina’s 1–$count, gescheiden door komma’s. Bereiken moeten oplopend zijn.';
+  }
+
+  @override
+  String get splitConfirm => 'Splitsen';
+
+  @override
+  String get splitFailed => 'Deze PDF kon niet worden gesplitst.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -2156,4 +2156,25 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Brak zapisanych podpisów.';
+
+  @override
+  String get splitTitle => 'Podziel PDF…';
+
+  @override
+  String get splitHelp =>
+      'Wpisz zakresy stron oddzielone przecinkami. Każdy zakres tworzy osobny plik PDF.';
+
+  @override
+  String get splitRanges => 'Zakresy stron';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Użyj stron od 1 do $count, oddzielonych przecinkami. Zakresy muszą być rosnące.';
+  }
+
+  @override
+  String get splitConfirm => 'Podziel';
+
+  @override
+  String get splitFailed => 'Nie udało się podzielić tego pliku PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -2120,4 +2120,25 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Nenhuma assinatura guardada.';
+
+  @override
+  String get splitTitle => 'Dividir PDF…';
+
+  @override
+  String get splitHelp =>
+      'Introduza intervalos de páginas separados por vírgulas. Cada intervalo cria um PDF separado.';
+
+  @override
+  String get splitRanges => 'Intervalos de páginas';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Use páginas de 1 a $count, separadas por vírgulas. Os intervalos devem ser crescentes.';
+  }
+
+  @override
+  String get splitConfirm => 'Dividir';
+
+  @override
+  String get splitFailed => 'Não foi possível dividir este PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -2157,4 +2157,25 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Нет сохранённых подписей.';
+
+  @override
+  String get splitTitle => 'Разделить PDF…';
+
+  @override
+  String get splitHelp =>
+      'Введите диапазоны страниц через запятую. Для каждого диапазона будет создан отдельный PDF.';
+
+  @override
+  String get splitRanges => 'Диапазоны страниц';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Укажите страницы от 1 до $count через запятую. Диапазоны должны идти по возрастанию.';
+  }
+
+  @override
+  String get splitConfirm => 'Разделить';
+
+  @override
+  String get splitFailed => 'Не удалось разделить этот PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -2105,4 +2105,25 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'ไม่มีลายเซ็นที่บันทึกไว้';
+
+  @override
+  String get splitTitle => 'แยก PDF…';
+
+  @override
+  String get splitHelp =>
+      'ป้อนช่วงหน้าโดยคั่นด้วยจุลภาค แต่ละช่วงจะสร้าง PDF แยกกัน';
+
+  @override
+  String get splitRanges => 'ช่วงหน้า';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'ใช้หน้า 1–$count โดยคั่นด้วยจุลภาค ช่วงหน้าต้องเรียงจากน้อยไปมาก';
+  }
+
+  @override
+  String get splitConfirm => 'แยก';
+
+  @override
+  String get splitFailed => 'ไม่สามารถแยก PDF นี้ได้';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -2115,4 +2115,25 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Kayıtlı imza yok.';
+
+  @override
+  String get splitTitle => 'PDF’yi böl…';
+
+  @override
+  String get splitHelp =>
+      'Sayfa aralıklarını virgülle ayırarak girin. Her aralık ayrı bir PDF oluşturur.';
+
+  @override
+  String get splitRanges => 'Sayfa aralıkları';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '1–$count arasındaki sayfaları virgülle ayırın. Aralıklar artan sırada olmalıdır.';
+  }
+
+  @override
+  String get splitConfirm => 'Böl';
+
+  @override
+  String get splitFailed => 'Bu PDF bölünemedi.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -2158,4 +2158,25 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Немає збережених підписів.';
+
+  @override
+  String get splitTitle => 'Розділити PDF…';
+
+  @override
+  String get splitHelp =>
+      'Введіть діапазони сторінок через кому. Для кожного діапазону буде створено окремий PDF.';
+
+  @override
+  String get splitRanges => 'Діапазони сторінок';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Укажіть сторінки від 1 до $count через кому. Діапазони мають бути за зростанням.';
+  }
+
+  @override
+  String get splitConfirm => 'Розділити';
+
+  @override
+  String get splitFailed => 'Не вдалося розділити цей PDF.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -2110,4 +2110,25 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => 'Không có chữ ký đã lưu.';
+
+  @override
+  String get splitTitle => 'Tách PDF…';
+
+  @override
+  String get splitHelp =>
+      'Nhập các khoảng trang, phân cách bằng dấu phẩy. Mỗi khoảng tạo một PDF riêng.';
+
+  @override
+  String get splitRanges => 'Khoảng trang';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return 'Dùng các trang từ 1 đến $count, phân cách bằng dấu phẩy. Các khoảng phải theo thứ tự tăng dần.';
+  }
+
+  @override
+  String get splitConfirm => 'Tách';
+
+  @override
+  String get splitFailed => 'Không thể tách PDF này.';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -2085,6 +2085,26 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
 
   @override
   String get signatureLibraryEmpty => '没有已保存的签名。';
+
+  @override
+  String get splitTitle => '拆分 PDF…';
+
+  @override
+  String get splitHelp => '输入以逗号分隔的页面范围。每个范围生成一个独立的 PDF。';
+
+  @override
+  String get splitRanges => '页面范围';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '请输入 1 至 $count 之间的页码，以逗号分隔。范围必须按升序填写。';
+  }
+
+  @override
+  String get splitConfirm => '拆分';
+
+  @override
+  String get splitFailed => '无法拆分此 PDF。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -4168,4 +4188,24 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get signatureLibraryEmpty => '沒有已儲存的簽名。';
+
+  @override
+  String get splitTitle => '分割 PDF…';
+
+  @override
+  String get splitHelp => '輸入以逗號分隔的頁面範圍。每個範圍會產生一個獨立的 PDF。';
+
+  @override
+  String get splitRanges => '頁面範圍';
+
+  @override
+  String splitInvalidRanges(int count) {
+    return '請輸入 1 至 $count 之間的頁碼，以逗號分隔。範圍必須按遞增順序填寫。';
+  }
+
+  @override
+  String get splitConfirm => '分割';
+
+  @override
+  String get splitFailed => '無法分割此 PDF。';
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Aangepaste stempels…",
   "signatureLibraryManage": "Handtekeningen beheren",
   "signatureLibraryRenameTitle": "Handtekening hernoemen",
-  "signatureLibraryEmpty": "Geen opgeslagen handtekeningen."
+  "signatureLibraryEmpty": "Geen opgeslagen handtekeningen.",
+  "splitTitle": "PDF splitsen…",
+  "splitHelp": "Voer paginabereiken in, gescheiden door komma’s. Elk bereik wordt een afzonderlijke PDF.",
+  "splitRanges": "Paginabereiken",
+  "splitInvalidRanges": "Gebruik pagina’s 1–{count}, gescheiden door komma’s. Bereiken moeten oplopend zijn.",
+  "splitConfirm": "Splitsen",
+  "splitFailed": "Deze PDF kon niet worden gesplitst."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Niestandardowe stemple…",
   "signatureLibraryManage": "Zarządzaj podpisami",
   "signatureLibraryRenameTitle": "Zmień nazwę podpisu",
-  "signatureLibraryEmpty": "Brak zapisanych podpisów."
+  "signatureLibraryEmpty": "Brak zapisanych podpisów.",
+  "splitTitle": "Podziel PDF…",
+  "splitHelp": "Wpisz zakresy stron oddzielone przecinkami. Każdy zakres tworzy osobny plik PDF.",
+  "splitRanges": "Zakresy stron",
+  "splitInvalidRanges": "Użyj stron od 1 do {count}, oddzielonych przecinkami. Zakresy muszą być rosnące.",
+  "splitConfirm": "Podziel",
+  "splitFailed": "Nie udało się podzielić tego pliku PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Carimbos personalizados…",
   "signatureLibraryManage": "Gerir assinaturas",
   "signatureLibraryRenameTitle": "Mudar o nome da assinatura",
-  "signatureLibraryEmpty": "Nenhuma assinatura guardada."
+  "signatureLibraryEmpty": "Nenhuma assinatura guardada.",
+  "splitTitle": "Dividir PDF…",
+  "splitHelp": "Introduza intervalos de páginas separados por vírgulas. Cada intervalo cria um PDF separado.",
+  "splitRanges": "Intervalos de páginas",
+  "splitInvalidRanges": "Use páginas de 1 a {count}, separadas por vírgulas. Os intervalos devem ser crescentes.",
+  "splitConfirm": "Dividir",
+  "splitFailed": "Não foi possível dividir este PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Пользовательские штампы…",
   "signatureLibraryManage": "Управление подписями",
   "signatureLibraryRenameTitle": "Переименовать подпись",
-  "signatureLibraryEmpty": "Нет сохранённых подписей."
+  "signatureLibraryEmpty": "Нет сохранённых подписей.",
+  "splitTitle": "Разделить PDF…",
+  "splitHelp": "Введите диапазоны страниц через запятую. Для каждого диапазона будет создан отдельный PDF.",
+  "splitRanges": "Диапазоны страниц",
+  "splitInvalidRanges": "Укажите страницы от 1 до {count} через запятую. Диапазоны должны идти по возрастанию.",
+  "splitConfirm": "Разделить",
+  "splitFailed": "Не удалось разделить этот PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "ตราประทับแบบกำหนดเอง…",
   "signatureLibraryManage": "จัดการลายเซ็น",
   "signatureLibraryRenameTitle": "เปลี่ยนชื่อลายเซ็น",
-  "signatureLibraryEmpty": "ไม่มีลายเซ็นที่บันทึกไว้"
+  "signatureLibraryEmpty": "ไม่มีลายเซ็นที่บันทึกไว้",
+  "splitTitle": "แยก PDF…",
+  "splitHelp": "ป้อนช่วงหน้าโดยคั่นด้วยจุลภาค แต่ละช่วงจะสร้าง PDF แยกกัน",
+  "splitRanges": "ช่วงหน้า",
+  "splitInvalidRanges": "ใช้หน้า 1–{count} โดยคั่นด้วยจุลภาค ช่วงหน้าต้องเรียงจากน้อยไปมาก",
+  "splitConfirm": "แยก",
+  "splitFailed": "ไม่สามารถแยก PDF นี้ได้"
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Özel damgalar…",
   "signatureLibraryManage": "İmzaları yönet",
   "signatureLibraryRenameTitle": "İmzayı yeniden adlandır",
-  "signatureLibraryEmpty": "Kayıtlı imza yok."
+  "signatureLibraryEmpty": "Kayıtlı imza yok.",
+  "splitTitle": "PDF’yi böl…",
+  "splitHelp": "Sayfa aralıklarını virgülle ayırarak girin. Her aralık ayrı bir PDF oluşturur.",
+  "splitRanges": "Sayfa aralıkları",
+  "splitInvalidRanges": "1–{count} arasındaki sayfaları virgülle ayırın. Aralıklar artan sırada olmalıdır.",
+  "splitConfirm": "Böl",
+  "splitFailed": "Bu PDF bölünemedi."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Користувацькі штампи…",
   "signatureLibraryManage": "Керувати підписами",
   "signatureLibraryRenameTitle": "Перейменувати підпис",
-  "signatureLibraryEmpty": "Немає збережених підписів."
+  "signatureLibraryEmpty": "Немає збережених підписів.",
+  "splitTitle": "Розділити PDF…",
+  "splitHelp": "Введіть діапазони сторінок через кому. Для кожного діапазону буде створено окремий PDF.",
+  "splitRanges": "Діапазони сторінок",
+  "splitInvalidRanges": "Укажіть сторінки від 1 до {count} через кому. Діапазони мають бути за зростанням.",
+  "splitConfirm": "Розділити",
+  "splitFailed": "Не вдалося розділити цей PDF."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "Con dấu tùy chỉnh…",
   "signatureLibraryManage": "Quản lý chữ ký",
   "signatureLibraryRenameTitle": "Đổi tên chữ ký",
-  "signatureLibraryEmpty": "Không có chữ ký đã lưu."
+  "signatureLibraryEmpty": "Không có chữ ký đã lưu.",
+  "splitTitle": "Tách PDF…",
+  "splitHelp": "Nhập các khoảng trang, phân cách bằng dấu phẩy. Mỗi khoảng tạo một PDF riêng.",
+  "splitRanges": "Khoảng trang",
+  "splitInvalidRanges": "Dùng các trang từ 1 đến {count}, phân cách bằng dấu phẩy. Các khoảng phải theo thứ tự tăng dần.",
+  "splitConfirm": "Tách",
+  "splitFailed": "Không thể tách PDF này."
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "自定义图章…",
   "signatureLibraryManage": "管理签名",
   "signatureLibraryRenameTitle": "重命名签名",
-  "signatureLibraryEmpty": "没有已保存的签名。"
+  "signatureLibraryEmpty": "没有已保存的签名。",
+  "splitTitle": "拆分 PDF…",
+  "splitHelp": "输入以逗号分隔的页面范围。每个范围生成一个独立的 PDF。",
+  "splitRanges": "页面范围",
+  "splitInvalidRanges": "请输入 1 至 {count} 之间的页码，以逗号分隔。范围必须按升序填写。",
+  "splitConfirm": "拆分",
+  "splitFailed": "无法拆分此 PDF。"
 }

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -618,5 +618,11 @@
   "annotationLibraryCustomStamps": "自訂戳記…",
   "signatureLibraryManage": "管理簽名",
   "signatureLibraryRenameTitle": "重新命名簽名",
-  "signatureLibraryEmpty": "沒有已儲存的簽名。"
+  "signatureLibraryEmpty": "沒有已儲存的簽名。",
+  "splitTitle": "分割 PDF…",
+  "splitHelp": "輸入以逗號分隔的頁面範圍。每個範圍會產生一個獨立的 PDF。",
+  "splitRanges": "頁面範圍",
+  "splitInvalidRanges": "請輸入 1 至 {count} 之間的頁碼，以逗號分隔。範圍必須按遞增順序填寫。",
+  "splitConfirm": "分割",
+  "splitFailed": "無法分割此 PDF。"
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4054,6 +4054,11 @@ class PdfEditingController extends ChangeNotifier {
   Uint8List exportPageRange(int start, int end) =>
       _document.extractPageRange(start, end);
 
+  /// Exports one standalone PDF per zero-based inclusive range, without an
+  /// edit or undo entry. See [PdfSplitter] for the extraction semantics.
+  List<Uint8List> exportPageRanges(List<PdfPageRange> ranges) =>
+      _document.extractPageRanges(ranges);
+
   // ---------------------------------------------------------------------
   // page selection (the thumbnail strip's multi-select)
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -13,6 +13,7 @@ import 'package:pdf_document/pdf_document.dart';
 import '../debug_overlays.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_range_dialog.dart';
+import '../split_dialog.dart';
 import '../pdf_page_view.dart';
 import '../pdf_viewer.dart';
 import '../popup_position.dart';
@@ -86,6 +87,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.onClose,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.onSplitPages,
     this.fileDropController,
     this.renderWorker,
     this.rasterCache,
@@ -166,6 +168,10 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// When given, an "Export pages…" entry appears in the page-actions
   /// footer menu.
   final void Function(Uint8List bytes)? onExportPages;
+
+  /// Receives one standalone PDF per range from "Split PDF…". When null,
+  /// that action is hidden. Outputs follow the user's range order.
+  final void Function(List<Uint8List> documents)? onSplitPages;
 
   /// Lets a PDF dragged in from outside the app (the desktop, a browser
   /// download) be dropped *between two tiles* - the strip paints an
@@ -736,6 +742,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                     final rtl = Directionality.of(context) == TextDirection.rtl;
                     final showPageActions = widget.onPickPdfToInsert != null ||
                         widget.onExportPages != null ||
+                        widget.onSplitPages != null ||
                         (widget.allowPageEditing &&
                             controller.hasPageClipboard);
                     final moveHandle = geometry.moveHandle(
@@ -781,6 +788,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                             onPickPdfToInsert:
                                                 widget.onPickPdfToInsert,
                                             onExportPages: widget.onExportPages,
+                                            onSplitPages: widget.onSplitPages,
                                           ),
                                       ],
                                     ),
@@ -837,6 +845,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                                   widget.onPickPdfToInsert,
                                               onExportPages:
                                                   widget.onExportPages,
+                                              onSplitPages: widget.onSplitPages,
                                             )
                                           : const SizedBox.shrink(),
                                     ),
@@ -1211,7 +1220,7 @@ PdfThumbnailDropEdge? _tileDropEdge(
   return null;
 }
 
-enum _PageAction { paste, insert, export }
+enum _PageAction { paste, insert, export, split }
 
 const _densePopupMenuHeight = 34.0;
 
@@ -1233,6 +1242,7 @@ class _PageActionsButton extends StatelessWidget {
     required this.allowPageEditing,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.onSplitPages,
   });
 
   final PdfEditingController controller;
@@ -1243,6 +1253,10 @@ class _PageActionsButton extends StatelessWidget {
   final bool allowPageEditing;
   final Future<Uint8List?> Function()? onPickPdfToInsert;
   final void Function(Uint8List bytes)? onExportPages;
+
+  /// Receives one standalone PDF per range from "Split PDF…". When null,
+  /// that action is hidden. Outputs follow the user's range order.
+  final void Function(List<Uint8List> documents)? onSplitPages;
 
   void _paste() {
     // paste the shared clipboard's pages after the current page, then
@@ -1293,6 +1307,31 @@ class _PageActionsButton extends StatelessWidget {
     onExport(controller.exportPageRange(range.start, range.end));
   }
 
+  Future<void> _split(BuildContext context) async {
+    final onSplit = onSplitPages;
+    if (onSplit == null) return;
+    final document = controller.document;
+    final ranges = await showPdfSplitDialog(
+      context,
+      pageCount: document.pageCount,
+    );
+    if (ranges == null ||
+        !context.mounted ||
+        !identical(controller.document, document)) {
+      return;
+    }
+    late final List<Uint8List> outputs;
+    try {
+      outputs = controller.exportPageRanges(ranges);
+    } catch (_) {
+      ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(
+        content: Text(pdfL10n(context).splitFailed),
+      ));
+      return;
+    }
+    onSplit(outputs);
+  }
+
   @override
   Widget build(BuildContext context) {
     final canPaste = allowPageEditing && controller.hasPageClipboard;
@@ -1311,6 +1350,8 @@ class _PageActionsButton extends StatelessWidget {
             _insert(context);
           case _PageAction.export:
             _export(context);
+          case _PageAction.split:
+            _split(context);
         }
       },
       itemBuilder: (context) => [
@@ -1331,6 +1372,14 @@ class _PageActionsButton extends StatelessWidget {
             value: _PageAction.insert,
             height: _densePopupMenuHeight,
             child: Text(pdfL10n(context).thumbInsertPdf,
+                style: _densePopupTextStyle(context)),
+          ),
+        if (onSplitPages != null)
+          PopupMenuItem(
+            key: const ValueKey('pdf-thumbnail-split-pages'),
+            value: _PageAction.split,
+            height: _densePopupMenuHeight,
+            child: Text(pdfL10n(context).splitTitle,
                 style: _densePopupTextStyle(context)),
           ),
         if (canExport)
@@ -1380,6 +1429,7 @@ class PdfThumbnailView extends StatefulWidget {
     this.allowPageEditing = true,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.onSplitPages,
     this.fileDropController,
     this.onOpenPage,
     this.renderWorker,
@@ -1419,6 +1469,10 @@ class PdfThumbnailView extends StatefulWidget {
   /// Receives the bytes of an exported page range; null hides the
   /// "Export pages…" page-action and the selection bar's export.
   final void Function(Uint8List bytes)? onExportPages;
+
+  /// Receives one standalone PDF per range from "Split PDF…". When null,
+  /// that action is hidden. Outputs follow the user's range order.
+  final void Function(List<Uint8List> documents)? onSplitPages;
 
   /// Lets a PDF dragged in from outside the app be dropped between two
   /// tiles, at the marked position in the page order. The host drives the
@@ -1816,6 +1870,7 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                           ),
                           if (widget.onPickPdfToInsert != null ||
                               widget.onExportPages != null ||
+                              widget.onSplitPages != null ||
                               (widget.allowPageEditing &&
                                   controller.hasPageClipboard))
                             _PageActionsButton(
@@ -1824,6 +1879,7 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                               allowPageEditing: widget.allowPageEditing,
                               onPickPdfToInsert: widget.onPickPdfToInsert,
                               onExportPages: widget.onExportPages,
+                              onSplitPages: widget.onSplitPages,
                             ),
                         ]),
                       ),

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -236,6 +236,7 @@ class PdfEditorView extends StatefulWidget {
     this.onDocumentChanged,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.onSplitPages,
     this.thumbnailDropController,
     this.onAction,
     this.onAnnotationTap,
@@ -330,6 +331,7 @@ class PdfEditorView extends StatefulWidget {
     this.onDocumentChanged,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.onSplitPages,
     this.thumbnailDropController,
     this.onAction,
     this.onAnnotationTap,
@@ -500,6 +502,11 @@ class PdfEditorView extends StatefulWidget {
   /// thumbnail strip's "Export pages…" action asks for the range, then
   /// hands the bytes here). When null the action is hidden.
   final void Function(Uint8List bytes)? onExportPages;
+
+  /// Receives all standalone PDFs from the thumbnail menu's "Split PDF…"
+  /// action in one call, in range order. The host saves or opens each result.
+  /// When null, the action is hidden. Does not modify the editing session.
+  final void Function(List<Uint8List> documents)? onSplitPages;
 
   /// Lets a PDF dragged in from outside the app be dropped at a chosen
   /// position in the page thumbnails (strip or full-area grid) instead of
@@ -792,6 +799,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         onDocumentChanged: complete ? widget.onDocumentChanged : null,
         onPickPdfToInsert: complete ? widget.onPickPdfToInsert : null,
         onExportPages: complete ? widget.onExportPages : null,
+        onSplitPages: complete ? widget.onSplitPages : null,
         thumbnailDropController:
             complete ? widget.thumbnailDropController : null,
         onAction: widget.onAction,
@@ -978,6 +986,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 onPickPdfToInsert:
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
+                onSplitPages: widget.onSplitPages,
                 // dropping a PDF between two tiles inserts it there; a
                 // read-only shell takes no structural page edits
                 fileDropController: features.pageEditing
@@ -1069,6 +1078,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 onPickPdfToInsert:
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
+                onSplitPages: widget.onSplitPages,
                 fileDropController: features.pageEditing
                     ? widget.thumbnailDropController
                     : null,

--- a/packages/dart_pdf_editor/lib/src/split_dialog.dart
+++ b/packages/dart_pdf_editor/lib/src/split_dialog.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'dialog.dart';
+import 'l10n/pdf_l10n.dart';
+
+/// Asks for comma-separated page ranges, one output PDF per item.
+///
+/// Input is one-based (for example `1-3, 7, 10-12`); the result contains
+/// zero-based inclusive ranges validated against [pageCount]. Cancellation
+/// returns null. Hosts can pass the result to
+/// `PdfEditingController.exportPageRanges` or [PdfSplitter.split].
+Future<List<PdfPageRange>?> showPdfSplitDialog(
+  BuildContext context, {
+  required int pageCount,
+}) {
+  if (pageCount < 1) {
+    throw RangeError.range(pageCount, 1, null, 'pageCount');
+  }
+  return showPdfDialog<List<PdfPageRange>>(
+    context: context,
+    builder: (_) => _SplitDialog(pageCount: pageCount),
+  );
+}
+
+class _SplitDialog extends StatefulWidget {
+  const _SplitDialog({required this.pageCount});
+
+  final int pageCount;
+
+  @override
+  State<_SplitDialog> createState() => _SplitDialogState();
+}
+
+class _SplitDialogState extends State<_SplitDialog> {
+  final _input = TextEditingController();
+  bool _invalid = false;
+
+  @override
+  void dispose() {
+    _input.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    try {
+      final ranges = PdfSplitter.parseRanges(
+        _input.text,
+        pageCount: widget.pageCount,
+      );
+      Navigator.of(context).pop(ranges);
+    } on FormatException {
+      setState(() => _invalid = true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = pdfL10n(context);
+    return AlertDialog(
+      key: const ValueKey('pdf-split-dialog'),
+      title: Text(l10n.splitTitle),
+      content: SizedBox(
+        width: 360,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(l10n.pageRangePageCount(widget.pageCount)),
+            const SizedBox(height: 12),
+            Text(l10n.splitHelp),
+            const SizedBox(height: 16),
+            TextField(
+              key: const ValueKey('pdf-split-ranges'),
+              controller: _input,
+              autofocus: true,
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _submit(),
+              onChanged: (_) {
+                if (_invalid) setState(() => _invalid = false);
+              },
+              decoration: InputDecoration(
+                labelText: l10n.splitRanges,
+                hintText: '1-3, 7, 10-12',
+                errorText:
+                    _invalid ? l10n.splitInvalidRanges(widget.pageCount) : null,
+                errorMaxLines: 3,
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          key: const ValueKey('pdf-split-cancel'),
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.cancel),
+        ),
+        FilledButton(
+          key: const ValueKey('pdf-split-confirm'),
+          onPressed: _submit,
+          child: Text(l10n.splitConfirm),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/dart_pdf_editor/test/split_dialog_test.dart
+++ b/packages/dart_pdf_editor/test/split_dialog_test.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> openSplit(WidgetTester tester) async {
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')),
+        kind: PointerDeviceKind.mouse);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-split-pages')));
+    await tester.pumpAndSettle();
+  }
+
+  test('batch export leaves selection, revision and undo state untouched', () {
+    final controller = PdfEditingController(buildMultiPagePdf(4));
+    addTearDown(controller.dispose);
+    controller.selectPage(2);
+    final document = controller.document;
+    final outputs = controller
+        .exportPageRanges(const [PdfPageRange(2, 3), PdfPageRange(0, 0)]);
+    expect(outputs.map((b) => PdfDocument.open(b).pageCount), [2, 1]);
+    expect(controller.document, same(document));
+    expect(controller.selectedPages, [2]);
+    expect(controller.canUndo, isFalse);
+  });
+
+  for (final grid in [false, true]) {
+    testWidgets(
+        'split delivers every output once from ${grid ? 'grid' : 'strip'}',
+        (tester) async {
+      final controller = PdfEditingController(buildMultiPagePdf(12));
+      addTearDown(controller.dispose);
+      controller.preferences.showThumbnailView = grid;
+      List<Uint8List>? outputs;
+      var calls = 0;
+      await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: PdfEditorView(
+        controller: controller,
+        features: const PdfEditorFeatures(pageEditing: false),
+        onSplitPages: (parts) {
+          outputs = parts;
+          calls++;
+        },
+      ))));
+      await tester.pump();
+      await openSplit(tester);
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-split-ranges')), '1-3, 7, 10-12');
+      await tester.tap(find.byKey(const ValueKey('pdf-split-confirm')));
+      await tester.pumpAndSettle();
+      expect(calls, 1);
+      expect(outputs!.map((b) => PdfDocument.open(b).pageCount), [3, 1, 3]);
+      expect(
+          String.fromCharCodes(
+              PdfDocument.open(outputs![1]).page(0).contentBytes()),
+          contains('(Page 7)'));
+      expect(controller.document.pageCount, 12);
+      expect(controller.canUndo, isFalse);
+    });
+  }
+
+  testWidgets(
+      'invalid ranges stay open, correction succeeds, cancel emits nothing',
+      (tester) async {
+    var calls = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: PdfEditorView(
+      bytes: buildMultiPagePdf(4),
+      onSplitPages: (_) => calls++,
+    ))));
+    await tester.pump();
+    await openSplit(tester);
+    for (final input in ['1,', '0', '2-1', '1-5']) {
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-split-ranges')), input);
+      await tester.tap(find.byKey(const ValueKey('pdf-split-confirm')));
+      await tester.pumpAndSettle();
+      expect(calls, 0);
+      expect(find.byKey(const ValueKey('pdf-split-dialog')), findsOneWidget);
+      expect(find.textContaining('Use pages 1–4'), findsOneWidget);
+    }
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-split-ranges')), '1-2, 4');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+    await openSplit(tester);
+    await tester.tap(find.byKey(const ValueKey('pdf-split-cancel')));
+    await tester.pumpAndSettle();
+    expect(calls, 1);
+  });
+
+  testWidgets('split is hidden without a batch callback', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: PdfEditorView(
+      bytes: buildMultiPagePdf(2),
+      onExportPages: (_) {},
+    ))));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')),
+        kind: PointerDeviceKind.mouse);
+    await tester.pumpAndSettle();
+    expect(
+        find.byKey(const ValueKey('pdf-thumbnail-split-pages')), findsNothing);
+    expect(find.byKey(const ValueKey('pdf-thumbnail-export-pages')),
+        findsOneWidget);
+  });
+
+  testWidgets('a revision during the dialog cannot export a different range',
+      (tester) async {
+    final controller = PdfEditingController(buildMultiPagePdf(4));
+    addTearDown(controller.dispose);
+    var calls = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: PdfEditorView(
+      controller: controller,
+      onSplitPages: (_) => calls++,
+    ))));
+    await tester.pump();
+    await openSplit(tester);
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-split-ranges')), '1-2');
+    controller.removePage(0);
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('pdf-split-confirm')));
+    await tester.pumpAndSettle();
+    expect(calls, 0);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add `PdfSplitter.split`, `splitRange`, and `splitExpression` for bytes-only
+  PDF splitting, with validated `PdfPageRange` batches and one-based range
+  parsing. `PdfDocument.extractPageRanges` reuses an already-open document.
+- Document splitting examples and the extraction semantics.
+
 ## 4.2.0
 
 - Add `PdfAnnotation.appearanceRotation`, the rotation an annotation's normal

--- a/packages/pdf_document/README.md
+++ b/packages/pdf_document/README.md
@@ -57,6 +57,57 @@ editor.addFreeText(0, const PdfRect(72, 600, 280, 660), 'Reviewed.');
 final saved = editor.save(); // incremental update
 ```
 
+## Splitting and extracting pages
+
+Create multiple PDFs in one call, with one output per range:
+
+```dart
+import 'package:pdf_document/pdf_document.dart';
+
+final parts = PdfSplitter.split(bytes, const [
+  PdfPageRange(0, 2), // pages 1–3
+  PdfPageRange(6, 6), // page 7
+  PdfPageRange(9, 11), // pages 10–12
+]); // List<Uint8List>, three independent PDFs in this order
+
+final firstThree = PdfSplitter.splitRange(bytes, 0, 2);
+final fromInput = PdfSplitter.splitExpression(bytes, '1-3, 7, 10-12');
+```
+
+API indices are **zero-based and inclusive**. Text expressions use **one-based
+page numbers**: each comma starts a separate output. Whitespace, overlapping
+ranges, repeated ranges, and caller-chosen range order are supported. Empty
+items, reversed ranges, and out-of-bounds pages are rejected. `parseRanges`
+validates text without generating PDFs:
+
+```dart
+final document = PdfDocument.open(bytes, password: 'secret');
+final ranges = PdfSplitter.parseRanges('1-3, 7', pageCount: document.pageCount);
+final parts = document.extractPageRanges(ranges); // reuse an open document
+final selection = document.extractPages([4, 0, 2]); // one PDF in this order
+final span = document.extractPageRange(0, 2); // one contiguous selection
+```
+
+The raw-bytes methods also accept `password:`. Each batch opens the source once
+and validates all ranges before generating outputs. Programmatic invalid ranges
+throw `ArgumentError`/`RangeError`; invalid expressions throw `FormatException`.
+All paths work on mobile, desktop, web, and the Dart VM with no `dart:io`.
+
+Extraction semantics:
+
+- Page annotations and objects reachable from each selected page are deep-copied.
+  Inherited page attributes are materialized, and the source is unchanged.
+- Destinations between retained pages are remapped within each output. A target
+  page excluded from that output is not copied along with the link.
+- The document information dictionary is retained. Document-level state outside
+  the page graph—outlines/bookmarks, the AcroForm field list, and named
+  destinations—is omitted. Copied widget annotations are not registered through
+  an AcroForm in the output.
+- Resources shared by selected pages remain shared within one output where
+  possible. Separate output PDFs have their own copies and can be edited
+  independently.
+- Extracting an encrypted source produces **unencrypted PDFs**.
+
 ## The suite
 
 | Package | Layer |

--- a/packages/pdf_document/lib/pdf_document.dart
+++ b/packages/pdf_document/lib/pdf_document.dart
@@ -33,6 +33,7 @@ export 'src/matrix_geometry.dart';
 export 'src/rect.dart';
 export 'src/signature.dart';
 export 'src/signing_identity.dart';
+export 'src/splitter.dart';
 export 'src/stamp_template.dart';
 export 'src/struct_tree.dart';
 export 'src/takeoff.dart';

--- a/packages/pdf_document/lib/src/splitter.dart
+++ b/packages/pdf_document/lib/src/splitter.dart
@@ -1,0 +1,134 @@
+import 'dart:typed_data';
+
+import 'document.dart';
+import 'editor.dart';
+
+/// An inclusive, zero-based page range for one output PDF.
+///
+/// For example, `PdfPageRange(0, 2)` selects pages 1–3. Bounds are checked
+/// against the source document when extracting; reversed ranges are rejected.
+class PdfPageRange {
+  const PdfPageRange(this.start, this.end);
+
+  final int start;
+  final int end;
+
+  void _validate(int pageCount) {
+    RangeError.checkValidIndex(start, null, 'start', pageCount);
+    RangeError.checkValidIndex(end, null, 'end', pageCount);
+    if (end < start) {
+      throw ArgumentError('end ($end) must not be before start ($start)');
+    }
+  }
+}
+
+/// Splits PDF bytes into standalone PDFs without file-system dependencies.
+///
+/// Each range produces one output, in the supplied order. Overlapping and
+/// repeated ranges are allowed; they produce independent documents. The source
+/// is opened once and all ranges are validated before any output is generated.
+///
+/// ```dart
+/// final parts = PdfSplitter.split(bytes, const [
+///   PdfPageRange(0, 2), // pages 1–3 in the first PDF
+///   PdfPageRange(6, 6), // page 7 in the second PDF
+///   PdfPageRange(9, 11), // pages 10–12 in the third PDF
+/// ]);
+/// final firstThree = PdfSplitter.splitRange(bytes, 0, 2);
+/// final fromInput = PdfSplitter.splitExpression(bytes, '1-3, 7, 10-12');
+/// ```
+///
+/// Extraction deep-copies page annotations and reachable resources, remaps
+/// destinations between retained pages within each output, and retains the
+/// document information dictionary. Outlines/bookmarks, the AcroForm field
+/// list, and named destinations are omitted. Copied widgets are therefore not
+/// registered in an AcroForm. Shared resources remain shared within an output
+/// where possible; separate outputs own their copies. Encrypted sources require
+/// their password and produce **unencrypted** outputs. The source is unchanged.
+abstract final class PdfSplitter {
+  /// Returns one PDF per zero-based, inclusive range in [ranges].
+  ///
+  /// An empty list or reversed range throws [ArgumentError]; a page outside
+  /// the document throws [RangeError]. Opening errors propagate to the caller.
+  static List<Uint8List> split(
+    Uint8List bytes,
+    List<PdfPageRange> ranges, {
+    String password = '',
+  }) =>
+      PdfDocument.open(bytes, password: password).extractPageRanges(ranges);
+
+  /// Returns a single PDF of pages [start] through [end], zero-based/inclusive.
+  static Uint8List splitRange(
+    Uint8List bytes,
+    int start,
+    int end, {
+    String password = '',
+  }) =>
+      split(bytes, [PdfPageRange(start, end)], password: password).single;
+
+  /// Opens [bytes] once and produces one PDF per comma-separated range.
+  ///
+  /// Unlike [split], [expression] uses one-based page numbers, as described
+  /// by [parseRanges]. Invalid input throws [FormatException].
+  static List<Uint8List> splitExpression(
+    Uint8List bytes,
+    String expression, {
+    String password = '',
+  }) {
+    final document = PdfDocument.open(bytes, password: password);
+    return document.extractPageRanges(
+      parseRanges(expression, pageCount: document.pageCount),
+    );
+  }
+
+  /// Parses one-based, inclusive ranges such as `1-3, 7, 10-12`.
+  ///
+  /// Each comma starts another output. Whitespace around numbers and separators
+  /// is ignored. Order, overlaps, and repeated ranges are preserved. Empty
+  /// input/items, non-integers, reversed ranges, and pages outside 1..[pageCount]
+  /// throw [FormatException]. The returned ranges use zero-based indices.
+  static List<PdfPageRange> parseRanges(
+    String expression, {
+    required int pageCount,
+  }) {
+    RangeError.checkNotNegative(pageCount, 'pageCount');
+    final result = <PdfPageRange>[];
+    for (final item in expression.split(',')) {
+      final match =
+          RegExp(r'^\s*([0-9]+)\s*(?:-\s*([0-9]+)\s*)?$').firstMatch(item);
+      final start = match == null ? null : int.tryParse(match[1]!);
+      final end = match == null ? null : int.tryParse(match[2] ?? match[1]!);
+      if (start == null ||
+          end == null ||
+          start < 1 ||
+          end < start ||
+          end > pageCount) {
+        throw FormatException(
+          'Use pages 1–$pageCount, separated by commas, with ascending ranges '
+          '(for example 1-3, 7, 10-12).',
+          expression,
+        );
+      }
+      result.add(PdfPageRange(start - 1, end - 1));
+    }
+    return result;
+  }
+}
+
+/// Batch extraction from an already-open document.
+extension PdfBatchPageExtraction on PdfDocument {
+  /// Returns one standalone PDF per range. See [PdfSplitter] for semantics.
+  ///
+  /// All ranges are checked before extraction; the document is unchanged.
+  List<Uint8List> extractPageRanges(List<PdfPageRange> ranges) {
+    if (ranges.isEmpty) {
+      throw ArgumentError.value(ranges, 'ranges', 'select at least one range');
+    }
+    for (final range in ranges) {
+      range._validate(pageCount);
+    }
+    return [
+      for (final range in ranges) extractPageRange(range.start, range.end),
+    ];
+  }
+}

--- a/packages/pdf_document/test/splitter_test.dart
+++ b/packages/pdf_document/test/splitter_test.dart
@@ -1,0 +1,133 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+List<String> labels(Uint8List bytes) {
+  final doc = PdfDocument.open(bytes);
+  return [
+    for (final page in doc.pages)
+      RegExp(r'\((Page \d+)\)')
+          .firstMatch(String.fromCharCodes(page.contentBytes()))!
+          .group(1)!,
+  ];
+}
+
+void main() {
+  test('batch preserves range order, overlaps and independent outputs', () {
+    final bytes = buildMultiPagePdf(5);
+    final before = Uint8List.fromList(bytes);
+    final parts = PdfSplitter.split(bytes, const [
+      PdfPageRange(3, 4),
+      PdfPageRange(0, 2),
+      PdfPageRange(1, 1),
+      PdfPageRange(3, 4),
+    ]);
+    expect(parts.map(labels), [
+      ['Page 4', 'Page 5'],
+      ['Page 1', 'Page 2', 'Page 3'],
+      ['Page 2'],
+      ['Page 4', 'Page 5'],
+    ]);
+    expect(identical(parts.first, parts.last), isFalse);
+    final editor = PdfEditor(PdfDocument.open(parts.first))..removePage(0);
+    expect(labels(editor.save()), ['Page 5']);
+    expect(labels(parts.last), ['Page 4', 'Page 5']);
+    expect(bytes, before);
+  });
+
+  test('single-range convenience includes both endpoints', () {
+    expect(labels(PdfSplitter.splitRange(buildMultiPagePdf(4), 1, 2)),
+        ['Page 2', 'Page 3']);
+  });
+
+  test('expression produces separate PDFs with one-based page numbers', () {
+    final parts = PdfSplitter.splitExpression(
+      buildMultiPagePdf(12),
+      '1-3, 7, 10-12',
+    );
+    expect(parts.map(labels), [
+      ['Page 1', 'Page 2', 'Page 3'],
+      ['Page 7'],
+      ['Page 10', 'Page 11', 'Page 12'],
+    ]);
+  });
+
+  test('parser tolerates whitespace and preserves repeats and order', () {
+    final ranges =
+        PdfSplitter.parseRanges(' 3 - 4 , 1, 3-4, 2-2 ', pageCount: 4);
+    expect(
+        ranges.map((r) => (r.start, r.end)), [(2, 3), (0, 0), (2, 3), (1, 1)]);
+  });
+
+  for (final input in [
+    '',
+    ' ',
+    ',',
+    '1,',
+    ',1',
+    '1,,2',
+    '0',
+    '-1',
+    '5',
+    '1-5',
+    '3-2',
+    '1-',
+    '-2',
+    '1-2-3',
+    '1.5',
+    '1 2',
+    'one',
+    '1;2',
+    '999999999999999999999999999999999999999999999'
+  ]) {
+    test('parser rejects "$input"', () {
+      expect(() => PdfSplitter.parseRanges(input, pageCount: 4),
+          throwsFormatException);
+    });
+  }
+
+  test('invalid batches and single ranges are rejected without mutation', () {
+    final doc = PdfDocument.open(buildMultiPagePdf(3));
+    for (final ranges in <List<PdfPageRange>>[
+      [],
+      [const PdfPageRange(2, 1)],
+      [const PdfPageRange(-1, 1)],
+      [const PdfPageRange(0, 1), const PdfPageRange(1, 3)],
+    ]) {
+      expect(() => doc.extractPageRanges(ranges), throwsArgumentError);
+    }
+    expect(() => PdfSplitter.splitRange(buildMultiPagePdf(3), 0, 1000000000),
+        throwsRangeError);
+    expect(doc.pageCount, 3);
+  });
+
+  test('password is forwarded and each encrypted-source output is plain', () {
+    final bytes = buildEncryptedPdf(revision: 4, userPassword: 'secret');
+    expect(() => PdfSplitter.splitRange(bytes, 0, 0),
+        throwsA(isA<CosPasswordException>()));
+    for (final part in PdfSplitter.split(
+        bytes, const [PdfPageRange(0, 0), PdfPageRange(0, 0)],
+        password: 'secret')) {
+      final doc = PdfDocument.open(part);
+      expect(doc.cos.isEncrypted, isFalse);
+      expect(String.fromCharCodes(doc.page(0).contentBytes()),
+          contains('Hello, world!'));
+    }
+    expect(
+        PdfDocument.open(
+                PdfSplitter.splitExpression(bytes, '1', password: 'secret')
+                    .single)
+            .cos
+            .isEncrypted,
+        isFalse);
+    expect(
+        PdfDocument.open(
+                PdfSplitter.splitRange(bytes, 0, 0, password: 'secret'))
+            .cos
+            .isEncrypted,
+        isFalse);
+  });
+}


### PR DESCRIPTION
Closes #367.

Adds the remaining PDF splitting API and UI. `PdfSplitter.split`, `splitRange`, and `splitExpression` accept raw bytes; batches open the source once and validate all ranges before producing independent PDFs. `PdfDocument.extractPageRanges` and `PdfEditingController.exportPageRanges` support already-open documents without changing the source or undo history.

The thumbnail sidebar and page grid expose **Split PDF…** when a host supplies `onSplitPages`. Input such as `1-3, 7, 10-12` creates three PDFs and delivers them together in range order. Existing single-file exports keep their callback. The example opens all extracted results in editable tabs, assigns distinct filenames, and enables Save immediately.

README and dartdoc examples cover zero-based API ranges, one-based expressions, passwords, and extraction semantics: page annotations/resources and document information are retained; document-level bookmarks, AcroForm registration, and named destinations are omitted; encrypted inputs produce unencrypted outputs. New UI text is translated across all supported locales, with generated localizations included.

Validation:
- Core splitting and page extraction suites: passed.
- Editor split dialog, shell, page operations, and thumbnail grid suites: passed.
- Example tabs, editing, and demo suites: passed, including new-tab editing/undo and Save availability.
- Workspace analysis with `--fatal-infos`: clean.
- ARB translation coverage: all 57 locale files pass.
- Example release web build: passed.
