### PR TITLE
Add Enter submission to editor and app dialogs

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Submit dialogs with Enter or numpad Enter; use Shift+Enter for multiline text.
+  Keep validation, disabled actions, and keyboard-focused Cancel buttons intact.
 - Apply US and UK/Australian English spellings consistently across app dialogs,
   editor controls and OCR messages, with CI checks for regional bundle drift.
 - Keep the browser responsive during PDF optimisation with a dedicated worker;

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -560,10 +560,11 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         title: Text(title),
         content: SizedBox(width: 420, child: Text(text)),
         actions: [
-          TextButton(
+          PdfDialogSubmit(
+              child: TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(),
             child: const Text('Close'),
-          ),
+          )),
         ],
       ),
     );

--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -958,7 +958,8 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(appL10n(context).cancel),
         ),
-        FilledButton.icon(
+        PdfDialogSubmit(
+            child: FilledButton.icon(
           key: const ValueKey('digital-signature-sign'),
           onPressed:
               (canSign && !_submitting) ? () => unawaited(_submit()) : null,
@@ -972,7 +973,7 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
           label: Text(_submitting
               ? appL10n(context).appSigRefreshingSignIn
               : appL10n(context).appSigSign),
-        ),
+        )),
       ],
     );
   }

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2113,11 +2113,12 @@ class _EditorScreenState extends State<EditorScreen>
             onPressed: () => Navigator.of(context).pop(_DropAction.open),
             child: Text(appL10n(context).editorOpenInNewTab(count)),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('drop-action-insert'),
             onPressed: () => Navigator.of(context).pop(_DropAction.insert),
             child: Text(appL10n(context).editorInsertPages),
-          ),
+          )),
         ],
       ),
     );
@@ -2473,10 +2474,11 @@ class _EditorScreenState extends State<EditorScreen>
             onPressed: () => Navigator.of(context).pop(false),
             child: Text(appL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(appL10n(context).editorDiscard),
-          ),
+          )),
         ],
       ),
     );

--- a/app/lib/image_export.dart
+++ b/app/lib/image_export.dart
@@ -75,13 +75,14 @@ Future<ImageExportOptions?> showImageExportDialog(BuildContext context) {
             onPressed: () => Navigator.of(context).pop(),
             child: Text(appL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('export-image-confirm'),
             onPressed: () => Navigator.of(context).pop(
               ImageExportOptions(format: format, dpi: dpi),
             ),
             child: Text(appL10n(context).imgExportExport),
-          ),
+          )),
         ],
       ),
     ),

--- a/app/lib/new_document.dart
+++ b/app/lib/new_document.dart
@@ -1,4 +1,5 @@
-import 'package:dart_pdf_editor/dart_pdf_editor.dart' show showPdfDialog;
+import 'package:dart_pdf_editor/dart_pdf_editor.dart'
+    show PdfDialogSubmit, showPdfDialog;
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
@@ -81,7 +82,8 @@ Future<PdfPageSize?> showNewDocumentDialog(BuildContext context) {
             onPressed: () => Navigator.of(context).pop(),
             child: Text(appL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('new-document-create'),
             onPressed: () => Navigator.of(context).pop(
               orientation == Orientation.portrait
@@ -89,7 +91,7 @@ Future<PdfPageSize?> showNewDocumentDialog(BuildContext context) {
                   : preset.size.landscape,
             ),
             child: Text(appL10n(context).newDocCreate),
-          ),
+          )),
         ],
       ),
     ),

--- a/app/lib/ocr_native.dart
+++ b/app/lib/ocr_native.dart
@@ -144,19 +144,19 @@ class OnDeviceOcr {
         key: const ValueKey('ocr-download-confirm'),
         title: Text(appL10n(context).ocrDownloadPromptTitle),
         content: Text(
-          appL10n(context)
-              .ocrDownloadPromptBody(sizeText, _model.displayName),
+          appL10n(context).ocrDownloadPromptBody(sizeText, _model.displayName),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
             child: Text(appL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('ocr-download-confirm-ok'),
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(appL10n(context).ocrDownload),
-          ),
+          )),
         ],
       ),
     );

--- a/app/lib/ocr_web.dart
+++ b/app/lib/ocr_web.dart
@@ -211,11 +211,12 @@ class _WebOcrConfirmDialog extends StatelessWidget {
           onPressed: () => Navigator.of(context).pop(false),
           child: Text(appL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('ocr-web-start'),
           onPressed: () => Navigator.of(context).pop(true),
           child: Text(appL10n(context).ocrWebStart),
-        ),
+        )),
       ],
     );
   }

--- a/app/lib/print_preview_dialog.dart
+++ b/app/lib/print_preview_dialog.dart
@@ -352,10 +352,11 @@ class _PrintPreviewDialogState extends State<PrintPreviewDialog> {
                               onPressed: () => Navigator.of(context).pop(),
                               child: Text(l10n.cancel)),
                           const SizedBox(width: 8),
-                          FilledButton(
-                              key: const ValueKey('print-preview-print'),
-                              onPressed: _addingFiles ? null : _print,
-                              child: Text(l10n.printPreviewPrint)),
+                          PdfDialogSubmit(
+                              child: FilledButton(
+                                  key: const ValueKey('print-preview-print'),
+                                  onPressed: _addingFiles ? null : _print,
+                                  child: Text(l10n.printPreviewPrint))),
                         ]),
                       ]),
                 ],

