### PR TITLE
Merge PDFs through a high-level API and Insert document action

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ shows PDF.js baselines, Dart renders, and diffs side by side, and the
 shows every print-conformance page we rasterize (our own renders, which
 are the baselines - so no diff column).
 
+## Merge PDFs
+
+```dart
+import 'package:pdf_document/pdf_document.dart';
+
+final mergedBytes = PdfMerger.merge([firstPdfBytes, secondPdfBytes]);
+```
+
+The bytes-only API runs on desktop, mobile, and web. It preserves the first
+PDF's encryption and viewing settings, imports form fields and bookmarks, and
+remaps named links. See [merge options and collision rules](packages/pdf_document/README.md#merge-pdfs).
+
+In DartPDF, choose **Insert document…** from the app menu to insert a PDF after
+the current page. Dropping PDFs on the thumbnail strip inserts at the marked
+position; dropping on the document offers **Insert pages** to append them.
+Each inserted file is one undo step and uses the existing save/recovery session.
+
 ## Performance
 
 **The default viewer has not reached PDFium interaction parity yet.** The most

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add **Insert document…** to the app menu: insert a PDF after the current page
+  as one undo step, with the existing tab identity and session recovery.
+- Preserve imported form fields, bookmarks, and named links when inserting PDFs.
+
 ## 4.2.0
 
 - Keep nearby pages sharp during slow scrolling and warm pages ahead of the

--- a/app/README.md
+++ b/app/README.md
@@ -29,6 +29,9 @@ AppImage and portable tarball builds remain available from
 - Open PDFs from the picker, the OS ("open with" / share), drag-and-drop
   (desktop + web), recent files, or a launch argument. Recent documents can
   be browsed as a page-thumbnail grid.
+- Merge PDFs with **Insert document…** in the app menu (after the current page),
+  or drop them on the thumbnail strip to choose an insertion point. Each file
+  inserts as one undo step, stays in the original tab, and is covered by recovery.
 - On mobile, scan straight to a new PDF or insert a scan into the current
   document, and capture a page or placed image with the camera.
 - The full editing UI from the SDK: annotations, ink, shapes, free text,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2019,6 +2019,34 @@ class _EditorScreenState extends State<EditorScreen>
     }
   }
 
+  /// The menu counterpart to dropping a PDF on a thumbnail: insert after the
+  /// current page, retain this tab's identity, and reveal the imported pages.
+  Future<void> _insertDocument(DocumentTab tab) async {
+    final session = tab.session;
+    if (session == null || _readOnly) return;
+    final l10n = appL10n(context);
+    final failure = pdfL10n(context).thumbInsertFileFailed;
+    try {
+      final bytes = await pickPdfBytes(l10n.fileTypePdf);
+      if (bytes == null ||
+          !mounted ||
+          !containsTab(tab) ||
+          _readOnly ||
+          !identical(tab.session, session)) {
+        return;
+      }
+      final at =
+          (tab.viewer!.currentPage + 1).clamp(0, session.document.pageCount);
+      session.insertPagesFromBytes(bytes, at: at);
+      if (identical(_active, tab)) _revealInsertedPage(at);
+      _toast(l10n.editorInsertedIntoTitle(1, tab.title));
+    } catch (e) {
+      AppDevTools.instance
+          .addLog('insert document failed: $e', level: DevLogLevel.error);
+      if (mounted) _toast('$failure ${openErrorSummary(e)}');
+    }
+  }
+
   /// Scrolls the active viewer to [index] - the first page a positioned
   /// insert just added. The revision swap rebuilds the viewer and a
   /// geometry-changing revision resets its scroll in a post-frame callback,
@@ -3085,6 +3113,16 @@ class _EditorScreenState extends State<EditorScreen>
                   _usesMobileShare ? null : _menuShortcut('S', shift: true),
             ),
           ),
