### PR TITLE
Stop stretching substituted glyphs across their character spacing

### DIFF
--- a/doc/dev-log/2026-09-06-character-spacing-is-not-shape.md
+++ b/doc/dev-log/2026-09-06-character-spacing-is-not-shape.md
@@ -1,0 +1,103 @@
+# Character spacing is a gap, not a shape (over-wide table digits)
+
+A bridging-details table from a CAD-exported form (ArialMT/Arial-BoldMT,
+none of them embedded) drew its row numbers - `3`, `4`, `5`, `6` - roughly
+four times too wide, fat enough to read as a different, bolder typeface than
+the rest of the sheet. Everything else on the page was fine.
+
+The content stream says it plainly:
+
+```
+15.137 Tc 54.96 396.24 Td
+( 3)Tj
+```
+
+At `/F1 9 Tf` that Tc is 1.68 em of character spacing per glyph - the export's
+way of reaching the next column - so the pen steps 2.24 em across a digit the
+font gives 0.556 em, after a leading space that steps 1.96 em.
+
+## The defect
+
+Exact substituted-glyph placement (#649) gives a substituted run one uniform
+horizontal glyph scale and puts every origin on the PDF's own pen offset. The
+scale was `Σ substitute advance ÷ Σ PDF pen step`. A pen step is a glyph's
+width *plus the spacing that follows it*, so a run carrying a Tc taught the
+device that the document's glyphs were that much wider than they are, and the
+shapes were stretched to fill the gap: 2.24 ÷ 0.556 = 4.02x on this table.
+
+The rule the code was missing is that **spacing is a gap to open, never a
+shape to stretch**. The uniform scale must weigh the substitute's glyphs
+against the widths the PDF gives *the same glyphs*, and the spacing must be
+left to the offsets, which already carry it.
+
+`PdfTextRun.glyphWidthAt(index, length)` (pdf_graphics `device.dart`) is that
+width: the pen step less the run's `letterSpacing`, plus the `wordSpacing`
+after a single-byte space. It is now the scale input at all three sites that
+copy-fit substituted glyphs:
+
+- `CanvasPdfDevice._buildPlacedLayout` (dart_pdf_editor `canvas_device.dart`)
+- `pdfCanvas2dTextLayout` (`web_surface_profile.dart`, the worker Canvas2D
+  surface)
+- `FlutterGpuTrueTypeTextOutliner.outline` (flutter_gpu `text_outliner.dart`)
+
+The whole-run path (no offset table, or a gradient/stroke run) was never
+affected: it reproduces Tc/Tw as real tracking through `TextStyle`, so its
+layout width already includes the spacing it is scaled against.
+
+## Words became pieces
+
+Correcting the scale alone breaks the other half of #649. A word was shaped
+whole when its interior agreed with the PDF's offsets within 0.02 em, and
+placed character by character otherwise. With the spacing out of the scale, an
+unspaced shaped word drifts from the offsets by one Tc per character, so every
+word of a document that sets *any* appreciable Tc failed that test and blew up
+into per-character `drawParagraph` calls.
+
+So the word/character binary is now a greedy cut: a word is broken into the
+longest **pieces** that can be shaped tight with no character landing more than
+`_placementToleranceEm` from its own offset, each piece drawn at the offset of
+its first character. A word the substitute agrees with is still one piece;
+disagreement - the substitute's own drift, or a Tc the shaped text does not
+carry - is spent at a cut instead of accumulating across the word. This is
+strictly better than the old binary, which exploded a whole word when only its
+tail drifted.
+
+Rejected on the way: giving a shaped word its Tc back through
+`TextStyle.letterSpacing` (Flutter) / `context.letterSpacing` (Canvas2D). It
+is faster, but both engines distribute letter spacing *around* each glyph -
+Skia paints a lone 'A' with `letterSpacing: 100` at x=50, not x=0 - so every
+part would need a half-spacing compensation for a rule neither engine
+documents, and being wrong about it puts a pathologically spaced glyph (this
+table's, at 0.84 em) visibly off its column.
+
+## Measurements
+
+45 lines of substituted prose, DPR 2, best of 15 (the raster figures are net
+of a 6.0 ms empty-page raster; `record` is the cold pass with the layout cache
+cleared, `raster` the warm pass):
+
+| Tc (em) | parts | record | raster (net) |
+| --- | --- | --- | --- |
+| 0 (before, and after) | 506 | 17.8 ms | 7.5 ms |
+| 0.005, per-character | 3042 | 10.3 ms | 10.1 ms |
+| 0.005, pieces | 944 | 21.6 ms | 8.4 ms |
+| 0.02, pieces | 2861 | 15.8 ms | 9.9 ms |
+
+A document that sets no Tc - most of them - is untouched: same parts, same
+cost. One that does pays ~15% more text raster than shaping its words whole
+would, and avoids the ~35% the per-character fallback would have cost. Steady
+paint recurs on every scroll and zoom; the cold shaping pass runs once per
+unique run.
+
+## Tests
+
+- `substituted_glyph_placement_test.dart` - `( 3)Tj` under `15.137 Tc` paints
+  a digit exactly as wide as an unspaced one, starting on the pen position the
+  PDF gives it; a 0.5 em Tc leaves four separate glyph blocks rather than one
+  solid stretched word.
+- `web_surface_profile_test.dart` - the Canvas2D plan's `unitsPerEm` ignores
+  the spacing, and a spaced word is cut so no part drifts.
+- `text_outliner_test.dart` - the GPU outliner copy-fits against the glyph
+  widths, not the spaced steps.
+- `interpreter_test.dart` - `glyphWidthAt` against the interpreter's own
+  offsets for a run carrying both Tc and Tw.

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -1244,10 +1244,10 @@ class CanvasPdfDevice
     return _placeableRun(run.text) ? offsets : null;
   }
 
-  /// How far, in em, a word's own shaped advance may differ from the PDF's
-  /// before [_buildPlacedLayout] stops shaping it whole and places its
-  /// characters individually. 0.02 em is 0.24pt at 12pt - an order of
-  /// magnitude under the drift this fixes, and small enough that the
+  /// How far, in em, a character shaped inside a piece may sit from the offset
+  /// the PDF gives it before [_buildPlacedLayout] cuts the piece there and
+  /// starts the next one on its own offset. 0.02 em is 0.24pt at 12pt - an
+  /// order of magnitude under the drift this fixes, and small enough that the
   /// difference is invisible where it is tolerated.
   static const double _placementToleranceEm = 0.02;
 
@@ -1257,8 +1257,12 @@ class CanvasPdfDevice
   /// same text under different advances is a different layout.
   _TextLayout _placedLayout(PdfTextRun run, List<double> offsets) {
     final c = run.color;
+    // Tc/Tw are in the key as well as the offsets: they set the shape scale
+    // and where the pieces are cut, and two runs can share an offset table
+    // without sharing them.
     final key = '${run.text} ${run.fontName ?? ''} '
         '${c.red},${c.green},${c.blue},${run.fillAlpha} '
+        '${run.letterSpacing},${run.wordSpacing} '
         'p${_offsetsHash(offsets)}';
     // A run with nothing to scale against falls back to whole-run shaping,
     // cached under this key too so the failed attempt is not repeated.
@@ -1266,28 +1270,34 @@ class CanvasPdfDevice
         key, () => _buildPlacedLayout(run, offsets) ?? _shapeLayout(run));
   }
 