--- a/app/lib/reduce_file_size.dart
+++ b/app/lib/reduce_file_size.dart
@@ -252,7 +252,8 @@ class _ReduceFileSizeDialogState extends State<_ReduceFileSizeDialog> {
                       }),
               child: Text(l10n.reduceSizeChangeSettings),
             ),
-            FilledButton(
+            PdfDialogSubmit(
+                child: FilledButton(
               key: const ValueKey('reduce-size-save'),
               onPressed: _saving ? null : _saveCopy,
               child: _saving
@@ -261,15 +262,16 @@ class _ReduceFileSizeDialogState extends State<_ReduceFileSizeDialog> {
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : Text(l10n.reduceSizeSaveCopy),
-            ),
+            )),
           ] else if (!_running)
-            FilledButton(
+            PdfDialogSubmit(
+                child: FilledButton(
               key: const ValueKey('reduce-size-run'),
               onPressed: widget.hasSignatures && !_allowInvalidateSignatures
                   ? null
                   : _run,
               child: Text(l10n.reduceSizeRun),
-            ),
+            )),
         ],
       ),
     );

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -52,26 +52,32 @@ Future<void> _openDefaultAppsSettings(BuildContext context) async {
 Future<void> _showDefaultAppSetup(BuildContext context) {
   return showPdfDialog<void>(
     context: context,
-    builder: (context) => AlertDialog(
-      title: Text(appL10n(context).settingsSetUpAsDefault),
-      content: Text(_defaultAppInstructions(context)),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(appL10n(context).close),
-        ),
-        if (_canOpenDefaultAppsSettings)
-          FilledButton.icon(
-            key: const ValueKey('default-app-open-settings'),
-            icon: const Icon(Icons.open_in_new),
-            label: Text(appL10n(context).settingsOpenSettings),
-            onPressed: () {
-              Navigator.of(context).pop();
-              _openDefaultAppsSettings(context);
-            },
+    builder: (context) {
+      final closeButton = TextButton(
+        onPressed: () => Navigator.of(context).pop(),
+        child: Text(appL10n(context).close),
+      );
+      return AlertDialog(
+        title: Text(appL10n(context).settingsSetUpAsDefault),
+        content: Text(_defaultAppInstructions(context)),
+        actions: [
+          if (_canOpenDefaultAppsSettings) closeButton,
+          PdfDialogSubmit(
+            child: _canOpenDefaultAppsSettings
+                ? FilledButton.icon(
+                    key: const ValueKey('default-app-open-settings'),
+                    icon: const Icon(Icons.open_in_new),
+                    label: Text(appL10n(context).settingsOpenSettings),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      _openDefaultAppsSettings(context);
+                    },
+                  )
+                : closeButton,
           ),
-      ],
-    ),
+        ],
+      );
+    },
   );
 }
 
@@ -305,10 +311,11 @@ class _SettingsDialogState extends State<_SettingsDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        PdfDialogSubmit(
+            child: TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(appL10n(context).close),
-        ),
+        )),
       ],
     );
   }