+          if (!_readOnly)
+            PopupMenuItem(
+              key: const ValueKey('menu-insert-document'),
+              height: _appMenuItemHeight(),
+              value: () => unawaited(_insertDocument(tab!)),
+              child: _appMenuTile(
+                icon: Icons.post_add_outlined,
+                title: appL10n(context).editorMenuInsertDocument,
+              ),
+            ),
           if (_canScan && !_readOnly)
             PopupMenuItem(
               key: const ValueKey('menu-insert-scan'),

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "طباعة…",
   "editorMenuSaveAs": "حفظ باسم…",
   "editorMenuScanDocument": "مسح إلى مستند جديد…",
+  "editorMenuInsertDocument": "إدراج مستند…",
   "editorMenuInsertScan": "إدراج مسح ضوئي…",
   "editorScanFailed": "تعذّر مسح المستند.",
   "editorInsertedScan": "تمت إضافة الصفحات الممسوحة ضوئيًا.",

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Drucken…",
   "editorMenuSaveAs": "Speichern unter…",
   "editorMenuScanDocument": "In neues Dokument scannen…",
+  "editorMenuInsertDocument": "Dokument einfügen…",
   "editorMenuInsertScan": "Scan einfügen…",
   "editorScanFailed": "Dokument konnte nicht gescannt werden.",
   "editorInsertedScan": "Gescannte Seiten eingefügt.",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -603,6 +603,8 @@
   "@editorMenuScanDocument": {
     "description": "App menu item (mobile/tablet) to scan pages with the device camera into a new document."
   },
+  "editorMenuInsertDocument": "Insert document…",
+  "@editorMenuInsertDocument": {"description": "Menu action to pick a PDF and insert its pages after the current page in the open document."},
   "editorMenuInsertScan": "Insert scan…",
   "@editorMenuInsertScan": {
     "description": "App menu item (mobile/tablet) to scan pages with the device camera and insert them into the open document."

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Imprimir…",
   "editorMenuSaveAs": "Guardar como…",
   "editorMenuScanDocument": "Escanear a un nuevo documento…",
+  "editorMenuInsertDocument": "Insertar documento…",
   "editorMenuInsertScan": "Insertar escaneo…",
   "editorScanFailed": "No se pudo escanear el documento.",
   "editorInsertedScan": "Páginas escaneadas insertadas.",

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Imprimer…",
   "editorMenuSaveAs": "Enregistrer sous…",
   "editorMenuScanDocument": "Numériser vers un nouveau document…",
+  "editorMenuInsertDocument": "Insérer un document…",
   "editorMenuInsertScan": "Insérer une numérisation…",
   "editorScanFailed": "Impossible de numériser le document.",
   "editorInsertedScan": "Pages numérisées insérées.",

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "प्रिंट करें…",
   "editorMenuSaveAs": "इस रूप में सहेजें…",
   "editorMenuScanDocument": "नए दस्तावेज़ में स्कैन करें…",
+  "editorMenuInsertDocument": "दस्तावेज़ डालें…",
   "editorMenuInsertScan": "स्कैन डालें…",
   "editorScanFailed": "दस्तावेज़ स्कैन नहीं किया जा सका।",
   "editorInsertedScan": "स्कैन किए गए पृष्ठ जोड़े गए।",

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Cetak…",
   "editorMenuSaveAs": "Simpan sebagai…",
   "editorMenuScanDocument": "Pindai ke dokumen baru…",
+  "editorMenuInsertDocument": "Sisipkan dokumen…",
   "editorMenuInsertScan": "Sisipkan pindaian…",
   "editorScanFailed": "Tidak dapat memindai dokumen.",
   "editorInsertedScan": "Halaman pindaian disisipkan.",

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Stampa…",
   "editorMenuSaveAs": "Salva con nome…",
   "editorMenuScanDocument": "Scansiona in un nuovo documento…",
+  "editorMenuInsertDocument": "Inserisci documento…",
   "editorMenuInsertScan": "Inserisci scansione…",
   "editorScanFailed": "Impossibile scansionare il documento.",
   "editorInsertedScan": "Pagine scansionate inserite.",

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "印刷…",
   "editorMenuSaveAs": "名前を付けて保存…",
   "editorMenuScanDocument": "新しいドキュメントにスキャン…",
+  "editorMenuInsertDocument": "ドキュメントを挿入…",
   "editorMenuInsertScan": "スキャンを挿入…",
   "editorScanFailed": "ドキュメントをスキャンできませんでした。",
   "editorInsertedScan": "スキャンしたページを挿入しました。",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "인쇄…",
   "editorMenuSaveAs": "다른 이름으로 저장…",
   "editorMenuScanDocument": "새 문서로 스캔…",
+  "editorMenuInsertDocument": "문서 삽입…",
   "editorMenuInsertScan": "스캔 삽입…",
   "editorScanFailed": "문서를 스캔할 수 없습니다.",
   "editorInsertedScan": "스캔한 페이지를 삽입했습니다.",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -811,6 +811,12 @@ abstract class AppLocalizations {
   /// **'Scan to new document…'**
   String get editorMenuScanDocument;
 
+  /// Menu action to pick a PDF and insert its pages after the current page in the open document.
+  ///
+  /// In en, this message translates to:
+  /// **'Insert document…'**
+  String get editorMenuInsertDocument;
+
   /// App menu item (mobile/tablet) to scan pages with the device camera and insert them into the open document.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -461,6 +461,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get editorMenuScanDocument => 'مسح إلى مستند جديد…';
 
   @override
+  String get editorMenuInsertDocument => 'إدراج مستند…';
+
+  @override
   String get editorMenuInsertScan => 'إدراج مسح ضوئي…';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -450,6 +450,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editorMenuScanDocument => 'In neues Dokument scannen…';
 
   @override
+  String get editorMenuInsertDocument => 'Dokument einfügen…';
+
+  @override
   String get editorMenuInsertScan => 'Scan einfügen…';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -446,6 +446,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editorMenuScanDocument => 'Scan to new document…';
 
   @override
+  String get editorMenuInsertDocument => 'Insert document…';
+
+  @override
   String get editorMenuInsertScan => 'Insert scan…';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -450,6 +450,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editorMenuScanDocument => 'Escanear a un nuevo documento…';
 
   @override
+  String get editorMenuInsertDocument => 'Insertar documento…';
+
+  @override
   String get editorMenuInsertScan => 'Insertar escaneo…';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -451,6 +451,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get editorMenuScanDocument => 'Numériser vers un nouveau document…';
 
   @override
+  String get editorMenuInsertDocument => 'Insérer un document…';
+
+  @override
   String get editorMenuInsertScan => 'Insérer une numérisation…';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -446,6 +446,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get editorMenuScanDocument => 'नए दस्तावेज़ में स्कैन करें…';
 
   @override
+  String get editorMenuInsertDocument => 'दस्तावेज़ डालें…';
+
+  @override
   String get editorMenuInsertScan => 'स्कैन डालें…';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -450,6 +450,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get editorMenuScanDocument => 'Pindai ke dokumen baru…';
 
   @override
+  String get editorMenuInsertDocument => 'Sisipkan dokumen…';
+
+  @override
   String get editorMenuInsertScan => 'Sisipkan pindaian…';
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -450,6 +450,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get editorMenuScanDocument => 'Scansiona in un nuovo documento…';
 
   @override
+  String get editorMenuInsertDocument => 'Inserisci documento…';
+
+  @override
   String get editorMenuInsertScan => 'Inserisci scansione…';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -439,6 +439,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get editorMenuScanDocument => '新しいドキュメントにスキャン…';
 
   @override
+  String get editorMenuInsertDocument => 'ドキュメントを挿入…';
+
+  @override
   String get editorMenuInsertScan => 'スキャンを挿入…';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -437,6 +437,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get editorMenuScanDocument => '새 문서로 스캔…';
 
   @override
+  String get editorMenuInsertDocument => '문서 삽입…';
+
+  @override
   String get editorMenuInsertScan => '스캔 삽입…';
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -450,6 +450,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get editorMenuScanDocument => 'Scannen naar nieuw document…';
 
   @override
+  String get editorMenuInsertDocument => 'Document invoegen…';
+
+  @override
   String get editorMenuInsertScan => 'Scan invoegen…';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -461,6 +461,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get editorMenuScanDocument => 'Skanuj do nowego dokumentu…';
 
   @override
+  String get editorMenuInsertDocument => 'Wstaw dokument…';
+
+  @override
   String get editorMenuInsertScan => 'Wstaw skan…';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -449,6 +449,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get editorMenuScanDocument => 'Digitalizar para novo documento…';
 
   @override
+  String get editorMenuInsertDocument => 'Inserir documento…';
+
+  @override
   String get editorMenuInsertScan => 'Inserir digitalização…';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -451,6 +451,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get editorMenuScanDocument => 'Сканировать в новый документ…';
 
   @override
+  String get editorMenuInsertDocument => 'Вставить документ…';
+
+  @override
   String get editorMenuInsertScan => 'Вставить скан…';
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -444,6 +444,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get editorMenuScanDocument => 'สแกนเป็นเอกสารใหม่…';
 
   @override
+  String get editorMenuInsertDocument => 'แทรกเอกสาร…';
+
+  @override
   String get editorMenuInsertScan => 'แทรกสแกน…';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -447,6 +447,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get editorMenuScanDocument => 'Yeni belgeye tara…';
 
   @override
+  String get editorMenuInsertDocument => 'Belge ekle…';
+
+  @override
   String get editorMenuInsertScan => 'Tarama ekle…';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -450,6 +450,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get editorMenuScanDocument => 'Сканувати в новий документ…';
 
   @override
+  String get editorMenuInsertDocument => 'Вставити документ…';
+
+  @override
   String get editorMenuInsertScan => 'Вставити скан…';
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -444,6 +444,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get editorMenuScanDocument => 'Quét thành tài liệu mới…';
 
   @override
+  String get editorMenuInsertDocument => 'Chèn tài liệu…';
+
+  @override
   String get editorMenuInsertScan => 'Chèn bản quét…';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -436,6 +436,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get editorMenuScanDocument => '扫描为新文档…';
 
   @override
+  String get editorMenuInsertDocument => '插入文档…';
+
+  @override
   String get editorMenuInsertScan => '插入扫描件…';
 
   @override
@@ -1459,6 +1462,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get editorMenuScanDocument => '掃描為新文件…';
+
+  @override
+  String get editorMenuInsertDocument => '插入文件…';
 
   @override
   String get editorMenuInsertScan => '插入掃描件…';

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Afdrukken…",
   "editorMenuSaveAs": "Opslaan als…",
   "editorMenuScanDocument": "Scannen naar nieuw document…",
+  "editorMenuInsertDocument": "Document invoegen…",
   "editorMenuInsertScan": "Scan invoegen…",
   "editorScanFailed": "Kan het document niet scannen.",
   "editorInsertedScan": "Gescande pagina's ingevoegd.",

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Drukuj…",
   "editorMenuSaveAs": "Zapisz jako…",
   "editorMenuScanDocument": "Skanuj do nowego dokumentu…",
+  "editorMenuInsertDocument": "Wstaw dokument…",
   "editorMenuInsertScan": "Wstaw skan…",
   "editorScanFailed": "Nie można zeskanować dokumentu.",
   "editorInsertedScan": "Wstawiono zeskanowane strony.",

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Imprimir…",
   "editorMenuSaveAs": "Salvar como…",
   "editorMenuScanDocument": "Digitalizar para novo documento…",
+  "editorMenuInsertDocument": "Inserir documento…",
   "editorMenuInsertScan": "Inserir digitalização…",
   "editorScanFailed": "Não foi possível digitalizar o documento.",
   "editorInsertedScan": "Páginas digitalizadas inseridas.",

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Печать…",
   "editorMenuSaveAs": "Сохранить как…",
   "editorMenuScanDocument": "Сканировать в новый документ…",
+  "editorMenuInsertDocument": "Вставить документ…",
   "editorMenuInsertScan": "Вставить скан…",
   "editorScanFailed": "Не удалось отсканировать документ.",
   "editorInsertedScan": "Отсканированные страницы вставлены.",

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "พิมพ์…",
   "editorMenuSaveAs": "บันทึกเป็น…",
   "editorMenuScanDocument": "สแกนเป็นเอกสารใหม่…",
+  "editorMenuInsertDocument": "แทรกเอกสาร…",
   "editorMenuInsertScan": "แทรกสแกน…",
   "editorScanFailed": "ไม่สามารถสแกนเอกสารได้",
   "editorInsertedScan": "แทรกหน้าที่สแกนแล้ว",

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Yazdır…",
   "editorMenuSaveAs": "Farklı kaydet…",
   "editorMenuScanDocument": "Yeni belgeye tara…",
+  "editorMenuInsertDocument": "Belge ekle…",
   "editorMenuInsertScan": "Tarama ekle…",
   "editorScanFailed": "Belge taranamadı.",
   "editorInsertedScan": "Taranan sayfalar eklendi.",

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "Друк…",
   "editorMenuSaveAs": "Зберегти як…",
   "editorMenuScanDocument": "Сканувати в новий документ…",
+  "editorMenuInsertDocument": "Вставити документ…",
   "editorMenuInsertScan": "Вставити скан…",
   "editorScanFailed": "Не вдалося відсканувати документ.",
   "editorInsertedScan": "Відскановані сторінки вставлено.",

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "In…",
   "editorMenuSaveAs": "Lưu thành…",
   "editorMenuScanDocument": "Quét thành tài liệu mới…",
+  "editorMenuInsertDocument": "Chèn tài liệu…",
   "editorMenuInsertScan": "Chèn bản quét…",
   "editorScanFailed": "Không thể quét tài liệu.",
   "editorInsertedScan": "Đã chèn các trang đã quét.",

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "打印…",
   "editorMenuSaveAs": "另存为…",
   "editorMenuScanDocument": "扫描为新文档…",
+  "editorMenuInsertDocument": "插入文档…",
   "editorMenuInsertScan": "插入扫描件…",
   "editorScanFailed": "无法扫描文档。",
   "editorInsertedScan": "已插入扫描的页面。",

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -113,6 +113,7 @@
   "editorMenuPrint": "列印…",
   "editorMenuSaveAs": "另存新檔…",
   "editorMenuScanDocument": "掃描為新文件…",
+  "editorMenuInsertDocument": "插入文件…",
   "editorMenuInsertScan": "插入掃描件…",
   "editorScanFailed": "無法掃描文件。",
   "editorInsertedScan": "已插入掃描的頁面。",

--- a/app/test/insert_document_test.dart
+++ b/app/test/insert_document_test.dart
@@ -1,0 +1,175 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart'
+    as fs;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/unsaved_changes.dart';
+
+import 'test_finders.dart';
+
+class _Picker extends fs.FileSelectorPlatform {
+  fs.XFile? file;
+  List<fs.XTypeGroup>? groups;
+
+  @override
+  Future<fs.XFile?> openFile(
+      {List<fs.XTypeGroup>? acceptedTypeGroups,
+      String? initialDirectory,
+      String? confirmButtonText}) async {
+    groups = acceptedTypeGroups;
+    return file;
+  }
+}
+
+void main() {
+  late PdfEditingPreferences prefs;
+  late _Picker picker;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+    picker = _Picker();
+    final old = fs.FileSelectorPlatform.instance;
+    fs.FileSelectorPlatform.instance = picker;
+    addTearDown(() {
+      fs.FileSelectorPlatform.instance = old;
+      prefs.dispose();
+    });
+  });
+
+  Future<PdfEditingController> open(WidgetTester tester,
+      {InMemoryUnsavedChangesStore? store}) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(
+      prefs: prefs,
+      initialDocument: (title: 'base.pdf', bytes: buildMultiPagePdf(2)),
+      unsavedChangesStore: store,
+    )));
+    await tester.pumpAndSettle();
+    return tester.widget<PdfViewer>(find.byType(PdfViewer).first).editing!;
+  }
+
+  Future<void> insert(WidgetTester tester) async {
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await tester.pumpAndSettle();
+    final item = find.byKey(const ValueKey('menu-insert-document'));
+    await tester.ensureVisible(item);
+    await tester.tap(item);
+    await tester.pumpAndSettle();
+  }
+
+  Finder getDirtyDot() => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.byWidgetPredicate(
+            (w) => w is Icon && w.icon == Icons.circle && w.size == 8),
+      );
+
+  testWidgets(
+      'Insert document uses bytes on every native platform and is one undo step',
+      (tester) async {
+    final session = await open(tester);
+    final before = session.bytes;
+    picker.file = fs.XFile.fromData(buildMultiPagePdf(3),
+        name: 'inserted.pdf', mimeType: 'application/pdf');
+    await insert(tester);
+
+    expect(session.document.pageCount, 5);
+    expect(session.canUndo, isTrue);
+    expect(getDirtyDot(), findsOneWidget);
+    expect(findMiddleEllipsisText('base.pdf'), findsWidgets);
+    expect(findMiddleEllipsisText('inserted.pdf'), findsNothing);
+    final reopened = PdfDocument.open(session.bytes);
+    expect([
+      for (var i = 0; i < 5; i++)
+        String.fromCharCodes(reopened.page(i).contentBytes())
+    ], [
+      for (final n in [1, 1, 2, 3, 2]) contains('(Page $n)')
+    ]);
+    final filter = picker.groups!.single;
+    expect(filter.extensions, contains('pdf'));
+    expect(filter.mimeTypes, contains('application/pdf'));
+    expect(filter.uniformTypeIdentifiers, contains('com.adobe.pdf'));
+
+    session.undo();
+    await tester.pumpAndSettle();
+    expect(session.bytes, before);
+    expect(session.canUndo, isFalse);
+    expect(getDirtyDot(), findsNothing);
+    session.redo();
+    await tester.pumpAndSettle();
+    expect(session.document.pageCount, 5);
+    expect(getDirtyDot(), findsOneWidget);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpWidget(const SizedBox());
+  }, variant: TargetPlatformVariant.all());
+
+  testWidgets('cancelled and invalid picks leave the current document intact',
+      (tester) async {
+    final session = await open(tester);
+    final before = session.bytes;
+    await insert(tester); // picker returns null
+    expect(session.bytes, before);
+    expect(session.canUndo, isFalse);
+    picker.file = fs.XFile.fromData(Uint8List.fromList('not a PDF'.codeUnits),
+        name: 'bad.pdf');
+    await insert(tester);
+    expect(session.bytes, before);
+    expect(session.canUndo, isFalse);
+    expect(find.textContaining("Couldn't insert that file."), findsOneWidget);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets(
+      'merged pages and the original tab identity survive session recovery',
+      (tester) async {
+    final store = InMemoryUnsavedChangesStore();
+    final session = await open(tester, store: store);
+    picker.file = fs.XFile.fromData(buildMultiPagePdf(3), name: 'inserted.pdf');
+    await insert(tester);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    final merged = session.bytes;
+    final records = await store.list();
+    expect(records, hasLength(1));
+    expect(records.single.title, 'base.pdf');
+    expect(records.single.length, merged.length);
+    expect(PdfDocument.open((await store.read(records.single))!).pageCount, 5);
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(prefs: prefs, unsavedChangesStore: store)));
+    await tester.pumpAndSettle();
+    final restored =
+        tester.widget<PdfViewer>(find.byType(PdfViewer).first).editing!;
+    expect(restored.document.pageCount, 5);
+    expect(restored.bytes, merged);
+    expect(findMiddleEllipsisText('base.pdf'), findsWidgets);
+    expect(getDirtyDot(), findsOneWidget);
+    await tester.pump(const Duration(seconds: 6));
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('read-only mode hides Insert document', (tester) async {
+    await open(tester);
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await tester.pumpAndSettle();
+    final mode = find.text('Switch to read-only');
+    await tester.ensureVisible(mode);
+    await tester.tap(mode);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('menu-insert-document')), findsNothing);
+    await tester.pumpWidget(const SizedBox());
+  });
+}

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add `PdfMerger.merge` for bytes-only merging with per-input passwords.
+- Preserve imported AcroForm fields, default font resources, named destinations,
+  and outline hierarchies; rename collisions and remap internal page targets.
+
 ## 4.2.0
 
 - Add `PdfAnnotation.appearanceRotation`, the rotation an annotation's normal

