### PR TITLE
Restore the thumbnail viewport box when reopening Pages

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -138,8 +138,8 @@ class PdfThumbnailSidebar extends StatefulWidget {
   final double minWidth;
   final double maxWidth;
 
-  /// Whether the strip scrolls the current page's tile into view when
-  /// the viewer's page changes.
+  /// Whether the strip scrolls the current page's tile into view when it
+  /// opens, following is enabled, or the viewer's page changes.
   final bool followsViewer;
 
   /// Whether pages can be reordered (drag) and deleted (footer button)
@@ -433,6 +433,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // tiles that just came into view
     _scroll.addListener(_onScroll);
     _attachDrop(widget.fileDropController);
+    _revealCurrentAfterLayout();
   }
 
   @override
@@ -446,6 +447,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       old.viewerController.removeListener(_onViewerChanged);
       widget.viewerController.addListener(_onViewerChanged);
       _lastCurrent = widget.viewerController.currentPage;
+    }
+    if (!identical(old.viewerController, widget.viewerController) ||
+        !identical(old.controller, widget.controller) ||
+        (!old.followsViewer && widget.followsViewer)) {
+      _revealCurrentAfterLayout();
     }
     if (!identical(old.controller.preferences, _preferences)) {
       old.controller.preferences.removeListener(_onPreferences);
@@ -531,6 +537,18 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // viewer just moved to even before the reveal scroll settles
     _cache.focus = current;
     if (widget.followsViewer) _revealPage(current);
+  }
+
+  /// A newly mounted strip may restore an old scroll offset from PageStorage,
+  /// while the viewer is already on another page. No current-page change will
+  /// arrive to reveal it, so synchronize once the strip has laid out. Read the
+  /// current controller in the callback in case navigation happened meanwhile.
+  void _revealCurrentAfterLayout() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.followsViewer) {
+        _revealPage(widget.viewerController.currentPage);
+      }
+    });
   }
 
   /// Renders one page's thumbnail straight into the shared cache - the idle

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -340,6 +340,79 @@ void main() {
   });
 
   group('the strip follows the viewer', () {
+    testWidgets('reopening the strip reveals the current page and viewport',
+        (tester) async {
+      final editing = PdfEditingController(buildVariedHeightPdf(112));
+      final viewer = PdfViewerController();
+      final shown = ValueNotifier(true);
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      addTearDown(shown.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ValueListenableBuilder<bool>(
+            valueListenable: shown,
+            builder: (context, visible, _) => Row(children: [
+              if (visible)
+                PdfThumbnailSidebar(
+                  key: const ValueKey('thumbnails'),
+                  controller: editing,
+                  viewerController: viewer,
+                  width: 220,
+                ),
+              Expanded(
+                key: const ValueKey('viewer'),
+                child: PdfViewer(
+                  initialFit: PdfViewerFit.width,
+                  document: editing.document,
+                  controller: viewer,
+                  editing: editing,
+                  pagePreviews: false,
+                ),
+              ),
+            ]),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      unawaited(viewer.jumpToPage(60));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Page 61').hitTestable(), findsOneWidget);
+
+      shown.value = false;
+      await tester.pump();
+      unawaited(viewer.jumpToPage(48));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(viewer.currentPage, 48);
+
+      shown.value = true;
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text('Page 49').hitTestable(), findsOneWidget);
+      final indicator = find.descendant(
+        of: find.byKey(const ValueKey('pdf-thumbnail-tile-chip-48')),
+        matching: find.byWidgetPredicate((w) =>
+            w is CustomPaint &&
+            w.painter.runtimeType.toString() == '_ViewportPainter'),
+      );
+      expect(indicator, findsOneWidget);
+      expect(
+          tester
+              .getRect(indicator)
+              .overlaps(tester.getRect(find.byType(PdfThumbnailSidebar))),
+          isTrue);
+      // ignore: avoid_dynamic_calls
+      expect((tester.widget<CustomPaint>(indicator).painter as dynamic).region,
+          viewer.visiblePageRegion(48));
+      await tester.pump(const Duration(seconds: 1));
+    });
+
     testWidgets('jumping pages scrolls the current tile into view',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(12));


### PR DESCRIPTION
## Summary

Reopening the Pages panel after navigating while it was hidden could restore its old scroll position, leaving the current thumbnail and viewport box off-screen. The strip now reveals the current page after layout when mounted, when its controllers change, or when following the viewer is re-enabled.

The reveal reads the latest controller state and respects `followsViewer: false` and disposal. A regression test closes the strip on page 61, navigates to page 49 in a 112-page mixed-height document, and checks that reopening reveals both the current thumbnail and its viewport indicator.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Bug fix

## Validation

- [x] Workspace dependencies resolved using Flutter 3.47.0 (`flutter pub get --offline`).
- [x] Repository formatter and `git diff --check`.
- [x] Workspace `dart analyze`: no issues.
- [x] 71 Flutter tests across `editing_panels_test.dart`, `editing_thumbnail_view_test.dart`, `editing_thumbnail_drop_test.dart`, `pdf_theme_test.dart`, and `panel_dock_test.dart`.
- [x] New regression failed before the fix and passed afterward.
- [x] All GitHub checks passed for `af08ecde`: full CI suite, platform builds, web-worker tests, coverage, preview deployments, GPU validation, and Android/iOS/macOS end-to-end tests.

The change affects sidebar navigation only; PDF parsing and raster output are unchanged. The separate Chromium E2E check is skipped by the workflow; the demo preview's browser performance journey passed.

## User experience

- [x] Opening the Pages panel brings the current thumbnail and viewport indicator into view.
- [x] Deferred work ignores disposed panels and respects disabled following.
- [x] Existing thumbnail navigation, file-drop, docking, and theme tests pass.

## Compatibility checklist

- [x] Package layering and import restrictions are preserved.
- [x] PDF parsing, writing, and lazy stream decoding are unchanged.
- [x] The regression uses the existing programmatic PDF fixture builder.