--- a/app/test/image_export_test.dart
+++ b/app/test/image_export_test.dart
@@ -3,6 +3,7 @@
 // here we cover the pure pieces: the dialog's returned options and the
 // suggested-filename builder.
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dart_pdf_editor_app/image_export.dart';
@@ -17,18 +18,18 @@ void main() {
     });
 
     test('keeps a name without a .pdf extension', () {
-      expect(imageExportFileName('scan', 2, ImageExportFormat.png),
-          'scan-p2.png');
+      expect(
+          imageExportFileName('scan', 2, ImageExportFormat.png), 'scan-p2.png');
     });
 
     test('falls back to a stem for an empty title', () {
-      expect(imageExportFileName('   ', 5, ImageExportFormat.png),
-          'page-p5.png');
+      expect(
+          imageExportFileName('   ', 5, ImageExportFormat.png), 'page-p5.png');
     });
   });
 
   group('showImageExportDialog', () {
-    testWidgets('returns PNG @ 150 dpi by default', (tester) async {
+    testWidgets('Enter returns PNG @ 150 dpi by default', (tester) async {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: Builder(
@@ -45,7 +46,7 @@ void main() {
       ));
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('export-image-confirm')));
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
     });
 

--- a/app/test/new_document_test.dart
+++ b/app/test/new_document_test.dart
@@ -1,5 +1,6 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -52,7 +53,8 @@ void main() {
     expect(find.text('A4 (210 × 297 mm)'), findsOneWidget);
   });
 
-  testWidgets('creates the selected page size and orientation', (tester) async {
+  testWidgets('Enter creates the selected page size and orientation',
+      (tester) async {
     await pumpApp(tester);
     await openNewDocumentDialog(tester);
 
@@ -62,7 +64,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Landscape'));
     await tester.pump();
-    await tester.tap(find.byKey(const ValueKey('new-document-create')));
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
 
     expect(findMiddleEllipsisText('Untitled.pdf'), findsWidgets);

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `PdfDialogSubmit` to mark a `showPdfDialog` primary button for Enter and
+  numpad Enter submission. Wire the stock editing dialogs to it, preserving
+  validation, IME composition, Shift+Enter, and keyboard-focused buttons.
 - Add complete Australian and UK English locales for editor controls, including
   colour, centre and organisation, while the base English locale uses US spelling.
   Localise the smart alignment guide hint.

--- a/packages/dart_pdf_editor/example/lib/feedback.dart
+++ b/packages/dart_pdf_editor/example/lib/feedback.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import 'package:dart_pdf_editor/dart_pdf_editor.dart'
+    show PdfDialogSubmit, showPdfDialog;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -37,8 +40,7 @@ Uri buildFeedbackUri(
   // Grow the attached report from the tail until the encoded URL would exceed
   // the budget, then keep the largest prefix that fits.
   String withReport(String value) => base
-      .replace(queryParameters: {...params, 'diagnostics': value})
-      .toString();
+      .replace(queryParameters: {...params, 'diagnostics': value}).toString();
 
   var attached = report;
   if (withReport(attached).length > maxUrlLength) {
@@ -74,7 +76,7 @@ Future<void> showFeedbackDialog(
   AppLog? log,
 }) {
   final appLog = log ?? AppLog.instance;
-  return showDialog<void>(
+  return showPdfDialog<void>(
     context: context,
     builder: (context) => _FeedbackDialog(
       log: appLog,
@@ -202,11 +204,12 @@ class _FeedbackDialogState extends State<_FeedbackDialog> {
           icon: const Icon(Icons.copy_outlined),
           label: Text(appL10n(context).feedbackCopyDiagnostics),
         ),
-        FilledButton.icon(
+        PdfDialogSubmit(
+            child: FilledButton.icon(
           onPressed: _open,
           icon: const Icon(Icons.open_in_new),
           label: Text(appL10n(context).feedbackOpenForm),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -403,7 +403,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
             page: viewer.selectionRectsOn(page),
         };
 
-        final noteText = await showDialog<String>(
+        final noteText = await showPdfDialog<String>(
           context: context,
           builder: (ctx) {
             final field = TextEditingController();
@@ -423,10 +423,11 @@ class _ViewerScreenState extends State<ViewerScreen> {
                   onPressed: () => Navigator.pop(ctx),
                   child: const Text('Cancel'),
                 ),
-                TextButton(
+                PdfDialogSubmit(
+                    child: TextButton(
                   onPressed: () => Navigator.pop(ctx, field.text),
                   child: const Text('Save'),
-                ),
+                )),
               ],
             );
           },
@@ -1213,7 +1214,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
 
   /// Prompts for a URL to open, prefilled with a known CORS-enabled sample.
   /// Returns null when cancelled.
-  Future<String?> _promptForUrl() => showDialog<String>(
+  Future<String?> _promptForUrl() => showPdfDialog<String>(
         context: context,
         builder: (context) =>
             const _OpenUrlDialog(initial: _sampleRemotePdfUrl),
@@ -1496,7 +1497,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
   Future<(PdfRasterFormat, double)?> _showImageExportDialog() {
     var format = PdfRasterFormat.png;
     var dpi = 150.0;
-    return showDialog<(PdfRasterFormat, double)>(
+    return showPdfDialog<(PdfRasterFormat, double)>(
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) => AlertDialog(
@@ -1537,10 +1538,11 @@ class _ViewerScreenState extends State<ViewerScreen> {
               onPressed: () => Navigator.of(context).pop(),
               child: Text(appL10n(context).cancel),
             ),
-            FilledButton(
+            PdfDialogSubmit(
+                child: FilledButton(
               onPressed: () => Navigator.of(context).pop((format, dpi)),
               child: Text(appL10n(context).exExport),
-            ),
+            )),
           ],
         ),
       ),
@@ -1562,7 +1564,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
 
     // Supply / confirm the OCR service credentials.
     final l10n = appL10n(context);
-    final settings = await showDialog<_OcrSettings>(
+    final settings = await showPdfDialog<_OcrSettings>(
       context: context,
       builder: (_) => _OcrSettingsDialog(
         endpoint: _ocrEndpoint,
@@ -1581,7 +1583,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
 
     final progress = ValueNotifier<String>(l10n.exPreparing);
     if (!mounted) return;
-    unawaited(showDialog<void>(
+    unawaited(showPdfDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (_) => _OcrProgressDialog(progress: progress),
@@ -2139,11 +2141,12 @@ class _OpenUrlDialogState extends State<_OpenUrlDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(appL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('open-url-confirm'),
           onPressed: _submit,
           child: Text(appL10n(context).exOpen),
-        ),
+        )),
       ],
     );
   }
@@ -2261,7 +2264,8 @@ class _OcrSettingsDialogState extends State<_OcrSettingsDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(appL10n(context).cancel),
         ),
-        FilledButton.icon(
+        PdfDialogSubmit(
+            child: FilledButton.icon(
           key: const ValueKey('ocr-run'),
           icon: const Icon(Icons.document_scanner_outlined),
           label: Text(appL10n(context).exRunOcr),
@@ -2275,7 +2279,7 @@ class _OcrSettingsDialogState extends State<_OcrSettingsDialog> {
               apiKey: key.isEmpty ? null : key,
             ));
           },
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/dialog.dart
+++ b/packages/dart_pdf_editor/lib/src/dialog.dart
@@ -1,4 +1,136 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Marks the primary button in a [showPdfDialog] as its Enter action.
+///
+/// Enter and numpad Enter invoke the button's current [ButtonStyleButton.onPressed]
+/// callback, including its validation. A disabled button cannot be submitted.
+/// Shift+Enter remains available for newlines in multiline text fields.
+/// Only one submit button should be mounted in each dialog at a time.
+class PdfDialogSubmit extends StatefulWidget {
+  const PdfDialogSubmit({super.key, required this.child});
+
+  final ButtonStyleButton child;
+
+  @override
+  State<PdfDialogSubmit> createState() => _PdfDialogSubmitState();
+}
+
+class _PdfDialogSubmitState extends State<PdfDialogSubmit> {
+  _PdfDialogKeyboardScopeState? _scope;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _attach();
+  }
+
+  void _attach() {
+    final scope =
+        context.findAncestorStateOfType<_PdfDialogKeyboardScopeState>();
+    if (identical(scope, _scope)) return;
+    _detach();
+    _scope = scope;
+    assert(scope == null || scope.submit == null,
+        'A dialog can only have one PdfDialogSubmit button.');
+    scope?.submit = this;
+  }
+
+  void _detach() {
+    if (identical(_scope?.submit, this)) _scope?.submit = null;
+    _scope = null;
+  }
+
+  @override
+  void activate() {
+    super.activate();
+    _attach();
+  }
+
+  @override
+  void deactivate() {
+    _detach();
+    super.deactivate();
+  }
+
+  @override
+  void dispose() {
+    _detach();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class _PdfDialogKeyboardScope extends StatefulWidget {
+  const _PdfDialogKeyboardScope({required this.builder});
+
+  final WidgetBuilder builder;
+
+  @override
+  State<_PdfDialogKeyboardScope> createState() =>
+      _PdfDialogKeyboardScopeState();
+}
+
+class _PdfDialogKeyboardScopeState extends State<_PdfDialogKeyboardScope> {
+  // Let the dialog route retain control of Tab traversal at its edges.
+  final _focus =
+      FocusScopeNode(traversalEdgeBehavior: TraversalEdgeBehavior.parentScope);
+  _PdfDialogSubmitState? submit;
+
+  @override
+  void dispose() {
+    _focus.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
+    if (submit == null ||
+        ModalRoute.of(context)?.isCurrent != true ||
+        (event.logicalKey != LogicalKeyboardKey.enter &&
+            event.logicalKey != LogicalKeyboardKey.numpadEnter)) {
+      return KeyEventResult.ignored;
+    }
+    final keyboard = HardwareKeyboard.instance;
+    if (keyboard.isShiftPressed ||
+        keyboard.isControlPressed ||
+        keyboard.isMetaPressed ||
+        keyboard.isAltPressed) {
+      return KeyEventResult.ignored;
+    }
+    final focusedContext = FocusManager.instance.primaryFocus?.context;
+    // Focused buttons (including Cancel) keep their normal activation. A
+    // segmented selector is a form value, so Enter still submits from there.
+    var focusedButton = false;
+    focusedContext?.visitAncestorElements((element) {
+      if (element.widget is SegmentedButton) {
+        focusedButton = false;
+        return false;
+      }
+      if (element.widget is ButtonStyleButton) focusedButton = true;
+      return element.widget is! AlertDialog;
+    });
+    if (focusedButton) return KeyEventResult.ignored;
+    final field = focusedContext?.findAncestorWidgetOfExactType<EditableText>();
+    final composing = field?.controller.value.composing;
+    if (composing != null && composing.isValid && !composing.isCollapsed) {
+      // Let the input method confirm its candidate before submitting the form.
+      return KeyEventResult.skipRemainingHandlers;
+    }
+    if (event is KeyDownEvent) submit?.widget.child.onPressed?.call();
+    // Consume repeats as well, so holding Enter cannot submit a second time.
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context) => FocusScope(
+        node: _focus,
+        autofocus: ModalRoute.of(context)?.requestFocus ?? true,
+        onKeyEvent: _onKeyEvent,
+        child: Builder(builder: widget.builder),
+      );
+}
 
 /// Shows a Material dialog inside the current Flutter view.
 ///
@@ -8,6 +140,7 @@ import 'package:flutter/material.dart';
 /// sheet that blocks its parent without accepting input. DartPDF still uses
 /// native [RegularWindow]s for real multi-window editing, while its modal
 /// prompts stay attached to the navigator that opened them.
+/// Wrap the primary action button in [PdfDialogSubmit] to submit with Enter.
 Future<T?> showPdfDialog<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -34,7 +167,7 @@ Future<T?> showPdfDialog<T>({
   return navigator.push<T>(
     DialogRoute<T>(
       context: context,
-      builder: builder,
+      builder: (context) => _PdfDialogKeyboardScope(builder: builder),
       barrierColor: barrierColor ??
           DialogTheme.of(context).barrierColor ??
           Theme.of(context).dialogTheme.barrierColor ??

--- a/packages/dart_pdf_editor/lib/src/editing/create_signing_identity_dialog.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/create_signing_identity_dialog.dart
@@ -173,7 +173,8 @@ class _CreateSigningIdentityFormState extends State<CreateSigningIdentityForm> {
                   child: Text(pdfL10n(context).cancel),
                 ),
                 const SizedBox(width: 8),
-                FilledButton(
+                PdfDialogSubmit(
+                    child: FilledButton(
                   onPressed: _busy ? null : _create,
                   child: _busy
                       ? const SizedBox(
@@ -182,7 +183,7 @@ class _CreateSigningIdentityFormState extends State<CreateSigningIdentityForm> {
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
                       : Text(pdfL10n(context).signIdCreate),
-                ),
+                )),
               ],
             ),
           ],

--- a/packages/dart_pdf_editor/lib/src/editing/digital_signature_removal.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/digital_signature_removal.dart
@@ -26,10 +26,11 @@ Future<bool> showPdfRemoveSignatureDialog(
           onPressed: () => Navigator.of(context).pop(false),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: () => Navigator.of(context).pop(true),
           child: Text(pdfL10n(context).remove),
-        ),
+        )),
       ],
     ),
   );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_annotation_library.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_annotation_library.dart
@@ -601,10 +601,11 @@ class PdfAnnotationLibraryDialog extends StatelessWidget {
           icon: const Icon(Icons.approval_outlined),
           label: Text(pdfL10n(context).annotationLibraryCustomStamps),
         ),
-        TextButton(
+        PdfDialogSubmit(
+            child: TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).close),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
@@ -487,7 +487,8 @@ class _BookmarkDialogState extends State<_BookmarkDialog> {
                 controller: _page,
                 decoration: InputDecoration(
                   labelText: pdfL10n(context).bookmarkPageFieldLabel,
-                  helperText: pdfL10n(context).bookmarkPageRangeHint(widget.pageCount),
+                  helperText:
+                      pdfL10n(context).bookmarkPageRangeHint(widget.pageCount),
                   border: const OutlineInputBorder(),
                 ),
                 keyboardType: TextInputType.number,
@@ -508,11 +509,12 @@ class _BookmarkDialogState extends State<_BookmarkDialog> {
             onPressed: () => Navigator.of(context).pop(),
             child: Text(pdfL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('pdf-bookmark-save'),
             onPressed: _save,
             child: Text(pdfL10n(context).save),
-          ),
+          )),
         ],
       );
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
@@ -642,10 +642,11 @@ Future<Color?> showPdfColorPicker(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: () => Navigator.of(context).pop(current),
           child: Text(pdfL10n(context).ok),
-        ),
+        )),
       ],
     ),
   );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_processing.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_processing.dart
@@ -391,11 +391,12 @@ class _ColorProcessingDialogState extends State<_ColorProcessingDialog> {
             onPressed: _applying ? null : () => Navigator.of(context).pop(),
             child: Text(pdfL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('pdf-color-process-apply'),
             onPressed: canApply ? () => unawaited(_apply()) : null,
             child: Text(pdfL10n(context).apply),
-          ),
+          )),
         ],
       ),
     );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_link.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_link.dart
@@ -140,10 +140,11 @@ class _AddLinkDialogState extends State<_AddLinkDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(l10n.cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: _submit,
           child: Text(l10n.ok),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_measure.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_measure.dart
@@ -74,8 +74,7 @@ class PdfMeasurementScale {
         unitLabel: measure.distance.isNotEmpty
             ? measure.distance.first.unit
             : measure.x.first.unit,
-        areaUnitLabel:
-            measure.area.isNotEmpty ? measure.area.first.unit : null,
+        areaUnitLabel: measure.area.isNotEmpty ? measure.area.first.unit : null,
         precision: measure.distance.isNotEmpty
             ? measure.distance.first.precision
             : 100,
@@ -96,7 +95,9 @@ class PdfMeasurementScale {
     final perPageUnit = unitsPerPoint * _pointsPerPageUnit(pageUnitLabel);
     var text = perPageUnit.toStringAsFixed(2);
     if (text.contains('.')) {
-      text = text.replaceFirst(RegExp(r'0+$'), '').replaceFirst(RegExp(r'\.$'), '');
+      text = text
+          .replaceFirst(RegExp(r'0+$'), '')
+          .replaceFirst(RegExp(r'\.$'), '');
     }
     return '1 $pageUnitLabel = $text $unitLabel';
   }
@@ -240,15 +241,18 @@ class _PdfScaleDialogState extends State<PdfScaleDialog> {
     // Carry over the on-page reference unit (the left-hand side) from an
     // existing scale; otherwise default to the device region's measurement
     // system (inches vs centimetres).
-    _pageUnit = (initial != null && _pdfPageUnits.contains(initial.pageUnitLabel))
-        ? initial.pageUnitLabel
-        : pdfDefaultPageUnit();
-    final perPageUnit =
-        initial == null ? 1.0 : initial.unitsPerPoint * _pointsPerPageUnit(_pageUnit);
+    _pageUnit =
+        (initial != null && _pdfPageUnits.contains(initial.pageUnitLabel))
+            ? initial.pageUnitLabel
+            : pdfDefaultPageUnit();
+    final perPageUnit = initial == null
+        ? 1.0
+        : initial.unitsPerPoint * _pointsPerPageUnit(_pageUnit);
     var text = perPageUnit.toStringAsFixed(2);
     if (text.contains('.')) {
-      text =
-          text.replaceFirst(RegExp(r'0+$'), '').replaceFirst(RegExp(r'\.$'), '');
+      text = text
+          .replaceFirst(RegExp(r'0+$'), '')
+          .replaceFirst(RegExp(r'\.$'), '');
     }
     _value = TextEditingController(text: text);
     // Carry over the real-world unit from an existing scale; otherwise
@@ -303,7 +307,8 @@ class _PdfScaleDialogState extends State<PdfScaleDialog> {
               key: const ValueKey('pdf-scale-value'),
               controller: _value,
               autofocus: true,
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
               textAlign: TextAlign.end,
               onSubmitted: (_) => _submit(),
             ),
@@ -336,11 +341,12 @@ class _PdfScaleDialogState extends State<PdfScaleDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-scale-apply'),
           onPressed: _submit,
           child: Text(pdfL10n(context).measSetScaleButton),
-        ),
+        )),
       ],
     );
   }