--- a/packages/pdf_document/README.md
+++ b/packages/pdf_document/README.md
@@ -57,6 +57,36 @@ editor.addFreeText(0, const PdfRect(72, 600, 280, 660), 'Reviewed.');
 final saved = editor.save(); // incremental update
 ```
 
+## Merge PDFs
+
+```dart
+import 'package:pdf_document/pdf_document.dart';
+
+final mergedBytes = PdfMerger.merge([coverBytes, reportBytes, appendixBytes]);
+final merged = PdfDocument.open(mergedBytes);
+print('${merged.pageCount} pages');
+```
+
+For protected inputs, pass a matching `passwords: ['', 'report-password', '']`
+list. The first input supplies the output's encryption, metadata, and viewing
+settings, including `/PageMode`. Imported streams are decrypted and re-encrypted
+with the first input's settings on save. An unprotected first input produces
+unprotected output; a protected first input keeps its password.
+
+Forms remain fillable. Colliding root field names gain `_2`, `_3`, … suffixes
+(for example, `client.name` becomes `client_2.name`); form font resources and
+default appearances are remapped together. Imported outlines retain their
+hierarchy, and named links resolve to their source's pages even when another
+input uses the same destination name. Colliding destination names are suffixed
+in the merged name tree.
+
+To insert into an existing edit session, use
+`editor.appendPagesFrom(source, at: pageIndex)` or Flutter's
+`editing.insertPagesFromBytes(bytes, at: pageIndex)`. A subset import keeps only
+widgets on the selected pages; destinations on omitted pages become inactive.
+Document-level attachments, XFA, and JavaScript from later inputs are not
+merged, and their signatures do not certify the output.
+
 ## The suite
 
 | Package | Layer |

--- a/packages/pdf_document/lib/src/document_merge.dart
+++ b/packages/pdf_document/lib/src/document_merge.dart
@@ -1,0 +1,277 @@
+part of 'editor.dart';
+
+/// Combines complete PDFs without a file-system or Flutter dependency.
+class PdfMerger {
+  PdfMerger._();
+
+  /// Concatenates [pdfs] in order. At least one input is required.
+  ///
+  /// ```dart
+  /// final merged = PdfMerger.merge([coverBytes, reportBytes, appendixBytes]);
+  /// final document = PdfDocument.open(merged);
+  /// print(document.pageCount);
+  /// ```
+  ///
+  /// [passwords], when supplied, must contain one password per input (use an
+  /// empty string for unprotected inputs). Wrong passwords throw
+  /// [CosPasswordException]. The first PDF remains the base: its encryption,
+  /// metadata, catalog viewing settings (including /PageMode), and original
+  /// bytes are retained. Later inputs are decrypted during import and saved
+  /// under the base's encryption. This never removes the base's password.
+  ///
+  /// Pages, their resources and annotations, AcroForm fields, named
+  /// destinations, and outlines are imported. Colliding root field names and
+  /// named destinations gain `_2`, `_3`, ... suffixes. Internal links resolve
+  /// in their source namespace before remapping, so duplicate destination
+  /// names do not redirect links into a different input. Other catalog data
+  /// from later inputs (such as attachments, XFA, and document JavaScript)
+  /// is not merged. Source signatures do not certify the merged document.
+  static Uint8List merge(List<Uint8List> pdfs, {List<String>? passwords}) {
+    if (pdfs.isEmpty) {
+      throw ArgumentError.value(pdfs, 'pdfs', 'provide at least one PDF');
+    }
+    if (passwords != null && passwords.length != pdfs.length) {
+      throw ArgumentError.value(
+          passwords, 'passwords', 'provide one password per PDF');
+    }
+    final documents = [
+      for (var i = 0; i < pdfs.length; i++)
+        PdfDocument.open(pdfs[i], password: passwords?[i] ?? ''),
+    ];
+    final editor = PdfEditor(documents.first);
+    for (final source in documents.skip(1)) {
+      editor.appendPagesFrom(source);
+    }
+    return Uint8List.fromList(editor.hasChanges ? editor.save() : pdfs.first);
+  }
+}
+
+extension on PdfEditor {
+  void _mergeImportedDocumentData(_PageImporter importer) {
+    _mergeFormFields(importer);
+    _mergeNamedDestinations(importer);
+    final source = importer.source;
+    final outlines = source.cos.resolve(source.catalog['Outlines']);
+    if (outlines is CosDictionary && outlines.containsKey('First')) {
+      final root = _ensureOutlineRoot();
+      final imported =
+          _importOutlineChildren(importer, outlines, <CosDictionary>{});
+      _relinkOutlineChildren(root, [..._outlineChildren(root), ...imported]);
+      _recountOutline(root);
+    }
+  }
+
+  void _mergeFormFields(_PageImporter importer) {
+    if (importer._formRoots.isEmpty) return;
+    final cos = document.cos;
+    final source = importer.source.cos;
+    final sourceForm = source.resolve(importer.source.catalog['AcroForm']);
+    final previous = cos.resolve(document.catalog['AcroForm']);
+    // Reassign the catalog entry: /AcroForm and its /Fields or /DR may all
+    // have been indirect. Mutating a resolved array would not stage its owner.
+    final form = CosDictionary({
+      if (previous is CosDictionary) ...previous.entries,
+    });
+    if (sourceForm is CosDictionary &&
+        source.resolve(sourceForm['NeedAppearances']) ==
+            const CosBoolean(true)) {
+      form['NeedAppearances'] = const CosBoolean(true);
+    }
+    final fields = cos.resolve(form['Fields']);
+    final roots = <CosObject>[if (fields is CosArray) ...fields.items];
+    final used = <String>{};
+    for (final root in roots) {
+      final dict = cos.resolve(root);
+      final name = dict is CosDictionary ? cos.resolve(dict['T']) : null;
+      if (name is CosString) used.add(name.text);
+    }
+
+    final renames = <String, Map<String, String>>{};
+    final oldResources = cos.resolve(form['DR']);
+    final resources = CosDictionary({
+      if (oldResources is CosDictionary) ...oldResources.entries,
+    });
+    final sourceResources =
+        sourceForm is CosDictionary ? source.resolve(sourceForm['DR']) : null;
+    if (sourceResources is CosDictionary) {
+      for (final entry in sourceResources.entries.entries) {
+        final incoming = source.resolve(entry.value);
+        final existing = cos.resolve(resources[entry.key]);
+        if (incoming is! CosDictionary) continue;
+        final category = CosDictionary({
+          if (existing is CosDictionary) ...existing.entries,
+        });
+        final names = category.entries.keys.toSet();
+        final mapping = renames[entry.key] = {};
+        for (final resource in incoming.entries.entries) {
+          final name = _uniqueImportName(resource.key, names);
+          mapping[resource.key] = name;
+          category[name] = importer.copyValue(resource.value);
+        }
+        resources[entry.key] = category;
+      }
+    }
+    if (resources.entries.isNotEmpty) form['DR'] = resources;
+
+    for (final root in importer._formRoots) {
+      final original = source.referenceTo(root) ?? root;
+      final copied = importer.copyValue(original);
+      final dict = importer._dictionaries[root]!;
+      final name = source.resolve(root['T']);
+      dict['T'] = CosString.fromText(
+          _uniqueImportName(name is CosString ? name.text : 'Imported', used));
+      dict.entries.remove('Parent');
+      // Form-level defaults belonged to the source. Materialize them on its
+      // roots so the destination's /DA and /Q cannot change imported fields.
+      if (sourceForm is CosDictionary) {
+        for (final key in ['DA', 'Q']) {
+          if (!dict.containsKey(key) && sourceForm.containsKey(key)) {
+            dict[key] = importer.copyValue(sourceForm[key]!);
+          }
+        }
+      }
+      roots.add(copied is CosReference ? copied : _updater.addObject(dict));
+    }
+    for (final node in importer._formNodes) {
+      final dict = importer._dictionaries[node];
+      if (dict == null) continue;
+      final da = cos.resolve(dict['DA']);
+      if (da is CosString) dict['DA'] = _remapDefaultAppearance(da, renames);
+    }
+    final calculationOrder =
+        sourceForm is CosDictionary ? source.resolve(sourceForm['CO']) : null;
+    if (calculationOrder is CosArray) {
+      final previousOrder = cos.resolve(form['CO']);
+      form['CO'] = CosArray([
+        if (previousOrder is CosArray) ...previousOrder.items,
+        for (final field in calculationOrder.items)
+          if (importer._formNodes.contains(source.resolve(field)))
+            importer.copyValue(field),
+      ]);
+    }
+    form['Fields'] = CosArray(roots);
+    document.catalog['AcroForm'] = form;
+    _updater.markChanged(document.catalog);
+  }
+
+  void _mergeNamedDestinations(_PageImporter importer) {
+    final incoming = _namedDestinations(importer.source);
+    if (incoming.isEmpty) return;
+    final existing = _namedDestinations(document);
+    final used = existing.keys.toSet();
+    for (final entry in incoming.entries) {
+      final dest = importer.copyDestination(entry.value);
+      if (dest is! CosArray || dest[0] is CosNull) continue;
+      existing[_uniqueImportName(entry.key, used)] = dest;
+    }
+    final keys = existing.keys.toList()
+      ..sort((a, b) {
+        final aa = CosString.fromText(a).bytes;
+        final bb = CosString.fromText(b).bytes;
+        for (var i = 0; i < math.min(aa.length, bb.length); i++) {
+          if (aa[i] != bb[i]) return aa[i].compareTo(bb[i]);
+        }
+        return aa.length.compareTo(bb.length);
+      });
+    final oldNames = document.cos.resolve(document.catalog['Names']);
+    document.catalog['Names'] = CosDictionary({
+      if (oldNames is CosDictionary) ...oldNames.entries,
+      'Dests': CosDictionary({
+        'Names': CosArray([
+          for (final key in keys) ...[CosString.fromText(key), existing[key]!],
+        ]),
+      }),
+    });
+    _updater.markChanged(document.catalog);
+  }
+
+  List<CosReference> _importOutlineChildren(
+      _PageImporter importer, CosDictionary parent, Set<CosDictionary> seen) {
+    final cos = importer.source.cos;
+    final out = <CosReference>[];
+    var node = cos.resolve(parent['First']);
+    while (node is CosDictionary && seen.add(node)) {
+      final dict = CosDictionary();
+      for (final key in ['Title', 'C', 'F', 'A', 'Dest']) {
+        final value = node[key];
+        if (value != null) {
+          dict[key] = key == 'Dest'
+              ? importer.copyDestination(value)
+              : importer.copyValue(value);
+        }
+      }
+      final ref = _updater.addObject(dict);
+      final count = cos.resolve(node['Count']);
+      _outlineOpenOverride[ref.objectNumber] =
+          count is! CosInteger || count.value >= 0;
+      final children = _importOutlineChildren(importer, node, seen);
+      _relinkOutlineChildren(ref, children);
+      out.add(ref);
+      node = cos.resolve(node['Next']);
+    }
+    return out;
+  }
+}
+
+String _uniqueImportName(String requested, Set<String> used) {
+  var name = requested;
+  for (var suffix = 2; !used.add(name); suffix++) {
+    name = '${requested}_$suffix';
+  }
+  return name;
+}
+
+Map<String, CosObject> _namedDestinations(PdfDocument document) {
+  final cos = document.cos;
+  final legacy = cos.resolve(document.catalog['Dests']);
+  final result = <String, CosObject>{
+    if (legacy is CosDictionary) ...legacy.entries,
+  };
+  final seen = <CosDictionary>{};
+  void walk(CosObject? value) {
+    final node = cos.resolve(value);
+    if (node is! CosDictionary || !seen.add(node)) return;
+    final names = cos.resolve(node['Names']);
+    if (names is CosArray) {
+      for (var i = 0; i + 1 < names.length; i += 2) {
+        final name = cos.resolve(names[i]);
+        if (name is CosString) {
+          result.putIfAbsent(name.text, () => names[i + 1]);
+        }
+      }
+    }
+    final kids = cos.resolve(node['Kids']);
+    if (kids is CosArray) {
+      for (final kid in kids.items) {
+        walk(kid);
+      }
+    }
+  }
+
+  final names = cos.resolve(document.catalog['Names']);
+  if (names is CosDictionary) walk(names['Dests']);
+  return result;
+}
+
+CosString _remapDefaultAppearance(
+    CosString da, Map<String, Map<String, String>> renames) {
+  final operations = ContentStreamParser.parse(da.bytes);
+  for (final op in operations) {
+    final category = switch (op.operator) {
+      'Tf' => 'Font',
+      'gs' => 'ExtGState',
+      'CS' || 'cs' => 'ColorSpace',
+      'SCN' || 'scn' => 'Pattern',
+      _ => null,
+    };
+    final mapping = renames[category];
+    if (mapping == null) continue;
+    for (var i = 0; i < op.operands.length; i++) {
+      final value = op.operands[i];
+      if (value is CosName && mapping.containsKey(value.value)) {
+        op.operands[i] = CosName(mapping[value.value]!);
+      }
+    }
+  }
+  return CosString(ContentStreamSerializer.serialize(operations));
+}

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -52,6 +52,7 @@ part 'form_styling.dart';
 part 'ocr_editor.dart';
 part 'pades_editor.dart';
 part 'page_editor.dart';
