### PR TITLE
Reveal the saved file in File Explorer after a Save As

### DIFF
--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -15,8 +15,10 @@ import 'pdf_mobile_source.dart';
 import 'web_file_picker_stub.dart'
     if (dart.library.js_interop) 'web_file_picker.dart';
 
-const _macosFileAccessChannel =
-    MethodChannel('dev.milanko.dartpdf/file_access');
+/// The runner channel for file operations the Flutter side cannot do itself:
+/// macOS security-scoped bookmarks and reads, and revealing a file in the
+/// platform file manager (macOS and Windows).
+const _fileAccessChannel = MethodChannel('dev.milanko.dartpdf/file_access');
 
 // The `label` shows in the native desktop file dialog's type-filter dropdown,
 // so it is localized: the callers (which have a BuildContext) pass the resolved
@@ -188,6 +190,9 @@ String? originPathForPickedFile(XFile file) => (!kIsWeb &&
 bool get _isMacOSDesktop =>
     !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
 
+bool get _isWindowsDesktop =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.windows;
+
 /// Creates a security-scoped bookmark for [path] on macOS.
 ///
 /// Returns null on other platforms, when [path] is absent, or when the native
@@ -196,7 +201,7 @@ bool get _isMacOSDesktop =>
 Future<String?> securityBookmarkForPath(String? path) async {
   if (!_isMacOSDesktop || path == null || path.isEmpty) return null;
   try {
-    final data = await _macosFileAccessChannel.invokeMethod<Uint8List>(
+    final data = await _fileAccessChannel.invokeMethod<Uint8List>(
       'bookmarkForPath',
       {'path': path},
     );
@@ -330,7 +335,7 @@ Future<Uint8List> readPdfAtPath(String path, {String? bookmark}) async {
   if (cached != null) return cached;
   if (_isMacOSDesktop && bookmark != null && bookmark.isNotEmpty) {
     try {
-      final bytes = await _macosFileAccessChannel.invokeMethod<Uint8List>(
+      final bytes = await _fileAccessChannel.invokeMethod<Uint8List>(
         'readFile',
         {'path': path, 'bookmark': bookmark},
       );
@@ -413,26 +418,37 @@ String? containingFolderPath(String path) {
   return trimmed.substring(0, index);
 }
 
-/// Reveals [path] in Finder, or opens its containing folder in File Explorer /
-/// the Linux file manager. Returns false when there is no usable origin path
-/// or the platform refuses to launch it.
+/// Reveals [path] in the platform file manager - Finder and File Explorer
+/// select the file itself, the Linux file manager gets its containing folder.
+/// Returns false when there is no usable origin path or the platform refuses
+/// the request.
 ///
 /// Finder needs the selected file rather than its parent directory: a
 /// sandboxed macOS app can hold a security-scoped grant for a OneDrive file
 /// without having access to the file's containing folder. [bookmark]
 /// reactivates that grant while Finder handles the reveal request.
+///
+/// Windows goes through the runner
+/// (`SHOpenFolderAndSelectItems`, windows/runner/file_dialogs.cpp) instead of
+/// shell-executing a `file:` URL for the folder. Asking the shell to "open" a
+/// folder URL is a navigation request that Explorer is free to serve from a
+/// window it already has - with the default "open each folder in the same
+/// window" it hands back whatever that window was showing, so a document saved
+/// somewhere new appeared to reveal its *old* location. Selecting the file is
+/// unambiguous, points at the file the user just saved, and matches what
+/// Finder already does. A runner without the method (an older build) falls
+/// back to the folder launch below rather than failing.
 Future<bool> openContainingFolder(String? path, {String? bookmark}) async {
   if (!supportsOpenContainingFolder || path == null) return false;
   final folder = containingFolderPath(path);
   if (folder == null) return false;
   if (_isMacOSDesktop) {
     try {
-      return await _macosFileAccessChannel.invokeMethod<bool>(
+      return await _fileAccessChannel.invokeMethod<bool>(
             'revealFile',
             {
               'path': path,
-              if (bookmark != null && bookmark.isNotEmpty)
-                'bookmark': bookmark,
+              if (bookmark != null && bookmark.isNotEmpty) 'bookmark': bookmark,
             },
           ) ??
           false;
@@ -442,7 +458,28 @@ Future<bool> openContainingFolder(String? path, {String? bookmark}) async {
       return false;
     }
   }
-  return launchUrl(Uri.file(folder), mode: LaunchMode.externalApplication);
+  if (_isWindowsDesktop) {
+    try {
+      final revealed = await _fileAccessChannel.invokeMethod<bool>(
+        'revealFile',
+        {'path': path},
+      );
+      if (revealed ?? false) return true;
+    } on MissingPluginException {
+      // No reveal in this runner; the folder launch below still works.
+    } catch (_) {
+      // Explorer refused the selection (a deleted file, a shell that cannot
+      // parse the path) - opening the folder is still better than nothing.
+    }
+  }
+  // `Uri.file` picks its separator rules from the *host* by default, which is
+  // the process running the code rather than the platform being targeted -
+  // fine in production, wrong under a test that overrides the platform. Say
+  // which shape [folder] has.
+  return launchUrl(
+    Uri.file(folder, windows: _isWindowsDesktop),
+    mode: LaunchMode.externalApplication,
+  );
 }
 
 /// Whether the current platform supports overwriting a file in place by path.
@@ -468,7 +505,7 @@ Future<SaveResult> saveBytesToPath(
   try {
     if (_isMacOSDesktop && bookmark != null && bookmark.isNotEmpty) {
       try {
-        final ok = await _macosFileAccessChannel.invokeMethod<bool>(
+        final ok = await _fileAccessChannel.invokeMethod<bool>(
           'writeFile',
           {'path': path, 'bookmark': bookmark, 'bytes': bytes},
         );

--- a/app/test/file_io_folder_test.dart
+++ b/app/test/file_io_folder_test.dart
@@ -110,9 +110,20 @@ void main() {
     testWidgets('Windows falls back to the folder without a runner reveal',
         (tester) async {
       final launched = _mockUrlLauncher();
-      // An older runner has no reveal method; a null reply is what the channel
-      // turns into MissingPluginException.
-      _mockFileAccess((call) async => null);
+      // A Dart build running against a runner that predates the reveal.
+      _mockFileAccess((call) async => throw MissingPluginException());
+
+      expect(
+          await openContainingFolder(r'C:\Users\ben\Desktop\copy.pdf'), isTrue);
+
+      expect(launched, [r'file:///C:/Users/ben/Desktop']);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
+
+    testWidgets('Windows falls back to the folder when the reveal errors',
+        (tester) async {
+      final launched = _mockUrlLauncher();
+      // The shell could not parse the item - deleted between save and click.
+      _mockFileAccess((call) async => throw PlatformException(code: 'failed'));
 
       expect(
           await openContainingFolder(r'C:\Users\ben\Desktop\copy.pdf'), isTrue);

--- a/app/test/file_io_folder_test.dart
+++ b/app/test/file_io_folder_test.dart
@@ -88,9 +88,89 @@ void main() {
       });
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
+    testWidgets('Windows selects the file through the runner', (tester) async {
+      final calls = <MethodCall>[];
+      final launched = _mockUrlLauncher();
+      _mockFileAccess((call) async {
+        calls.add(call);
+        return true;
+      });
+
+      expect(
+          await openContainingFolder(r'C:\Users\ben\Desktop\copy.pdf'), isTrue);
+
+      expect(calls.single.method, 'revealFile');
+      expect(
+          calls.single.arguments, {'path': r'C:\Users\ben\Desktop\copy.pdf'});
+      // Naming the item is the whole point: no folder URL is launched, so
+      // Explorer cannot answer with a window it already had open elsewhere.
+      expect(launched, isEmpty);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
+
+    testWidgets('Windows falls back to the folder without a runner reveal',
+        (tester) async {
+      final launched = _mockUrlLauncher();
+      // An older runner has no reveal method; a null reply is what the channel
+      // turns into MissingPluginException.
+      _mockFileAccess((call) async => null);
+
+      expect(
+          await openContainingFolder(r'C:\Users\ben\Desktop\copy.pdf'), isTrue);
+
+      expect(launched, [r'file:///C:/Users/ben/Desktop']);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
+
+    testWidgets('Windows falls back to the folder when Explorer refuses',
+        (tester) async {
+      final launched = _mockUrlLauncher();
+      _mockFileAccess((call) async => false);
+
+      expect(
+          await openContainingFolder(r'C:\Users\ben\Desktop\copy.pdf'), isTrue);
+
+      expect(launched, [r'file:///C:/Users/ben/Desktop']);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.windows));
+
+    testWidgets('Linux opens the containing folder', (tester) async {
+      final launched = _mockUrlLauncher();
+
+      expect(await openContainingFolder('/home/ben/Desktop/copy.pdf'), isTrue);
+
+      expect(launched, ['file:///home/ben/Desktop']);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
     testWidgets('returns false on unsupported platforms before launching',
         (tester) async {
       expect(await openContainingFolder('/Users/ben/file.pdf'), isFalse);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
+}
+
+/// Records the URLs `launchUrl` is handed, reporting success.
+List<String> _mockUrlLauncher() {
+  final launched = <String>[];
+  const channel = MethodChannel('plugins.flutter.io/url_launcher');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+    if (call.method == 'launch') {
+      launched.add((call.arguments as Map)['url'] as String);
+    }
+    return true;
+  });
+  addTearDown(() => TestDefaultBinaryMessengerBinding
+      .instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, null));
+  return launched;
+}
+
+/// Answers the runner's file-access channel with [handler]. The channel must
+/// always be handled: an unmocked one leaves the reply pending forever under
+/// flutter_test, so a "no such method" runner is a handler returning null.
+void _mockFileAccess(Future<Object?> Function(MethodCall call) handler) {
+  const channel = MethodChannel('dev.milanko.dartpdf/file_access');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, handler);
+  addTearDown(() => TestDefaultBinaryMessengerBinding
+      .instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, null));
 }

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -8,6 +8,7 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 import 'package:dart_pdf_editor_app/middle_ellipsis_text.dart';
 
@@ -514,6 +515,50 @@ void main() {
     expect(find.byKey(const ValueKey('tab-menu-open-folder')), findsOneWidget);
     expect(find.text('Open in Finder'), findsOneWidget);
   }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+
+  testWidgets('reveal follows a Save As to a new folder', (tester) async {
+    // The reveal has to name where the document lives *now*: after a Save As
+    // the tab's origin moves with it, and the menu must not point back at the
+    // file it was opened from.
+    const fileAccess = MethodChannel('dev.milanko.dartpdf/file_access');
+    final calls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(fileAccess,
+        (call) async {
+      calls.add(call);
+      // A bookmark for the new path on macOS; unused (and unasked) elsewhere.
+      return call.method == 'bookmarkForPath'
+          ? Uint8List.fromList([1, 2, 3])
+          : true;
+    });
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(fileAccess, null));
+
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        saveDocumentAs: (context, bytes, name) async =>
+            SaveResult.saved('/Users/ben/Desktop/copy.pdf'),
+      ),
+    ));
+    await tester.pump();
+    await openTab(tester, 'alpha.pdf', path: '/Users/ben/Documents/alpha.pdf');
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('menu-save-as')));
+    await tester.pumpAndSettle();
+    expect(tabTitle('copy.pdf'), findsOneWidget);
+
+    calls.clear();
+    await rightClickTab(tester, 'copy.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-open-folder')));
+    await tester.pumpAndSettle();
+
+    final reveal = calls.singleWhere((call) => call.method == 'revealFile');
+    expect((reveal.arguments as Map)['path'], '/Users/ben/Desktop/copy.pdf');
+  },
+      variant: const TargetPlatformVariant(
+          <TargetPlatform>{TargetPlatform.macOS, TargetPlatform.windows}));
 
   testWidgets('right-click hides folder action for memory-only tabs',
       (tester) async {

--- a/app/windows/runner/file_dialogs.cpp
+++ b/app/windows/runner/file_dialogs.cpp
@@ -1,5 +1,6 @@
 #include "file_dialogs.h"
 
+#include <shlobj.h>
 #include <shobjidl.h>
 #include <windows.h>
 
@@ -172,6 +173,19 @@ FileDialogResult ShowOpenFileDialog(HWND owner,
 FileDialogResult ShowSaveFileDialog(HWND owner,
                                     const FileDialogRequest& request) {
   return ShowDialog(owner, request, /*save=*/true);
+}
+
+bool RevealFileInExplorer(const std::wstring& path) {
+  if (path.empty()) return false;
+  // ILCreateFromPathW resolves the path against the shell namespace, so a
+  // stale or non-filesystem path fails here rather than opening the wrong
+  // window. COM is already initialised (STA) on the platform thread by
+  // main.cpp, which is where channel calls land.
+  PIDLIST_ABSOLUTE item = ::ILCreateFromPathW(path.c_str());
+  if (item == nullptr) return false;
+  const HRESULT hr = ::SHOpenFolderAndSelectItems(item, 0, nullptr, 0);
+  ::ILFree(item);
+  return SUCCEEDED(hr);
 }
 
 }  // namespace dart_pdf

--- a/app/windows/runner/file_dialogs.h
+++ b/app/windows/runner/file_dialogs.h
@@ -51,6 +51,18 @@ FileDialogResult ShowOpenFileDialog(HWND owner,
 FileDialogResult ShowSaveFileDialog(HWND owner,
                                     const FileDialogRequest& request);
 
+// Opens |path|'s folder in File Explorer with the file itself selected, the
+// way Finder's "Reveal in Finder" behaves. Returns false when the path cannot
+// be parsed by the shell (it no longer exists, or is not a filesystem path) or
+// Explorer refuses the request, which lets the Dart side fall back to plainly
+// launching the containing folder.
+//
+// Shell-executing a `file:` URL for the folder - what url_launcher does - is a
+// navigation request Explorer may serve from a window it already has, so it
+// could surface a folder the user was looking at earlier instead of this one.
+// SHOpenFolderAndSelectItems names the item, so there is nothing to guess.
+bool RevealFileInExplorer(const std::wstring& path);
+
 }  // namespace dart_pdf
 
 #endif  // RUNNER_FILE_DIALOGS_H_

--- a/app/windows/runner/platform_channels.cpp
+++ b/app/windows/runner/platform_channels.cpp
@@ -26,6 +26,8 @@ constexpr char kWindowGeometryChannelName[] =
     "dev.milanko.dartpdf/window_geometry";
 constexpr char kFileDialogChannelName[] =
     "dev.milanko.dartpdf/file_dialogs";
+constexpr char kFileAccessChannelName[] =
+    "dev.milanko.dartpdf/file_access";
 
 const flutter::EncodableValue* Lookup(const flutter::EncodableMap& map,
                                       const char* key) {
@@ -426,6 +428,34 @@ void DartPdfPlatformChannels::Register(flutter::BinaryMessenger* messenger) {
           return;
         }
         result->Success(DialogPayload(dialog));
+      });
+
+  // Revealing a saved document in File Explorer. url_launcher can only ask the
+  // shell to "open" the containing folder, which Explorer is free to serve
+  // from a window it already has - so a document saved to a new folder could
+  // surface the one the user was looking at before. Naming the item leaves
+  // nothing to guess, and selects the file the way Finder does on macOS (the
+  // Dart side shares that channel's `revealFile`; see lib/file_io.dart).
+  file_access_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          messenger, kFileAccessChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  file_access_channel_->SetMethodCallHandler(
+      [](const flutter::MethodCall<flutter::EncodableValue>& call,
+         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+             result) {
+        if (call.method_name() != "revealFile") {
+          result->NotImplemented();
+          return;
+        }
+        const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+        const std::wstring path = OptionalString(args, "path");
+        if (path.empty()) {
+          result->Error("bad_args", "revealFile expects a path");
+          return;
+        }
+        result->Success(
+            flutter::EncodableValue(dart_pdf::RevealFileInExplorer(path)));
       });
 }
 

--- a/app/windows/runner/platform_channels.h
+++ b/app/windows/runner/platform_channels.h
@@ -46,6 +46,8 @@ class DartPdfPlatformChannels {
       native_print_channel_;
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       file_dialog_channel_;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      file_access_channel_;
   std::unique_ptr<DartPdfWindowsDropService> windows_drop_service_;
   NativePrinter native_printer_;
 };

--- a/doc/dev-log/2026-09-07-reveal-saved-file-in-explorer.md
+++ b/doc/dev-log/2026-09-07-reveal-saved-file-in-explorer.md
@@ -1,0 +1,62 @@
+# "Open in File Explorer" could show the document's old folder (Windows)
+
+Reported: after a Save As to a different folder, the tab context menu's
+**Open in File Explorer** opened the location the document had been opened
+*from*, not the one it had just been saved to.
+
+## What was ruled out first
+
+The app-side half is sound, and now has a test that says so
+(`app/test/tabs_menu_test.dart`, "reveal follows a Save As to a new folder").
+`EditorScreen._save` adopts the destination on a successful Save As -
+`tab.originPath`/`originBookmark`/title all move to the new file, `cachePath`
+is dropped - and `_showTabMenu` reads `tab.originPath` when the action runs,
+not when the menu is built. Driving that end to end (open a file-backed tab,
+Save As, right-click, Open in File Explorer) reveals the new path on macOS and
+Windows alike.
+
+## The actual mechanism
+
+`openContainingFolder` asked `url_launcher` to open a `file:` URL for the
+*containing folder*. On Windows that lands in
+`ShellExecuteW(nullptr, L"open", L"file:///C:/...")`, which is a request to
+open a folder, not to show a particular file. Explorer is free to answer it
+from a window it already has - with the shell's default "open each folder in
+the same window", the user gets whatever that window was showing. Right after
+opening a PDF from `Documents` and saving it to `Desktop`, the window Explorer
+reaches for is the one still parked on `Documents`: the document's old
+location.
+
+macOS never had this: its reveal goes through the runner and calls
+`NSWorkspace.activateFileViewerSelecting`, which names the file.
+
+## Fix
+
+Windows now reveals through the runner too, the same way:
+
+- `windows/runner/file_dialogs.cpp` gains `RevealFileInExplorer`, which turns
+  the path into a PIDL (`ILCreateFromPathW`) and calls
+  `SHOpenFolderAndSelectItems`. The item is named, so there is nothing for the
+  shell to resolve from an existing window, and the saved file comes up
+  selected - the same affordance Finder gives.
+- `windows/runner/platform_channels.cpp` registers
+  `dev.milanko.dartpdf/file_access` (the channel macOS already uses for
+  bookmarks and its own `revealFile`) with the one `revealFile` method.
+- `lib/file_io.dart`'s `openContainingFolder` calls it on Windows and **falls
+  back** to the old folder launch when the runner has no such method (a Dart
+  build running against an older runner) or when the shell refuses the item
+  (a file deleted between the save and the click).
+
+`shell32`/`ole32` were already linked for the common-item dialogs, and COM is
+already initialised STA on the platform thread by `main.cpp`, so the reveal
+needed no build changes.
+
+## Also fixed here
+
+`Uri.file(folder)` takes its separator rules from the **host** process, not
+from `defaultTargetPlatform`. That is the same thing in production, but it
+means a Windows path formatted on any other host silently becomes a relative,
+percent-encoded URI (`C%3A%5CUsers%5C...`) - which is what a
+`TargetPlatformVariant` test sees. The call now passes `windows:` explicitly,
+so the folder fallback is honest under test and pinned by
+`app/test/file_io_folder_test.dart`.


### PR DESCRIPTION
## Summary

The tab context menu's **Open in File Explorer** could show the folder a document was opened *from* rather than the one it had just been saved to.

The app-side half turned out to be sound, and now has a test that says so: `EditorScreen._save` adopts the Save As destination (path, bookmark, title; `cachePath` dropped) and `_showTabMenu` reads `tab.originPath` when the action runs, not when the menu is built. Driving that end to end — open a file-backed tab, Save As, right-click, Open in File Explorer — reveals the new path.

The reveal itself was the weak link. `openContainingFolder` asked `url_launcher` to open a `file:` URL for the *containing folder*, which on Windows lands in `ShellExecuteW(nullptr, L"open", L"file:///C:/…")`. That is a request to open a folder, not to show a particular file, and Explorer is free to answer it from a window it already has — with the shell's default "open each folder in the same window", the user gets whatever that window was showing. Right after opening a PDF from `Documents` and saving it to `Desktop`, that window is the one still parked on `Documents`. macOS never had this: its reveal goes through the runner and calls `NSWorkspace.activateFileViewerSelecting`, which names the file.

Windows now reveals the same way:

- `windows/runner/file_dialogs.cpp` gains `RevealFileInExplorer` — path → PIDL (`ILCreateFromPathW`) → `SHOpenFolderAndSelectItems`. The item is named, so there is nothing for the shell to resolve from an existing window, and the saved file comes up selected.
- `windows/runner/platform_channels.cpp` registers `dev.milanko.dartpdf/file_access` (the channel macOS already uses for bookmarks and its own `revealFile`) with the one `revealFile` method.
- `lib/file_io.dart` calls it on Windows and **falls back** to the old folder launch when the runner has no such method (a Dart build against an older runner) or when the shell refuses the item (file deleted between save and click).

`shell32`/`ole32` were already linked for the common-item dialogs and COM is already initialised STA on the platform thread, so no build changes were needed.

Also fixed here: `Uri.file(folder)` takes its separator rules from the **host** process rather than `defaultTargetPlatform`. Identical in production, but it means a Windows path formatted on any other host silently becomes a relative, percent-encoded URI (`C%3A%5CUsers%5C…`) — which is exactly what a `TargetPlatformVariant` test sees. The folder fallback now passes `windows:` explicitly and is pinned by a test.

Background and the reasoning trail are in `doc/dev-log/2026-09-07-reveal-saved-file-in-explorer.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app <!-- app/ (DartPDF) -->
- [x] Documentation / CI / repository metadata only <!-- dev-log entry -->

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: nothing outside `app/` is touched, so the library suites and the render corpora are unaffected. `cd app && fvm flutter test` was run over the suites that cover this area — `file_io_folder_test.dart`, `tabs_menu_test.dart`, `save_shortcuts_test.dart`, `multi_window_test.dart`, `rename_document_test.dart`, `unsaved_changes_recovery_test.dart`, `digital_signature_test.dart` — all passing. The Windows runner change cannot be exercised from this Linux environment; the Dart side of it is covered by mocked-channel tests, including both fallbacks.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered. <!-- both fallbacks keep the old folder-open behaviour, and a reveal that fails end to end still toasts "Could not open containing folder" -->
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked. <!-- the action is desktop right-click only; unchanged -->
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out. <!-- a single user-initiated shell call; no render or memory path involved -->

## PDF fixtures and screenshots

None needed — the change is in file-manager integration, not document handling.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory. <!-- the reveal goes over a platform channel, so file_io.dart still compiles for web -->
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The Windows behaviour needs a real Windows build to confirm end to end; if the old folder still comes up there, the cause is upstream of the shell call and I'd want the exact repro (which platform, and whether the "Saved to …" toast named the new path).
- Linux is deliberately unchanged: its label is "Open containing folder" and `xdg-open` on the folder navigates honestly. Selecting the file there would mean the `org.freedesktop.FileManager1` D-Bus interface, which is worth a separate change.
- `openContainingFolderLabel` is still hardcoded English while everything around it is localised — noticed in passing, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NP8G4Ccpv1iPyvViLSD22L

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP8G4Ccpv1iPyvViLSD22L)_