@@ -356,7 +362,8 @@ Future<(double, String)?> showPdfCalibrationLengthDialog(
 }) =>
     showPdfDialog<(double, String)>(
       context: context,
-      builder: (context) => _PdfCalibrationLengthDialog(initialUnit: initialUnit),
+      builder: (context) =>
+          _PdfCalibrationLengthDialog(initialUnit: initialUnit),
     );
 
 /// Asks for the extrusion depth of a volume measurement, in the scale's
@@ -414,7 +421,8 @@ class _PdfDepthDialogState extends State<_PdfDepthDialog> {
               key: const ValueKey('pdf-depth-value'),
               controller: _value,
               autofocus: true,
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
               textAlign: TextAlign.end,
               onSubmitted: (_) => _submit(),
             ),
@@ -430,11 +438,12 @@ class _PdfDepthDialogState extends State<_PdfDepthDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-depth-apply'),
           onPressed: _submit,
           child: Text(pdfL10n(context).measMeasure),
-        ),
+        )),
       ],
     );
   }
@@ -525,11 +534,12 @@ class _PdfCalibrationLengthDialogState
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-calibrate-apply'),
           onPressed: _submit,
           child: Text(pdfL10n(context).measSetScaleButton),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
@@ -401,10 +401,11 @@ class _PdfSignatureLibraryDialogState extends State<PdfSignatureLibraryDialog> {
           icon: const Icon(Icons.add),
           label: Text(pdfL10n(context).tbDrawNewSignature),
         ),
