### PR TITLE
Fix Android scanning and polish mobile document controls

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -125,6 +125,8 @@ jobs:
             --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
           flutter build appbundle --release \
             --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+      - name: Verify scanner survives release shrinking
+        run: python3 tool/check_android_scanner.py app/build/app/outputs/flutter-apk/app-release.apk
       - uses: actions/upload-artifact@v7
         with:
           name: android

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix Android document scanning failing before the camera opens in release
+  builds. Preserve ML Kit's reflection constructors during code shrinking and
+  check the packaged APK before publishing release artifacts.
 - Apply US and UK/Australian English spellings consistently across app dialogs,
   editor controls and OCR messages, with CI checks for regional bundle drift.
 - Keep the browser responsive during PDF optimisation with a dedicated worker;

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Separate panel buttons from Settings and Reflow in the mobile Controls menu.
 - Rename a PDF on Android and iOS by tapping its title (the active tab on
   tablets). Keep the new name in Recent files, session recovery, and sharing.
 - Fix Android document scanning failing before the camera opens in release

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Hide shortcut hints and shortcut settings on Android and iOS when no physical
+  keyboard is connected, updating menus and tooltips as keyboards attach or detach.
 - Separate panel buttons from Settings and Reflow in the mobile Controls menu.
 - Rename a PDF on Android and iOS by tapping its title (the active tab on
   tablets). Keep the new name in Recent files, session recovery, and sharing.

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Rename a PDF on Android and iOS by tapping its title (the active tab on
+  tablets). Keep the new name in Recent files, session recovery, and sharing.
 - Fix Android document scanning failing before the camera opens in release
   builds. Preserve ML Kit's reflection constructors during code shrinking and
   check the packaged APK before publishing release artifacts.

--- a/app/RELEASING.md
+++ b/app/RELEASING.md
@@ -57,6 +57,20 @@ not the next rolling build.
 > release builds use the app's configured compile SDK and should be verified
 > before each Play upload.
 
