### PR TITLE
Add persistent vertical alignment for text fields

### DIFF
--- a/packages/pdf_document/README.md
+++ b/packages/pdf_document/README.md
@@ -57,6 +57,52 @@ editor.addFreeText(0, const PdfRect(72, 600, 280, 660), 'Reviewed.');
 final saved = editor.save(); // incremental update
 ```
 
+## Text-field vertical alignment
+
+Vertical placement is independent of wrapping and horizontal `align` / `/Q`:
+
+```dart
+editor.setTextValue(field, 'First line\nSecond line',
+    multiline: true,
+    verticalAlignment: PdfFormTextVerticalAlignment.center);
+
+// Save a template preference without changing its value.
+editor.setTextFieldStyle(field,
+    verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+
+// Omitted/null alignment retains the preference, including after reopening.
+editor.setTextValue(field, 'A later value');
+print(field.textVerticalAlignment);
+editor.clearTextFieldVerticalAlignment(field); // restore legacy placement
+```
+
+`top`, `center`, and `bottom` position the whole block after wrapping and
+font auto-sizing, inside the existing 2-point padding. Each line occupies an
+em-height box with the existing 1.15-times-font-size baseline spacing; there
+is no extra leading before the first or after the last line. If the block
+cannot fit, it is top anchored and clipped so its beginning stays visible.
+Existing font sizes, auto-size limits and long-word clipping are unchanged.
+With no saved preference, multiline fields retain top placement and single-line
+fields retain their existing ascent-centred placement. Explicit `center`
+centres the em-height block even for a single line, so its baseline can differ
+slightly from legacy single-line placement.
+
+The preference is a **dart-pdf private extension**, following the library's
+existing `DartPdf…` metadata convention. It is stored as a PDF text string
+(`top`, `center`, or `bottom`) in `/DartPdfTextVerticalAlignment` on the terminal
+text-field dictionary, applies to all that field's widgets, and is not
+inherited from parent fields. Absent, unknown or malformed values use legacy
+placement; ordinary fills preserve unknown metadata. Clearing removes the
+entry. Changing value, style, size or rotation regenerates appearances using
+the saved preference.
+
+This key is not a standard PDF property or a claim of a registered developer
+prefix. `/Q` remains horizontal justification. Standard `/AP` appearances
+carry the visible result for other viewers, but editors that do not understand
+the private preference can replace the placement when editing or regenerating
+appearances, and may discard the metadata. A flattened export retains the
+painted placement but no longer has editable fields.
+
 ## Reduce file size
 
 ```dart

--- a/packages/pdf_document/README.md
+++ b/packages/pdf_document/README.md
@@ -73,7 +73,11 @@ editor.setTextFieldStyle(field,
 // Omitted/null alignment retains the preference, including after reopening.
 editor.setTextValue(field, 'A later value');
 print(field.textVerticalAlignment);
-editor.clearTextFieldVerticalAlignment(field); // restore legacy placement
+// Clear the preference while restyling, with one appearance regeneration.
+editor.setTextFieldStyle(field, color: 0x000000,
+    verticalAlignment: PdfFormTextVerticalAlignment.legacy);
+// Or clear it alone:
+editor.clearTextFieldVerticalAlignment(field);
 ```
 
 `top`, `center`, and `bottom` position the whole block after wrapping and
@@ -93,7 +97,7 @@ existing `DartPdf…` metadata convention. It is stored as a PDF text string
 text-field dictionary, applies to all that field's widgets, and is not
 inherited from parent fields. Absent, unknown or malformed values use legacy
 placement; ordinary fills preserve unknown metadata. Clearing removes the
-entry. Changing value, style, size or rotation regenerates appearances using
+entry; `legacy` is never stored and the getter returns null. Changing value, style, size or rotation regenerates appearances using
 the saved preference.
 
 This key is not a standard PDF property or a claim of a registered developer

--- a/packages/pdf_document/lib/src/form.dart
+++ b/packages/pdf_document/lib/src/form.dart
@@ -20,6 +20,21 @@ enum PdfFieldType {
   unknown,
 }
 
+/// Vertical placement of a text field's complete wrapped block.
+///
+/// This is a dart-pdf appearance preference, not a standard AcroForm entry.
+/// It is independent of horizontal quadding and the multiline flag.
+enum PdfFormTextVerticalAlignment {
+  /// Place the first line at the top padding.
+  top,
+
+  /// Centre the complete block within the padded widget.
+  center,
+
+  /// Place the bottom of the complete block at the bottom padding.
+  bottom,
+}
+
 /// The document's interactive form (§12.7.2): the catalog's /AcroForm
 /// dictionary plus the field tree hanging off /Fields.
 class PdfAcroForm {
@@ -371,9 +386,8 @@ class PdfFormField {
 
   PdfFieldType get type => switch (fieldTypeName) {
         'Tx' => PdfFieldType.text,
-        'Ch' => flags & comboFlag != 0
-            ? PdfFieldType.comboBox
-            : PdfFieldType.listBox,
+        'Ch' =>
+          flags & comboFlag != 0 ? PdfFieldType.comboBox : PdfFieldType.listBox,
         'Btn' => flags & pushButtonFlag != 0
             ? PdfFieldType.pushButton
             : flags & radioFlag != 0
@@ -396,6 +410,26 @@ class PdfFormField {
   bool get isRequired => flags & requiredFlag != 0;
   bool get isMultiline => flags & multilineFlag != 0;
   bool get isPassword => flags & passwordFlag != 0;
+
+  /// The saved dart-pdf vertical alignment, or null for legacy placement
+  /// (top for multiline fields, ascent-centred for single-line fields).
+  ///
+  /// Stored as a text string in the private /DartPdfTextVerticalAlignment
+  /// entry on this terminal field, applying to all its widgets. It is not
+  /// inherited from parent fields. Unknown values and malformed entries are
+  /// ignored. Other editors may ignore or remove this private preference
+  /// when they regenerate appearances; /Q remains horizontal alignment.
+  PdfFormTextVerticalAlignment? get textVerticalAlignment {
+    if (type != PdfFieldType.text) return null;
+    final raw = _cos.resolve(dict['DartPdfTextVerticalAlignment']);
+    if (raw is! CosString) return null;
+    return switch (raw.text) {
+      'top' => PdfFormTextVerticalAlignment.top,
+      'center' => PdfFormTextVerticalAlignment.center,
+      'bottom' => PdfFormTextVerticalAlignment.bottom,
+      _ => null,
+    };
+  }
 
   /// /Q quadding: 0 left (default), 1 centered, 2 right.
   int get quadding {

--- a/packages/pdf_document/lib/src/form.dart
+++ b/packages/pdf_document/lib/src/form.dart
@@ -25,6 +25,11 @@ enum PdfFieldType {
 /// This is a dart-pdf appearance preference, not a standard AcroForm entry.
 /// It is independent of horizontal quadding and the multiline flag.
 enum PdfFormTextVerticalAlignment {
+  /// Remove the saved preference and restore the multiline-dependent default.
+  /// This command is never stored; [PdfFormField.textVerticalAlignment] then
+  /// returns null.
+  legacy,
+
   /// Place the first line at the top padding.
   top,
 
@@ -386,8 +391,9 @@ class PdfFormField {
 
   PdfFieldType get type => switch (fieldTypeName) {
         'Tx' => PdfFieldType.text,
-        'Ch' =>
-          flags & comboFlag != 0 ? PdfFieldType.comboBox : PdfFieldType.listBox,
+        'Ch' => flags & comboFlag != 0
+            ? PdfFieldType.comboBox
+            : PdfFieldType.listBox,
         'Btn' => flags & pushButtonFlag != 0
             ? PdfFieldType.pushButton
             : flags & radioFlag != 0

--- a/packages/pdf_document/lib/src/form_editor.dart
+++ b/packages/pdf_document/lib/src/form_editor.dart
@@ -18,6 +18,11 @@ extension PdfFormFilling on PdfEditor {
   /// the appearance regenerates - pass true to let long values wrap in
   /// fields authored as single-line. Null leaves the flag alone.
   ///
+  /// [verticalAlignment] saves a dart-pdf vertical placement preference for
+  /// the whole wrapped block. Null retains the saved preference, or the
+  /// legacy placement when none is saved. See
+  /// [PdfFormField.textVerticalAlignment] for interoperability limits.
+  ///
   /// /V stores [value] verbatim (UTF-16BE when it leaves Latin-1); the
   /// generated appearance replaces characters the byte-encoded
   /// appearance fonts cannot show with spaces.
@@ -25,6 +30,7 @@ extension PdfFormFilling on PdfEditor {
     PdfFormField field,
     String value, {
     bool? multiline,
+    PdfFormTextVerticalAlignment? verticalAlignment,
     PdfTextDirection textDirection = PdfTextDirection.auto,
   }) {
     _checkFillable(field, const {PdfFieldType.text});
@@ -35,9 +41,27 @@ extension PdfFormFilling on PdfEditor {
             : field.flags & ~PdfFormField.multilineFlag,
       );
     }
+    _setTextVerticalAlignment(field, verticalAlignment);
     field.dict['V'] = CosString.fromText(value);
     _regenerateVariableText(field, value, textDirection: textDirection);
     _finishFieldEdit(field);
+  }
+
+  /// Removes the saved vertical preference and regenerates all widgets
+  /// using legacy placement, without changing the value or multiline flag.
+  void clearTextFieldVerticalAlignment(PdfFormField field) {
+    _checkFillable(field, const {PdfFieldType.text});
+    field.dict.entries.remove('DartPdfTextVerticalAlignment');
+    _regenerateVariableText(field, field.value ?? '');
+    _finishFieldEdit(field);
+  }
+
+  void _setTextVerticalAlignment(
+      PdfFormField field, PdfFormTextVerticalAlignment? alignment) {
+    if (alignment != null) {
+      field.dict['DartPdfTextVerticalAlignment'] =
+          CosString.fromText(alignment.name);
+    }
   }
 
   /// Fills a push-button field with an image (the conventional way PDF
@@ -457,6 +481,7 @@ extension PdfFormFilling on PdfEditor {
   }) {
     final cos = document.cos;
     final da = _parseDefaultAppearance(field.defaultAppearance);
+    final verticalAlignment = field.textVerticalAlignment;
     final fontDict = _formFont(field.form, da.fontName);
     // an embedded (Type0) /DR font shows text as 2-byte glyph ids: reparse
     // its program so the appearance can encode and measure with it. A
@@ -527,6 +552,21 @@ extension PdfFormFilling on PdfEditor {
         lines = [single];
       }
 
+      double? firstBaselineY;
+      if (verticalAlignment != null) {
+        // Match the shared centre-block metric: em-height lines separated
+        // by the existing leading, with no extra leading outside the block.
+        // Clamp overflowing blocks to the top so the beginning stays visible.
+        final blockHeight = size + (lines.length - 1) * size * lineFactor;
+        final spare = math.max(0.0, visual.height - 2 * pad - blockHeight);
+        final offset = switch (verticalAlignment) {
+          PdfFormTextVerticalAlignment.top => 0.0,
+          PdfFormTextVerticalAlignment.center => spare / 2,
+          PdfFormTextVerticalAlignment.bottom => spare,
+        };
+        firstBaselineY = visual.top - pad - offset - size * font.ascent / 1000;
+      }
+
       final resolvedDirection = field.quadding == 2
           ? PdfTextDirection.rtl
           : textDirection.resolve(rawText);
@@ -556,8 +596,8 @@ extension PdfFormFilling on PdfEditor {
         align: align,
         padding: pad,
         lineHeight: size * lineFactor,
-        vAlign:
-            multiline ? PdfTextBoxVAlign.top : PdfTextBoxVAlign.centerLine,
+        vAlign: multiline ? PdfTextBoxVAlign.top : PdfTextBoxVAlign.centerLine,
+        firstBaselineY: firstBaselineY,
         clip: false,
         clampAlign: true,
         measureLine: (s) => measure(s, size),

--- a/packages/pdf_document/lib/src/form_editor.dart
+++ b/packages/pdf_document/lib/src/form_editor.dart
@@ -20,7 +20,8 @@ extension PdfFormFilling on PdfEditor {
   ///
   /// [verticalAlignment] saves a dart-pdf vertical placement preference for
   /// the whole wrapped block. Null retains the saved preference, or the
-  /// legacy placement when none is saved. See
+  /// legacy placement when none is saved. Pass
+  /// [PdfFormTextVerticalAlignment.legacy] to clear it in the same edit. See
   /// [PdfFormField.textVerticalAlignment] for interoperability limits.
   ///
   /// /V stores [value] verbatim (UTF-16BE when it leaves Latin-1); the
@@ -51,14 +52,16 @@ extension PdfFormFilling on PdfEditor {
   /// using legacy placement, without changing the value or multiline flag.
   void clearTextFieldVerticalAlignment(PdfFormField field) {
     _checkFillable(field, const {PdfFieldType.text});
-    field.dict.entries.remove('DartPdfTextVerticalAlignment');
+    _setTextVerticalAlignment(field, PdfFormTextVerticalAlignment.legacy);
     _regenerateVariableText(field, field.value ?? '');
     _finishFieldEdit(field);
   }
 
   void _setTextVerticalAlignment(
       PdfFormField field, PdfFormTextVerticalAlignment? alignment) {
-    if (alignment != null) {
+    if (alignment == PdfFormTextVerticalAlignment.legacy) {
+      field.dict.entries.remove('DartPdfTextVerticalAlignment');
+    } else if (alignment != null) {
       field.dict['DartPdfTextVerticalAlignment'] =
           CosString.fromText(alignment.name);
     }
@@ -552,21 +555,6 @@ extension PdfFormFilling on PdfEditor {
         lines = [single];
       }
 
-      double? firstBaselineY;
-      if (verticalAlignment != null) {
-        // Match the shared centre-block metric: em-height lines separated
-        // by the existing leading, with no extra leading outside the block.
-        // Clamp overflowing blocks to the top so the beginning stays visible.
-        final blockHeight = size + (lines.length - 1) * size * lineFactor;
-        final spare = math.max(0.0, visual.height - 2 * pad - blockHeight);
-        final offset = switch (verticalAlignment) {
-          PdfFormTextVerticalAlignment.top => 0.0,
-          PdfFormTextVerticalAlignment.center => spare / 2,
-          PdfFormTextVerticalAlignment.bottom => spare,
-        };
-        firstBaselineY = visual.top - pad - offset - size * font.ascent / 1000;
-      }
-
       final resolvedDirection = field.quadding == 2
           ? PdfTextDirection.rtl
           : textDirection.resolve(rawText);
@@ -596,8 +584,15 @@ extension PdfFormFilling on PdfEditor {
         align: align,
         padding: pad,
         lineHeight: size * lineFactor,
-        vAlign: multiline ? PdfTextBoxVAlign.top : PdfTextBoxVAlign.centerLine,
-        firstBaselineY: firstBaselineY,
+        vAlign: switch (verticalAlignment) {
+          PdfFormTextVerticalAlignment.top => PdfTextBoxVAlign.top,
+          PdfFormTextVerticalAlignment.center => PdfTextBoxVAlign.centerBlock,
+          PdfFormTextVerticalAlignment.bottom => PdfTextBoxVAlign.bottomBlock,
+          PdfFormTextVerticalAlignment.legacy ||
+          null =>
+            multiline ? PdfTextBoxVAlign.top : PdfTextBoxVAlign.centerLine,
+        },
+        clampVerticalAlign: verticalAlignment != null,
         clip: false,
         clampAlign: true,
         measureLine: (s) => measure(s, size),

--- a/packages/pdf_document/lib/src/form_styling.dart
+++ b/packages/pdf_document/lib/src/form_styling.dart
@@ -20,7 +20,11 @@ extension PdfFormStyling on PdfEditor {
   /// the box (the §12.7.3.3 auto-size convention). [color] is `0xRRGGBB`.
   /// [align] writes /Q (left/centre/right). [multiline] toggles the /Ff
   /// multiline flag (bit 13). Throws when [field] isn't a text field or is
-  /// read-only.
+  /// read-only. [verticalAlignment] saves placement of the complete wrapped
+  /// block; null leaves the saved preference unchanged. See
+  /// [PdfFormField.textVerticalAlignment] for its private storage format and
+  /// interoperability limits. Use [PdfFormFilling.clearTextFieldVerticalAlignment]
+  /// to restore legacy placement.
   void setTextFieldStyle(
     PdfFormField field, {
     PdfTextFont? font,
@@ -29,6 +33,7 @@ extension PdfFormStyling on PdfEditor {
     int? color,
     PdfTextAlign? align,
     bool? multiline,
+    PdfFormTextVerticalAlignment? verticalAlignment,
   }) {
     _checkFillable(field, const {PdfFieldType.text});
 
@@ -38,6 +43,7 @@ extension PdfFormStyling on PdfEditor {
           : field.flags & ~PdfFormField.multilineFlag);
     }
     if (align != null) field.dict['Q'] = CosInteger(align.quadding);
+    _setTextVerticalAlignment(field, verticalAlignment);
 
     if (font != null || fontSize != null || autoSize != null || color != null) {
       final current = _parseDefaultAppearance(field.defaultAppearance);

--- a/packages/pdf_document/lib/src/form_styling.dart
+++ b/packages/pdf_document/lib/src/form_styling.dart
@@ -23,8 +23,8 @@ extension PdfFormStyling on PdfEditor {
   /// read-only. [verticalAlignment] saves placement of the complete wrapped
   /// block; null leaves the saved preference unchanged. See
   /// [PdfFormField.textVerticalAlignment] for its private storage format and
-  /// interoperability limits. Use [PdfFormFilling.clearTextFieldVerticalAlignment]
-  /// to restore legacy placement.
+  /// interoperability limits. Pass [PdfFormTextVerticalAlignment.legacy] to
+  /// clear the preference together with other style changes in one edit.
   void setTextFieldStyle(
     PdfFormField field, {
     PdfTextFont? font,

--- a/packages/pdf_document/lib/src/text_box_appearance.dart
+++ b/packages/pdf_document/lib/src/text_box_appearance.dart
@@ -137,6 +137,9 @@ List<String> pdfWrapText(
 /// `q`/`Q`, any page/widget orientation transform, background and border
 /// decoration, and marked-content wrappers - and supplies the parts that vary:
 ///
+/// - [firstBaselineY], when supplied, overrides [vAlign] with an absolute
+///   baseline in [box]'s coordinate space. The caller owns vertical placement
+///   and overflow policy; subsequent lines still step down by [lineHeight].
 /// - [measureLine] measures a line's advance for alignment (defaults to
 ///   `font.measure`); pass a closure that folds in character spacing or
 ///   horizontal scaling when the appearance uses them.
@@ -157,6 +160,7 @@ void writePdfTextBox(
   required double padding,
   required double lineHeight,
   PdfTextBoxVAlign vAlign = PdfTextBoxVAlign.top,
+  double? firstBaselineY,
   bool clip = true,
   bool clampAlign = false,
   bool leading = false,
@@ -166,8 +170,7 @@ void writePdfTextBox(
   int? underlineColor,
 }) {
   final measure = measureLine ?? (String s) => font.measure(s, fontSize);
-  final emit =
-      emitLine ?? (ContentWriter w, String s) => w.showText(s);
+  final emit = emitLine ?? (ContentWriter w, String s) => w.showText(s);
   final ascentPts = fontSize * font.ascent / 1000;
 
   if (clip) {
@@ -182,25 +185,29 @@ void writePdfTextBox(
   writeColor?.call(writer);
 
   final double firstY;
-  switch (vAlign) {
-    case PdfTextBoxVAlign.top:
-      firstY = box.top - padding - ascentPts;
-    case PdfTextBoxVAlign.centerBlock:
-      // The N line boxes stack to `N*lineHeight`, centred in the box. Within
-      // each box the glyphs occupy the em (`fontSize`), so the extra
-      // `lineHeight - fontSize` of leading splits half above the ascent and
-      // half below the descent. Placing the first baseline one ascent below
-      // the block top would drop that whole gap below the last line and shove
-      // the block up until the top line's ascenders press against - and are
-      // clipped by - the top edge. Reserving the half-leading above the first
-      // line keeps the ink centred and the top line clear of the clip.
-      final blockTop =
-          box.bottom + (box.height + lines.length * lineHeight) / 2;
-      final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
-      firstY = blockTop - halfLeading - ascentPts;
-    case PdfTextBoxVAlign.centerLine:
-      final centered = (box.height - ascentPts) / 2;
-      firstY = box.bottom + (centered < padding ? padding : centered);
+  if (firstBaselineY != null) {
+    firstY = firstBaselineY;
+  } else {
+    switch (vAlign) {
+      case PdfTextBoxVAlign.top:
+        firstY = box.top - padding - ascentPts;
+      case PdfTextBoxVAlign.centerBlock:
+        // The N line boxes stack to `N*lineHeight`, centred in the box. Within
+        // each box the glyphs occupy the em (`fontSize`), so the extra
+        // `lineHeight - fontSize` of leading splits half above the ascent and
+        // half below the descent. Placing the first baseline one ascent below
+        // the block top would drop that whole gap below the last line and shove
+        // the block up until the top line's ascenders press against - and are
+        // clipped by - the top edge. Reserving the half-leading above the first
+        // line keeps the ink centred and the top line clear of the clip.
+        final blockTop =
+            box.bottom + (box.height + lines.length * lineHeight) / 2;
+        final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
+        firstY = blockTop - halfLeading - ascentPts;
+      case PdfTextBoxVAlign.centerLine:
+        final centered = (box.height - ascentPts) / 2;
+        firstY = box.bottom + (centered < padding ? padding : centered);
+    }
   }
 
   final underlines = <PdfTextUnderline>[];

--- a/packages/pdf_document/lib/src/text_box_appearance.dart
+++ b/packages/pdf_document/lib/src/text_box_appearance.dart
@@ -27,6 +27,9 @@ enum PdfTextBoxVAlign {
   /// panel's `centerVertical` layout.
   centerBlock,
 
+  /// The complete em-height block ends at the bottom padding.
+  bottomBlock,
+
   /// A single line centred by its ascent within the box, clamped to the top
   /// padding - single-line form fields.
   centerLine,
@@ -137,9 +140,9 @@ List<String> pdfWrapText(
 /// `q`/`Q`, any page/widget orientation transform, background and border
 /// decoration, and marked-content wrappers - and supplies the parts that vary:
 ///
-/// - [firstBaselineY], when supplied, overrides [vAlign] with an absolute
-///   baseline in [box]'s coordinate space. The caller owns vertical placement
-///   and overflow policy; subsequent lines still step down by [lineHeight].
+/// - [clampVerticalAlign] top-anchors overfull centre/bottom blocks at the
+///   text padding so their beginning remains visible. Defaults to false to
+///   preserve existing signature-panel placement.
 /// - [measureLine] measures a line's advance for alignment (defaults to
 ///   `font.measure`); pass a closure that folds in character spacing or
 ///   horizontal scaling when the appearance uses them.
@@ -160,7 +163,7 @@ void writePdfTextBox(
   required double padding,
   required double lineHeight,
   PdfTextBoxVAlign vAlign = PdfTextBoxVAlign.top,
-  double? firstBaselineY,
+  bool clampVerticalAlign = false,
   bool clip = true,
   bool clampAlign = false,
   bool leading = false,
@@ -170,7 +173,8 @@ void writePdfTextBox(
   int? underlineColor,
 }) {
   final measure = measureLine ?? (String s) => font.measure(s, fontSize);
-  final emit = emitLine ?? (ContentWriter w, String s) => w.showText(s);
+  final emit =
+      emitLine ?? (ContentWriter w, String s) => w.showText(s);
   final ascentPts = fontSize * font.ascent / 1000;
 
   if (clip) {
@@ -184,30 +188,38 @@ void writePdfTextBox(
   if (leading) writer.leading(lineHeight);
   writeColor?.call(writer);
 
-  final double firstY;
-  if (firstBaselineY != null) {
-    firstY = firstBaselineY;
-  } else {
-    switch (vAlign) {
-      case PdfTextBoxVAlign.top:
-        firstY = box.top - padding - ascentPts;
-      case PdfTextBoxVAlign.centerBlock:
-        // The N line boxes stack to `N*lineHeight`, centred in the box. Within
-        // each box the glyphs occupy the em (`fontSize`), so the extra
-        // `lineHeight - fontSize` of leading splits half above the ascent and
-        // half below the descent. Placing the first baseline one ascent below
-        // the block top would drop that whole gap below the last line and shove
-        // the block up until the top line's ascenders press against - and are
-        // clipped by - the top edge. Reserving the half-leading above the first
-        // line keeps the ink centred and the top line clear of the clip.
-        final blockTop =
-            box.bottom + (box.height + lines.length * lineHeight) / 2;
-        final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
-        firstY = blockTop - halfLeading - ascentPts;
-      case PdfTextBoxVAlign.centerLine:
-        final centered = (box.height - ascentPts) / 2;
-        firstY = box.bottom + (centered < padding ? padding : centered);
-    }
+  double firstY;
+  switch (vAlign) {
+    case PdfTextBoxVAlign.top:
+      firstY = box.top - padding - ascentPts;
+    case PdfTextBoxVAlign.centerBlock:
+      // The N line boxes stack to `N*lineHeight`, centred in the box. Within
+      // each box the glyphs occupy the em (`fontSize`), so the extra
+      // `lineHeight - fontSize` of leading splits half above the ascent and
+      // half below the descent. Placing the first baseline one ascent below
+      // the block top would drop that whole gap below the last line and shove
+      // the block up until the top line's ascenders press against - and are
+      // clipped by - the top edge. Reserving the half-leading above the first
+      // line keeps the ink centred and the top line clear of the clip.
+      final blockTop =
+          box.bottom + (box.height + lines.length * lineHeight) / 2;
+      final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
+      firstY = blockTop - halfLeading - ascentPts;
+    case PdfTextBoxVAlign.bottomBlock:
+      // Leading belongs only between em-height lines. Form auto-size keeps
+      // its conservative n * lineHeight fit test, including trailing leading;
+      // placement must not add that trailing gap to the visible block.
+      final blockHeight = fontSize + (lines.length - 1) * lineHeight;
+      firstY = box.bottom + padding + blockHeight - ascentPts;
+    case PdfTextBoxVAlign.centerLine:
+      final centered = (box.height - ascentPts) / 2;
+      firstY = box.bottom + (centered < padding ? padding : centered);
+  }
+
+  if (clampVerticalAlign &&
+      (vAlign == PdfTextBoxVAlign.centerBlock ||
+          vAlign == PdfTextBoxVAlign.bottomBlock)) {
+    firstY = math.min(firstY, box.top - padding - ascentPts);
   }
 
   final underlines = <PdfTextUnderline>[];

--- a/packages/pdf_document/test/form_vertical_alignment_test.dart
+++ b/packages/pdf_document/test/form_vertical_alignment_test.dart
@@ -1,0 +1,317 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+const _key = 'DartPdfTextVerticalAlignment';
+
+(PdfEditor, PdfFormField) _fixture({bool multiline = true}) {
+  final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+  final field = editor.addTextField(
+      0, 'notes', const PdfRect(100, 200, 300, 260),
+      multiline: multiline);
+  editor.setTextFieldStyle(field, fontSize: 10);
+  return (editor, field);
+}
+
+PdfFormField _field(PdfDocument doc) =>
+    PdfAcroForm.of(doc)!.fieldNamed('notes')!;
+
+String _appearance(PdfDocument doc, PdfFormField field, [int index = 0]) {
+  final ap = doc.cos.resolve(field.widgets[index]['AP']) as CosDictionary;
+  final stream = doc.cos.resolve(ap['N']) as CosStream;
+  return latin1.decode(doc.cos.decodeStreamData(stream));
+}
+
+List<(double, double)> _baselines(String content) {
+  var x = 0.0, y = 0.0;
+  return [
+    for (final m in RegExp(r'(-?[\d.]+) (-?[\d.]+) Td').allMatches(content))
+      (x += double.parse(m[1]!), y += double.parse(m[2]!)),
+  ];
+}
+
+void main() {
+  test('explicit baseline overrides vertical mode and preserves line spacing',
+      () {
+    final w = ContentWriter();
+    writePdfTextBox(w, const PdfRect(10, 20, 110, 70), ['a', 'b'],
+        font: PdfStandardFont.helvetica,
+        fontSize: 10,
+        align: PdfTextAlign.left,
+        padding: 3,
+        lineHeight: 12,
+        vAlign: PdfTextBoxVAlign.centerLine,
+        firstBaselineY: 42);
+    expect(
+        _baselines(latin1.decode(w.takeBytes())), [(13.0, 42.0), (13.0, 30.0)]);
+  });
+
+  for (final multiline in [false, true]) {
+    test('no preference preserves legacy placement (multiline=$multiline)', () {
+      final (editor, field) = _fixture(multiline: multiline);
+      editor.setTextValue(field, 'a\nb');
+      final out = PdfDocument.open(editor.save());
+      final saved = _field(out);
+      expect(saved.textVerticalAlignment, isNull);
+      expect(saved.dict.containsKey(_key), isFalse);
+      expect(_baselines(_appearance(out, saved)).first.$2,
+          closeTo(multiline ? 50.82 : 26.41, 0.001));
+    });
+
+    for (final alignment in PdfFormTextVerticalAlignment.values) {
+      for (final horizontal in PdfTextAlign.values) {
+        test('$alignment / $horizontal (multiline=$multiline)', () {
+          final (editor, field) = _fixture(multiline: multiline);
+          editor.setTextFieldStyle(field, align: horizontal);
+          editor.setTextValue(field, multiline ? 'a\nb' : 'a',
+              verticalAlignment: alignment);
+          final out = PdfDocument.open(editor.save());
+          final saved = _field(out);
+          expect(saved.textVerticalAlignment, alignment);
+          expect(saved.isMultiline, multiline);
+          expect(saved.quadding, horizontal.quadding);
+          expect(saved.widgetRect(0), const PdfRect(100, 200, 300, 260));
+          expect(PdfAcroForm.of(out)!.needsAppearances, isFalse);
+          final positions = _baselines(_appearance(out, saved));
+          final expectedY = switch (alignment) {
+            PdfFormTextVerticalAlignment.top => 50.82,
+            PdfFormTextVerticalAlignment.center => multiline ? 33.57 : 27.82,
+            PdfFormTextVerticalAlignment.bottom => multiline ? 16.32 : 4.82,
+          };
+          expect(positions.first.$2, closeTo(expectedY, 0.001));
+          final width = PdfStandardFont.helvetica.measure('a', 10);
+          final expectedX = switch (horizontal) {
+            PdfTextAlign.left => 2.0,
+            PdfTextAlign.center => (200 - width) / 2,
+            PdfTextAlign.right => 198 - width,
+          };
+          expect(positions.first.$1, closeTo(expectedX, 0.001));
+          expect(positions, hasLength(multiline ? 2 : 1));
+          if (multiline) {
+            expect(
+                positions.first.$2 - positions.last.$2, closeTo(11.5, 0.001));
+          }
+        });
+      }
+    }
+  }
+
+  test('saved style survives reopen, refill, restyle, resize and rename', () {
+    final (editor, field) = _fixture();
+    editor.setTextFieldStyle(field,
+        verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    final reopened = PdfEditor(PdfDocument.open(editor.save()));
+    final saved = _field(reopened.document);
+    expect(saved.textVerticalAlignment, PdfFormTextVerticalAlignment.bottom);
+    reopened.setTextValue(saved, 'a\nb');
+    reopened.setTextFieldStyle(saved, color: 0xFF0000, fontSize: 12);
+    reopened.resizeFormWidget('notes', 0, const PdfRect(100, 200, 300, 300));
+    reopened.renameField(saved, 'renamed');
+    final out = PdfDocument.open(reopened.save());
+    final result = PdfAcroForm.of(out)!.fieldNamed('renamed')!;
+    expect(result.textVerticalAlignment, PdfFormTextVerticalAlignment.bottom);
+    expect(result.value, 'a\nb');
+    expect(result.appearanceColor, 0xFF0000);
+    expect(_baselines(_appearance(out, result)).last.$2, closeTo(5.384, 0.001));
+  });
+
+  test('fill can replace a saved preference and independently toggle wrapping',
+      () {
+    final (editor, field) = _fixture();
+    editor.setTextFieldStyle(field,
+        verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    editor.setTextValue(field, 'a\nb',
+        multiline: false,
+        verticalAlignment: PdfFormTextVerticalAlignment.center);
+    final out = PdfDocument.open(editor.save());
+    expect(_field(out).isMultiline, isFalse);
+    expect(
+        _field(out).textVerticalAlignment, PdfFormTextVerticalAlignment.center);
+    expect(_appearance(out, _field(out)), contains('(a b) Tj'));
+  });
+
+  for (final multiline in [false, true]) {
+    test('clear restores legacy placement (multiline=$multiline)', () {
+      final (editor, field) = _fixture(multiline: multiline);
+      editor.setTextValue(field, 'a\nb',
+          verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+      final reopened = PdfEditor(PdfDocument.open(editor.save()));
+      reopened.clearTextFieldVerticalAlignment(_field(reopened.document));
+      final out = PdfDocument.open(reopened.save());
+      final saved = _field(out);
+      expect(saved.textVerticalAlignment, isNull);
+      expect(saved.dict.containsKey(_key), isFalse);
+      expect(saved.value, 'a\nb');
+      expect(saved.isMultiline, multiline);
+      expect(_baselines(_appearance(out, saved)).first.$2,
+          closeTo(multiline ? 50.82 : 26.41, 0.001));
+    });
+  }
+
+  test('malformed and unknown metadata is ignored and preserved on refill', () {
+    for (final raw in <CosObject>[
+      CosString.fromText('future-value'),
+      const CosInteger(2),
+      const CosName('bottom'),
+      CosDictionary({}),
+    ]) {
+      final (editor, field) = _fixture();
+      field.dict[_key] = raw;
+      editor.setTextValue(field, 'a\nb');
+      final out = PdfDocument.open(editor.save());
+      expect(_field(out).textVerticalAlignment, isNull);
+      expect(_field(out).dict.containsKey(_key), isTrue);
+      expect(_baselines(_appearance(out, _field(out))).first.$2,
+          closeTo(50.82, 0.001));
+    }
+  });
+
+  test('overflow retains the beginning and clips without moving the field', () {
+    for (final alignment in PdfFormTextVerticalAlignment.values) {
+      final (editor, field) = _fixture();
+      editor.resizeFormWidget('notes', 0, const PdfRect(100, 200, 130, 210));
+      editor.setTextValue(field, 'longunbrokenword\na\nb',
+          verticalAlignment: alignment);
+      final out = PdfDocument.open(editor.save());
+      final content = _appearance(out, _field(out));
+      expect(_baselines(content).first, (2.0, 0.82));
+      expect(content, contains('1 1 28 8 re'));
+      expect(content, contains('W'));
+      expect(content, contains('(longunbrokenword) Tj'));
+      expect(_field(out).value, 'longunbrokenword\na\nb');
+      expect(_field(out).appearanceFontSize, 10);
+    }
+  });
+
+  test('wrapping, line endings and blank lines precede block alignment', () {
+    final (editor, field) = _fixture();
+    editor.resizeFormWidget('notes', 0, const PdfRect(100, 200, 130, 280));
+    editor.setTextValue(field, 'aa bb cc\r\n\rdd\n',
+        verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    final out = PdfDocument.open(editor.save());
+    final content = _appearance(out, _field(out));
+    expect(RegExp(r'\((.*?)\) Tj').allMatches(content).map((m) => m[1]),
+        ['aa bb', 'cc', '', 'dd', '']);
+    expect(_baselines(content).last.$2, closeTo(4.82, 0.001));
+  });
+
+  test(
+      'auto-size retains its minimum and overflowing blocks remain top anchored',
+      () {
+    final (editor, field) = _fixture();
+    editor.resizeFormWidget('notes', 0, const PdfRect(100, 200, 130, 208));
+    editor.setTextFieldStyle(field,
+        autoSize: true, verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    editor.setTextValue(field, 'a\nb\nc');
+    final out = PdfDocument.open(editor.save());
+    final content = _appearance(out, _field(out));
+    expect(content, contains('/Helv 4 Tf'));
+    expect(_baselines(content).first.$2, closeTo(3.128, 0.001));
+    expect(_field(out).appearanceFontSize, 0);
+  });
+
+  test('one field preference updates widgets of different sizes', () {
+    final editor = PdfEditor(PdfDocument.open(buildAcroFormPdf()));
+    final field = editor.acroForm!.fieldNamed('color')!;
+    // Reuse the fixture's parent + two widget structure as a text field.
+    field.dict['FT'] = const CosName('Tx');
+    field.dict['Ff'] = const CosInteger(0);
+    editor.resizeFormWidget('color', 0, const PdfRect(72, 400, 272, 440));
+    editor.resizeFormWidget('color', 1, const PdfRect(72, 500, 172, 560));
+    editor.setTextFieldStyle(field, fontSize: 10);
+    editor.setTextValue(field, 'Shared',
+        verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    final out = PdfDocument.open(editor.save());
+    final saved = PdfAcroForm.of(out)!.fieldNamed('color')!;
+    expect(saved.widgets, hasLength(2));
+    expect(saved.value, 'Shared');
+    expect(saved.textVerticalAlignment, PdfFormTextVerticalAlignment.bottom);
+    for (var i = 0; i < 2; i++) {
+      expect(saved.widgets[i].containsKey(_key), isFalse);
+      expect(_baselines(_appearance(out, saved, i)).single.$2,
+          closeTo(4.82, 0.001));
+    }
+  });
+
+  for (final rotation in [90, 180, 270]) {
+    test('rotation $rotation preserves preference in oriented widget space',
+        () {
+      final (editor, field) = _fixture(multiline: false);
+      editor.setTextValue(field, 'a',
+          verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+      final reopened = PdfEditor(PdfDocument.open(editor.save()));
+      reopened.rotatePages([0], rotation);
+      final out = PdfDocument.open(reopened.save());
+      final saved = _field(out);
+      expect(saved.textVerticalAlignment, PdfFormTextVerticalAlignment.bottom);
+      final rect = saved.widgetRect(0)!;
+      final visualBottom =
+          rotation == 180 ? 0.0 : (rect.height - rect.width) / 2;
+      expect(_baselines(_appearance(out, saved)).single.$2,
+          closeTo(visualBottom + 4.82, 0.001));
+      expect(_appearance(out, saved), contains('cm'));
+    });
+  }
+
+  test('embedded font placement survives reopening without live font objects',
+      () {
+    final (editor, field) = _fixture();
+    final font = PdfEmbeddedFont.parse(
+        File('test/fonts/DejaVuSans.ttf').readAsBytesSync());
+    editor.setTextFieldStyle(field,
+        font: font, verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    final reopened = PdfEditor(PdfDocument.open(editor.save()));
+    reopened.setTextValue(_field(reopened.document), 'Wörld\nAgain');
+    final out = PdfDocument.open(reopened.save());
+    final content = _appearance(out, _field(out));
+    expect(content, contains('> Tj'));
+    expect(_baselines(content).last.$2, closeTo(12 - font.ascent / 100, 0.001));
+  });
+
+  test('rejects non-text and read-only fields before changing their metadata',
+      () {
+    final editor = PdfEditor(PdfDocument.open(buildAcroFormPdf()));
+    final button = editor.acroForm!.fieldNamed('agree')!;
+    expect(
+        () => editor.setTextFieldStyle(button,
+            verticalAlignment: PdfFormTextVerticalAlignment.bottom),
+        throwsArgumentError);
+    expect(() => editor.clearTextFieldVerticalAlignment(button),
+        throwsArgumentError);
+    final field = editor.acroForm!.fieldNamed('name')!;
+    field.dict['Ff'] = const CosInteger(PdfFormField.readOnlyFlag);
+    expect(
+        () => editor.setTextValue(field, 'changed',
+            verticalAlignment: PdfFormTextVerticalAlignment.bottom),
+        throwsStateError);
+    expect(
+        () => editor.clearTextFieldVerticalAlignment(field), throwsStateError);
+    expect(field.dict.containsKey(_key), isFalse);
+    expect(button.dict.containsKey(_key), isFalse);
+  });
+
+  test('flattening keeps the saved appearance placement', () {
+    final (editor, field) = _fixture();
+    editor.setTextValue(field, 'a\nb',
+        verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+    final reopened = PdfEditor(PdfDocument.open(editor.save()));
+    final before = _appearance(reopened.document, _field(reopened.document));
+    reopened.flattenForm();
+    final out = PdfDocument.open(reopened.save());
+    expect(PdfAcroForm.of(out)?.fields ?? [], isEmpty);
+    final resources =
+        out.cos.resolve(out.page(0).dict['Resources']) as CosDictionary;
+    final xobjects = out.cos.resolve(resources['XObject']) as CosDictionary;
+    final appearances = [
+      for (final entry in xobjects.entries.entries)
+        if (entry.key.startsWith('FlatAnnot'))
+          latin1.decode(out.cos
+              .decodeStreamData(out.cos.resolve(entry.value) as CosStream)),
+    ];
+    expect(appearances, contains(before));
+  });
+}

--- a/packages/pdf_document/test/form_vertical_alignment_test.dart
+++ b/packages/pdf_document/test/form_vertical_alignment_test.dart
@@ -35,21 +35,6 @@ List<(double, double)> _baselines(String content) {
 }
 
 void main() {
-  test('explicit baseline overrides vertical mode and preserves line spacing',
-      () {
-    final w = ContentWriter();
-    writePdfTextBox(w, const PdfRect(10, 20, 110, 70), ['a', 'b'],
-        font: PdfStandardFont.helvetica,
-        fontSize: 10,
-        align: PdfTextAlign.left,
-        padding: 3,
-        lineHeight: 12,
-        vAlign: PdfTextBoxVAlign.centerLine,
-        firstBaselineY: 42);
-    expect(
-        _baselines(latin1.decode(w.takeBytes())), [(13.0, 42.0), (13.0, 30.0)]);
-  });
-
   for (final multiline in [false, true]) {
     test('no preference preserves legacy placement (multiline=$multiline)', () {
       final (editor, field) = _fixture(multiline: multiline);
@@ -71,13 +56,18 @@ void main() {
               verticalAlignment: alignment);
           final out = PdfDocument.open(editor.save());
           final saved = _field(out);
-          expect(saved.textVerticalAlignment, alignment);
+          expect(
+              saved.textVerticalAlignment,
+              alignment == PdfFormTextVerticalAlignment.legacy
+                  ? isNull
+                  : alignment);
           expect(saved.isMultiline, multiline);
           expect(saved.quadding, horizontal.quadding);
           expect(saved.widgetRect(0), const PdfRect(100, 200, 300, 260));
           expect(PdfAcroForm.of(out)!.needsAppearances, isFalse);
           final positions = _baselines(_appearance(out, saved));
           final expectedY = switch (alignment) {
+            PdfFormTextVerticalAlignment.legacy => multiline ? 50.82 : 26.41,
             PdfFormTextVerticalAlignment.top => 50.82,
             PdfFormTextVerticalAlignment.center => multiline ? 33.57 : 27.82,
             PdfFormTextVerticalAlignment.bottom => multiline ? 16.32 : 4.82,
@@ -150,6 +140,63 @@ void main() {
       expect(_baselines(_appearance(out, saved)).first.$2,
           closeTo(multiline ? 50.82 : 26.41, 0.001));
     });
+  }
+
+  for (final multiline in [false, true]) {
+    for (final style in [false, true]) {
+      test(
+          'legacy clears during ${style ? "style" : "fill"} (multiline=$multiline)',
+          () {
+        final (editor, field) = _fixture(multiline: multiline);
+        editor.setTextValue(field, 'old',
+            verticalAlignment: PdfFormTextVerticalAlignment.bottom);
+        final reopened = PdfEditor(PdfDocument.open(editor.save()));
+        final target = _field(reopened.document);
+        if (style) {
+          reopened.setTextFieldStyle(target,
+              color: 0xFF0000,
+              verticalAlignment: PdfFormTextVerticalAlignment.legacy);
+        } else {
+          reopened.setTextValue(target, 'new',
+              verticalAlignment: PdfFormTextVerticalAlignment.legacy);
+        }
+        final out = PdfDocument.open(reopened.save());
+        final saved = _field(out);
+        expect(saved.dict.containsKey(_key), isFalse);
+        expect(saved.textVerticalAlignment, isNull);
+        expect(saved.value, style ? 'old' : 'new');
+        if (style) expect(saved.appearanceColor, 0xFF0000);
+        expect(_baselines(_appearance(out, saved)).first.$2,
+            closeTo(multiline ? 50.82 : 26.41, 0.001));
+      });
+    }
+  }
+
+  for (final mode in [
+    PdfTextBoxVAlign.centerBlock,
+    PdfTextBoxVAlign.bottomBlock
+  ]) {
+    for (final clamp in [false, true]) {
+      test('shared $mode overflow clamp=$clamp', () {
+        final w = ContentWriter();
+        writePdfTextBox(w, const PdfRect(10, 20, 110, 40), ['a', 'b', 'c'],
+            font: PdfStandardFont.helvetica,
+            fontSize: 10,
+            align: PdfTextAlign.left,
+            padding: 3,
+            lineHeight: 12,
+            vAlign: mode,
+            clampVerticalAlign: clamp);
+        final positions = _baselines(latin1.decode(w.takeBytes()));
+        final expected = clamp
+            ? 29.82
+            : mode == PdfTextBoxVAlign.centerBlock
+                ? 39.82
+                : 49.82;
+        expect(positions.first.$2, closeTo(expected, 0.001));
+        expect(positions.first.$2 - positions.last.$2, closeTo(24, 0.001));
+      });
+    }
   }
 
   test('malformed and unknown metadata is ignored and preserved on refill', () {


### PR DESCRIPTION
## Summary

Text fields currently choose vertical placement solely from their multiline flag, so callers cannot centre or bottom-align wrapped text. Add `PdfFormTextVerticalAlignment` and optional `verticalAlignment` arguments to `setTextValue` and `setTextFieldStyle`, plus a saved-setting getter, a `legacy` option that clears the preference during the same fill/style operation, and a standalone clear operation.

The preference applies to the complete wrapped block in every widget and survives saved/reopened fills, restyling, resizing and rotation. Omitted preferences preserve legacy rendering. Overfull blocks stay top anchored and clipped; wrapping, horizontal justification and auto-sizing retain their existing policies.

Persistence follows the existing private `DartPdf…` marker convention. The README documents its representation and interoperability limits. All placement math lives in `writePdfTextBox`: form settings map to `PdfTextBoxVAlign.top`, `centerBlock`, and the new `bottomBlock`. Its opt-in `clampVerticalAlign` keeps overfull form blocks top anchored while preserving existing signature-panel placement. Form auto-size retains its conservative fit metric; the bottom-block calculation documents why placement excludes trailing leading.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Rendering change
- [x] Editing behavior change

## Validation

Used the repository-pinned Flutter 3.47.0 / Dart 3.13.0 SDK directly (equivalent to the FVM commands):

- [x] `flutter pub get`
- [x] `dart analyze --fatal-infos`
- [x] `pdf_cos`: 373 tests passed
- [x] `pdf_document`: 1,039 passed; 1 skipped
- [x] `pdf_graphics`: 1,064 passed
- [x] `dart_pdf_editor`: 2,690 passed; 29 skipped
- [x] Repository formatting wrapper and lockstep dependency check (the two unrelated pre-existing layouts flagged in review were restored after formatting)
- [x] PDF parse/render smoke test
- [ ] Example app smoke test

New regressions cover single/multiline placement across horizontal alignments, legacy defaults, persistence, clearing during fill/style, shared-helper overflow clamping enabled/disabled, unknown/malformed metadata, wrapping and blank lines, overflow and auto-size floor, multiple widgets, rotation, embedded fonts, read-only/type guards and flattening.

## User experience

This is a library API change; no editor control is introduced. A downstream application's unchanged form-filling function was exercised against the modified library, including its forced `multiline: true` call. Its full app UI was not launched.

## PDF fixtures and screenshots

Automated regressions use programmatically generated fixtures. Validation before the shared-helper refactor also used a two-page form with fabricated values: all 119 fields and 123 widgets survived interactive fills, with unchanged names, rectangles and page content streams. In Poppler, explicit top matched legacy rendering, and centred interactive and flattened outputs matched pixel-for-pixel. A synthetic alignment comparison was also rendered and visually checked with the library's Flutter renderer. Local form files are not included in this contribution.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Unknown/malformed preference values fall back without throwing.
- [x] Raw PDF stream bytes remain lazy until decoding is required.
- [x] Test fixtures are generated rather than hand-editing byte offsets.

## Compatibility notes

`/DartPdfTextVerticalAlignment` is a library-private text string (`top`, `center`, `bottom`) stored on the terminal field, not inherited; it is not a standard AcroForm property, and no developer-prefix registration is claimed. Other editors may change placement or discard the preference when rebuilding appearances.

Explicit centre aligns the em-height block even for one line; legacy single-line placement remains ascent-centred when no preference is saved. Alignment is applied by the shared helper after existing wrapping/auto-size work. `legacy` removes the private key rather than storing a fourth value; the getter then returns null. No package versions or dependency constraints changed.