-        TextButton(
+        PdfDialogSubmit(
+            child: TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).close),
-        ),
+        )),
       ],
     );
   }
@@ -758,14 +759,15 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: _isEmpty
               ? null
               : () => Navigator.of(context).pop(PdfInkSignature.fromPad(
                   _strokes, _pressures, _ink,
                   strokeWidth: _strokeWidth)),
           child: Text(pdfL10n(context).done),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -374,10 +374,11 @@ class PdfStampPickerDialog extends StatelessWidget {
           onPressed: () => _create(context),
           child: Text(pdfL10n(context).stampNewStamp),
         ),
-        TextButton(
+        PdfDialogSubmit(
+            child: TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).close),
-        ),
+        )),
       ],
     );
   }
@@ -878,8 +879,8 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
                       key: const ValueKey('pdf-stamp-width'),
                       controller: _width,
                       keyboardType: TextInputType.number,
-                      decoration:
-                          InputDecoration(labelText: pdfL10n(context).stampWidth),
+                      decoration: InputDecoration(
+                          labelText: pdfL10n(context).stampWidth),
                       onSubmitted: (_) => _commitSize(),
                     ),
                   ),
@@ -890,8 +891,8 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
                       key: const ValueKey('pdf-stamp-height'),
                       controller: _height,
                       keyboardType: TextInputType.number,