-  /// Builds the layout [_placedLayout] caches: one part per **word** - a
-  /// maximal span of non-whitespace characters - drawn at that word's own
-  /// offset, so a word can never drift from the geometry selection and search
-  /// are computed from. A word whose shaped advance disagrees with the PDF's
-  /// by more than [_placementToleranceEm] is broken down further and placed
-  /// character by character, which is what a run of prose against a mismatched
-  /// substitute needs. Whitespace lays no ink down and is positioned by the
-  /// offsets around it, so it gets no part at all.
+  /// Builds the layout [_placedLayout] caches: one part per shapeable **piece**
+  /// of a word - a maximal span the substitute can shape tight without any
+  /// character landing more than [_placementToleranceEm] from its own PDF
+  /// offset - drawn at the offset of that piece's first character, so nothing
+  /// can drift from the geometry selection and search are computed from. A word
+  /// the substitute agrees with is one piece; a run of prose against a
+  /// mismatched substitute, or one whose Tc the shaped text does not carry,
+  /// cuts as often as the tolerance demands and spends each disagreement at a
+  /// cut instead of accumulating it. Whitespace lays no ink down and is
+  /// positioned by the offsets around it, so it gets no part at all.
   ///
-  /// Words rather than characters throughout because the draw call is the
-  /// cost: a `drawParagraph` per character measured 3.7x the record pass and
-  /// 1.6x the full DPR-2 raster on a page of non-embedded prose. Shaping a
-  /// word whole also keeps its internal kerning, which the PDF's own advances
-  /// do not contradict at this tolerance.
+  /// Pieces rather than characters because the draw call is the cost: a
+  /// `drawParagraph` per character measured 3.7x the record pass and 1.6x the
+  /// full DPR-2 raster on a page of non-embedded prose. Shaping a piece whole
+  /// also keeps its internal kerning, which the PDF's own advances do not
+  /// contradict at this tolerance.
   ///
   /// The glyph *shapes* take one uniform horizontal scale, so their proportions
   /// stay even (scaling each word to its own advance would squeeze an `i` far
   /// harder than an `o`); only the origins become exact. That scale is
-  /// `Σ natural ÷ Σ PDF advance` over the ink-bearing characters alone, so
+  /// `Σ natural ÷ Σ PDF glyph width` over the ink-bearing characters alone, so
   /// neither the substitute's idea of a space (Skia's width for a lone
-  /// whitespace layout is not something to build on) nor the run's Tc/Tw
-  /// (already inside [offsets]) can skew it.
+  /// whitespace layout is not something to build on) nor the run's Tc/Tw can
+  /// skew it: the PDF's width for a glyph is its pen step less the spacing
+  /// that follows it ([PdfTextRun.glyphWidthAt]), because spacing is a gap to
+  /// open, never a shape to stretch. A `( 3)Tj` under a `15.137 Tc` - a CAD
+  /// export reaching the next table column - is a digit in a 2.24 em step, and
+  /// scaling it to that step drew it four times too wide.
   ///
   /// The caller derives `scaleX = run.width × renderSize ÷ layout.width` and
   /// paints under `scaleX / renderSize`, so reporting `run.width × k` for a