+For Android, also build the release APK and run the scanner packaging check
+from the repository root before uploading a bundle:
+
+```sh
+cd app
+fvm flutter build apk --release
+cd ..
+python3 tool/check_android_scanner.py app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+This checks ML Kit's manifest-registered constructors in the minified DEX.
+Debug builds and Flutter tests cannot detect release shrinking breaking scanner
+initialization. CI runs the same check before uploading Android artifacts.
+
 ## In-app update checker
 
 The app checks these Releases for a newer build (`app/lib/update.dart`,

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -49,6 +49,7 @@ android {
 
     buildTypes {
         release {
+            proguardFiles("proguard-rules.pro")
             signingConfig = if (keystorePropertiesFile.exists()) {
                 signingConfigs.getByName("release")
             } else {

--- a/app/android/app/proguard-rules.pro
+++ b/app/android/app/proguard-rules.pro
@@ -1,0 +1,8 @@
+# ML Kit discovers these classes by name from AndroidManifest.xml and calls
+# getDeclaredConstructor().newInstance(). AGP 9's strict R8 full mode no longer
+# implicitly keeps the no-argument constructor when a class is kept. Without
+# this rule CommonComponentRegistrar survives but its constructor does not:
+# ML Kit initialization fails and every document scan throws before launch.
+-keep,allowoptimization class com.google.mlkit.** implements com.google.firebase.components.ComponentRegistrar {
+    public <init>();
+}

--- a/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
@@ -6,8 +6,12 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.hardware.input.InputManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.CancellationSignal
 import android.os.ParcelFileDescriptor
 import android.print.PageRange
@@ -19,6 +23,7 @@ import android.provider.OpenableColumns
 import android.system.ErrnoException
 import android.system.Os
 import android.system.OsConstants
+import android.view.InputDevice
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -32,13 +37,15 @@ import kotlin.math.roundToInt
 
 /// Forwards PDFs the OS opens in the app - a Files "open", a download tap, or a
 /// share - to the Dart `IncomingFileService` over a single method channel.
-class MainActivity : FlutterActivity() {
+class MainActivity : FlutterActivity(), InputManager.InputDeviceListener {
     private val channelName = "dev.milanko.dartpdf/incoming"
     private val imageClipboardChannelName = "dev.milanko.dartpdf/image_clipboard"
     private val nativePrintChannelName = "dev.milanko.dartpdf/native_print"
     private val mobileFileChannelName = "dev.milanko.dartpdf/mobile_file"
     private val memoryChannelName = "dev.milanko.dartpdf/memory"
     private var channel: MethodChannel? = null
+    private var keyboardChannel: MethodChannel? = null
+    private var keyboardInputManager: InputManager? = null
 
     /// The file the activity was launched with, drained by `getInitialFile`.
     private var pending: Map<String, Any>? = null
@@ -54,6 +61,19 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        keyboardChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger, "dev.milanko.dartpdf/keyboard"
+        ).also { keyboard ->
+            keyboard.setMethodCallHandler { call, result ->
+                if (call.method == "isConnected") {
+                    result.success(hasPhysicalKeyboard())
+                } else {
+                    result.notImplemented()
+                }
+            }
+        }
+        keyboardInputManager = (getSystemService(Context.INPUT_SERVICE) as InputManager)
+            .also { it.registerInputDeviceListener(this, Handler(Looper.getMainLooper())) }
         val ch = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
         ch.setMethodCallHandler { call, result ->
             if (call.method == "getInitialFile") {
@@ -134,6 +154,30 @@ class MainActivity : FlutterActivity() {
 
         channel = ch
         handleIntent(intent, initial = true)
+    }
+
+    private fun hasPhysicalKeyboard(): Boolean = InputDevice.getDeviceIds().any { id ->
+        val device = InputDevice.getDevice(id)
+        // Volume buttons, remotes, and the virtual keyboard are not typing keyboards.
+        device != null && !device.isVirtual &&
+            (Build.VERSION.SDK_INT < 27 || device.isEnabled) &&
+            device.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC
+    }
+
+    private fun notifyKeyboardChanged() {
+        keyboardChannel?.invokeMethod("changed", hasPhysicalKeyboard())
+    }
+
+    override fun onInputDeviceAdded(deviceId: Int) = notifyKeyboardChanged()
+    override fun onInputDeviceRemoved(deviceId: Int) = notifyKeyboardChanged()
+    override fun onInputDeviceChanged(deviceId: Int) = notifyKeyboardChanged()
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        keyboardInputManager?.unregisterInputDeviceListener(this)
+        keyboardInputManager = null
+        keyboardChannel?.setMethodCallHandler(null)
+        keyboardChannel = null
+        super.cleanUpFlutterEngine(flutterEngine)
     }
 
     private fun handleMobileFile(

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Flutter
+import GameController
 import UIKit
 
 @main
@@ -6,6 +7,12 @@ import UIKit
   UIPrintInteractionControllerDelegate {
   private var nativePrintChannel: FlutterMethodChannel?
   private var preparedPrintSize: CGSize?
+  private var keyboardChannel: FlutterMethodChannel?
+  private var keyboardObservers: [NSObjectProtocol] = []
+
+  deinit {
+    keyboardObservers.forEach(NotificationCenter.default.removeObserver)
+  }
 
   override func application(
     _ application: UIApplication,
@@ -16,6 +23,32 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "KeyboardAvailability") {
+      let channel = FlutterMethodChannel(
+        name: "dev.milanko.dartpdf/keyboard", binaryMessenger: registrar.messenger())
+      channel.setMethodCallHandler { call, result in
+        if call.method == "isConnected" {
+          result(GCKeyboard.coalesced != nil)
+        } else {
+          result(FlutterMethodNotImplemented)
+        }
+      }
+      keyboardChannel = channel
+      keyboardObservers.forEach(NotificationCenter.default.removeObserver)
+      keyboardObservers = [
+        Notification.Name.GCKeyboardDidConnect,
+        Notification.Name.GCKeyboardDidDisconnect,
+      ].map { name in
+        NotificationCenter.default.addObserver(
+          forName: name, object: nil, queue: .main
+        ) { [weak self] notification in
+          // These notifications describe the first connection / last disconnection.
+          self?.keyboardChannel?.invokeMethod(
+            "changed", arguments: notification.name == .GCKeyboardDidConnect)
+        }
+      }
+    }
 
     // Print without a bundled PDF engine: the Dart side hands over the whole
     // PDF and UIKit renders its vector content itself (CoreGraphics), keeping

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -10,6 +10,7 @@ import 'devtools.dart';
 import 'document_tab.dart';
 import 'editor_screen.dart';
 import 'keyless_signing.dart';
+import 'keyboard_availability.dart';
 import 'l10n/app_localizations.dart';
 import 'oidc_signin.dart';
 import 'platform_fonts.dart';
@@ -213,6 +214,7 @@ class _DartPdfWindow extends StatelessWidget {
       ]),
       builder: (context, _) => MaterialApp(
         title: 'DartPDF',
+        builder: (context, child) => KeyboardAvailability(child: child!),
         localizationsDelegates: const [
           ...AppLocalizations.localizationsDelegates,
           DartPdfEditorLocalizations.delegate,

--- a/app/lib/autosave.dart
+++ b/app/lib/autosave.dart
@@ -69,12 +69,12 @@ class AutosaveController {
         recovered.add(RecoveredDocument(record: record, bytes: bytes));
       }
     } catch (e) {
-      AppDevTools.instance
-          .addLog('unsaved-changes recovery failed: $e', level: DevLogLevel.error);
+      AppDevTools.instance.addLog('unsaved-changes recovery failed: $e',
+          level: DevLogLevel.error);
     }
     if (recovered.isNotEmpty) {
-      AppDevTools.instance
-          .addLog('recovered ${recovered.length} document(s) with unsaved changes');
+      AppDevTools.instance.addLog(
+          'recovered ${recovered.length} document(s) with unsaved changes');
     }
     return recovered;
   }
@@ -149,6 +149,9 @@ class AutosaveController {
     mirror.written = null;
     await _delete(mirror.id);
   }
+
+  /// Renaming changes recovery metadata without notifying the PDF controller.
+  void noteMetadataChanged(DocumentTab tab) => _onChanged(tab);
 
   /// Writes every pending mirror now, without waiting out the debounce. Called
   /// when the app is backgrounded - on mobile and the web that may be the last
@@ -273,8 +276,8 @@ class AutosaveController {
       await store.write(record, bytes);
       mirror.written = record;
     } catch (e) {
-      AppDevTools.instance
-          .addLog('unsaved-changes mirror failed: $e', level: DevLogLevel.error);
+      AppDevTools.instance.addLog('unsaved-changes mirror failed: $e',
+          level: DevLogLevel.error);
     } finally {
       mirror.writing = false;
     }

--- a/app/lib/command_palette.dart
+++ b/app/lib/command_palette.dart
@@ -11,6 +11,8 @@
 // Every result carries the surface it came from ("Menu", "Shapes tool",
 // "Panel"), because the palette is meant to *teach* where a command lives
 // rather than become a second place to learn.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart'
+    show PdfKeyboardAvailability;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -269,11 +271,12 @@ class _CommandPaletteState extends State<_CommandPalette> {
                     style:
                         TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
                   ),
-                  Text(
-                    l.paletteKeyHints,
-                    style:
-                        TextStyle(fontSize: 11, color: scheme.onSurfaceVariant),
-                  ),
+                  if (PdfKeyboardAvailability.of(context))
+                    Text(
+                      l.paletteKeyHints,
+                      style: TextStyle(
+                          fontSize: 11, color: scheme.onSurfaceVariant),
+                    ),
                 ],
               ),
             ),
@@ -354,9 +357,10 @@ class _CommandRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final fg = command.enabled ? scheme.onSurface : scheme.onSurfaceVariant;
-    final trailing = command.enabled
-        ? command.shortcut
-        : (command.disabledReason ?? command.shortcut);
+    final shortcut =
+        PdfKeyboardAvailability.of(context) ? command.shortcut : null;
+    final trailing =
+        command.enabled ? shortcut : (command.disabledReason ?? shortcut);
     return MouseRegion(
       onEnter: command.enabled ? (_) => onHover() : null,
       child: Material(

--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -203,7 +203,8 @@ class DocumentTab {
         isLoading = false;
 
   /// The filename shown by the tab. Save As updates it to the chosen file's
-  /// name while keeping this tab's editing and viewer sessions alive.
+  /// name; mobile title taps rename the app's copy and its share filename.
+  /// Both keep this tab's editing and viewer sessions alive.
   String title;
   final String? error;
   final bool isLoading;

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -3022,49 +3022,56 @@ class _EditorScreenState extends State<EditorScreen>
     bool middleEllipsis = false,
     bool hidePdfExtension = false,
   }) =>
-      ListTile(
-        leading: Icon(icon),
-        title: middleEllipsis
-            ? MiddleEllipsisText(
-                title,
-                hidePdfExtension: hidePdfExtension,
-              )
-            : Text(title, overflow: overflow),
-        subtitle: subtitle,
-        trailing: trailing ??
-            (shortcut == null
-                ? null
-                : Text(
-                    shortcut,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  )),
-        contentPadding: EdgeInsets.zero,
-        minTileHeight: _usesCompactAppMenu
-            ? subtitle == null
-                ? _compactAppMenuItemHeight
-                : _compactRecentMenuItemHeight
-            : null,
-        minVerticalPadding: _usesCompactAppMenu ? 0 : null,
-      );
+      Builder(
+          builder: (context) => ListTile(
+                leading: Icon(icon),
+                title: middleEllipsis
+                    ? MiddleEllipsisText(
+                        title,
+                        hidePdfExtension: hidePdfExtension,
+                      )
+                    : Text(title, overflow: overflow),
+                subtitle: subtitle,
+                trailing: trailing ??
+                    (shortcut == null || !PdfKeyboardAvailability.of(context)
+                        ? null
+                        : Text(
+                            shortcut,
+                            style:
+                                Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
+                                    ),
+                          )),
+                contentPadding: EdgeInsets.zero,
+                minTileHeight: _usesCompactAppMenu
+                    ? subtitle == null
+                        ? _compactAppMenuItemHeight
+                        : _compactRecentMenuItemHeight
+                    : null,
+                minVerticalPadding: _usesCompactAppMenu ? 0 : null,
+              ));
 
   List<PopupMenuEntry<VoidCallback>> _recentMenuItems(
       BuildContext menuContext) {
     final recents = _recentMenuEntries();
-    final trailing = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          _menuShortcut('O', shift: true),
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-        ),
-        const SizedBox(width: 12),
-        const Icon(Icons.arrow_right),
-      ],
-    );
+    final trailing = Builder(
+        builder: (context) => Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (PdfKeyboardAvailability.of(context)) ...[
+                  Text(
+                    _menuShortcut('O', shift: true),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                const Icon(Icons.arrow_right),
+              ],
+            ));
     return [
       PopupMenuItem<VoidCallback>(
         height: _appMenuItemHeight(),

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -42,6 +42,7 @@ import 'printing.dart';
 import 'recent_thumbnails.dart';
 import 'recents.dart';
 import 'reduce_file_size.dart';
+import 'rename_document.dart';
 import 'session_store.dart';
 import 'settings_screen.dart';
 import 'tab_drag.dart';
@@ -2543,6 +2544,30 @@ class _EditorScreenState extends State<EditorScreen>
     if (result.message != null) _toast(result.message!);
   }
 
+  /// Mobile picks are app-managed copies; their title is the share filename.
+  /// Keep the live edit session and its saved baseline while renaming the copy.
+  Future<void> _renameDocument(DocumentTab tab) async {
+    if (!_usesMobileShare || tab.session == null) return;
+    final name = await showRenameDocumentDialog(context, tab.title);
+    if (!mounted || !_tabs.contains(tab) || name == null || name == tab.title) {
+      return;
+    }
+    final oldTitle = tab.title;
+    setState(() => tab.title = name);
+    _autosave.noteMetadataChanged(tab);
+    unawaited(_persistSession());
+    // Update existing metadata immediately. A pending initial snapshot reads
+    // tab.title when it records its Recent entry, so it also gets the new name.
+    unawaited(_recents.rename(
+        tab.originPath ?? tab.cachePath ?? oldTitle, tab.title));
+    if (tab.originPath == null && tab.cachePath == null && canCacheRecentPdfs) {
+      // New scans have no source snapshot yet. Give the renamed copy a
+      // reusable source for Recent files and session restoration too.
+      await _snapshotOpenedDocument(tab, tab.session!.bytes);
+      if (mounted && _tabs.contains(tab)) _autosave.noteMetadataChanged(tab);
+    }
+  }
+
   // --- printing ------------------------------------------------------------
 
   Future<void> _reduceFileSize(DocumentTab tab) async {
@@ -3974,6 +3999,26 @@ class _EditorScreenState extends State<EditorScreen>
       tab?.title.isEmpty ?? true ? appL10n(context).editorUntitled : tab!.title,
       hidePdfExtension: tab?.title.isNotEmpty ?? false,
     );
+    if (_usesMobileShare && tab?.session != null) {
+      title = Semantics(
+        button: true,
+        child: Tooltip(
+          message: appL10n(context).rename,
+          child: InkWell(
+            key: const ValueKey('mobile-document-title'),
+            onTap: () => unawaited(_renameDocument(tab!)),
+            child: ConstrainedBox(
+              constraints:
+                  const BoxConstraints(minHeight: kMinInteractiveDimension),
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: title,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
     if (_nativeTabDragging && tab?.session != null) {
       title = _buildNativeTabDragSource(tab!, title);
     }
@@ -4468,7 +4513,13 @@ class _EditorScreenState extends State<EditorScreen>
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
-          onTap: () => setState(() => _activeIndex = index),
+          onTap: () {
+            if (selected && _usesMobileShare && tab.session != null) {
+              unawaited(_renameDocument(tab));
+            } else {
+              setState(() => _activeIndex = index);
+            }
+          },
           onSecondaryTapUp: (details) =>
               _showTabMenu(index, details.globalPosition),
           child: Padding(

--- a/app/lib/keyboard_availability.dart
+++ b/app/lib/keyboard_availability.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Connects the mobile platform's keyboard inventory to all app routes.
+class KeyboardAvailability extends StatefulWidget {
+  const KeyboardAvailability({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<KeyboardAvailability> createState() => _KeyboardAvailabilityState();
+}
+
+class _KeyboardAvailabilityState extends State<KeyboardAvailability>
+    with WidgetsBindingObserver {
+  static const _channel = MethodChannel('dev.milanko.dartpdf/keyboard');
+  final _mobile = switch (defaultTargetPlatform) {
+    TargetPlatform.android ||
+    TargetPlatform.iOS ||
+    TargetPlatform.fuchsia =>
+      true,
+    _ => false,
+  };
+  late bool _connected = !_mobile;
+  int _revision = 0;
+
+  bool get _usesNativeSignal => _mobile && !kIsWeb;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_usesNativeSignal) return;
+    WidgetsBinding.instance.addObserver(this);
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'changed' && call.arguments is bool) {
+        _revision++;
+        _update(call.arguments as bool);
+      }
+    });
+    unawaited(_refresh());
+  }
+
+  Future<void> _refresh() async {
+    final revision = ++_revision;
+    try {
+      final connected = await _channel.invokeMethod<bool>('isConnected');
+      // A connection notification is newer than an in-flight inventory read.
+      if (revision == _revision && connected != null) _update(connected);
+    } on MissingPluginException {
+      // Unsupported hosts retain the conservative mobile default.
+    } on PlatformException {
+      // Keep the last known state if a lifecycle refresh fails.
+    }
+  }
+
+  void _update(bool connected) {
+    if (mounted && connected != _connected) {
+      setState(() => _connected = connected);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) unawaited(_refresh());
+  }
+
+  @override
+  void dispose() {
+    if (_usesNativeSignal) {
+      WidgetsBinding.instance.removeObserver(this);
+      _channel.setMethodCallHandler(null);
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => PdfKeyboardAvailability(
+        connected: _connected,
+        child: widget.child,
+      );
+}

--- a/app/lib/recents.dart
+++ b/app/lib/recents.dart
@@ -149,6 +149,23 @@ class RecentsStore extends ChangeNotifier {
     await _persist();
   }
 
+  /// Updates a document's display/share name, preserving its source and order.
+  Future<void> rename(String id, String title) async {
+    final index = _items.indexWhere((entry) => entry.id == id);
+    if (index < 0 || _items[index].title == title) return;
+    final entry = _items[index];
+    _items[index] = RecentFile(
+      title: title,
+      path: entry.path,
+      cachePath: entry.cachePath,
+      cacheAvailable: entry.cacheAvailable,
+      bookmark: entry.bookmark,
+      openedAt: entry.openedAt,
+    );
+    notifyListeners();
+    await _persist();
+  }
+
   Future<void> clear() async {
     _items.clear();
     notifyListeners();

--- a/app/lib/rename_document.dart
+++ b/app/lib/rename_document.dart
@@ -1,0 +1,82 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart' show showPdfDialog;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'l10n/app_l10n.dart';
+import 'middle_ellipsis_text.dart';
+
+/// Renames the app's document copy and the filename used when sharing it.
+Future<String?> showRenameDocumentDialog(BuildContext context, String name) =>
+    showPdfDialog<String>(
+      context: context,
+      builder: (_) => _RenameDocumentDialog(name: name),
+    );
+
+class _RenameDocumentDialog extends StatefulWidget {
+  const _RenameDocumentDialog({required this.name});
+
+  final String name;
+
+  @override
+  State<_RenameDocumentDialog> createState() => _RenameDocumentDialogState();
+}
+
+class _RenameDocumentDialogState extends State<_RenameDocumentDialog> {
+  late final _name = TextEditingController(text: widget.name)
+    ..selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: pdfDisplayName(widget.name).length,
+    );
+
+  String? get _filename {
+    var stem = _name.text.trim();
+    while (stem.toLowerCase().endsWith('.pdf')) {
+      stem = stem.substring(0, stem.length - 4).trim();
+    }
+    if (stem.replaceAll('.', '').trim().isEmpty) return null;
+    return '$stem.pdf';
+  }
+
+  void _submit() {
+    final filename = _filename;
+    if (filename != null) Navigator.of(context).pop(filename);
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = appL10n(context);
+    return AlertDialog(
+      title: Text(l10n.rename),
+      content: TextField(
+        key: const ValueKey('rename-document-name'),
+        controller: _name,
+        autofocus: true,
+        textInputAction: TextInputAction.done,
+        textCapitalization: TextCapitalization.sentences,
+        autocorrect: false,
+        inputFormatters: [
+          FilteringTextInputFormatter.deny(RegExp(r'[/\\\x00-\x1f\x7f]')),
+        ],
+        onChanged: (_) => setState(() {}),
+        onSubmitted: (_) => _submit(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.cancel),
+        ),
+        FilledButton(
+          key: const ValueKey('rename-document-confirm'),
+          onPressed: _filename == null ? null : _submit,
+          child: Text(l10n.rename),
+        ),
+      ],
+    );
+  }
+}

--- a/app/test/keyboard_availability_test.dart
+++ b/app/test/keyboard_availability_test.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/keyboard_availability.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const channel = MethodChannel('dev.milanko.dartpdf/keyboard');
+  const codec = StandardMethodCodec();
+  final mobilePlatforms =
+      TargetPlatformVariant({TargetPlatform.android, TargetPlatform.iOS});
+  late bool connected;
+  late int queries;
+  late TestDefaultBinaryMessenger messenger;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    connected = false;
+    queries = 0;
+    messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      expect(call.method, 'isConnected');
+      queries++;
+      return connected;
+    });
+  });
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  Future<void> notify(WidgetTester tester, bool value) async {
+    connected = value;
+    final reply = Completer<void>();
+    messenger.handlePlatformMessage(
+        channel.name,
+        codec.encodeMethodCall(MethodCall('changed', value)),
+        (_) => reply.complete());
+    await reply.future;
+    await tester.pump();
+  }
+
+  Widget root(Widget child) => MaterialApp(
+        builder: (context, child) => KeyboardAvailability(child: child!),
+        home: Scaffold(body: child),
+      );
+
+  Widget signal() => Builder(
+      builder: (context) =>
+          Text('keyboard: ${PdfKeyboardAvailability.of(context)}'));
+
+  testWidgets('mobile tracks keyboard connections and refreshes after resume',
+      (tester) async {
+    connected = true;
+    await tester.pumpWidget(root(signal()));
+    await tester.pump();
+    expect(find.text('keyboard: true'), findsOneWidget);
+    await notify(tester, false);
+    expect(find.text('keyboard: false'), findsOneWidget);
+    // The software keyboard opening is not a physical connection.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    addTearDown(tester.view.resetViewInsets);
+    await tester.pump();
+    expect(find.text('keyboard: false'), findsOneWidget);
+    await notify(tester, true);
+    expect(find.text('keyboard: true'), findsOneWidget);
+    connected = false;
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    expect(find.text('keyboard: false'), findsOneWidget);
+    expect(queries, 2);
+  }, variant: mobilePlatforms);
+
+  testWidgets('an old inventory reply cannot overwrite a newer disconnect',
+      (tester) async {
+    final inventory = Completer<bool>();
+    messenger.setMockMethodCallHandler(channel, (_) => inventory.future);
+    await tester.pumpWidget(root(signal()));
+    expect(find.text('keyboard: false'), findsOneWidget);
+    await notify(tester, true);
+    await notify(tester, false);
+    inventory.complete(true);
+    await tester.pump();
+    expect(find.text('keyboard: false'), findsOneWidget);
+  });
+
+  testWidgets('missing mobile bridge keeps hints hidden', (tester) async {
+    messenger.setMockMethodCallHandler(channel, null);
+    await tester.pumpWidget(root(signal()));
+    await tester.pump();
+    expect(find.text('keyboard: false'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('desktop keeps shortcut hints without querying the mobile bridge',
+      (tester) async {
+    await tester.pumpWidget(root(signal()));
+    expect(find.text('keyboard: true'), findsOneWidget);
+    expect(queries, 0);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  testWidgets('an open app menu updates shortcut hints without losing actions',
+      (tester) async {
+    final prefs = PdfEditingPreferences();
+    addTearDown(prefs.dispose);
+    await tester.pumpWidget(root(EditorScreen(prefs: prefs)));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    expect(find.text('New document…'), findsOneWidget);
+    expect(find.text('Ctrl+N'), findsNothing);
+    expect(find.text('Ctrl+K'), findsNothing);
+    await notify(tester, true);
+    expect(find.text('Ctrl+N'), findsOneWidget);
+    expect(find.text('Ctrl+K'), findsOneWidget);
+    await notify(tester, false);
+    expect(find.text('Ctrl+N'), findsNothing);
+    expect(find.text('Ctrl+K'), findsNothing);
+    await tester.tap(find.byKey(const ValueKey('menu-command-palette')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.byKey(const ValueKey('command-palette-field')), 'print');
+    await tester.pumpAndSettle();
+    expect(find.text('Ctrl+P'), findsNothing);
+    // A disabled command still explains why it is unavailable.
+    expect(find.text('Needs an open document'), findsOneWidget);
+    await notify(tester, true);
+    expect(find.textContaining('↑'), findsOneWidget);
+    await notify(tester, false);
+    expect(find.textContaining('↑'), findsNothing);
+  });
+
+  testWidgets('tooltips and open mobile Settings follow keyboard availability',
+      (tester) async {
+    tester.view.physicalSize = const Size(430, 1400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    final prefs = PdfEditingPreferences();
+    addTearDown(prefs.dispose);
+    await tester.pumpWidget(
+        root(PdfEditorView(bytes: buildClassicPdf(), preferences: prefs)));
+    await tester.pumpAndSettle();
+    expect(find.byTooltip('Undo'), findsOneWidget);
+    await notify(tester, true);
+    expect(find.byTooltip('Undo (⌘Z)'), findsOneWidget);
+    await notify(tester, false);
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-controls')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('pdf-shell-shortcuts')), findsNothing);
+    await notify(tester, true);
+    expect(find.byKey(const ValueKey('pdf-shell-shortcuts')), findsOneWidget);
+    await notify(tester, false);
+    expect(find.byKey(const ValueKey('pdf-shell-shortcuts')), findsNothing);
+  });
+
+  testWidgets('hidden hints do not disable keyboard commands', (tester) async {
+    final prefs = PdfEditingPreferences();
+    addTearDown(prefs.dispose);
+    await tester.pumpWidget(root(EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildClassicPdf(), title: 'Report.pdf'))));
+    await tester.pumpAndSettle();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyK);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('command-palette')), findsOneWidget);
+    expect(find.text('Ctrl+N'), findsNothing);
+  });
+}

--- a/app/test/keyboard_availability_test.dart
+++ b/app/test/keyboard_availability_test.dart
@@ -173,4 +173,25 @@ void main() {
     expect(find.byKey(const ValueKey('command-palette')), findsOneWidget);
     expect(find.text('Ctrl+N'), findsNothing);
   });
+
+  testWidgets('open tablet Settings updates when the keyboard disconnects',
+      (tester) async {
+    connected = true;
+    tester.view.physicalSize = const Size(1000, 1100);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(root(PdfEditorView(bytes: buildClassicPdf())));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')));
+    await tester.pumpAndSettle();
+    expect(find.text('Keyboard shortcuts…'), findsOneWidget);
+    await notify(tester, false);
+    expect(find.text('Keyboard shortcuts…'), findsNothing);
+    expect(find.text('Show annotations'), findsOneWidget);
+    await notify(tester, true);
+    expect(find.text('Keyboard shortcuts…'), findsOneWidget);
+    await tester.tap(find.text('Keyboard shortcuts…'));
+    await tester.pumpAndSettle();
+    expect(find.text('Keyboard shortcuts'), findsOneWidget);
+  });
 }

--- a/app/test/recents_test.dart
+++ b/app/test/recents_test.dart
@@ -63,6 +63,26 @@ void main() {
     expect(store.isEmpty, isTrue);
   });
 
+  test('rename preserves cached identity, availability and ordering', () async {
+    final store = RecentsStore();
+    addTearDown(store.dispose);
+    await store.add(title: 'old.pdf', cachePath: 'cached', bookmark: 'access');
+    await store.add(title: 'newest.pdf', path: '/newest.pdf');
+    await store.updateCachedAvailability({'cached'}, {});
+    final openedAt = store.items.last.openedAt;
+    await store.rename('cached', 'renamed.pdf');
+
+    final restored = RecentsStore();
+    addTearDown(restored.dispose);
+    await restored.load();
+    expect(restored.items.map((entry) => entry.title),
+        ['newest.pdf', 'renamed.pdf']);
+    expect(restored.items.last.id, 'cached');
+    expect(restored.items.last.cacheAvailable, isFalse);
+    expect(restored.items.last.bookmark, 'access');
+    expect(restored.items.last.openedAt, openedAt);
+  });
+
   test('eviction preserves identity, order and a usable original path',
       () async {
     final store = RecentsStore();

--- a/app/test/rename_document_test.dart
+++ b/app/test/rename_document_test.dart
@@ -1,0 +1,204 @@
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
+import 'package:dart_pdf_editor_app/recents.dart';
+import 'package:dart_pdf_editor_app/unsaved_changes.dart';
+
+import 'test_finders.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+  late InMemoryUnsavedChangesStore recovery;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+    recovery = InMemoryUnsavedChangesStore();
+  });
+  tearDown(() => prefs.dispose());
+
+  final title = find.byKey(const ValueKey('mobile-document-title'));
+  final name = find.byKey(const ValueKey('rename-document-name'));
+  final confirm = find.byKey(const ValueKey('rename-document-confirm'));
+
+  Future<void> pump(
+    WidgetTester tester, {
+    String? initialTitle = 'Original.pdf',
+    bool wide = false,
+    Future<SaveResult> Function(BuildContext, Uint8List, String)? save,
+  }) async {
+    tester.view.physicalSize = Size(wide ? 1200 : 430, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        unsavedChangesStore: recovery,
+        initialDocument: initialTitle == null
+            ? null
+            : (bytes: buildClassicPdf(), title: initialTitle),
+        saveDocumentAs: save,
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> rename(WidgetTester tester, String value) async {
+    await tester.tap(title);
+    await tester.pumpAndSettle();
+    await tester.enterText(name, value);
+    await tester.tap(confirm);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+
+  testWidgets(
+      'title rename keeps edits and uses the new PDF filename for Share',
+      (tester) async {
+    String? sharedName;
+    Uint8List? sharedBytes;
+    await pump(tester, save: (_, bytes, filename) async {
+      sharedName = filename;
+      sharedBytes = bytes;
+      return SaveResult.cancelled;
+    });
+    final before =
+        tester.widget<PdfEditorView>(find.byType(PdfEditorView)).controller!;
+    before.addBookmark('Keep this edit');
+    final editedBytes = before.bytes;
+    await tester.pump();
+
+    await tester.tap(title);
+    await tester.pumpAndSettle();
+    final field = tester.widget<TextField>(name);
+    expect(field.controller!.text, 'Original.pdf');
+    expect(field.controller!.selection,
+        const TextSelection(baseOffset: 0, extentOffset: 8));
+    await tester.enterText(name, '  Project notes  ');
+    await tester.tap(confirm);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    final after =
+        tester.widget<PdfEditorView>(find.byType(PdfEditorView)).controller!;
+    expect(identical(before, after), isTrue);
+    expect(after.bytes, editedBytes);
+    expect(after.canUndo, isTrue);
+    expect(findMiddleEllipsisText('Project notes.pdf'), findsOneWidget);
+    expect((await recovery.list()).single.title, 'Project notes.pdf');
+
+    await tester.tap(find.byKey(const ValueKey('mobile-app-save')));
+    await tester.pumpAndSettle();
+    expect(sharedName, 'Project notes.pdf');
+    expect(sharedBytes, editedBytes);
+  });
+
+  testWidgets('iOS keyboard Done accepts Unicode and normalizes the extension',
+      (tester) async {
+    await pump(tester);
+    await tester.tap(title);
+    await tester.pumpAndSettle();
+    await tester.enterText(name, '測量 – Café.PDF');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(name, findsNothing);
+    expect(findMiddleEllipsisText('測量 – Café.pdf'), findsOneWidget);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+  testWidgets('empty names cannot submit and Cancel preserves the title',
+      (tester) async {
+    await pump(tester);
+    await tester.tap(title);
+    await tester.pumpAndSettle();
+    for (final invalid in ['', '  ', '.pdf', '..']) {
+      await tester.enterText(name, invalid);
+      await tester.pump();
+      expect(tester.widget<FilledButton>(confirm).onPressed, isNull);
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(name, findsOneWidget);
+    }
+    await tester.enterText(name, 'Do not save this');
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(findMiddleEllipsisText('Original.pdf'), findsOneWidget);
+    expect(await recovery.list(), isEmpty);
+  });
+
+  testWidgets('pasted paths cannot escape the shared filename', (tester) async {
+    await pump(tester);
+    await rename(tester, 'Reports/September\\notes.pdf.pdf');
+    expect(findMiddleEllipsisText('ReportsSeptembernotes.pdf'), findsOneWidget);
+  });
+
+  testWidgets('renaming persists the cached source in Recent and session state',
+      (tester) async {
+    final bytes = Uint8List.fromList(buildClassicPdf());
+    await recovery.write(
+      UnsavedRecord(
+        id: 'scan',
+        title: 'Untitled.pdf',
+        cachePath: '/private/scan-cache.pdf',
+        length: bytes.length,
+        savedLength: -1,
+      ),
+      bytes,
+    );
+    final recents = RecentsStore();
+    addTearDown(recents.dispose);
+    await recents.add(
+        title: 'Untitled.pdf', cachePath: '/private/scan-cache.pdf');
+    await pump(tester, initialTitle: null);
+    await rename(tester, 'Site inspection');
+
+    final restoredRecents = RecentsStore();
+    addTearDown(restoredRecents.dispose);
+    await restoredRecents.load();
+    expect(restoredRecents.items.single.title, 'Site inspection.pdf');
+    expect(restoredRecents.items.single.cachePath, '/private/scan-cache.pdf');
+    final storedPrefs = await SharedPreferences.getInstance();
+    final session =
+        jsonDecode(storedPrefs.getString('dart_pdf_editor_app.session')!)
+            as List;
+    expect(session.single['t'], 'Site inspection.pdf');
+    expect(session.single['c'], '/private/scan-cache.pdf');
+    expect((await recovery.list()).single.title, 'Site inspection.pdf');
+  });
+
+  testWidgets('the active tablet tab also renames on a title tap',
+      (tester) async {
+    await pump(tester, wide: true);
+    expect(title, findsNothing);
+    await tester.tap(find.descendant(
+      of: find.byKey(const ValueKey('tab-strip')),
+      matching: findMiddleEllipsisText('Original.pdf'),
+    ));
+    await tester.pumpAndSettle();
+    expect(name, findsOneWidget);
+    await tester.enterText(name, 'Tablet scan');
+    await tester.tap(confirm);
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(findMiddleEllipsisText('Tablet scan.pdf'), findsOneWidget);
+  });
+
+  testWidgets('a narrow desktop title does not open mobile rename',
+      (tester) async {
+    await pump(tester);
+    expect(title, findsNothing);
+    await tester.tap(findMiddleEllipsisText('Original.pdf'));
+    await tester.pumpAndSettle();
+    expect(name, findsNothing);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+}

--- a/doc/dev-log/2026-09-06-android-scan-release-shrinking.md
+++ b/doc/dev-log/2026-09-06-android-scan-release-shrinking.md
@@ -1,0 +1,56 @@
+# Android scan launch failure in the Play release
+
+Reproduced on a Pixel 6 running Android 17 with the Play-installed DartPDF
+4.2.0 (35). Both scan actions displayed "Couldn't scan the document" without
+opening the scanner. The process log identified an earlier startup failure:
+
+```text
+ComponentDiscovery: Invalid component registrar.
+Could not instantiate com.google.mlkit.common.internal.CommonComponentRegistrar
+Caused by: java.lang.NoSuchMethodException:
+  com.google.mlkit.common.internal.CommonComponentRegistrar.<init> []
+```
+
+`MlKitInitProvider` could not populate ML Kit's component registry. The first
+`flutter_doc_scanner` call then threw a `NullPointerException` during scanner
+client construction. The plugin also left its pending result set after this
+synchronous exception, so later attempts failed immediately too.
+
+The installed APK confirmed the cause: its manifest still listed
+`CommonComponentRegistrar`, and its DEX still contained the named class and
+component factory, but **no constructor**. The previous URI read-back and
+image-to-PDF fixes run after capture and cannot repair SDK initialization.
+
+AGP 9 enables `android.r8.strictFullModeForKeepRules`: keeping a class no longer
+implicitly keeps its default constructor. See the [AGP 9 behavior changes](https://developer.android.com/build/releases/agp-9-0-0-release-notes#behavior-changes).
+The app uses AGP 9.1.1, and Flutter enables release shrinking by default.
+
+`app/android/app/proguard-rules.pro` now keeps ML Kit component registrar names
+and their public no-argument constructors explicitly. Other code still shrinks
+and optimizes normally. The release build explicitly includes the file.
+
+`tool/check_android_scanner.py` reads the actual APK manifest with the SDK's
+`apkanalyzer`, finds ML Kit's registered components, and checks their raw DEX
+for the public constructors. It fails against the Play-installed broken APK.
+The Android release workflow runs it before uploading artifacts. Widget tests
+alone cannot cover this failure: they mock native scanning and do not run R8.
+
+## Validation
+
+- All 23 tests in `app/test/doc_scan_io_test.dart` and
+  `app/test/doc_scan_menu_test.dart` pass.
+- The checker rejects the APK pulled from the Pixel's Play installation and
+  passes against the corrected, minified arm64 release APK. Disassembly shows
+  `public constructor <init>()V` in `CommonComponentRegistrar` again.
+- Installed a minified release test copy under
+  `dev.milanko.dartpdf.scantest`, using a temporary Gradle init script to change
+  only its application ID. This preserves the Play app's data and documents.
+  Scan opened ML Kit's camera UI. Ben completed a scan, the app opened a
+  one-page Untitled document, and he confirmed it works. The test app and its
+  document were left installed; the Play app still needs the next release.
+
+Fresh-worktree build note: run `flutter build apk --release` with its normal
+pub/registration step. The first `--no-pub` build picked up a test-generated
+`GeneratedPluginRegistrant` containing `integration_test`, which release mode
+excludes from Gradle dependencies. Regenerating for release resolved that local
+build failure; no plugin source patch was needed for this fix.

--- a/doc/dev-log/2026-09-06-keyboard-shortcut-visibility.md
+++ b/doc/dev-log/2026-09-06-keyboard-shortcut-visibility.md
@@ -23,8 +23,11 @@ updates. Command-palette key labels and navigation hints disappear, while
 disabled-action explanations remain. Undo/redo/save use their existing
 localized plain labels; tool tooltips omit their key suffixes. Shortcut
 configuration is hidden from Settings without changing any bindings.
+The tablet popup reads availability inside a mounted menu entry because
+`PopupMenuButton.itemBuilder` runs only when opening. This keeps an open
+Settings popup current on both disconnect and reconnect, without an empty row.
 
-Validation: 8 keyboard regressions cover Android/iOS connection changes,
+Validation: 9 keyboard regressions cover Android/iOS connection changes,
 software-keyboard exclusion, foreground refresh, stale query replies,
 missing bridges, live menus/Settings/tooltips, and functioning commands with
 hidden hints. The existing app menu/palette/save regressions (18) and shell/

--- a/doc/dev-log/2026-09-06-keyboard-shortcut-visibility.md
+++ b/doc/dev-log/2026-09-06-keyboard-shortcut-visibility.md
@@ -1,0 +1,34 @@
+# Show shortcut hints when a mobile keyboard is connected
+
+The native app's `KeyboardAvailability` wraps the Navigator through
+`MaterialApp.builder`. It publishes `PdfKeyboardAvailability` for menus,
+dialogs, the command palette, and the editor toolbar. Mobile starts with
+hints hidden until the native inventory reports a keyboard; desktop keeps
+its normal hints. The reusable editor scope defaults to showing hints when
+the host does not supply a connection signal. Mobile web has no native
+inventory and conservatively hides hints.
+
+Android uses `InputManager.InputDeviceListener` and queries enabled,
+non-virtual, alphabetic input devices. This excludes on-screen keyboards,
+volume keys, and remotes. The `isEnabled` check is gated at API 27.
+iOS queries `GCKeyboard.coalesced` and observes first-connect/last-disconnect
+notifications. Both bridges use `dev.milanko.dartpdf/keyboard` with an
+`isConnected` query and `changed` events. Foregrounding refreshes inventory;
+a sequence guard prevents an old query reply from overriding a newer event.
+Native APIs: [Android InputDevice](https://developer.android.com/reference/android/view/InputDevice)
+and [Apple keyboard notifications](https://developer.apple.com/documentation/foundation/nsnotification/name-swift.struct/gckeyboarddidconnect).
+
+App-menu tiles read the scope in their own Builders so an already-open menu
+updates. Command-palette key labels and navigation hints disappear, while
+disabled-action explanations remain. Undo/redo/save use their existing
+localized plain labels; tool tooltips omit their key suffixes. Shortcut
+configuration is hidden from Settings without changing any bindings.
+
+Validation: 8 keyboard regressions cover Android/iOS connection changes,
+software-keyboard exclusion, foreground refresh, stale query replies,
+missing bridges, live menus/Settings/tooltips, and functioning commands with
+hidden hints. The existing app menu/palette/save regressions (18) and shell/
+tool-shortcut suites (92) pass. Changed Dart files analyze cleanly. The
+Android ARM64 release builds and passes the scanner-constructor APK check;
+the iOS simulator app also builds successfully.
+The Pixel remains disconnected, so physical attach/detach has not been tested.

--- a/doc/dev-log/2026-09-06-mobile-controls-groups.md
+++ b/doc/dev-log/2026-09-06-mobile-controls-groups.md
@@ -1,0 +1,16 @@
+# Group mobile Controls by purpose
+
+`PdfShellControlItem.group` separates View, Panels, and document actions.
+Both editor and reader shells mark their panel controls explicitly. Settings
+and Reflow sit under the existing localized View heading alongside zoom;
+panel buttons get the localized Panels heading. Host-provided Save/Share
+stays in a separate action row when present. Empty groups are omitted.
+
+The sheet now scrolls within 90% of the screen height so the added section
+does not strand controls on smaller displays. Existing tile keys, selected
+states, and close-then-open behavior remain intact.
+
+Validation: all 80 `pdf_shell_test.dart` tests pass and changed files analyze
+cleanly. A temporary Flutter rendering harness verified the dark Controls
+sheet at 430×956 and reached/opened Properties after shrinking to 430×430;
+the harness was removed after visual inspection. The Pixel was disconnected.

--- a/doc/dev-log/2026-09-06-mobile-document-rename.md
+++ b/doc/dev-log/2026-09-06-mobile-document-rename.md
@@ -1,0 +1,26 @@
+# Rename mobile documents from the title
+
+Android and iOS title taps now open the localized Rename dialog; on tablets,
+the selected tab does the same. A rename updates the app-managed document
+name and Share filename while retaining the editing controller, PDF bytes,
+undo history, and saved baseline.
+
+`app/lib/rename_document.dart` owns the dialog and controller lifecycle.
+The initial selection excludes `.pdf`; confirmation trims whitespace,
+normalizes the extension, accepts Unicode, and rejects empty or dot-only
+names. Input filtering removes path separators and control characters.
+
+`RecentsStore.rename` keeps source identity, cache availability, bookmarks,
+order, and opened time. Session metadata is persisted immediately, and
+`AutosaveController.noteMetadataChanged` schedules updated recovery metadata
+without creating a PDF revision. New scans without a reusable source also
+receive a private snapshot. Recent-name updates run immediately: putting
+them behind background cache pruning delayed persistence unnecessarily.
+
+Validation: 65 app tests pass across rename, Recents, tabs, save shortcuts,
+and unsaved-change storage/recovery. Rename coverage includes Android and
+iOS, tablet title taps, cancellation, validation, sharing, metadata
+persistence, and preserving the live edit session. Changed Dart files
+analyze cleanly. The Android ARM64 release builds and passes the APK scanner
+constructor check. Device installation was deferred when Ben unplugged the
+Pixel; the rename flow has not yet been checked on physical hardware.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `PdfKeyboardAvailability` so hosts can hide shortcut hints and shortcut
+  settings when a physical keyboard is unavailable. Shortcut bindings stay active.
 - Group mobile Controls into View and Panels sections in both shells, keeping
   Settings and Reflow with view controls and allowing the sheet to scroll.
 - Add complete Australian and UK English locales for editor controls, including

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Group mobile Controls into View and Panels sections in both shells, keeping
+  Settings and Reflow with view controls and allowing the sheet to scroll.
 - Add complete Australian and UK English locales for editor controls, including
   colour, centre and organisation, while the base English locale uses US spelling.
   Localise the smart alignment guide hint.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -108,6 +108,7 @@ export 'src/search_panel.dart';
 export 'src/search_field_style.dart';
 export 'src/scrollbar.dart';
 export 'src/theme.dart';
+export 'src/keyboard_availability.dart';
 export 'src/tile_layer.dart';
 export 'src/tile_raster_backend.dart';
 export 'src/tile_store.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_tool_catalog.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_tool_catalog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../l10n/pdf_l10n.dart';
 import 'editing_controller.dart';
 import 'tool_shortcuts.dart';
+import '../keyboard_availability.dart';
 
 /// One entry in the tool catalogue: an editing [tool] or a text [markup]
 /// kind, with the icon the dock draws for it.
@@ -244,6 +245,7 @@ String pdfEditToolTooltipWithShortcut(
   Map<PdfEditTool, PdfToolShortcut> shortcuts = pdfEditToolShortcuts,
 }) {
   final tip = pdfEditToolTooltip(context, tool);
+  if (!PdfKeyboardAvailability.of(context)) return tip;
   final key = pdfEditToolShortcutLabel(tool, shortcuts: shortcuts);
   return key == null ? tip : '$tip ($key)';
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -40,6 +40,7 @@ import 'editing_tool_behavior.dart';
 import 'text_prompt.dart';
 import 'text_style_prompt.dart';
 import 'tool_shortcuts.dart';
+import '../keyboard_availability.dart';
 
 /// Builds a custom widget inside [PdfEditingToolbar].
 typedef PdfEditingToolbarWidgetBuilder = Widget Function(
@@ -113,7 +114,9 @@ Future<void> showPdfEditingGuidesDialog(
                   key: const ValueKey('pdf-grid-snap'),
                   secondary: const Icon(Icons.grid_4x4),
                   title: const Text('Snap to grid'),
-                  subtitle: const Text('Hold Alt to bypass snapping'),
+                  subtitle: PdfKeyboardAvailability.of(context)
+                      ? const Text('Hold Alt to bypass snapping')
+                      : null,
                   value: preferences.snapToGrid,
                   onChanged: (value) => preferences.snapToGrid = value,
                 ),
@@ -505,10 +508,6 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// mobile tool tiles, and the active-tool caption.
   String _toolName(BuildContext context, PdfEditTool tool) =>
       pdfEditToolLabel(context, tool);
-
-  /// The full tooltip for a tool.
-  String _toolTip(BuildContext context, PdfEditTool tool) =>
-      pdfEditToolTooltip(context, tool);
 
   /// The bare, localized name of a text-markup tool (for mobile tiles).
   String _markupName(BuildContext context, PdfMarkupKind markup) =>
@@ -1555,13 +1554,17 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         IconButton(
           key: const ValueKey('pdf-undo'),
           icon: const Icon(Icons.undo),
-          tooltip: pdfL10n(context).tbUndoShortcut,
+          tooltip: PdfKeyboardAvailability.of(context)
+              ? pdfL10n(context).tbUndoShortcut
+              : pdfL10n(context).undo,
           onPressed: controller.canUndo ? controller.undo : null,
         ),
         IconButton(
           key: const ValueKey('pdf-redo'),
           icon: const Icon(Icons.redo),
-          tooltip: pdfL10n(context).tbRedoShortcut,
+          tooltip: PdfKeyboardAvailability.of(context)
+              ? pdfL10n(context).tbRedoShortcut
+              : pdfL10n(context).redo,
           onPressed: controller.canRedo ? controller.redo : null,
         ),
         _DockDivider(axis: axis),
@@ -1594,7 +1597,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         _DockDivider(axis: axis),
         IconButton(
           icon: const Icon(Icons.save_alt),
-          tooltip: pdfL10n(context).tbSaveShortcut,
+          tooltip: PdfKeyboardAvailability.of(context)
+              ? pdfL10n(context).tbSaveShortcut
+              : pdfL10n(context).save,
           // disabled while the document matches what was opened - there's
           // nothing to write until an edit bumps the revision cursor
           onPressed: controller.isModified
@@ -2550,14 +2555,18 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             IconButton(
               key: const ValueKey('pdf-undo'),
               icon: const Icon(Icons.undo),
-              tooltip: pdfL10n(context).tbUndoShortcut,
+              tooltip: PdfKeyboardAvailability.of(context)
+                  ? pdfL10n(context).tbUndoShortcut
+                  : pdfL10n(context).undo,
               visualDensity: VisualDensity.compact,
               onPressed: controller.canUndo ? controller.undo : null,
             ),
             IconButton(
               key: const ValueKey('pdf-redo'),
               icon: const Icon(Icons.redo),
-              tooltip: pdfL10n(context).tbRedoShortcut,
+              tooltip: PdfKeyboardAvailability.of(context)
+                  ? pdfL10n(context).tbRedoShortcut
+                  : pdfL10n(context).redo,
               visualDensity: VisualDensity.compact,
               onPressed: controller.canRedo ? controller.redo : null,
             ),
@@ -3070,9 +3079,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final markup = entry.markup;
     if (markup != null) return _markupTip(context, markup);
     final tool = entry.tool!;
-    final tip = _toolTip(context, tool);
-    final key = pdfEditToolShortcutLabel(tool, shortcuts: widget.toolShortcuts);
-    return key == null ? tip : '$tip ($key)';
+    return pdfEditToolTooltipWithShortcut(context, tool,
+        shortcuts: widget.toolShortcuts);
   }
 
   /// The settings block under the sheet's tool grid - reuses the same

--- a/packages/dart_pdf_editor/lib/src/keyboard_availability.dart
+++ b/packages/dart_pdf_editor/lib/src/keyboard_availability.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+/// Whether a physical keyboard is available for shortcut hints and settings.
+///
+/// Place this above the Navigator (for example in MaterialApp.builder) so
+/// menus and dialogs update too. Hosts supply their platform's connection
+/// signal; without this scope, the editor retains its usual shortcut hints.
+/// This affects presentation only, never the shortcut bindings themselves.
+class PdfKeyboardAvailability extends InheritedWidget {
+  const PdfKeyboardAvailability({
+    super.key,
+    required this.connected,
+    required super.child,
+  });
+
+  final bool connected;
+
+  static bool of(BuildContext context) =>
+      context
+          .dependOnInheritedWidgetOfExactType<PdfKeyboardAvailability>()
+          ?.connected ??
+      true;
+
+  @override
+  bool updateShouldNotify(PdfKeyboardAvailability oldWidget) =>
+      connected != oldWidget.connected;
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1511,6 +1511,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   if (features.reflowView) reflowControl,
                   for (final item in panelItems)
                     PdfShellControlItem(
+                      group: PdfShellControlGroup.panels,
                       key: item.key,
                       icon: item.icon,
                       label: item.tooltip,
@@ -1519,6 +1520,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     ),
                   if (widget.onSave != null && widget.showSaveButton)
                     PdfShellControlItem(
+                      group: PdfShellControlGroup.actions,
                       key: const ValueKey('pdf-shell-save'),
                       icon: widget.saveButtonIcon,
                       label: widget.saveButtonLabel ?? pdfL10n(context).save,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -532,6 +532,7 @@ class _PdfReaderState extends State<PdfReader> {
                   ),
                   if (features.thumbnails)
                     PdfShellControlItem(
+                      group: PdfShellControlGroup.panels,
                       key: const ValueKey('pdf-shell-thumbnails-toggle'),
                       icon: Icons.grid_view,
                       label: pdfL10n(context).shellPanelPages,
@@ -541,6 +542,7 @@ class _PdfReaderState extends State<PdfReader> {
                     ),
                   if (features.bookmarks)
                     PdfShellControlItem(
+                      group: PdfShellControlGroup.panels,
                       key: const ValueKey('pdf-shell-bookmarks-toggle'),
                       icon: Icons.bookmarks_outlined,
                       label: pdfL10n(context).shellPanelBookmarks,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -11,6 +11,7 @@ import 'editing/editing_preferences.dart';
 import 'editing/editing_toolbar.dart' show showPdfEditingGuidesDialog;
 import 'editing/tool_shortcuts.dart';
 import 'l10n/pdf_l10n.dart';
+import 'keyboard_availability.dart';
 import 'pdf_viewer.dart';
 import 'scrollbar.dart';
 import 'search_field_style.dart';
@@ -1898,7 +1899,9 @@ Future<void> showPdfShellViewOptionsSheet(
                   ),
                   onTap: onAuthorPressed,
                 ),
-              if (toolShortcuts != null && onToolShortcutsChanged != null)
+              if (PdfKeyboardAvailability.of(context) &&
+                  toolShortcuts != null &&
+                  onToolShortcutsChanged != null)
                 ListTile(
                   key: const ValueKey('pdf-shell-shortcuts'),
                   leading: const Icon(Icons.keyboard_outlined),
@@ -2078,7 +2081,9 @@ class PdfShellViewOptionsButton extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
             ),
           ),
-        if (toolShortcuts != null && onToolShortcutsChanged != null)
+        if (PdfKeyboardAvailability.of(context) &&
+            toolShortcuts != null &&
+            onToolShortcutsChanged != null)
           PopupMenuItem(
             key: const ValueKey('pdf-shell-shortcuts'),
             value: _ViewOption.shortcuts,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -958,6 +958,8 @@ bool pdfShellShowThumbnailSidebar(
       (!compact || preferences.hasShowThumbnailSidebarPreference);
 }
 
+enum PdfShellControlGroup { view, panels, actions }
+
 /// A right-side shell control that collapses into the mobile Controls sheet.
 class PdfShellControlItem {
   const PdfShellControlItem({
@@ -965,6 +967,7 @@ class PdfShellControlItem {
     required this.icon,
     required this.label,
     required this.onPressed,
+    this.group = PdfShellControlGroup.view,
     this.selected = false,
     this.enabled = true,
   });
@@ -973,6 +976,7 @@ class PdfShellControlItem {
   final IconData icon;
   final String label;
   final VoidCallback onPressed;
+  final PdfShellControlGroup group;
   final bool selected;
   final bool enabled;
 }
@@ -1022,17 +1026,28 @@ class PdfShellBar extends StatelessWidget {
   final List<Widget> compactSheetChildren;
 
   Future<void> _showControls(BuildContext context) {
-    final controls = compactControls;
+    final viewControls = compactControls
+        .where((control) => control.group == PdfShellControlGroup.view)
+        .toList();
+    final panels = compactControls
+        .where((control) => control.group == PdfShellControlGroup.panels)
+        .toList();
+    final actions = compactControls
+        .where((control) => control.group == PdfShellControlGroup.actions)
+        .toList();
     final children = compactSheetChildren;
     return showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
       isScrollControlled: true,
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * 0.9,
+      ),
       builder: (context) => _ShellControlsSheetScope(
         close: () => Navigator.of(context).maybePop(),
         child: SafeArea(
           top: false,
-          child: Padding(
+          child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(14, 0, 14, 16),
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -1047,37 +1062,25 @@ class PdfShellBar extends StatelessWidget {
                   ],
                 ),
                 const SizedBox(height: 14),
-                if (children.isNotEmpty) ...[
+                if (children.isNotEmpty || viewControls.isNotEmpty) ...[
                   _ShellSheetSectionLabel(pdfL10n(context).shellSectionView),
                   const SizedBox(height: 10),
                   for (final child in children) child,
+                  if (viewControls.isNotEmpty)
+                    _ShellControlGrid(controls: viewControls),
                   const SizedBox(height: 14),
                 ],
-                if (controls.isNotEmpty) ...[
-                  _ShellSheetSectionLabel(pdfL10n(context).shellSectionShell),
+                if (panels.isNotEmpty) ...[
+                  _ShellSheetSectionLabel(pdfL10n(context).shellPanels),
                   const SizedBox(height: 10),
-                  GridView.count(
-                    crossAxisCount: 4,
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    childAspectRatio: 1.15,
-                    mainAxisSpacing: 6,
-                    crossAxisSpacing: 6,
-                    children: [
-                      for (final control in controls)
-                        _ShellControlTile(
-                          key: control.key,
-                          icon: control.icon,
-                          label: control.label,
-                          active: control.selected,
-                          enabled: control.enabled,
-                          onTap: () {
-                            Navigator.of(context).pop();
-                            control.onPressed();
-                          },
-                        ),
-                    ],
-                  ),
+                  _ShellControlGrid(controls: panels),
+                ],
+                if (actions.isNotEmpty) ...[
+                  if (children.isNotEmpty ||
+                      viewControls.isNotEmpty ||
+                      panels.isNotEmpty)
+                    const Divider(height: 28),
+                  _ShellControlGrid(controls: actions),
                 ],
               ],
             ),
@@ -1273,6 +1276,37 @@ class _ShellSheetSectionLabel extends StatelessWidget {
               .onSurfaceVariant
               .withValues(alpha: 0.72),
         ),
+      );
+}
+
+class _ShellControlGrid extends StatelessWidget {
+  const _ShellControlGrid({required this.controls});
+
+  final List<PdfShellControlItem> controls;
+
+  @override
+  Widget build(BuildContext context) => GridView.count(
+        crossAxisCount: 4,
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        physics: const NeverScrollableScrollPhysics(),
+        childAspectRatio: 1.15,
+        mainAxisSpacing: 6,
+        crossAxisSpacing: 6,
+        children: [
+          for (final control in controls)
+            _ShellControlTile(
+              key: control.key,
+              icon: control.icon,
+              label: control.label,
+              active: control.selected,
+              enabled: control.enabled,
+              onTap: () {
+                Navigator.of(context).pop();
+                control.onPressed();
+              },
+            ),
+        ],
       );
 }
 

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -2081,21 +2081,42 @@ class PdfShellViewOptionsButton extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
             ),
           ),
-        if (PdfKeyboardAvailability.of(context) &&
-            toolShortcuts != null &&
-            onToolShortcutsChanged != null)
-          PopupMenuItem(
-            key: const ValueKey('pdf-shell-shortcuts'),
-            value: _ViewOption.shortcuts,
-            child: ListTile(
-              leading: const Icon(Icons.keyboard_outlined),
-              title: Text(pdfL10n(context).shellKeyboardShortcutsMenu),
-              contentPadding: EdgeInsets.zero,
-            ),
-          ),
+        if (toolShortcuts != null && onToolShortcutsChanged != null)
+          const _KeyboardShortcutMenuItem(),
       ],
     );
   }
+}
+
+// PopupMenuButton builds its entries only when opening. Read availability
+// inside the mounted entry so an open tablet menu also tracks keyboard changes.
+class _KeyboardShortcutMenuItem extends PopupMenuEntry<_ViewOption> {
+  const _KeyboardShortcutMenuItem();
+
+  @override
+  double get height => kMinInteractiveDimension;
+
+  @override
+  bool represents(_ViewOption? value) => value == _ViewOption.shortcuts;
+
+  @override
+  State<_KeyboardShortcutMenuItem> createState() =>
+      _KeyboardShortcutMenuItemState();
+}
+
+class _KeyboardShortcutMenuItemState extends State<_KeyboardShortcutMenuItem> {
+  @override
+  Widget build(BuildContext context) => PdfKeyboardAvailability.of(context)
+      ? PopupMenuItem<_ViewOption>(
+          key: const ValueKey('pdf-shell-shortcuts'),
+          value: _ViewOption.shortcuts,
+          child: ListTile(
+            leading: const Icon(Icons.keyboard_outlined),
+            title: Text(pdfL10n(context).shellKeyboardShortcutsMenu),
+            contentPadding: EdgeInsets.zero,
+          ),
+        )
+      : const SizedBox.shrink();
 }
 
 /// One item in the shell's grouped panel switch.

--- a/tool/check_android_scanner.py
+++ b/tool/check_android_scanner.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Check ML Kit's reflection entry points in an actual release APK.
+
+Flutter/widget tests and debug APKs cannot catch R8 removing a constructor.
+Run after `flutter build apk --release` (also run by release-app.yml):
+  python3 tool/check_android_scanner.py app/build/app/outputs/flutter-apk/app-release.apk
+
+Requires apkanalyzer from the Android SDK command-line tools, found on PATH or
+under ANDROID_HOME/ANDROID_SDK_ROOT, or supplied with --apkanalyzer.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+ANDROID = "{http://schemas.android.com/apk/res/android}"
+DISCOVERY_SERVICE = "com.google.mlkit.common.internal.MlKitComponentDiscoveryService"
+COMMON_REGISTRAR = "com.google.mlkit.common.internal.CommonComponentRegistrar"
+REGISTRAR_PREFIX = "com.google.firebase.components:"
+REGISTRAR_TYPE = "com.google.firebase.components.ComponentRegistrar"
+
+
+def find_apkanalyzer():
+    executable = shutil.which("apkanalyzer")
+    if executable:
+        return executable
+    for variable in ("ANDROID_HOME", "ANDROID_SDK_ROOT"):
+        sdk = os.environ.get(variable)
+        if sdk:
+            executable = Path(sdk) / "cmdline-tools/latest/bin/apkanalyzer"
+            if executable.is_file():
+                return str(executable)
+    raise RuntimeError("Set ANDROID_HOME or pass --apkanalyzer with its SDK path")
+
+
+def check_apk(apk, apkanalyzer):
+    def analyze(*args):
+        return subprocess.run(
+            [apkanalyzer, *args, str(apk)], check=True, capture_output=True, text=True
+        ).stdout
+
+    manifest = ET.fromstring(analyze("manifest", "print"))
+    registrars = set()
+    for service in manifest.iter("service"):
+        if service.get(ANDROID + "name") != DISCOVERY_SERVICE:
+            continue
+        for metadata in service.findall("meta-data"):
+            name = metadata.get(ANDROID + "name", "")
+            if (metadata.get(ANDROID + "value") == REGISTRAR_TYPE
+                    and name.startswith(REGISTRAR_PREFIX)):
+                registrars.add(name[len(REGISTRAR_PREFIX):])
+    if COMMON_REGISTRAR not in registrars:
+        raise RuntimeError("ML Kit's common registrar is missing from the APK manifest")
+
+    for registrar in sorted(registrars):
+        # Read the un-mapped DEX, not the pre-shrink class files or R8 seeds.
+        # Looking up the manifest's name also catches accidental obfuscation.
+        code = analyze("dex", "code", "--class", registrar)
+        if not re.search(r"^\.method public constructor <init>\(\)V\s*$", code, re.M):
+            raise RuntimeError(
+                f"{registrar} has no public no-argument constructor in {apk}; "
+                "release document scanning will fail during ML Kit initialization"
+            )
+        print(f"OK: {registrar} has its reflectively invoked constructor")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("apk", type=Path)
+    parser.add_argument("--apkanalyzer")
+    args = parser.parse_args()
+    try:
+        check_apk(args.apk, args.apkanalyzer or find_apkanalyzer())
+    except (OSError, RuntimeError, ET.ParseError, subprocess.CalledProcessError) as error:
+        print(f"Android scanner check failed: {error}", file=sys.stderr)
+        if isinstance(error, subprocess.CalledProcessError):
+            print(error.stderr, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Android release builds could show “Couldn't scan the document” before the camera opened because R8 removed an ML Kit constructor used through reflection. Preserve that constructor and check the packaged APK before publishing releases.

This also improves the mobile document workflow:

- Tap the document title (or active tablet tab) to rename the app's copy. The name persists in Recent files and recovery and is used when sharing; edits and undo history survive.
- Separate View controls (zoom, Settings, Reflow) from Panels in the mobile Controls sheet, with scrolling on shorter screens.
- Hide shortcut hints and shortcut settings without a connected physical keyboard on Android/iOS, updating open menus when keyboards connect or disconnect. Shortcut bindings remain active.

## Affected packages

- [x] `dart_pdf_editor`
- [x] DartPDF app (`app/`)
- [x] Release workflow, APK validation tool, and documentation

## Change type

- [x] Bug fix
- [x] Feature

## Validation

- [x] Android ARM64 release build and APK scanner-constructor check on the final PR commit.
- [x] iOS simulator build on the final PR commit.
- [x] Real camera scan completed successfully on a Pixel 6; user confirmed the scanned page displays correctly.
- [x] Targeted app rename, recovery, Recents, menu, palette, keyboard, and save tests.
- [x] Editor shell and tool-shortcut tests.
- [x] Visual inspection of Controls at phone size and a short-screen scroll/access check.
- [x] Repository-wide `dart analyze --fatal-infos` and 181 targeted tests pass after merging current `main` (89 app tests, 92 editor tests), including a regression for disconnect/reconnect while tablet Settings is open.
- [x] All GitHub checks are green on `b7e544cb`: full test suite, Android/iOS/macOS Patrol end-to-end tests, web Patrol, GPU checks, coverage, and preview builds/deployments.

## User experience

- [x] Rename cancellation, empty/invalid names, Unicode, extension handling, keyboard submission, persistence, sharing, and undo preservation are covered.
- [x] Keyboard connection changes, stale inventory replies, software-keyboard exclusion, and live menu/Settings updates are covered by platform-channel tests.
- [x] Panel actions and shortcut execution retain their existing behavior.

## Compatibility checklist

- [x] PDF engine layering is preserved; no new `dart:io` imports in `lib/`.
- [x] PDF content and parser/rendering behavior are unchanged by the UI changes.
- [x] Tests use programmatically generated PDFs.

## Notes for reviewers

The keyboard signal is native on Android/iOS. Desktop keeps its usual hints; mobile web conservatively hides them because it has no native keyboard inventory. Hosts can supply `PdfKeyboardAvailability` above their Navigator; without that scope, the reusable editor retains its existing hints.

Physical keyboard attach/detach and the newer mobile UI changes have not been tested on the Pixel since it was unplugged. The isolated Android test build preserves the existing test app's data and is ready for the next device connection.