-                      decoration:
-                          InputDecoration(labelText: pdfL10n(context).stampHeight),
+                      decoration: InputDecoration(
+                          labelText: pdfL10n(context).stampHeight),
                       onSubmitted: (_) => _commitSize(),
                     ),
                   ),
@@ -1056,10 +1057,12 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: _components.isEmpty
               ? null
               : () {
+                  _commitSize();
                   final initial = widget.initial;
                   Navigator.of(context).pop(PdfCustomStamp(
                     text: _caption,
@@ -1070,7 +1073,7 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
                   ));
                 },
           child: Text(pdfL10n(context).save),
-        ),
+        )),
       ],
     );
   }
@@ -1240,8 +1243,8 @@ class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
   }
 
   void _tapUp(TapUpDetails details, Size size) {
-    widget.onSelect(_hitComponent(_toTemplate(details.localPosition, size),
-        _scale(size)));
+    widget.onSelect(
+        _hitComponent(_toTemplate(details.localPosition, size), _scale(size)));
   }
 
   void _queueDelta(Offset delta) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -155,11 +155,12 @@ Future<void> showPdfEditingGuidesDialog(
         ),
       ),
       actions: [
-        TextButton(
+        PdfDialogSubmit(
+            child: TextButton(
           key: const ValueKey('pdf-guides-done'),
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).done),
-        ),
+        )),
       ],
     ),
   );
@@ -1342,11 +1343,12 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             onPressed: () => Navigator.of(context).pop(false),
             child: Text(pdfL10n(context).cancel),
           ),
-          FilledButton(
+          PdfDialogSubmit(
+              child: FilledButton(
             key: const ValueKey('pdf-redaction-confirm-apply'),
             onPressed: () => Navigator.of(context).pop(true),
             child: Text(pdfL10n(context).apply),
-          ),
+          )),
         ],
       ),
     );