@@ -1298,12 +1308,14 @@ class CanvasPdfDevice
   _TextLayout? _buildPlacedLayout(PdfTextRun run, List<double> offsets) {
     final text = run.text;
     var natural = 0.0; // Σ natural width of the ink-bearing glyphs
-    var advance = 0.0; // Σ PDF advance of the same glyphs
+    var advance = 0.0; // Σ width the PDF gives the same glyphs, spacing off
     for (var i = 0; i < text.length;) {
       final step = _runeLengthAt(text, i);
       if (!_isTrimWhitespace(text.codeUnitAt(i))) {
+        final width = run.glyphWidthAt(i, step);
+        if (width == null) return null;
         natural += _glyphLayout(_runeAt(text, i), run).width;
-        advance += offsets[i + step] - offsets[i];
+        advance += width;
       }
       i += step;
     }
@@ -1313,6 +1325,21 @@ class CanvasPdfDevice
     final style = _styleFor(run, foreground: null, applySpacing: false);
     final parts = <_GlyphRun>[];
     double? baseline;
+
+    // Emits `[from, to)` as one part, drawn at the offset the PDF gives its
+    // first character. A single character is served from the glyph cache the
+    // measuring pass above has already filled: retaining that painter beats
+    // shaping a fresh paragraph for every character of every unique CAD label,
+    // and the retained reference keeps it alive if the glyph-cache LRU later
+    // drops its own ownership (disposing this layout releases it again).
+    void emit(int from, int to) {
+      final part = to - from == _runeLengthAt(text, from)
+          ? _glyphLayout(_runeAt(text, from), run).retain()
+          : _shapeString(text.substring(from, to), style);
+      baseline ??= part.baseline;
+      parts.add(_GlyphRun(part, offsets[from] * k));
+    }
+
     var i = 0;
     while (i < text.length) {
       if (_isTrimWhitespace(text.codeUnitAt(i))) {
@@ -1323,56 +1350,35 @@ class CanvasPdfDevice
       while (end < text.length && !_isTrimWhitespace(text.codeUnitAt(end))) {
         end += _runeLengthAt(text, end);
       }
-      if (_wordHolds(run, offsets, i, end, k)) {
-        final word = _shapeString(text.substring(i, end), style);
-        baseline ??= word.baseline;
-        parts.add(_GlyphRun(word, offsets[i] * k));
-      } else {
-        for (var j = i; j < end;) {
-          final step = _runeLengthAt(text, j);
-          // The natural-width pass above has already populated this exact
-          // glyph/style in the shared cache. Retain that painter for the
-          // placed run instead of shaping a fresh paragraph for every
-          // character of every unique CAD label. The retained reference keeps
-          // it alive if the glyph-cache LRU later evicts its own ownership;
-          // disposing this placed layout releases the borrowed reference.
-          final glyph = _glyphLayout(_runeAt(text, j), run).retain();
-          baseline ??= glyph.baseline;
-          parts.add(_GlyphRun(glyph, offsets[j] * k));
-          j += step;
+      // Cut the word into the longest pieces that can be shaped tight without
+      // any character landing more than [_placementToleranceEm] from its own
+      // PDF offset, each drawn at the offset of its first character. A word
+      // whose substitute already agrees comes out whole - one part, shaping and
+      // kerning intact - and every disagreement, whether the substitute's own
+      // drift or a Tc the shaped text does not carry, is spent at a cut instead
+      // of accumulating across the word.
+      var start = i;
+      var shaped = 0.0; // px shaped since [start]
+      for (var j = i; j < end;) {
+        if (j > start &&
+            (shaped / k - (offsets[j] - offsets[start])).abs() >
+                _placementToleranceEm) {
+          emit(start, j);
+          start = j;
+          shaped = 0;
         }
+        // The substitute's own advance stands in for where the shaped piece
+        // puts this character: cross-character kerning is unaccounted for, a
+        // fraction of the tolerance, and it can only cut a piece sooner.
+        shaped += _glyphLayout(_runeAt(text, j), run).width;
+        j += _runeLengthAt(text, j);
       }
+      emit(start, end);
       i = end;
     }
     if (parts.isEmpty) return null;
     return _TextLayout.composed(parts, run.width * k, baseline ?? 0,
         ownsParts: true);
-  }
-
-  /// Whether the word `[start, end)` of [run] can be shaped whole without any
-  /// of its characters landing more than [_placementToleranceEm] from the
-  /// offset the PDF gives it.
-  ///
-  /// Checked at *every* character boundary, not just the word's end: matching
-  /// only a total is the very defect this replaces, and a two-character word
-  /// can have an exact total with a badly placed interior. The substitute's own
-  /// per-character advances stand in for where the shaped word would put each
-  /// character, so cross-character kerning is unaccounted for - a fraction of
-  /// the tolerance, and it only ever moves a word from whole-shaped to
-  /// per-character placement, which is the safe direction.
-  bool _wordHolds(
-      PdfTextRun run, List<double> offsets, int start, int end, double k) {
-    final tolerance = _placementToleranceEm;
-    var natural = 0.0; // em, from the substitute's own advances
-    for (var i = start; i < end;) {
-      final step = _runeLengthAt(run.text, i);
-      if ((natural - (offsets[i] - offsets[start])).abs() > tolerance) {
-        return false;
-      }
-      natural += _glyphLayout(_runeAt(run.text, i), run).width / k;
-      i += step;
-    }
-    return (natural - (offsets[end] - offsets[start])).abs() <= tolerance;
   }
 
   /// One laid-out [TextPainter] for [text] in [style], owned by the caller.

--- a/packages/dart_pdf_editor/lib/src/web_surface_profile.dart
+++ b/packages/dart_pdf_editor/lib/src/web_surface_profile.dart
@@ -22,8 +22,9 @@ class PdfCanvas2dTextLayout {
   final List<PdfCanvas2dTextPart> parts;
 }
 
-/// How far a substitute's natural boundary may differ from the PDF's before a
-/// word is split into independently positioned glyphs.
+/// How far a character shaped inside one part may sit from the offset the PDF
+/// gives it before the part is cut there and the next one starts on its own
+/// offset.
 const double _canvas2dPlacementToleranceEm = 0.02;
 
 /// Plans substituted text at the PDF's own per-character advances.
@@ -33,8 +34,13 @@ const double _canvas2dPlacementToleranceEm = 0.02;
 /// wrong when (for example) unembedded Century Gothic is painted with
 /// Helvetica. [measureText] measures one character in the active Canvas2D font;
 /// the returned plan applies one uniform horizontal glyph scale while placing
-/// each mismatched character at its PDF offset. Words whose interior already
-/// agrees within 0.02 em remain whole so their shaping and kerning are kept.
+/// each mismatched character at its PDF offset. That scale weighs the
+/// substitute's glyphs against the widths the PDF gives the same glyphs -
+/// [PdfTextRun.glyphWidthAt], the pen step less the spacing that follows it -
+/// so a run set with a large Tc opens its gaps instead of stretching its
+/// glyphs across them. A word is painted in the longest pieces that stay
+/// within 0.02 em of the PDF's own offsets, so one the substitute agrees with
+/// is painted whole and keeps its shaping and kerning.
 /// Font-family substitution is responsible for compatible glyph proportions;
 /// individual glyphs are never distorted to force them into their cells.
 ///
@@ -74,8 +80,13 @@ PdfCanvas2dTextLayout? pdfCanvas2dTextLayout(
     if (_canvas2dTrimWhitespace(codeUnit)) continue;
     final width = widthOf(codeUnit);
     if (!width.isFinite) return null;
+    // The glyph's own width, not the pen's step across it: the step carries
+    // the run's Tc, and scaling shapes by it stretches a spaced digit to fill
+    // the gap instead of leaving the gap open.
+    final glyphWidth = run.glyphWidthAt(i, 1);
+    if (glyphWidth == null) return null;
     natural += width;
-    advance += offsets[i + 1] - offsets[i];
+    advance += glyphWidth;
   }
   if (natural <= 0 || advance <= 0) return null;
 
@@ -93,42 +104,34 @@ PdfCanvas2dTextLayout? pdfCanvas2dTextLayout(
         end < text.length && !_canvas2dTrimWhitespace(text.codeUnitAt(end))) {
       end++;
     }
-    if (_canvas2dWordHolds(text, offsets, start, end, unitsPerEm, widthOf)) {
-      parts.add(PdfCanvas2dTextPart(
-        text.substring(start, end),
-        offsets[start] * unitsPerEm,
-      ));
-    } else {
-      for (var i = start; i < end; i++) {
+    // Cut the word into the longest pieces the browser can shape tight without
+    // a character landing more than 0.02 em from its own PDF offset, each
+    // painted at the offset of its first character. A word the substitute
+    // already agrees with stays whole; a disagreement - the substitute's own
+    // drift, or a Tc the shaped text does not carry - is spent at a cut
+    // instead of accumulating across the word.
+    var piece = start;
+    var shaped = 0.0;
+    for (var i = start; i < end; i++) {
+      if (i > piece &&
+          (shaped / unitsPerEm - (offsets[i] - offsets[piece])).abs() >
+              _canvas2dPlacementToleranceEm) {
         parts.add(PdfCanvas2dTextPart(
-          text.substring(i, i + 1),
-          offsets[i] * unitsPerEm,
+          text.substring(piece, i),
+          offsets[piece] * unitsPerEm,
         ));
+        piece = i;
+        shaped = 0;
       }
+      shaped += widthOf(text.codeUnitAt(i));
     }
+    parts.add(PdfCanvas2dTextPart(
+      text.substring(piece, end),
+      offsets[piece] * unitsPerEm,
+    ));
     start = end;
   }
   return parts.isEmpty ? null : PdfCanvas2dTextLayout(unitsPerEm, parts);
-}
-
-bool _canvas2dWordHolds(
-  String text,
-  List<double> offsets,
-  int start,
-  int end,
-  double unitsPerEm,
-  double Function(int codeUnit) widthOf,
-) {
-  var natural = 0.0;
-  for (var i = start; i < end; i++) {
-    if ((natural / unitsPerEm - (offsets[i] - offsets[start])).abs() >
-        _canvas2dPlacementToleranceEm) {
-      return false;
-    }
-    natural += widthOf(text.codeUnitAt(i));
-  }
-  return (natural / unitsPerEm - (offsets[end] - offsets[start])).abs() <=
-      _canvas2dPlacementToleranceEm;
 }
 
 bool _canvas2dPlaceableRun(String text) {

--- a/packages/dart_pdf_editor/test/substituted_glyph_placement_test.dart
+++ b/packages/dart_pdf_editor/test/substituted_glyph_placement_test.dart
@@ -48,12 +48,15 @@ Future<List<int>> _inkColumns(PdfTextRun run) async {
 
 /// A two-character run drawn at 20pt from the page origin-ish, with the PDF
 /// claiming [offsets] for its character boundaries.
-PdfTextRun _run(String text, List<double>? offsets, double width) => PdfTextRun(
+PdfTextRun _run(String text, List<double>? offsets, double width,
+        [double letterSpacing = 0]) =>
+    PdfTextRun(
       text: text,
       transform: const PdfMatrix(20, 0, 0, 20, 20, 60),
       color: const PdfColor(0, 0, 0),
       width: width,
       charOffsets: offsets,
+      letterSpacing: letterSpacing,
       fontName: 'Helvetica',
       fontSize: 20,
     );
@@ -139,6 +142,69 @@ void main() {
       expect(columns.first, closeTo(20, 2));
       expect(gap.first, closeTo(40, 3));
       expect(gap.last, closeTo(79, 3));
+    });
+  });
+
+  testWidgets('character spacing opens a gap instead of stretching the glyph',
+      (tester) async {
+    await tester.runAsync(() async {
+      // `( 3)Tj` under a `15.137 Tc` at 9pt: how a bridging-details table
+      // reaches its column. The pen steps 2.24 em across the digit - 0.556 em
+      // of glyph plus 1.68 em of character spacing - and sizing the glyph by
+      // that step drew a digit four times too wide. The spacing is a gap to
+      // open, so the digit must come out exactly as wide as an unspaced one.
+      const tc = 15.137 / 9;
+      const space = 0.278 + tc;
+      const digit = 0.556 + tc;
+      final spaced = await _inkColumns(PdfTextRun(
+        text: ' 3',
+        transform: const PdfMatrix(20, 0, 0, 20, 20, 60),
+        color: const PdfColor(0, 0, 0),
+        width: space + digit,
+        visibleWidth: space + digit,
+        leadingSpace: space,
+        charOffsets: const [0, space, space + digit],
+        letterSpacing: tc,
+        fontName: 'Helvetica',
+        fontSize: 20,
+      ));
+      final plain = await _inkColumns(_run('3', [0, 0.556], 0.556));
+
+      expect(spaced, isNotEmpty);
+      expect(spaced.last - spaced.first, closeTo(plain.last - plain.first, 1),
+          reason: 'the spaced digit must keep its own shape');
+      // The gap is in front of it: the digit starts at the pen position the
+      // PDF gives it, 20 + 1.96 * 20.
+      expect(spaced.first, closeTo(20 + space * 20 + (plain.first - 20), 2));
+    });
+  });
+
+  testWidgets('a spaced word keeps its glyph shapes and its pen positions',
+      (tester) async {
+    await tester.runAsync(() async {
+      // The test font is fixed-pitch and inks its full advance, so a 0.5 em Tc
+      // is a run whose pen steps 1.5 em across a 1 em glyph. Stretching the
+      // shapes to the step paints the word solid; the spacing is a gap, so the
+      // glyphs must stay 1 em wide with 0.5 em of paper between them - each
+      // still starting on the offset the PDF gives it.
+      final columns =
+          await _inkColumns(_run('AAAA', [0, 1.5, 3, 4.5, 6], 6, 0.5));
+      final blocks = <List<int>>[];
+      for (final x in columns) {
+        if (blocks.isEmpty || x > blocks.last.last + 1) {
+          blocks.add([x]);
+        } else {
+          blocks.last.add(x);
+        }
+      }
+
+      expect(blocks, hasLength(4), reason: 'one block of ink per glyph');
+      for (var i = 0; i < blocks.length; i++) {
+        expect(blocks[i].first, closeTo(20 + i * 30, 2),
+            reason: 'glyph $i starts on its own 1.5 em pen step');
+        expect(blocks[i].last - blocks[i].first, closeTo(20, 2),
+            reason: 'glyph $i keeps its own 1 em width');
+      }
     });
   });
 

--- a/packages/dart_pdf_editor/test/web_surface_profile_test.dart
+++ b/packages/dart_pdf_editor/test/web_surface_profile_test.dart
@@ -14,6 +14,7 @@ PdfTextRun _run({
   double width = 3.5,
   List<double>? charOffsets,
   String fontName = 'Helvetica',
+  double letterSpacing = 0,
 }) =>
     PdfTextRun(
       text: text,
@@ -25,6 +26,7 @@ PdfTextRun _run({
       fill: fill,
       strokeColor: strokeColor,
       charOffsets: charOffsets,
+      letterSpacing: letterSpacing,
     );
 
 void main() {
@@ -155,6 +157,63 @@ void main() {
     expect(layout!.parts, hasLength(1));
     expect(layout.parts.single.text, 'Territory');
     expect(layout.parts.single.x, 0);
+  });
+
+  test('Canvas2D sizes glyphs by the PDF width, not the spaced pen step', () {
+    // `( 3)Tj` under a `15.137 Tc` at 9pt - a bridging-details table reaching
+    // its column. The pen steps 2.24 em across a digit the PDF gives 0.556 em,
+    // and scaling the glyph to the step drew it four times too wide.
+    const tc = 15.137 / 9;
+    const space = 0.278 + tc;
+    const digit = 0.556 + tc;
+    final layout = pdfCanvas2dTextLayout(
+      _run(
+        text: ' 3',
+        width: space + digit,
+        charOffsets: const [0, space, space + digit],
+        letterSpacing: tc,
+      ),
+      (_) => 55.6,
+    );
+
+    expect(layout, isNotNull);
+    expect(layout!.unitsPerEm, closeTo(100, 1e-9),
+        reason: 'the digit is drawn at its own width, spacing left as a gap');
+    expect(layout.parts.single.text, '3');
+    expect(layout.parts.single.x / layout.unitsPerEm, closeTo(space, 1e-12),
+        reason: 'the gap the Tc opens is still in front of the digit');
+  });
+
+  test('Canvas2D cuts a spaced word where its interior would drift', () {
+    // A Tc the shaped text does not carry pushes the characters apart a
+    // fortieth of an em at a time; the parts must be cut before any of them
+    // sits more than the 0.02 em tolerance from its own offset.
+    const tc = 0.025;
+    final offsets = <double>[0];
+    for (var i = 0; i < 4; i++) {
+      offsets.add(offsets.last + 0.5 + tc);
+    }
+    final layout = pdfCanvas2dTextLayout(
+      _run(
+        text: 'BOOK',
+        width: offsets.last,
+        charOffsets: offsets,
+        letterSpacing: tc,
+      ),
+      (_) => 50,
+    );
+
+    expect(layout, isNotNull);
+    expect(layout!.unitsPerEm, closeTo(100, 1e-9));
+    expect(layout.parts.length, greaterThan(1),
+        reason: 'shaping the word whole would leave its tail 0.075 em short');
+    expect(layout.parts.map((part) => part.text).join(), 'BOOK');
+    var index = 0;
+    for (final part in layout.parts) {
+      expect(part.x / layout.unitsPerEm, closeTo(offsets[index], 1e-12),
+          reason: 'every part starts on the PDF offset of its first character');
+      index += part.text.length;
+    }
   });
 
   test('Century Gothic routes to the metric-compatible Canvas2D family', () {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/text_outliner.dart
@@ -139,8 +139,13 @@ class FlutterGpuTrueTypeTextOutliner implements FlutterGpuTextOutliner {
         outline = face.outlineForGlyph(glyphId);
         final advance = face.advanceForGlyph(glyphId);
         if (outline == null || advance == null || advance <= 0) return null;
+        // The width the PDF gives this glyph, not the pen's step across it:
+        // the step carries the run's Tc, and copy-fitting shapes to it
+        // stretches a widely spaced digit to fill its gap.
+        final pdfWidth = run.glyphWidthAt(index, length);
+        if (pdfWidth == null) return null;
         naturalAdvance += advance;
-        pdfAdvance += offsets[index + length] - offsets[index];
+        pdfAdvance += pdfWidth;
       }
       resolved.add(_ResolvedGlyph(index, length, outline));
       index += length;

--- a/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/text_outliner_test.dart
@@ -19,6 +19,7 @@ void main() {
     List<double> offsets, {
     double width = 1.6,
     String fontName = 'Helvetica',
+    double letterSpacing = 0,
   }) =>
       PdfTextRun(
         text: text,
@@ -28,6 +29,7 @@ void main() {
         fontName: fontName,
         fontSize: 20,
         charOffsets: offsets,
+        letterSpacing: letterSpacing,
       );
 
   test('retains PDF origins and copy-fits glyph shapes uniformly', () {
@@ -54,6 +56,21 @@ void main() {
     );
     expect(firstPageX, 40);
     expect(secondPageX, 64);
+  });
+
+  test('copy-fits against the PDF glyph widths, not the spaced pen steps', () {
+    // Fixture natural advances are A=.6, B=1.0. The PDF gives them the same
+    // widths and adds a 0.5 em Tc, so the pen steps 1.1 and 1.5 em - copy-
+    // fitting to those steps would blow the outlines up by 1.44x. Only the
+    // origins take the spacing.
+    final outlined = outliner.outline(
+      run('AB', const [0, 1.1, 2.6], width: 2.6, letterSpacing: 0.5),
+    );
+    expect(outlined, isNotNull);
+    expect(outlined!.transform.a, closeTo(20, 1e-9),
+        reason: 'the glyphs keep their own width');
+    expect(outlined.charOffsets, const [0, 1.1, 2.6]);
+    expect(outlined.glyphs![1].offset, closeTo(1.1, 1e-9));
   });
 
   test('keeps whitespace as an empty placement at its PDF offset', () {

--- a/packages/pdf_graphics/lib/src/device.dart
+++ b/packages/pdf_graphics/lib/src/device.dart
@@ -193,6 +193,42 @@ class PdfTextRun {
   /// must fall back to interpolating across [width] when it is absent.
   final List<double>? charOffsets;
 
+  /// The width the PDF gives the glyph starting at [index] and spanning
+  /// [length] code units, in em, with this run's spacing taken back off - the
+  /// glyph's own advance rather than the pen's.
+  ///
+  /// [charOffsets] are pen positions, so a step across one glyph carries the
+  /// [letterSpacing] (and, after a space, the [wordSpacing]) that follows it.
+  /// Spacing is not shape. A device substituting a system font sizes its
+  /// glyphs by measuring them against the width the document gives them, and
+  /// measuring against the pen step instead stretches the shapes to swallow
+  /// the gap: `( 3)Tj` under a `15.137 Tc` - how a CAD export reaches the next
+  /// table column - is a digit 0.556 em wide inside a 2.24 em step, and comes
+  /// out four times too wide. Placement still uses the offsets themselves, so
+  /// the spacing stays in the geometry where it belongs.
+  ///
+  /// Returns null when there is no offset table to read, or when [index] and
+  /// [length] fall outside it. Never negative: a Tc tight enough to walk the
+  /// pen backwards clamps to 0. One character code can map to several
+  /// characters through /ToUnicode, and the interpreter splits such a code's
+  /// advance evenly across them; each piece is then charged the spacing once,
+  /// which understates a spaced ligature's pieces.
+  double? glyphWidthAt(int index, int length) {
+    final offsets = charOffsets;
+    if (offsets == null ||
+        index < 0 ||
+        length <= 0 ||
+        index + length >= offsets.length) {
+      return null;
+    }
+    var spacing = letterSpacing;
+    if (length == 1 && index < text.length && text.codeUnitAt(index) == 0x20) {
+      spacing += wordSpacing;
+    }
+    final step = offsets[index + length] - offsets[index];
+    return step > spacing ? step - spacing : 0.0;
+  }
+
   bool get hasOutlines =>
       glyphs != null && glyphs!.any((g) => g.outline != null);
 }

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -438,6 +438,30 @@ void main() {
       }
     });
 
+    test('glyphWidthAt takes the spacing back off the pen step', () {
+      // The pen step across a glyph is its own width plus the Tc that follows
+      // it (plus the Tw after a space). A device substituting a system font
+      // sizes its glyphs against the width the document gives them, so it
+      // needs the step without that spacing - sizing to the step is what drew
+      // a `15.137 Tc` table digit four times too wide.
+      final run = interpret('BT /F1 24 Tf 5 Tc 10 Tw 72 720 Td (ab cd) Tj ET')
+          .texts
+          .single;
+      // in em, as the offsets are (the run transform carries the 24pt size)
+      double width(int i) => run.glyphWidthAt(i, 1)! * 24;
+      expect(width(0), closeTo(measureHelvetica('a', 24), 1e-9));
+      expect(width(1), closeTo(measureHelvetica('b', 24), 1e-9));
+      expect(width(2), closeTo(measureHelvetica(' ', 24), 1e-9),
+          reason: 'the space is charged both its Tc and its Tw');
+      expect(width(4), closeTo(measureHelvetica('d', 24), 1e-9),
+          reason: 'the last glyph is charged the Tc that follows it too');
+      expect(run.glyphWidthAt(0, 2)! * 24,
+          closeTo(measureHelvetica('ab', 24) + 5, 1e-9),
+          reason: 'a multi-character span keeps its interior spacing');
+      expect(run.glyphWidthAt(5, 1), isNull, reason: 'past the last glyph');
+      expect(run.glyphWidthAt(0, 0), isNull);
+    });
+
     test('an embedded run pays for no offset table (#649)', () {
       // Its glyph list already carries the same positions, so collecting them
       // again would be a list per run for nothing.


### PR DESCRIPTION
## Summary

A CAD-exported bridging form drew its table row numbers (`3`, `4`, `5`, `6`) roughly four times too wide - wide and heavy enough to read as a different typeface than the rest of the sheet. The fonts (ArialMT / Arial-BoldMT, none embedded) carry correct `/Widths`; the rows are

```
15.137 Tc 54.96 396.24 Td
( 3)Tj
```

At `/F1 9 Tf` that Tc is 1.68 em of character spacing per glyph - the export's way of reaching the next column - so the pen steps 2.24 em across a digit the font gives 0.556 em.

Exact substituted-glyph placement (#649) scales glyph shapes by `Σ substitute advance ÷ Σ PDF pen step`, and a pen step is a glyph's width **plus the spacing that follows it**. The run therefore taught the device that the document's glyphs were 4x wider than they are. Spacing is a gap to open, never a shape to stretch.

- `PdfTextRun.glyphWidthAt(index, length)` (new, `pdf_graphics/device.dart`) is the pen step less the run's `letterSpacing`, plus the `wordSpacing` after a single-byte space. It now feeds the uniform scale in all three places that copy-fit substituted glyphs: `CanvasPdfDevice._buildPlacedLayout`, `pdfCanvas2dTextLayout` (worker Canvas2D surface) and `FlutterGpuTrueTypeTextOutliner.outline`. Origins keep using the offsets themselves, so the spacing stays in the geometry selection, search and extraction are computed from.
- With the spacing out of the scale, an unspaced shaped word drifts from the offsets by one Tc per character, so the old shape-the-word-or-explode-it-into-characters rule sent every word of a Tc-carrying document to per-character placement. A word is now cut into the longest **pieces** that shape within the existing 0.02 em tolerance of the PDF's offsets: whole words stay whole where the substitute agrees, and each disagreement is spent at a cut instead of accumulating across the word. That is strictly better than the old binary, which exploded a whole word when only its tail drifted.
- The whole-run path (no offset table, or a gradient/stroke run) was never affected - it reproduces Tc/Tw as real tracking through `TextStyle`, so its measured width already includes the spacing it is scaled against.

Rejected on the way, and written up in the dev-log note: giving a shaped word its Tc back through `TextStyle.letterSpacing` / `context.letterSpacing`. It is faster on spaced text, but both engines distribute letter spacing *around* each glyph (Skia paints a lone `A` with `letterSpacing: 100` at x=50), so every part would need a half-spacing compensation for a rule neither engine documents.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log note)

Also `dart_pdf_editor_flutter_gpu`, which the template predates.

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean at repo root)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test` (990 passed)
- [x] `cd packages/pdf_graphics && fvm dart test` (1064 passed, Ghent + pdf.js corpus tests included)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2694 passed)
- [x] Ghent corpus test or baseline update - ran, **no baseline change needed**: the VM render baselines do not go through the substituting canvas device
- [x] Real PDF corpus parse/render smoke test - the reported document rendered before/after through `PdfPageRenderer.renderImage`
- [ ] Example app smoke test

`pdf_cos` is untouched by this change. `dart_pdf_editor_flutter_gpu`'s suite was also run (15 passed, 106 skipped without a GPU).

### Performance

45 lines of substituted prose, DPR 2, best of 15; raster figures are net of a 6.0 ms empty-page raster, `record` is the cold pass with the layout cache cleared, `raster` the warm one:

| Tc (em) | parts | record | raster (net) |
| --- | --- | --- | --- |
| 0 (before, and after) | 506 | 17.8 ms | 7.5 ms |
| 0.005, per-character | 3042 | 10.3 ms | 10.1 ms |
| 0.005, pieces (this PR) | 944 | 21.6 ms | 8.4 ms |
| 0.02, pieces (this PR) | 2861 | 15.8 ms | 9.9 ms |

A document that sets no Tc - most of them - is untouched: same parts, same cost. One that does pays ~15% more text raster than shaping its words whole would, and avoids the ~35% the per-character fallback would have cost. Steady-state paint recurs on every scroll and zoom; the cold shaping pass runs once per unique run.

## User experience

- [x] The affected user journey and expected outcome are described above: non-embedded text set with character spacing (CAD and office exports do this routinely) now paints at its own glyph widths instead of stretched to fill the spacing.
- [ ] Completion, cancellation, disabled, loading, and error states were considered - not applicable, this is a paint-time change with no new states.
- [ ] Keyboard/mouse/touch/accessibility paths - not applicable; selection, search and hit-testing geometry are unchanged, since only the glyph shapes moved.
- [ ] Preview, commit, undo/redo, save, reopen - not applicable, nothing is written to the document.
- [x] Journey-level latency measured - see the table above.

## PDF fixtures and screenshots

The reporting document is a customer form and is not attached. The behaviour is pinned by programmatic fixtures instead: `substituted_glyph_placement_test.dart` renders `( 3)Tj` under a `15.137 Tc` and asserts the digit's ink is exactly as wide as an unspaced one and starts on the pen position the PDF gives it, plus a 0.5 em Tc case that must leave four separate glyph blocks rather than one solid stretched word. `web_surface_profile_test.dart`, `text_outliner_test.dart` and `interpreter_test.dart` cover the other three surfaces. All four new tests fail on the pre-fix code.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `PdfTextRun.glyphWidthAt` returns null rather than guessing when there is no offset table or the span falls outside it; every call site declines the placed path in that case, falling back to the established whole-run shaping.
- A `/ToUnicode` code that maps to several characters has its advance split evenly by the interpreter, so each piece is charged the spacing once - documented on the helper. It understates a spaced ligature's pieces; the sum is clamped at zero and a run that clamps to nothing falls back to whole-run shaping.
- The `_placedLayout` cache key gained Tc/Tw: they now set the shape scale and the cut points, and two runs can share an offset table without sharing them.
- Background: doc/dev-log/2026-09-06-character-spacing-is-not-shape.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyJhDde4UD7KMvwfMy9Aja

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyJhDde4UD7KMvwfMy9Aja)_