+part 'document_merge.dart';
 part 'signature_editor.dart';
 part 'struct_tree_editor.dart';
 part 'vector_snapshot.dart';

--- a/packages/pdf_document/lib/src/page_editor.dart
+++ b/packages/pdf_document/lib/src/page_editor.dart
@@ -123,6 +123,15 @@ extension PdfPageOperations on PdfEditor {
   /// together keep working; destinations that point at source pages left
   /// behind become null (following them would drag the whole source
   /// document along).
+  ///
+  /// Imported form fields remain fillable; colliding root field names gain
+  /// `_2`, `_3`, ... suffixes. Named destinations and outlines are imported,
+  /// with internal links resolved against the source before remapping. The
+  /// destination keeps its encryption, metadata, and /PageMode. Source
+  /// encryption is removed from imported objects and the destination's
+  /// encryption (if any) is applied on save. Open either input with its
+  /// password before calling this method. See [PdfMerger.merge] for bytes in,
+  /// bytes out merging.
   void appendPagesFrom(PdfDocument source, {List<int>? indices, int? at}) {
     if (identical(source.cos, document.cos)) {
       throw ArgumentError(
@@ -138,9 +147,11 @@ extension PdfPageOperations on PdfEditor {
     final leaves = _materializedLeaves();
     final insertAt = at ?? leaves.length;
     RangeError.checkValueInInterval(insertAt, 0, leaves.length, 'at');
-    final importer = _PageImporter(source, _updater.addObject);
+    final importer =
+        _PageImporter(source, _updater.addObject, documentData: true);
     final imported = importer.importPages(picks);
     _rebuildPageTree([...leaves]..insertAll(insertAt, imported));
+    _mergeImportedDocumentData(importer);
   }
 
   /// Collects the current leaves in order, copying any attributes a page
@@ -289,15 +300,21 @@ class _Leaf {
 /// a /Pages node, or to a page that is not part of the import set, copies
 /// as null instead of dragging the rest of the document along.
 class _PageImporter {
-  _PageImporter(this.source, this._add);
+  _PageImporter(this.source, this._add, {this.documentData = false});
 
   final PdfDocument source;
   final CosReference Function(CosObject) _add;
   final Map<CosReference, CosObject> _mapped = {};
+  final bool documentData;
+  final Map<CosDictionary, CosDictionary> _dictionaries = Map.identity();
+  final Map<int, CosReference> _pageRefs = {};
+  final Set<CosDictionary> _formNodes = Set.identity();
+  final List<CosDictionary> _formRoots = [];
 
   List<_Leaf> importPages(List<int> indices) {
     final cos = source.cos;
     final pages = [for (final i in indices) source.page(i)];
+    if (documentData) _prepareForms(pages);
 
     // pre-register every imported page so references between them - link
     // destinations, annotation /P entries - remap instead of dropping
@@ -308,6 +325,8 @@ class _PageImporter {
       leaves.add(_Leaf(ref, dest, isNew: true));
       final srcRef = cos.referenceTo(page.dict);
       if (srcRef != null) _mapped[srcRef] = ref;
+      _dictionaries[page.dict] = dest;
+      _pageRefs[indices[leaves.length - 1]] = ref;
     }
 
     for (var i = 0; i < pages.length; i++) {
@@ -347,8 +366,10 @@ class _PageImporter {
       case CosStream stream: // direct streams are illegal, but tolerate
         return _copyStream(null, stream);
       case CosDictionary dict:
-        final out = CosDictionary();
-        dict.entries.forEach((key, item) => out[key] = copyValue(item));
+        final existing = _dictionaries[dict];
+        if (existing != null) return existing;
+        final out = _dictionaries[dict] = CosDictionary();
+        _copyDictionary(dict, out);
         return out;
       case CosArray array:
         return CosArray([for (final item in array.items) copyValue(item)]);
@@ -369,10 +390,10 @@ class _PageImporter {
       case CosStream stream:
         return _copyStream(ref, stream);
       case CosDictionary dict:
-        final out = CosDictionary();
+        final out = _dictionaries[dict] = CosDictionary();
         final outRef = _add(out);
         _mapped[ref] = outRef;
-        dict.entries.forEach((key, item) => out[key] = copyValue(item));
+        _copyDictionary(dict, out);
         return outRef;
       case CosNull():
         return CosNull.instance;
@@ -380,6 +401,90 @@ class _PageImporter {
         // an indirectly referenced scalar - inline it at the use site
         return copyValue(target);
     }
+  }
+
+  void _copyDictionary(CosDictionary dict, CosDictionary out) {
+    final cos = source.cos;
+    final action = cos.resolve(dict['S']);
+    for (final entry in dict.entries.entries) {
+      final key = entry.key;
+      final value = entry.value;
+      if (documentData &&
+          (key == 'Dest' ||
+              (key == 'D' && action is CosName && action.value == 'GoTo'))) {
+        out[key] = copyDestination(value);
+      } else if (documentData && key == 'Kids' && _formNodes.contains(dict)) {
+        final kids = cos.resolve(value);
+        if (kids is CosArray) {
+          out[key] = CosArray([
+            for (final kid in kids.items)
+              if (_formNodes.contains(cos.resolve(kid))) copyValue(kid),
+          ]);
+        }
+      } else {
+        out[key] = copyValue(value);
+      }
+    }
+  }
+
+  /// Keep only field-tree branches with widgets on selected pages. Walking
+  /// from the widgets also includes orphan fields missing from /Fields.
+  void _prepareForms(List<PdfPage> pages) {
+    final roots = <CosDictionary>{};
+    final cos = source.cos;
+    // A full-document merge also carries nonvisual fields (for example,
+    // hidden calculation values). A subset only carries on-page branches.
+    if (pages.map((p) => p.dict).toSet().length == source.pageCount) {
+      void include(CosObject? value) {
+        final node = cos.resolve(value);
+        if (node is! CosDictionary || !_formNodes.add(node)) return;
+        final kids = cos.resolve(node['Kids']);
+        if (kids is CosArray) {
+          for (final kid in kids.items) {
+            include(kid);
+          }
+        }
+      }
+
+      final form = cos.resolve(source.catalog['AcroForm']);
+      final fields = form is CosDictionary ? cos.resolve(form['Fields']) : null;
+      if (fields is CosArray) {
+        for (final field in fields.items) {
+          final root = cos.resolve(field);
+          if (root is CosDictionary && roots.add(root)) {
+            _formRoots.add(root);
+            include(root);
+          }
+        }
+      }
+    }
+    for (final page in pages) {
+      for (final widget in page.annotations.whereType<PdfWidgetAnnotation>()) {
+        var node = widget.dict;
+        final seen = <CosDictionary>{};
+        while (seen.add(node)) {
+          _formNodes.add(node);
+          final parent = source.cos.resolve(node['Parent']);
+          if (parent is! CosDictionary) {
+            if (roots.add(node)) _formRoots.add(node);
+            break;
+          }
+          node = parent;
+        }
+      }
+    }
+  }
+
+  /// Resolve names in the SOURCE namespace, so the destination's same-named
+  /// bookmark can never steal a link. Page-number destinations remap too.
+  CosObject copyDestination(CosObject value) {
+    final dest = PdfDestination.parse(source, value);
+    if (dest == null) return CosNull.instance;
+    return CosArray([
+      _pageRefs[dest.pageIndex] ?? CosNull.instance,
+      CosName(dest.fit),
+      for (final p in dest.params) p == null ? CosNull.instance : CosReal(p),
+    ]);
   }
 
   /// Copies a stream, registering its reference (when indirect) before
@@ -391,13 +496,43 @@ class _PageImporter {
   CosObject _copyStream(CosReference? ref, CosStream stream) {
     final bytes = _payloadOf(stream);
     final out = CosStream(CosDictionary(), bytes);
-    final outRef = ref != null ? _mapped[ref] = _add(out) : null;
+    final outRef = _add(out);
+    if (ref != null) _mapped[ref] = outRef;
     stream.dictionary.entries.forEach((key, item) {
       if (key == 'Length') return; // recomputed below
       out.dictionary[key] = copyValue(item);
     });
+    // /Crypt belongs to the source security handler. The payload is already
+    // decrypted; retaining /Identity would exempt it from the destination's
+    // encryption, and a named source crypt filter may not exist there at all.
+    final filter = source.cos.resolve(stream.dictionary['Filter']);
+    final filters =
+        filter is CosArray ? filter.items : [if (filter is CosName) filter];
+    final parms = source.cos.resolve(stream.dictionary['DecodeParms']);
+    final kept = <int>[
+      for (var i = 0; i < filters.length; i++)
+        if (source.cos.resolve(filters[i]) != const CosName('Crypt')) i,
+    ];
+    if (filters.any((f) => source.cos.resolve(f) == const CosName('Crypt'))) {
+      if (kept.isEmpty) {
+        out.dictionary.entries.remove('Filter');
+        out.dictionary.entries.remove('DecodeParms');
+      } else {
+        out.dictionary['Filter'] = CosArray([
+          for (final i in kept) copyValue(filters[i]),
+        ]);
+        if (parms is CosArray) {
+          out.dictionary['DecodeParms'] = CosArray([
+            for (final i in kept)
+              i < parms.length ? copyValue(parms[i]) : CosNull.instance,
+          ]);
+        } else {
+          out.dictionary.entries.remove('DecodeParms');
+        }
+      }
+    }
     out.dictionary['Length'] = CosInteger(bytes.length);
-    return outRef ?? out;
+    return outRef;
   }
 
   Uint8List _payloadOf(CosStream stream) {

--- a/packages/pdf_document/test/merge_test.dart
+++ b/packages/pdf_document/test/merge_test.dart
@@ -1,0 +1,392 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+// Independent, from-scratch fixture: indirect field/name-tree arrays, a shared
+// multi-widget field, inherited form defaults, and a named link/bookmark.
+Uint8List richPdf(String label,
+    {String font = 'Helvetica', bool legacy = false}) {
+  final b = CosDocumentBuilder();
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = b.add(pages);
+  final leaves = [
+    for (var i = 0; i < 2; i++)
+      CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(612),
+          const CosInteger(792)
+        ]),
+        'Resources': CosDictionary(),
+        'Contents': b.add(CosStream(CosDictionary(),
+            Uint8List.fromList('BT ($label ${i + 1}) Tj ET'.codeUnits))),
+      })
+  ];
+  final refs = [for (final leaf in leaves) b.add(leaf)];
+  pages['Kids'] = CosArray(refs);
+  pages['Count'] = const CosInteger(2);
+  final root = CosDictionary({'T': CosString.fromText('client')});
+  final rootRef = b.add(root);
+  final field = CosDictionary({
+    'Parent': rootRef,
+    'T': CosString.fromText('name'),
+    'FT': const CosName('Tx'),
+    'V': CosString.fromText(label),
+  });
+  final fieldRef = b.add(field);
+  root['Kids'] = b.add(CosArray([fieldRef]));
+  final widgets = [
+    for (var i = 0; i < 2; i++)
+      b.add(CosDictionary({
+        'Type': const CosName('Annot'),
+        'Subtype': const CosName('Widget'),
+        'Parent': fieldRef,
+        'P': refs[i],
+        'Rect': CosArray([
+          const CosInteger(20),
+          const CosInteger(20),
+          const CosInteger(180),
+          const CosInteger(50)
+        ]),
+      }))
+  ];
+  field['Kids'] = b.add(CosArray(widgets));
+  final link = b.add(CosDictionary({
+    'Type': const CosName('Annot'),
+    'Subtype': const CosName('Link'),
+    'Rect': CosArray([
+      const CosInteger(20),
+      const CosInteger(60),
+      const CosInteger(180),
+      const CosInteger(80)
+    ]),
+    'A': b.add(CosDictionary(
+        {'S': const CosName('GoTo'), 'D': CosString.fromText('chapter')})),
+  }));
+  leaves[0]['Annots'] = b.add(CosArray([widgets[0], link]));
+  leaves[1]['Annots'] = b.add(CosArray([widgets[1]]));
+  final destination = CosArray([
+    refs[1],
+    const CosName('XYZ'),
+    const CosInteger(10),
+    const CosInteger(700),
+    CosNull.instance
+  ]);
+  final outlines = CosDictionary({'Type': const CosName('Outlines')});
+  final outlinesRef = b.add(outlines);
+  final heading = CosDictionary({
+    'Title': CosString.fromText(label),
+    'Parent': outlinesRef,
+    'Dest': const CosName('chapter'),
+    'Count': const CosInteger(-1),
+    'F': const CosInteger(2),
+  });
+  final headingRef = b.add(heading);
+  final child = b.add(CosDictionary({
+    'Title': CosString.fromText('Start'), 'Parent': headingRef,
+    // Integer page destinations must be remapped, not copied verbatim.
+    'A': CosDictionary({
+      'S': const CosName('GoTo'),
+      'D': CosArray([const CosInteger(0), const CosName('Fit')])
+    }),
+  }));
+  heading['First'] = child;
+  heading['Last'] = child;
+  outlines['First'] = headingRef;
+  outlines['Last'] = headingRef;
+  outlines['Count'] = const CosInteger(1);
+  final catalog = b.add(CosDictionary({
+    'Type': const CosName('Catalog'),
+    'Pages': pagesRef,
+    'PageMode': CosName(legacy ? 'UseThumbs' : 'UseOutlines'),
+    'Outlines': outlinesRef,
+    if (legacy)
+      'Dests': CosDictionary({'chapter': destination})
+    else
+      'Names': b.add(CosDictionary({
+        'Dests': b.add(CosDictionary({
+          'Kids': CosArray([
+            b.add(CosDictionary({
+              'Names': b.add(CosArray([
+                CosString.fromText('chapter'),
+                CosDictionary({'D': destination}),
+              ]))
+            })),
+          ])
+        })),
+      })),
+    'AcroForm': b.add(CosDictionary({
+      'Fields': b.add(CosArray([rootRef])),
+      'DA': CosString.fromText('/F1 11 Tf 0 g'),
+      'Q': const CosInteger(2),
+      'DR': b.add(CosDictionary({
+        'Font': CosDictionary({
+          'F1': b.add(CosDictionary({
+            'Type': const CosName('Font'),
+            'Subtype': const CosName('Type1'),
+            'BaseFont': CosName(font)
+          })),
+        })
+      })),
+    })),
+  }));
+  return b.build(
+      root: catalog,
+      info: b.add(CosDictionary({'Title': CosString.fromText(label)})));
+}
+
+void main() {
+  test('bytes-only merge preserves order and leaves input buffers unchanged',
+      () {
+    final first = buildMultiPagePdf(2);
+    final original = Uint8List.fromList(first);
+    final result =
+        PdfMerger.merge([first, buildMultiPagePdf(3), buildMultiPagePdf(1)]);
+    final doc = PdfDocument.open(result);
+    expect(doc.pageCount, 6);
+    expect([
+      for (var i = 0; i < 6; i++)
+        String.fromCharCodes(doc.page(i).contentBytes())
+    ], [
+      for (final n in [1, 2, 1, 2, 3, 1]) contains('(Page $n)')
+    ]);
+    expect(first, original);
+    expect(result.sublist(0, first.length), original);
+    final single = PdfMerger.merge([first]);
+    expect(single, first);
+    expect(identical(single, first), isFalse);
+  });
+
+  test('invalid input and password lists fail explicitly', () {
+    expect(() => PdfMerger.merge([]), throwsArgumentError);
+    expect(() => PdfMerger.merge([buildMultiPagePdf(1)], passwords: []),
+        throwsArgumentError);
+    expect(() => PdfMerger.merge([Uint8List(0)]),
+        throwsA(isA<CosParseException>()));
+    expect(
+        () => PdfMerger.merge(
+            [buildMultiPagePdf(1), buildEncryptedPdf(userPassword: 'secret')]),
+        throwsA(isA<CosPasswordException>()));
+  });
+
+  for (final revision in [2, 3, 4, 6]) {
+    for (final encryptedBase in [false, true]) {
+      test(
+          'R$revision source imports into ${encryptedBase ? 'encrypted' : 'plain'} base',
+          () {
+        final base = encryptedBase
+            ? buildEncryptedPdf(revision: revision, userPassword: 'base')
+            : buildMultiPagePdf(1);
+        final incoming =
+            buildEncryptedPdf(revision: revision, userPassword: 'source');
+        final result = PdfMerger.merge([base, incoming, buildMultiPagePdf(1)],
+            passwords: [encryptedBase ? 'base' : '', 'source', '']);
+        final doc =
+            PdfDocument.open(result, password: encryptedBase ? 'base' : '');
+        expect(doc.cos.isEncrypted, encryptedBase);
+        expect(doc.pageCount, 3);
+        expect(String.fromCharCodes(doc.page(1).contentBytes()),
+            contains('Hello, world!'));
+        expect(String.fromCharCodes(doc.page(2).contentBytes()),
+            contains('Page 1'));
+        if (encryptedBase) {
+          expect(() => PdfDocument.open(result),
+              throwsA(isA<CosPasswordException>()));
+          expect(doc.info['Title'], 'Secret Title');
+        }
+      });
+    }
+  }
+
+  for (final cryptName in ['Identity', 'StdCF']) {
+    for (final compressed in [false, true]) {
+      test(
+          'source /Crypt $cryptName (${compressed ? 'Flate' : 'raw'}) is replaced by destination encryption',
+          () {
+        final source = PdfDocument.open(
+            buildEncryptedPdf(revision: 4, userPassword: 'source'),
+            password: 'source');
+        final update = CosIncrementalUpdater(source.cos);
+        final content =
+            Uint8List.fromList('BT (imported crypt stream) Tj ET'.codeUnits);
+        final payload = compressed
+            ? Uint8List.fromList(ZLibEncoder().encode(content))
+            : content;
+        final crypt = CosDictionary({'Name': CosName(cryptName)});
+        final stream = CosStream(
+            CosDictionary({
+              'Filter': compressed
+                  ? CosArray(
+                      [const CosName('Crypt'), const CosName('FlateDecode')])
+                  : const CosName('Crypt'),
+              'DecodeParms':
+                  compressed ? CosArray([crypt, CosNull.instance]) : crypt,
+            }),
+            payload);
+        source.page(0).dict['Contents'] = update.addObject(stream);
+        update.markChanged(source.page(0).dict);
+        final input = update.save();
+        for (final encryptedBase in [false, true]) {
+          final base = encryptedBase
+              ? buildEncryptedPdf(revision: 6, userPassword: 'base')
+              : buildMultiPagePdf(1);
+          final merged = PdfMerger.merge([base, input],
+              passwords: [encryptedBase ? 'base' : '', 'source']);
+          final result =
+              PdfDocument.open(merged, password: encryptedBase ? 'base' : '');
+          expect(result.page(1).contentBytes(), content);
+          final imported =
+              result.cos.resolve(result.page(1).dict['Contents']) as CosStream;
+          final filters = imported.dictionary['Filter'];
+          if (compressed) {
+            expect((filters as CosArray).items, [const CosName('FlateDecode')]);
+          } else {
+            expect(filters, isNull);
+          }
+          if (encryptedBase) expect(imported.rawBytes, isNot(payload));
+        }
+      });
+    }
+  }
+
+  test('form defaults come along when the destination has no AcroForm', () {
+    final source = PdfDocument.open(richPdf('source', font: 'Courier'));
+    final form = PdfAcroForm.of(source)!;
+    form.dict['NeedAppearances'] = const CosBoolean(true);
+    final update = CosIncrementalUpdater(source.cos)..markChanged(form.dict);
+    final doc = PdfDocument.open(
+        PdfMerger.merge([buildMultiPagePdf(1), update.save()]));
+    final imported = PdfAcroForm.of(doc)!;
+    expect(imported.needsAppearances, isTrue);
+    expect(imported.fields.single.name, 'client.name');
+    expect(imported.fields.single.widgetPageIndex(0), 1);
+    expect(imported.fields.single.widgetPageIndex(1), 2);
+  });
+
+  test('form strings and outlines are re-encrypted with the destination', () {
+    final merged = PdfMerger.merge([
+      buildEncryptedPdf(revision: 6, userPassword: 'base'),
+      richPdf('source'),
+    ], passwords: [
+      'base',
+      ''
+    ]);
+    final doc = PdfDocument.open(merged, password: 'base');
+    expect(PdfAcroForm.of(doc)!.fields.single.value, 'source');
+    expect(PdfOutline.of(doc).items.single.title, 'source');
+    expect(PdfDestination.parse(doc, const CosName('chapter'))!.pageIndex, 2);
+    expect(String.fromCharCodes(merged), isNot(contains('(source)')));
+  });
+
+  test('complete imports include hidden fields and their calculation order',
+      () {
+    final source = PdfDocument.open(richPdf('source'));
+    final form = PdfAcroForm.of(source)!;
+    final update = CosIncrementalUpdater(source.cos);
+    final hidden = update.addObject(CosDictionary({
+      'FT': const CosName('Tx'),
+      'T': CosString.fromText('hidden'),
+      'V': CosString.fromText('stored value'),
+    }));
+    final fields = source.cos.resolve(form.dict['Fields']) as CosArray;
+    form.dict['Fields'] = CosArray([...fields.items, hidden]);
+    form.dict['CO'] = CosArray([hidden]);
+    update.markChanged(form.dict);
+    final bytes = update.save();
+    final doc = PdfDocument.open(PdfMerger.merge([bytes, bytes]));
+    final merged = PdfAcroForm.of(doc)!;
+    expect(merged.fields.map((f) => f.name),
+        ['client.name', 'hidden', 'client_2.name', 'hidden_2']);
+    expect(merged.fieldNamed('hidden_2')!.value, 'stored value');
+    final order = doc.cos.resolve(merged.dict['CO']) as CosArray;
+    expect(order.length, 2);
+    expect(
+        doc.cos.resolve(order[1]), same(merged.fieldNamed('hidden_2')!.dict));
+  });
+
+  test('forms retain widgets, values and independent default resources', () {
+    final first = richPdf('base', legacy: true);
+    final source = richPdf('source', font: 'Courier');
+    final sourceBefore = Uint8List.fromList(source);
+    final merged = PdfMerger.merge([first, source, source]);
+    final doc = PdfDocument.open(merged);
+    final form = PdfAcroForm.of(doc)!;
+    expect(form.fields.map((f) => f.name),
+        ['client.name', 'client_2.name', 'client_3.name']);
+    for (var i = 0; i < 3; i++) {
+      final field = form.fields[i];
+      expect(field.widgets, hasLength(2));
+      expect([field.widgetPageIndex(0), field.widgetPageIndex(1)],
+          [i * 2, i * 2 + 1]);
+    }
+    final resources = form.defaultResources!;
+    final fonts = doc.cos.resolve(resources['Font']) as CosDictionary;
+    final courier = doc.cos.resolve(fonts['F1_2']) as CosDictionary;
+    expect(courier['BaseFont'], const CosName('Courier'));
+    final imported = form.fieldNamed('client_2.name')!;
+    final parent = doc.cos.resolve(imported.dict['Parent']) as CosDictionary;
+    expect((doc.cos.resolve(parent['DA']) as CosString).text,
+        contains('/F1_2 11 Tf'));
+    expect(parent['Q'], const CosInteger(2));
+    final edit = PdfEditor(doc)..setTextValue(imported, 'changed');
+    final reopened = PdfDocument.open(edit.save());
+    final fields = PdfAcroForm.of(reopened)!.fields;
+    expect(fields.map((f) => f.value), ['base', 'changed', 'source']);
+    expect(fields[1].widgets.every((w) => w.containsKey('AP')), isTrue);
+    expect(source, sourceBefore);
+  });
+
+  test('named destinations, links, outline hierarchy and PageMode survive', () {
+    final doc = PdfDocument.open(PdfMerger.merge([
+      richPdf('base', legacy: true),
+      richPdf('source'),
+      richPdf('third'),
+    ]));
+    expect(doc.catalog['PageMode'], const CosName('UseThumbs'));
+    expect(doc.info['Title'], 'base');
+    for (var i = 0; i < 3; i++) {
+      final name = i == 0 ? 'chapter' : 'chapter_${i + 1}';
+      final dest = PdfDestination.parse(doc, CosString.fromText(name))!;
+      expect(dest.pageIndex, i * 2 + 1);
+      expect(dest.params, [10, 700, null]);
+      final link =
+          doc.page(i * 2).annotations.whereType<PdfLinkAnnotation>().single;
+      expect((link.action as PdfGoToAction).destination.pageIndex, i * 2 + 1);
+    }
+    final outline = PdfOutline.of(doc);
+    expect(outline.items.map((i) => i.title), ['base', 'source', 'third']);
+    for (var i = 0; i < 3; i++) {
+      final item = outline.items[i];
+      expect(item.destination!.pageIndex, i * 2 + 1);
+      expect(item.open, isFalse);
+      expect(item.bold, isTrue);
+      expect(item.children.single.destination!.pageIndex, i * 2);
+    }
+    expect(PdfOutline.rootCount(doc), 3);
+  });
+
+  test('subset insertion prunes off-page widgets and cannot alias named links',
+      () {
+    final editor = PdfEditor(PdfDocument.open(richPdf('base')))
+      ..appendPagesFrom(PdfDocument.open(richPdf('source')),
+          indices: [0], at: 1);
+    final doc = PdfDocument.open(editor.save());
+    expect(doc.pageCount, 3);
+    final field = PdfAcroForm.of(doc)!.fieldNamed('client_2.name')!;
+    expect(field.widgets, hasLength(1));
+    expect(field.widgetPageIndex(0), 1);
+    final link = doc.page(1).annotations.whereType<PdfLinkAnnotation>().single;
+    expect(link.action, isNull); // source's chapter was on the omitted page
+    expect(PdfDestination.parse(doc, const CosName('chapter'))!.pageIndex, 2);
+    expect(PdfDestination.parse(doc, const CosName('chapter_2')), isNull);
+    expect(PdfOutline.of(doc).items.last.children.single.destination!.pageIndex,
+        1);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #366.

`PdfMerger.merge([firstBytes, secondBytes], passwords: [...])` combines PDFs through a bytes-only API. The first input supplies encryption, metadata, and `/PageMode`; imported objects are saved using that encryption. Page imports now preserve forms, named destinations, and outlines, including colliding field/font names, nonvisual form fields, and calculation order. Source crypt filters are removed after decryption so `/Crypt /Identity` cannot leave imported content unencrypted in a protected destination.

DartPDF gains **Insert document…** in the app menu, inserting after the current page as one undo step. Existing thumbnail drops and the window's Insert pages action use the upgraded importer. Regression coverage verifies that the original tab becomes dirty and the merged bytes survive undo, redo, and session recovery. The menu label is translated in every supported locale, and both READMEs include usage examples.

## Affected packages

- [x] `pdf_document`
- [x] DartPDF app (`app/`)
- [x] Documentation

## Change type

- [x] Feature
- [x] Bug fix
- [x] Editing behavior change

## Validation

- [x] Flutter workspace dependency resolution
- [x] `dart analyze --fatal-infos` (whole workspace)
- [x] `dart run tool/check_arb_coverage.dart`
- [x] `cd packages/pdf_document && dart test` — 890 passed, one existing skip
- [x] Editor `editing_page_ops_test.dart` and `editing_form_test.dart` — 89 passed
- [x] App insertion, drop insertion, session restore, and autosave suites — 46 passed
- [x] `cd app && flutter build web --release --no-pub`
- [x] Independent Poppler `pdfinfo` and `pdftotext` check of a saved merge containing two separately filled forms

Checks used the repository's pinned Flutter 3.47.0 SDK. Engine tests cover RC4 R2/R3, AES-128 R4, AES-256 R6, encrypted sources and destinations, explicit crypt filters, form collisions and default resources, both named-destination formats, outline hierarchy, and subset imports.

## User experience

- [x] Insert-after-current journey, completion, cancellation, read-only state, and invalid-file error paths covered.
- [x] Native platform widget variants covered; the picker filter includes extensions, MIME types, and Apple type identifiers.
- [x] Committed/reopened pages, dirty title indicator, one-step undo/redo, and recovery agree.

The menu uses standard Material focus, semantics, and input handling. No physical-device run or new latency benchmark was performed. Rendering itself is unchanged, so no corpus baselines were updated.

## Compatibility checklist

- [x] Layering is preserved, with no new `dart:io` or Flutter imports in the engine.
- [x] Encoded stream payloads remain encoded during import; encrypted payloads are decrypted without decoding image/content filters.
- [x] Fixtures use programmatic object builders with computed offsets.

## Notes for reviewers

Collision suffixes apply to root field names (`client.name` → `client_2.name`) and named destinations. Imported links resolve against their source before remapping, so duplicate names cannot redirect them into the first PDF. Only selected pages' widget branches are retained for subset imports; targets on omitted pages become inactive.

Later inputs' document-level attachments, XFA, and JavaScript are not merged. Their signatures do not certify the merged file. The first PDF's password is retained; encrypted imports into an unprotected base produce unprotected output. These policies are documented in dartdoc and the README.