--- a/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
@@ -145,10 +145,11 @@ Future<String?> showPdfTextPrompt(
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           onPressed: () => Navigator.of(context).pop(field.text),
           child: Text(pdfL10n(context).ok),
-        ),
+        )),
       ],
     ),
   );

--- a/packages/dart_pdf_editor/lib/src/editing/text_style_prompt.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/text_style_prompt.dart
@@ -70,8 +70,8 @@ Future<PdfStyledTextEdit?> showPdfStyledTextPrompt(
 }) {
   return showPdfDialog<PdfStyledTextEdit>(
     context: context,
-    builder: (context) =>
-        _StyledTextDialog(initial: initial, palette: palette, pickFont: pickFont),
+    builder: (context) => _StyledTextDialog(
+        initial: initial, palette: palette, pickFont: pickFont),
   );
 }
 
@@ -262,11 +262,12 @@ class _StyledTextDialogState extends State<_StyledTextDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-styled-ok'),
           onPressed: _submit,
           child: Text(pdfL10n(context).apply),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/page_range_dialog.dart
+++ b/packages/dart_pdf_editor/lib/src/page_range_dialog.dart
@@ -132,11 +132,12 @@ class _PdfPageRangeDialogState extends State<_PdfPageRangeDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(pdfL10n(context).cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-page-range-confirm'),
           onPressed: _submit,
           child: Text(widget.confirmLabel),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/lib/src/split_dialog.dart
+++ b/packages/dart_pdf_editor/lib/src/split_dialog.dart
@@ -96,11 +96,12 @@ class _SplitDialogState extends State<_SplitDialog> {
           onPressed: () => Navigator.of(context).pop(),
           child: Text(l10n.cancel),
         ),
-        FilledButton(
+        PdfDialogSubmit(
+            child: FilledButton(
           key: const ValueKey('pdf-split-confirm'),
           onPressed: _submit,
           child: Text(l10n.splitConfirm),
-        ),
+        )),
       ],
     );
   }

--- a/packages/dart_pdf_editor/test/dialog_test.dart
+++ b/packages/dart_pdf_editor/test/dialog_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/src/foundation/_features.dart' show isWindowingEnabled;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -51,4 +52,228 @@ void main() {
       isWindowingEnabled = original;
     }
   });
+
+  for (final key in [
+    LogicalKeyboardKey.enter,
+    LogicalKeyboardKey.numpadEnter
+  ]) {
+    testWidgets('${key.debugName} submits a focused text prompt once',
+        (tester) async {
+      String? result;
+      var completions = 0;
+      await openDialog(tester, (context) async {
+        result =
+            await showPdfTextPrompt(context, title: 'Name', initial: 'Old');
+        completions++;
+      });
+      expect(
+          tester
+              .widget<EditableText>(find.byType(EditableText))
+              .focusNode
+              .hasFocus,
+          isTrue);
+      await tester.enterText(find.byType(TextField), 'New');
+      // Flutter's legacy Windows test key-code map omits numpad Enter.
+      // Use Linux key data while exercising each platform's widget behavior.
+      await tester.sendKeyEvent(key, platform: 'linux');
+      await tester.pumpAndSettle();
+      expect(result, 'New');
+      expect(completions, 1);
+      expect(find.byType(AlertDialog), findsNothing);
+    }, variant: TargetPlatformVariant.all());
+  }
+
+  testWidgets('Enter accepts the current color after editing its hex field',
+      (tester) async {
+    Color? result;
+    await openDialog(tester, (context) async {
+      result = await showPdfColorPicker(context, initial: Colors.red);
+    });
+    await tester.enterText(find.byType(TextField), '00FF00');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(result, const Color(0xFF00FF00));
+  });
+
+  testWidgets('Enter saves a stamp with pending size edits', (tester) async {
+    PdfCustomStamp? result;
+    await openDialog(tester, (context) async {
+      result = await showPdfStampEditor(context);
+    });
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-stamp-text')), 'APPROVED');
+    await tester.enterText(
+        find.byKey(const ValueKey('pdf-stamp-width')), '320');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(result?.text, 'APPROVED');
+    expect(result?.template?.width, 320);
+  });
+
+  testWidgets('Shift+Enter leaves a multiline prompt open; Enter submits it',
+      (tester) async {
+    String? result;
+    await openDialog(tester, (context) async {
+      result = await showPdfTextPrompt(context, title: 'Note', multiline: true);
+    });
+    await tester.enterText(find.byType(TextField), 'First');
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.pump();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    // The platform text-input client supplies the newline after the shortcut
+    // leaves Shift+Enter unhandled.
+    await tester.enterText(find.byType(TextField), 'First\nSecond');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(result, 'First\nSecond');
+  });
+
+  testWidgets('Enter confirms IME composition before submitting',
+      (tester) async {
+    String? result;
+    await openDialog(tester, (context) async {
+      result = await showPdfTextPrompt(context, title: 'Name');
+    });
+    final field = tester.widget<TextField>(find.byType(TextField)).controller!;
+    field.value = const TextEditingValue(
+      text: '東京',
+      selection: TextSelection.collapsed(offset: 2),
+      composing: TextRange(start: 0, end: 2),
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(result, isNull);
+    field.clearComposing();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(result, '東京');
+  });
+
+  testWidgets(
+      'disabled submit stays open and reads the enabled button on rebuild',
+      (tester) async {
+    var enabled = false;
+    var submits = 0;
+    late StateSetter update;
+    await openDialog(
+        tester,
+        (context) => showPdfDialog<void>(
+              context: context,
+              builder: (context) =>
+                  StatefulBuilder(builder: (context, setState) {
+                update = setState;
+                return AlertDialog(
+                  content: const TextField(autofocus: true),
+                  actions: [
+                    PdfDialogSubmit(
+                        child: FilledButton(
+                      onPressed: enabled
+                          ? () {
+                              submits++;
+                            }
+                          : null,
+                      child: const Text('Save'),
+                    ))
+                  ],
+                );
+              }),
+            ));
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(submits, 0);
+    update(() => enabled = true);
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyRepeatEvent(LogicalKeyboardKey.enter);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+    expect(submits, 1);
+  });
+
+  testWidgets(
+      'nested dialogs submit independently and restore the outer action',
+      (tester) async {
+    var outerSubmits = 0;
+    String? innerResult;
+    await openDialog(
+        tester,
+        (context) => showPdfDialog<void>(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('Outer'),
+                content: TextButton(
+                  onPressed: () async {
+                    innerResult = await showPdfTextPrompt(context,
+                        title: 'Inner', initial: 'Value');
+                  },
+                  child: const Text('Open inner'),
+                ),
+                actions: [
+                  PdfDialogSubmit(
+                      child: FilledButton(
+                    onPressed: () {
+                      outerSubmits++;
+                      Navigator.of(context).pop();
+                    },
+                    child: const Text('Save outer'),
+                  ))
+                ],
+              ),
+            ));
+    await tester.tap(find.text('Open inner'));
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(innerResult, 'Value');
+    expect(outerSubmits, 0);
+    expect(find.text('Outer'), findsOneWidget);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(outerSubmits, 1);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('Enter activates Cancel when it has keyboard focus',
+      (tester) async {
+    final cancelFocus = FocusNode();
+    addTearDown(cancelFocus.dispose);
+    bool? result;
+    await openDialog(tester, (context) async {
+      result = await showPdfDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          actions: [
+            TextButton(
+              focusNode: cancelFocus,
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            PdfDialogSubmit(
+                child: FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Save'),
+            )),
+          ],
+        ),
+      );
+    });
+    cancelFocus.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(result, isFalse);
+  }, variant: TargetPlatformVariant.all());
+}
+
+Future<void> openDialog(
+    WidgetTester tester, Future<void> Function(BuildContext) open) async {
+  await tester.pumpWidget(MaterialApp(
+      home: Builder(
+    builder: (context) =>
+        TextButton(onPressed: () => open(context), child: const Text('Open')),
+  )));
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
 }

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -738,8 +738,7 @@ void main() {
           find.byKey(const ValueKey('pdf-bookmark-title')), 'Chapter 1');
       await tester.enterText(
           find.byKey(const ValueKey('pdf-bookmark-page')), '2');
-      await tester.tap(find.byKey(const ValueKey('pdf-bookmark-save')),
-          kind: PointerDeviceKind.mouse);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
 
       expect(editing.outline.items.single.title, 'Chapter 1');
@@ -750,8 +749,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.enterText(
           find.byKey(const ValueKey('pdf-bookmark-title')), 'Renamed');
-      await tester.tap(find.byKey(const ValueKey('pdf-bookmark-save')),
-          kind: PointerDeviceKind.mouse);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
 
       expect(editing.outline.items.single.title, 'Renamed');


### PR DESCRIPTION
## Summary

Dialogs now submit with Enter or numpad Enter from their fields and selectors, using the same callback and validation as the primary button. Shift+Enter remains available for multiline text, composing IME input is left to the input method, and a keyboard-focused Cancel button keeps its normal action.

`PdfDialogSubmit` marks the primary button inside `showPdfDialog`. The editor, app, and example dialogs use this shared behavior. Stamp saving also commits pending width/height edits so submitting from either size field includes the typed value.

## Affected packages

- [x] `dart_pdf_editor`
- [x] DartPDF app
- [x] Example app

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] Workspace dependencies resolved with Flutter 3.47.0.
- [x] `dart analyze` — no issues.
- [x] Keyboard regression tests across Flutter platform variants: Enter/numpad Enter, focused Cancel, disabled actions, key repeats, IME composition, multiline input, and nested dialogs.
- [x] Affected editor suites: stamps, signatures, signing identity, links, measurements, page operations, splitting, color processing, text styles, annotation library, and shells/bookmarks.
- [x] Affected app suites: new document, image export, file-size reduction, signing, print preview, settings, and OCR menu.
- [x] Example feedback, remote-open, editing, and demo tests.
- [x] `git diff --check`.

Full repository, build, and E2E checks run in PR CI. No PDF rendering algorithms or corpus baselines change.

## User experience

- [x] The affected journey and expected outcome are described above.
- [x] Completion, cancellation, disabled/loading actions, validation, focus, and text composition are covered.
- [x] Existing pointer flows remain covered by the affected widget suites.
- [x] No additional PDF interpretation or rendering work is introduced.

## Compatibility checklist

- [x] Layering and web compatibility are preserved; no new platform imports outside the Flutter UI.
- [x] PDF parsing, serialization, lazy streams, and corpus fixtures are unchanged.

## Notes for reviewers

Only explicitly marked buttons become Enter defaults. Progress dialogs and selection-only dialogs without a primary submission action retain their existing behavior.
