### PR TITLE
Optimize dense vector PDF parsing and zoom replay

### DIFF
--- a/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
+++ b/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
@@ -16,8 +16,10 @@ Three changes address measured costs:
   budget and a 65,536-entry cap, participates in global memory-pressure
   eviction, and releases its cache on disposal. Direct interpretation does
   not retain one-shot paths.
-- After a heavy visible page paints, the viewer prepares its text through the
-  worker, one focused page at a time. Search shares pending requests, stale
+- After a heavy visible page paints and the viewport/render scheduler stays
+  idle for 500 ms, the viewer prepares its text through the worker, one focused
+  page at a time. Motion cancels the pending warm. Search shares pending
+  requests and promotes them to foreground priority; stale
   revision replies cannot populate the current cache, and speculative failure
   never falls back to the UI isolate. A gesture made before warming completes
   can still pay the existing synchronous extraction cost.
@@ -72,3 +74,7 @@ Validation completed:
   dashed strokes, clipping, eviction, and memory pressure.
 - Ghent and PDF.js interpretation corpora: 225 tests.
 - Ghent and PDF.js rendering corpora: 218 tests; no baseline updates.
+
+PR review follow-up: idle-window cancellation and native/browser priority
+promotion have regression coverage. Worker queue promotion forwards through
+both cache and pool wrappers without launching a duplicate extraction.

--- a/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
+++ b/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
@@ -1,0 +1,74 @@
+# Dense vector sheet: parsing, zoom replay, and first-drag latency
+
+The supplied single-page engineering sheet is 3.94 MB on disk, but expands to
+31.96 MB of content, 1,096,964 operators, and 3,504,274 numeric tokens. Its
+421 × 269 pt page carries 705,104 path segments and 13,452 text runs. The PDF
+is a local benchmark input and is not included in the repository.
+
+Three changes address measured costs:
+
+- The COS lexer accumulates numeric values while scanning their boundaries,
+  avoiding a second byte pass. Existing integer/decimal precision limits and
+  malformed-input fallback behavior stay intact.
+- A retained scene caches native path geometry across zoom and detail replays.
+  Fill rules have separate entries; transforms, paints, dashes, clipping, and
+  drawing order remain unchanged. Each scene has a 32 MiB estimated geometry
+  budget and a 65,536-entry cap, participates in global memory-pressure
+  eviction, and releases its cache on disposal. Direct interpretation does
+  not retain one-shot paths.
+- After a heavy visible page paints, the viewer prepares its text through the
+  worker, one focused page at a time. Search shares pending requests, stale
+  revision replies cannot populate the current cache, and speculative failure
+  never falls back to the UI isolate. A gesture made before warming completes
+  can still pay the existing synchronous extraction cost.
+
+## Measurements
+
+Local native Flutter test engine, seven measured pairs per scale after warmup,
+with alternating cached/uncached order and identical commands and decoded
+images. Times below are medians in milliseconds. Raster timing includes RGBA
+readback; these are renderer measurements, not browser or full-app latency.
+
+| Scale | Rebuild paths | Reuse paths | Raster before | Raster after |
+| --- | ---: | ---: | ---: | ---: |
+| 2× | 103.76 | 64.25 | 87.70 | 85.34 |
+| 4× | 102.74 | 61.59 | 102.88 | 103.52 |
+| 8× | 96.56 | 63.26 | 128.97 | 128.74 |
+
+At 4×, replay work falls 40%, and replay plus raster falls from approximately
+206 ms to 165 ms (20%). Raster cost is unchanged. The scene retained 47,620
+paths, estimated at 30,571,520 bytes, with zero evictions during this run.
+
+A separate same-process streaming-parser A/B, alternating the original and
+optimized lexer for ten runs each, improved median parsing from 246.46 ms to
+208.52 ms (15.4%). Every one of the file's 4,679,417 tokens matched the original
+lexer exactly, including types, offsets, signed zero, and byte values.
+
+Fresh local text extraction measured 625 ms cold and 426–430 ms after VM
+warming. Preparing it on the worker removes that main-isolate work from
+ordinary first interaction once the warm result is ready.
+
+## Reproduction and verification
+
+From `packages/dart_pdf_editor`:
+
+```sh
+PDF_PATH=/absolute/path/to/dense.pdf \
+  fvm flutter test --no-pub test/benchmark_path_replay_test.dart --reporter expanded
+```
+
+Optional `PDF_PAGE` selects a zero-based page, `PDF_BENCHMARK_SCALES=2,4,8`
+chooses scales, and `PDF_BENCHMARK_OUT=/tmp/replay.json` saves measurements.
+The first pair at each scale verifies identical RGBA pixels.
+
+Validation completed:
+
+- Exact pixels at 2×, 4×, and 8× for cached versus uncached replay.
+- Before/after worker-rendered PNG at 4× is byte-identical.
+- All 376 pdf_cos tests, including numeric boundary regressions.
+- 50,012 original/optimized numeric cases under dart2js `-O2` and Node.
+- 137 viewer, search, worker, hover, and touch-selection regression tests.
+- 11 native-path-cache and retained-scene tests, including fill rules,
+  dashed strokes, clipping, eviction, and memory pressure.
+- Ghent and PDF.js interpretation corpora: 225 tests.
+- Ghent and PDF.js rendering corpora: 218 tests; no baseline updates.

--- a/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
+++ b/doc/dev-log/2026-09-08-dense-vector-pdf-performance.md
@@ -15,7 +15,9 @@ Three changes address measured costs:
   drawing order remain unchanged. Each scene has a 32 MiB estimated geometry
   budget and a 65,536-entry cap, participates in global memory-pressure
   eviction, and releases its cache on disposal. Direct interpretation does
-  not retain one-shot paths.
+  not retain one-shot paths. Once a path would exceed either limit it is
+  returned uncached, preserving a reusable subset for repeated scans of pages
+  larger than the cache.
 - After a heavy visible page paints and the viewport/render scheduler stays
   idle for 500 ms, the viewer prepares its text through the worker, one focused
   page at a time. Motion cancels the pending warm. Search shares pending
@@ -33,13 +35,15 @@ readback; these are renderer measurements, not browser or full-app latency.
 
 | Scale | Rebuild paths | Reuse paths | Raster before | Raster after |
 | --- | ---: | ---: | ---: | ---: |
-| 2× | 103.76 | 64.25 | 87.70 | 85.34 |
-| 4× | 102.74 | 61.59 | 102.88 | 103.52 |
-| 8× | 96.56 | 63.26 | 128.97 | 128.74 |
+| 2× | 102.56 | 57.31 | 86.21 | 84.84 |
+| 4× | 99.23 | 54.85 | 101.71 | 97.43 |
+| 8× | 108.75 | 55.44 | 126.54 | 125.43 |
 
-At 4×, replay work falls 40%, and replay plus raster falls from approximately
-206 ms to 165 ms (20%). Raster cost is unchanged. The scene retained 47,620
-paths, estimated at 30,571,520 bytes, with zero evictions during this run.
+At 4×, replay work falls 45%, and replay plus raster falls from approximately
+201 ms to 152 ms (24%). Most of the gain is in replay; rasterization remains
+the larger phase. The scene retained 47,620 paths, estimated at 30,571,520
+bytes, with zero evictions during this final run, which includes the cache
+follow-up below.
 
 A separate same-process streaming-parser A/B, alternating the original and
 optimized lexer for ten runs each, improved median parsing from 246.46 ms to
@@ -78,3 +82,41 @@ Validation completed:
 PR review follow-up: idle-window cancellation and native/browser priority
 promotion have regression coverage. Worker queue promotion forwards through
 both cache and pool wrappers without launching a duplicate extraction.
+
+The wide-CAD regression also exposed quadratic eviction in the shared cache:
+finding the newest map key scanned the entire cache, and finding the oldest
+scanned deleted slots. A linked recency list now keeps ordinary touches and
+evictions constant-time. In a local overflow microbenchmark, 32,768 insertions
+at capacities of 8,192, 16,384, and 32,768 took 1,210–3,361 ms before and 5–8 ms
+after. Memory limits and resource ownership are unchanged. Focused tests cover
+repeated turnovers, nullable keys, remap collisions, and reentrant builders.
+
+A synthetic 160,001-command replay visits 88,084 native paths, beyond the
+65,536-entry limit. Stable admission retains that many paths with no churn:
+458,752 hits and zero evictions across the measured replays. Cached replay
+measured 1,113.3 ms versus 1,131.9 ms uncached (1.6% less), with 2.5% less
+replay plus raster time and identical pixels. The small gain on this oversized
+case is expected: the unretained geometry still has to be rebuilt.
+
+## Follow-up opportunities
+
+The strongest next candidate is selective replay around transparency groups.
+This file's 24 groups and 16 soft masks currently make `PdfRegionReplayIndex`
+reject the whole transcript, disabling viewport culling and cached tiles. A
+probe found only four outermost group spans, containing 228 of 171,406 raw
+commands. Indexing balanced groups as indivisible units could retain their
+compositing semantics while culling the rest of the drawing. Their bounds must
+include mask subcommands and all paint effects; the probe's ordinary paint
+bounds are not sufficient. This improvement has not been implemented or timed.
+
+Text preparation could reuse extraction-ready runs from the original worker
+recording instead of interpreting the page again. It must preserve character
+advances, bidi ordering and invisible text, and exclude annotation appearances
+and mask-only content. Warming currently hides the repeated walk after the
+result is ready; it does not eliminate it.
+
+Rasterization remains approximately 100 ms at 4×. Profiling the soft-mask
+layers could establish whether explicit conservative bounds or reusable mask
+surfaces help. Their small painted footprints suggest an opportunity, but the
+raster engine may already infer tight bounds, so a measured comparison is
+needed before changing compositing.

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math' as math;
 
 /// One bounded, least-recently-used cache that every in-package cache is built
@@ -5,10 +6,10 @@ import 'dart:math' as math;
 /// place instead of being re-derived - subtly differently, and with a fresh
 /// off-by-one each time - at six call sites.
 ///
-/// A plain Dart map is insertion-ordered, so its first key is the
-/// least-recently used; a lookup or store does a remove-then-reinsert to move
-/// the entry to the most-recently-used end. Two independent bounds cap growth,
-/// either or both of which a call site may leave off:
+/// A key map provides lookups and a linked list tracks recency, so touching an
+/// entry or evicting the oldest one takes constant time even when the cache is
+/// full. Two independent bounds cap growth, either or both of which a call site
+/// may leave off:
 ///
 ///  * a **weight budget** ([maxWeight]) measured in whatever unit the
 ///    [weigher] returns - decoded image bytes, exact-raster pixels, retained
@@ -86,8 +87,11 @@ class PdfBudgetedCache<K, V> {
 
   int _maxWeight;
 
-  // LinkedHashMap insertion order is the LRU order.
-  final Map<K, _Entry<V>> _entries = {};
+  // Keep recency separately: Map.keys.last traverses the whole map, and even
+  // Map.keys.first scans deleted slots after repeated evictions. Dense path
+  // caches turn both into quadratic work once their entry budget is full.
+  final Map<K, _Entry<K, V>> _entries = {};
+  LinkedList<_Entry<K, V>> _recency = LinkedList();
   int _weight = 0;
   bool _disposed = false;
   int _hits = 0;
@@ -134,7 +138,7 @@ class PdfBudgetedCache<K, V> {
         protectMostRecent: protectMostRecent,
       );
       if (victim == null) break;
-      _removeEntry(victim, eviction: true);
+      _removeEntry(victim.key, eviction: true);
     }
   }
 
@@ -145,10 +149,10 @@ class PdfBudgetedCache<K, V> {
   int get length => _entries.length;
 
   /// The retained values, least-recently used first.
-  Iterable<V> get values => _entries.values.map((e) => e.value);
+  Iterable<V> get values => _recency.map((e) => e.value);
 
   /// The retained keys, least-recently used first.
-  Iterable<K> get keys => _entries.keys;
+  Iterable<K> get keys => _recency.map((e) => e.key);
 
   /// Lookups served from a retained value.
   int get hits => _hits;
@@ -174,13 +178,13 @@ class PdfBudgetedCache<K, V> {
   /// The value for [key] - a clone when a [cloner] was supplied, else the
   /// stored value - moved to most-recently-used, or null on a miss.
   V? take(K key) {
-    final entry = _entries.remove(key);
+    final entry = _entries[key];
     if (entry == null) {
       _misses++;
       return null;
     }
     _hits++;
-    _entries[key] = entry; // touch → most-recently-used
+    _touch(entry);
     final cloner = _cloner;
     return cloner == null ? entry.value : cloner(entry.value);
   }
@@ -201,7 +205,9 @@ class PdfBudgetedCache<K, V> {
       return value;
     }
     _removeEntry(key);
-    _entries[key] = _Entry(value, weight);
+    final entry = _Entry(key, value, weight);
+    _entries[key] = entry;
+    _recency.add(entry);
     _weight += weight;
     _trim();
     if (_clearsUnderMemoryPressure && weight > 0) {
@@ -237,20 +243,32 @@ class PdfBudgetedCache<K, V> {
   /// process-wide text-layout cache) is never disposed, so this path is a
   /// documented contract rather than a live one.
   V getOrAdd(K key, V Function() ifAbsent) {
-    final entry = _entries.remove(key);
+    final entry = _entries[key];
     if (entry != null) {
       _hits++;
-      _entries[key] = entry;
+      _touch(entry);
       return entry.value;
     }
     _misses++;
     final value = ifAbsent();
     if (_disposed) return value;
+    final inserted = _entries[key];
+    if (inserted != null && identical(inserted.value, value)) {
+      // A builder can store and return the same resource. It is already owned
+      // by this cache; replacing it would dispose the value we are returning.
+      _touch(inserted);
+      return value;
+    }
     final weight = _weigher?.call(value) ?? 0;
     if (_rejectOversize && _hasWeightBudget && weight > _maxWeight) {
       return value;
     }
-    _entries[key] = _Entry(value, weight);
+    // The builder may have populated this key reentrantly. Its displaced
+    // value must leave both the lookup map and recency list before replacement.
+    _removeEntry(key);
+    final added = _Entry(key, value, weight);
+    _entries[key] = added;
+    _recency.add(added);
     _weight += weight;
     _trim();
     if (_clearsUnderMemoryPressure && weight > 0) {
@@ -267,7 +285,7 @@ class PdfBudgetedCache<K, V> {
   /// the pages an incremental revision changed instead of clearing the whole
   /// cache. Counters and every non-matching entry are untouched.
   void evictWhere(bool Function(K key) test) {
-    final doomed = _entries.keys.where(test).toList();
+    final doomed = keys.where(test).toList();
     for (final key in doomed) {
       _removeEntry(key);
     }
@@ -282,29 +300,35 @@ class PdfBudgetedCache<K, V> {
   /// wins and the displaced value is disposed.
   void remapKeys(K Function(K key) keyFor) {
     if (_disposed || _entries.isEmpty) return;
-    final remapped = <K, _Entry<V>>{};
-    for (final entry in _entries.entries) {
+    final remapped = <K, _Entry<K, V>>{};
+    final recency = LinkedList<_Entry<K, V>>();
+    for (final entry in _recency) {
       final key = keyFor(entry.key);
       final displaced = remapped.remove(key);
       if (displaced != null) {
+        displaced.unlink();
         _weight -= displaced.weight;
         _disposer?.call(displaced.value);
       }
-      remapped[key] = entry.value;
+      final replacement = _Entry(key, entry.value, entry.weight);
+      remapped[key] = replacement;
+      recency.add(replacement);
     }
     _entries
       ..clear()
       ..addAll(remapped);
+    _recency = recency;
   }
 
   /// Empties the cache, disposing every retained value. Counters survive - a
   /// clear is a cache operation, not a fresh measurement. Any clones already
   /// handed out are unaffected.
   void clear() {
-    for (final entry in _entries.values) {
+    for (final entry in _recency) {
       _disposer?.call(entry.value);
     }
     _entries.clear();
+    _recency.clear();
     _weight = 0;
   }
 
@@ -329,12 +353,19 @@ class PdfBudgetedCache<K, V> {
   void _removeEntry(K key, {bool eviction = false}) {
     final entry = _entries.remove(key);
     if (entry == null) return;
+    entry.unlink();
     _weight -= entry.weight;
     if (eviction) {
       _evictions++;
       _onEvicted?.call(key, entry.value);
     }
     _disposer?.call(entry.value);
+  }
+
+  void _touch(_Entry<K, V> entry) {
+    if (identical(entry, _recency.last)) return;
+    entry.unlink();
+    _recency.add(entry);
   }
 
   void _trim() {
@@ -347,7 +378,7 @@ class PdfBudgetedCache<K, V> {
       while (_weight > _maxWeight) {
         final victim = _oldestEvictable(requireWeight: true);
         if (victim == null) break;
-        _removeEntry(victim, eviction: true);
+        _removeEntry(victim.key, eviction: true);
       }
     }
     // Count cap: evict the least-recently-used entries - weight-0 or not -
@@ -355,36 +386,34 @@ class PdfBudgetedCache<K, V> {
     final maxEntries = _maxEntries;
     if (maxEntries != null) {
       while (_entries.length > maxEntries) {
-        final oldest = _entries.keys.first;
-        if (oldest == _protectedKey) break;
-        _removeEntry(oldest, eviction: true);
+        // maxEntries is at least one, so an overflowing list's first entry
+        // cannot also be its protected, most-recently-used last entry.
+        _removeEntry(_recency.first.key, eviction: true);
       }
     }
   }
 
-  /// The most-recently-used key - the one eviction always protects. Null only
-  /// when the cache is empty.
-  K? get _protectedKey => _entries.isEmpty ? null : _entries.keys.last;
-
   /// The least-recently-used key eligible for weight eviction: the oldest whose
   /// weight is non-zero (when [requireWeight]) and that is not the protected
   /// most-recently-used entry. Null when no such entry exists.
-  K? _oldestEvictable({
+  _Entry<K, V>? _oldestEvictable({
     required bool requireWeight,
     bool protectMostRecent = true,
   }) {
-    final protikey = protectMostRecent ? _protectedKey : null;
-    for (final entry in _entries.entries) {
-      if (entry.key == protikey) continue;
-      if (requireWeight && entry.value.weight == 0) continue;
-      return entry.key;
+    if (_recency.isEmpty) return null;
+    final protected = protectMostRecent ? _recency.last : null;
+    for (final entry in _recency) {
+      if (identical(entry, protected)) break;
+      if (requireWeight && entry.weight == 0) continue;
+      return entry;
     }
     return null;
   }
 }
 
-class _Entry<V> {
-  _Entry(this.value, this.weight);
+final class _Entry<K, V> extends LinkedListEntry<_Entry<K, V>> {
+  _Entry(this.key, this.value, this.weight);
+  final K key;
   final V value;
   final int weight;
 }

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -8,6 +8,7 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'budgeted_cache.dart';
+import 'canvas_path_cache.dart';
 import 'font_substitution.dart';
 import 'image_decoder.dart';
 import 'perf_log.dart';
@@ -48,7 +49,12 @@ class CanvasPdfDevice
         PdfTiledCellSink,
         PdfTextBatchSink,
         PdfTransparencyGroupDevice {
-  CanvasPdfDevice(this.canvas, {this.images = const {}, this.pixelRatio = 1});
+  CanvasPdfDevice(this.canvas,
+      {this.images = const {}, this.pixelRatio = 1, this.pathCache});
+
+  /// Reuses native path geometry when replaying an immutable retained scene.
+  /// Direct interpretation leaves this null because its paths are one-shot.
+  final PdfCanvasPathCache? pathCache;
 
   final Canvas canvas;
 
@@ -597,7 +603,7 @@ class CanvasPdfDevice
   @override
   void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
     canvas.drawPath(
-      _toUiPath(path, rule),
+      _cachedUiPath(path, rule),
       _solidFillPaint(color, alpha),
     );
   }
@@ -606,7 +612,7 @@ class CanvasPdfDevice
   void fillPathGradient(
       PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {
     canvas.drawPath(
-      _toUiPath(path, rule),
+      _cachedUiPath(path, rule),
       Paint()
         ..shader = _shaderFor(gradient)
         ..blendMode = _fillElementBlend
@@ -673,7 +679,7 @@ class CanvasPdfDevice
         }
       }
     }
-    var uiPath = _toUiPath(path, PdfFillRule.nonzero);
+    var uiPath = _cachedUiPath(path, PdfFillRule.nonzero);
     if (stroke.dashArray.any((d) => d > 0)) {
       uiPath = _dashPath(uiPath, stroke.dashArray, stroke.dashPhase);
     }
@@ -830,7 +836,7 @@ class CanvasPdfDevice
     if (rect != null) {
       canvas.clipRect(rect, doAntiAlias: false);
     } else {
-      canvas.clipPath(_toUiPath(path, rule), doAntiAlias: false);
+      canvas.clipPath(_cachedUiPath(path, rule), doAntiAlias: false);
     }
   }
 
@@ -1856,6 +1862,10 @@ class CanvasPdfDevice
         : ui.Gradient.linear(Offset(c[0], c[1]), Offset(c[2], c[3]), colors,
             stops, TileMode.clamp, matrix);
   }
+
+  ui.Path _cachedUiPath(PdfPath path, PdfFillRule rule) =>
+      pathCache?.pathFor(path, rule, () => _toUiPath(path, rule)) ??
+      _toUiPath(path, rule);
 
   static ui.Path _toUiPath(PdfPath path, PdfFillRule rule) {
     final out = _emptyUiPath(rule);

--- a/packages/dart_pdf_editor/lib/src/canvas_path_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_path_cache.dart
@@ -10,6 +10,9 @@ import 'budgeted_cache.dart';
 /// zoom stalls the UI isolate. These paths contain page-space geometry only;
 /// transforms, paints, dashes, and clipping still run in their original order.
 /// Never mutate either the source geometry or a returned path while retained.
+/// Once full, the cache preserves its admitted subset: cycling an immutable
+/// transcript larger than an LRU would otherwise evict every path before its
+/// next use. Memory-pressure eviction reopens admission as space becomes free.
 class PdfCanvasPathCache {
   PdfCanvasPathCache({int maxWeight = 32 << 20, int maxEntries = 65536})
       : _paths = PdfBudgetedCache<(PdfPath, PdfFillRule), _CanvasPath>(
@@ -31,7 +34,11 @@ class PdfCanvasPathCache {
     // Conservative estimate: a cubic needs six float32 coordinates and a
     // verb, plus per-path native/Dart/map overhead. Count is capped separately
     // because short paths also dominate some CAD exports.
-    _paths.put(key, _CanvasPath(path, 192 + source.segmentCount * 32));
+    final weight = 192 + source.segmentCount * 32;
+    if (_paths.length < _paths.maxEntries! &&
+        weight <= _paths.maxWeight - _paths.weight) {
+      _paths.put(key, _CanvasPath(path, weight));
+    }
     return path;
   }
 

--- a/packages/dart_pdf_editor/lib/src/canvas_path_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_path_cache.dart
@@ -1,0 +1,45 @@
+import 'dart:ui' as ui;
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'budgeted_cache.dart';
+
+/// Native geometry owned by one immutable retained command transcript.
+///
+/// Building a dense sheet's hundreds of thousands of path verbs again at each
+/// zoom stalls the UI isolate. These paths contain page-space geometry only;
+/// transforms, paints, dashes, and clipping still run in their original order.
+/// Never mutate either the source geometry or a returned path while retained.
+class PdfCanvasPathCache {
+  PdfCanvasPathCache({int maxWeight = 32 << 20, int maxEntries = 65536})
+      : _paths = PdfBudgetedCache<(PdfPath, PdfFillRule), _CanvasPath>(
+          maxWeight: maxWeight,
+          maxEntries: maxEntries,
+          weigher: (value) => value.weight,
+          rejectOversize: true,
+          clearsUnderMemoryPressure: true,
+          debugLabel: 'canvas-paths',
+        );
+
+  final PdfBudgetedCache<(PdfPath, PdfFillRule), _CanvasPath> _paths;
+
+  ui.Path pathFor(PdfPath source, PdfFillRule rule, ui.Path Function() build) {
+    final key = (source, rule);
+    final cached = _paths.take(key);
+    if (cached != null) return cached.path;
+    final path = build();
+    // Conservative estimate: a cubic needs six float32 coordinates and a
+    // verb, plus per-path native/Dart/map overhead. Count is capped separately
+    // because short paths also dominate some CAD exports.
+    _paths.put(key, _CanvasPath(path, 192 + source.segmentCount * 32));
+    return path;
+  }
+
+  void dispose() => _paths.dispose();
+}
+
+class _CanvasPath {
+  const _CanvasPath(this.path, this.weight);
+  final ui.Path path;
+  final int weight;
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2108,7 +2108,8 @@ class _PdfViewerState extends State<PdfViewer>
   // A failed warm should not retry on every frame, or retain an old document.
   WeakReference<PdfPage>? _textWarmAttempt;
   bool _textWarmRunning = false;
-  bool _textWarmScheduled = false;
+  Timer? _textWarmTimer;
+  static const _textWarmIdleDelay = Duration(milliseconds: 500);
   final PdfPageObjectCache<List<PdfAnnotation>> _annotCache =
       PdfPageObjectCache();
   final PdfPageObjectCache<List<PdfAnnotation>> _visibleAnnotCache =
@@ -2191,6 +2192,7 @@ class _PdfViewerState extends State<PdfViewer>
       _setSlowScrollRasterWarmDirection(0);
     }
     _renderScheduler.parked = !widget.active;
+    _scheduleVisibleTextWarm();
   }
 
   /// Releases settled render work only after this frame has rebuilt the page
@@ -2213,6 +2215,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   void _beginMotionRenderHold() {
     _cancelPreviewPrerenderSchedule();
+    _cancelVisibleTextWarm();
     _motionHoldReleaseTimer?.cancel();
     _motionHoldReleaseTimer = null;
     _renderScheduler.slowMotion = false;
@@ -2575,6 +2578,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// that notification as the wake-up edge instead.
   void _onRenderSchedulerActivity() {
     _scheduleRasterWarm();
+    _scheduleVisibleTextWarm();
     if (_renderScheduler.busy) {
       _tileBackendWarmUpTimer?.cancel();
       _tileBackendWarmUpTimer = null;
@@ -2951,6 +2955,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// window; releasing then started a 200-500 ms CAD raster in the middle of
   /// an otherwise continuous wheel stream.
   void _onScrollForDetail() {
+    _cancelVisibleTextWarm();
     _trackScrollVelocity();
     // the scheduler drains held pages nearest the viewport first
     _renderScheduler.focus = _jumpFocusPage ?? _controller.currentPage;
@@ -4181,6 +4186,7 @@ class _PdfViewerState extends State<PdfViewer>
       _slowScrollRasterWarmGeneration++;
       _scheduleTileBackendWarmUp();
     }
+    _scheduleVisibleTextWarm();
   }
 
   /// The revision controller notified. It owns the document revisions, so a
@@ -4199,6 +4205,7 @@ class _PdfViewerState extends State<PdfViewer>
     } else {
       setState(() {});
     }
+    _scheduleVisibleTextWarm();
   }
 
   /// Reconciles cached state to a document swap - from [_loadedDocument] to
@@ -4211,6 +4218,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// document/controller) and from [_onRevisionControllerChanged] (a new
   /// revision with no host rebuild).
   void _swapDocument({bool preserveRevisionViewport = false}) {
+    _cancelVisibleTextWarm();
     final reconcileClock = Stopwatch()..start();
     final document = _document;
     if (preserveRevisionViewport &&
@@ -5009,6 +5017,7 @@ class _PdfViewerState extends State<PdfViewer>
   void dispose() {
     _commandWarmGeneration++;
     _slowScrollRasterWarmGeneration++;
+    _cancelVisibleTextWarm();
     // A namespace is private to this State and cannot be reused after dispose.
     // Retire it explicitly so the process-wide store neither lands an old
     // asynchronous raster nor retains an unreachable viewer token.
@@ -5727,7 +5736,10 @@ class _PdfViewerState extends State<PdfViewer>
       {int priority = 0}) {
     final key = (document, page);
     final existing = _workerTextRequests[key];
-    if (existing != null) return existing;
+    if (existing != null) {
+      worker.promoteTextExtraction(index, priority: priority);
+      return existing;
+    }
     final request = Future<PdfPageText?>.sync(
       () => worker.extractText(index, priority: priority),
     ).onError((error, stackTrace) => null);
@@ -5740,15 +5752,27 @@ class _PdfViewerState extends State<PdfViewer>
     return request;
   }
 
+  bool get _visibleTextWarmIdle =>
+      mounted &&
+      widget.active &&
+      !_renderScheduler.busy &&
+      !_motionRenderHoldActive &&
+      !(_settleTimer?.isActive ?? false);
+
+  void _cancelVisibleTextWarm() {
+    _textWarmTimer?.cancel();
+    _textWarmTimer = null;
+  }
+
   /// Warm only the focused, already-painted heavy page, one at a time. A
   /// mouse grab-pan tests for text before choosing its gesture; leaving text
   /// cold until that press causes another full synchronous content walk.
-  /// Submit the ready frame first, then let the worker prepare that hit test.
+  /// The worker's text walk cannot yield to an urgent render, so wait for a
+  /// quiet viewport and idle render scheduler before preparing that hit test.
   void _scheduleVisibleTextWarm() {
-    if (_textWarmScheduled ||
-        _textWarmRunning ||
-        !mounted ||
-        !widget.active ||
+    _cancelVisibleTextWarm();
+    if (_textWarmRunning ||
+        !_visibleTextWarmIdle ||
         _pages.isEmpty ||
         !(_effectiveRenderWorker?.isActive ?? false)) {
       return;
@@ -5761,16 +5785,14 @@ class _PdfViewerState extends State<PdfViewer>
         page.rawContentLength <= PdfViewer.hoverTextExtractMaxRawContentBytes) {
       return;
     }
-    _textWarmScheduled = true;
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      _textWarmScheduled = false;
-      if (mounted) unawaited(_warmVisiblePageText());
+    _textWarmTimer = Timer(_textWarmIdleDelay, () {
+      _textWarmTimer = null;
+      if (_visibleTextWarmIdle) unawaited(_warmVisiblePageText());
     });
-    SchedulerBinding.instance.scheduleFrame();
   }
 
   Future<void> _warmVisiblePageText() async {
-    if (_textWarmRunning || !mounted || !widget.active || _pages.isEmpty) {
+    if (_textWarmRunning || !_visibleTextWarmIdle || _pages.isEmpty) {
       return;
     }
     final index = _controller.currentPage;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2103,6 +2103,12 @@ class _PdfViewerState extends State<PdfViewer>
   // warm only near the viewport (derived on hit-test/selection/search), so a
   // cap well above the working set never evicts an on-screen page.
   final PdfPageObjectCache<PdfPageText> _textCache = PdfPageObjectCache();
+  final Map<(PdfDocument, PdfPage), Future<PdfPageText?>> _workerTextRequests =
+      {};
+  // A failed warm should not retry on every frame, or retain an old document.
+  WeakReference<PdfPage>? _textWarmAttempt;
+  bool _textWarmRunning = false;
+  bool _textWarmScheduled = false;
   final PdfPageObjectCache<List<PdfAnnotation>> _annotCache =
       PdfPageObjectCache();
   final PdfPageObjectCache<List<PdfAnnotation>> _visibleAnnotCache =
@@ -4782,6 +4788,7 @@ class _PdfViewerState extends State<PdfViewer>
     final changed =
         ready ? _rasteredPages.add(index) : _rasteredPages.remove(index);
     if (!changed) return;
+    if (ready) _scheduleVisibleTextWarm();
     _controller._pageRenderActivity.notify();
     final completedJump = ready && index == _jumpFocusPage;
     if (PdfPerfLog.enabled && ready) {
@@ -5368,6 +5375,7 @@ class _PdfViewerState extends State<PdfViewer>
       // nothing after it can be visible either.
       if (found && offset - widget.pageSpacing >= viewEnd) break;
     }
+    final pageChanged = current != _controller.currentPage;
     _controller._setCurrentPage(current);
     // A viewport that fell entirely inside the gap between two pages overlaps
     // none of them; the page the centre is on is still what the user is at.
@@ -5377,6 +5385,7 @@ class _PdfViewerState extends State<PdfViewer>
       qualityFirst < 0 ? current : qualityFirst,
       qualityLast < 0 ? current : qualityLast,
     );
+    if (pageChanged) _scheduleVisibleTextWarm();
   }
 
   /// The span of pages overlapping the viewport - see [_PdfOnScreenSpan].
@@ -5688,15 +5697,115 @@ class _PdfViewerState extends State<PdfViewer>
   Future<PdfPageText> _extractText(int index) async {
     final cached = _textCache[index];
     if (cached != null) return cached;
+    final document = _document;
+    final page = _pages[index];
     final textCache = widget.textCache;
     final key = widget.documentId;
+    final PdfPageText text;
     if (textCache != null && key != null && widget.editing == null) {
-      final text =
-          await textCache.get(key, index, () => _extractPageText(index));
-      return _textCache.putIfAbsent(index, () => text);
+      text = await textCache.get(
+          key, index, () => _extractPageText(index, document, page));
+    } else {
+      text = await _extractPageText(index, document, page);
     }
-    final text = await _extractPageText(index);
-    return _textCache.putIfAbsent(index, () => text);
+    return _textPageIsCurrent(index, document, page)
+        ? _textCache.putIfAbsent(index, () => text)
+        : text;
+  }
+
+  bool _textPageIsCurrent(int index, PdfDocument document, PdfPage page) =>
+      mounted &&
+      identical(_document, document) &&
+      index < _pages.length &&
+      identical(_pages[index], page);
+
+  /// Search and the speculative warm share one worker request for a page.
+  /// Keys carry revision identity: an old worker reply must never populate
+  /// the same page index after a document edit or replacement.
+  Future<PdfPageText?> _workerPageText(
+      int index, PdfDocument document, PdfPage page, PdfRenderWorker worker,
+      {int priority = 0}) {
+    final key = (document, page);
+    final existing = _workerTextRequests[key];
+    if (existing != null) return existing;
+    final request = Future<PdfPageText?>.sync(
+      () => worker.extractText(index, priority: priority),
+    ).onError((error, stackTrace) => null);
+    _workerTextRequests[key] = request;
+    unawaited(request.whenComplete(() {
+      if (identical(_workerTextRequests[key], request)) {
+        _workerTextRequests.remove(key);
+      }
+    }));
+    return request;
+  }
+
+  /// Warm only the focused, already-painted heavy page, one at a time. A
+  /// mouse grab-pan tests for text before choosing its gesture; leaving text
+  /// cold until that press causes another full synchronous content walk.
+  /// Submit the ready frame first, then let the worker prepare that hit test.
+  void _scheduleVisibleTextWarm() {
+    if (_textWarmScheduled ||
+        _textWarmRunning ||
+        !mounted ||
+        !widget.active ||
+        _pages.isEmpty ||
+        !(_effectiveRenderWorker?.isActive ?? false)) {
+      return;
+    }
+    final index = _controller.currentPage;
+    final page = _pages[index];
+    if (!_rasteredPages.contains(index) ||
+        _textCache[index] != null ||
+        identical(_textWarmAttempt?.target, page) ||
+        page.rawContentLength <= PdfViewer.hoverTextExtractMaxRawContentBytes) {
+      return;
+    }
+    _textWarmScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _textWarmScheduled = false;
+      if (mounted) unawaited(_warmVisiblePageText());
+    });
+    SchedulerBinding.instance.scheduleFrame();
+  }
+
+  Future<void> _warmVisiblePageText() async {
+    if (_textWarmRunning || !mounted || !widget.active || _pages.isEmpty) {
+      return;
+    }
+    final index = _controller.currentPage;
+    if (!_rasteredPages.contains(index) || !_onScreenSpan.contains(index)) {
+      return;
+    }
+    final document = _document;
+    final page = _pages[index];
+    final worker = _effectiveRenderWorker;
+    if (_textCache[index] != null ||
+        identical(_textWarmAttempt?.target, page) ||
+        page.rawContentLength <= PdfViewer.hoverTextExtractMaxRawContentBytes ||
+        worker == null ||
+        !worker.isActive) {
+      return;
+    }
+    _textWarmAttempt = WeakReference(page);
+    _textWarmRunning = true;
+    try {
+      final text =
+          await _workerPageText(index, document, page, worker, priority: 3);
+      if (text != null && _textPageIsCurrent(index, document, page)) {
+        _textCache.putIfAbsent(index, () => text);
+      }
+      // A declining/failed worker leaves the cache cold. Speculation must
+      // never fall back to a synchronous extraction on the UI isolate.
+    } finally {
+      _textWarmRunning = false;
+      if (!_textPageIsCurrent(index, document, page)) {
+        _textWarmAttempt = null;
+      }
+      // Navigation or a revision may have changed the focused page while
+      // this request was pending. Only that latest page gets the next turn.
+      if (mounted) _scheduleVisibleTextWarm();
+    }
   }
 
   /// Extracts page [index]'s text off the UI isolate through the render worker
@@ -5705,13 +5814,16 @@ class _PdfViewerState extends State<PdfViewer>
   /// runs on the UI thread; the worker - kept in step with the current revision
   /// like the render path - moves it off. Search drives this; hover keeps its
   /// synchronous [_pageText] path, already gated by content size.
-  Future<PdfPageText> _extractPageText(int index) async {
+  Future<PdfPageText> _extractPageText(
+      int index, PdfDocument document, PdfPage page) async {
     final worker = _effectiveRenderWorker;
-    if (worker != null && worker.isActive) {
-      final text = await worker.extractText(index);
+    if (worker != null &&
+        worker.isActive &&
+        _textPageIsCurrent(index, document, page)) {
+      final text = await _workerPageText(index, document, page, worker);
       if (text != null) return text;
     }
-    return PdfTextExtractor.extract(_document, index);
+    return PdfTextExtractor.extract(document, index);
   }
 
   Future<List<PdfSearchResult>> _searchAllPages(
@@ -6169,8 +6281,8 @@ class _PdfViewerState extends State<PdfViewer>
   /// appears immediately, as it always has. For a HEAVY page (see
   /// [hoverTextExtractMaxRawContentBytes]) it never triggers the multi-hundred-
   /// ms extraction from a mere mouse-move: it uses the text only if already
-  /// resident (warmed by a real selection/search), else returns false and the
-  /// cursor stays grab. Touch (iPad) never hovers, so a finger pan never
+  /// resident (warmed by the worker or a selection/search), else returns false
+  /// and the cursor stays grab. Touch (iPad) never hovers, so a finger pan never
   /// reaches this at all.
   bool _hoverTextCursorAt(Offset local, {(int, double, double)? at}) {
     final point = at ?? _pagePointAt(local);

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -537,6 +537,13 @@ abstract class PdfRenderWorker {
   Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) async =>
       null;
 
+  /// Raises the priority of an existing text extraction without submitting
+  /// another walk. A foreground search uses this when it joins speculative
+  /// text preparation. Lower numbers are more urgent; this never demotes work
+  /// or starts an extraction when none is pending. Custom backends may ignore
+  /// the hint. Both built-in worker backends update queued/in-flight requests.
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) {}
+
   /// Whether this backend can bind a browser-owned zero-copy page surface.
   ///
   /// True only for a live Web Worker (and wrappers/pools containing one).
@@ -1099,6 +1106,15 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
   Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) =>
       _workers[_workerForPage(pageIndex, priority: priority)]
           .extractText(pageIndex, priority: priority);
+
+  @override
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) {
+    // Text preparation can have background affinity. Do not route again at
+    // foreground priority: find the existing request without moving it.
+    for (final worker in _workers) {
+      worker.promoteTextExtraction(pageIndex, priority: priority);
+    }
+  }
 
   @override
   bool get supportsRevisionUpdate =>
@@ -1665,6 +1681,10 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
   @override
   Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) =>
       _inner.extractText(pageIndex, priority: priority);
+
+  @override
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) =>
+      _inner.promoteTextExtraction(pageIndex, priority: priority);
 
   @override
   void dispose() {

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -379,6 +379,20 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   }
 
   @override
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) {
+    var changed = false;
+    for (final request in [if (_inFlight != null) _inFlight!, ..._queue]) {
+      if (request.kind == _RequestKind.extractText &&
+          request.pageIndex == pageIndex &&
+          priority < request.priority) {
+        request.priority = priority;
+        changed = true;
+      }
+    }
+    if (changed) _pump();
+  }
+
+  @override
   Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) async {
     if (_disposed || _spawnFailed) return null;
     final request = _PendingRequest.extractText(priority, _seq++, pageIndex);
@@ -708,7 +722,7 @@ class _PendingRequest {
         onPartialBytes = null;
 
   final _RequestKind kind;
-  final int priority;
+  int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -580,6 +580,20 @@ class _WebRenderWorker extends PdfRenderWorker {
   }
 
   @override
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) {
+    var changed = false;
+    for (final request in [if (_inFlight != null) _inFlight!, ..._queue]) {
+      if (request.kind == _WebRequestKind.extractText &&
+          request.pageIndex == pageIndex &&
+          priority < request.priority) {
+        request.priority = priority;
+        changed = true;
+      }
+    }
+    if (changed) _pump();
+  }
+
+  @override
   Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) async {
     if (_disposed || _failed) return null;
     final request = _WebPending.extractText(priority, _seq++, pageIndex);
@@ -1062,7 +1076,7 @@ class _WebPending {
         onPartialBytes = null;
 
   final _WebRequestKind kind;
-  final int priority;
+  int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -24,6 +24,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'banded_transcript.dart';
 import 'canvas_device.dart';
+import 'canvas_path_cache.dart';
 import 'image_decoder.dart';
 import 'perf_log.dart';
 import 'renderer.dart';
@@ -146,6 +147,11 @@ class PdfRetainedScene {
   /// annotations, rotation). A different plan needs a new recording -
   /// annotations are baked into [commands].
   final PdfPageRenderPlan plan;
+
+  // Native geometry is scale-independent. Keep it beside the transcript so
+  // every zoom/tile replay avoids rebuilding the same path verbs on the UI
+  // thread. The cache is bounded, pressure-aware, and dies with this scene.
+  PdfCanvasPathCache? _pathCache;
 
   /// The interpreter's transcript of the page, in paint order.
   final List<PdfRenderCommand> commands;
@@ -699,7 +705,8 @@ class PdfRetainedScene {
 
   void _replayOnto(Canvas canvas, {Rect? rasterRegion}) {
     PdfPageRenderer.preparePageCanvas(canvas, page, plan);
-    final device = CanvasPdfDevice(canvas, images: _images);
+    final device = CanvasPdfDevice(canvas,
+        images: _images, pathCache: _pathCache ??= PdfCanvasPathCache());
     if (rasterRegion != null && spatialRegionReplay) {
       final index = _ensureRegionIndex();
       final pageRegion = _pageSpaceRegion(rasterRegion);
@@ -1084,6 +1091,8 @@ class PdfRetainedScene {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _pathCache?.dispose();
+    _pathCache = null;
     _regionIndex = null;
     _bands = null;
     // An accelerated backend normally drops worker-carried RGBA immediately

--- a/packages/dart_pdf_editor/test/benchmark_path_replay_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_path_replay_test.dart
@@ -1,0 +1,148 @@
+// Paired A/B of retained native geometry against rebuilding the same paths.
+// PDF_PATH=/path/to/dense.pdf fvm flutter test --no-pub \
+//   test/benchmark_path_replay_test.dart --reporter expanded
+// The PDF stays local. Each pair uses identical commands, images and scale;
+// alternating order controls warming. The first pair also compares RGBA bytes.
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/image_decoder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  testWidgets('paired dense-page path replay benchmark', (tester) async {
+    final path = Platform.environment['PDF_PATH'];
+    if (path == null) {
+      markTestSkipped('set PDF_PATH');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final bytes = File(path).readAsBytesSync();
+      final pageIndex =
+          int.tryParse(Platform.environment['PDF_PAGE'] ?? '') ?? 0;
+      final page = PdfDocument.open(bytes).page(pageIndex);
+      final worker = PdfRenderWorker.start(bytes);
+      try {
+        final commands = (await worker.record(pageIndex, imagePixelRatio: 8))!;
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            maxImagePixelRatio: 8);
+        try {
+          final requests = <PdfImageRequest>[];
+          PdfPageRenderer.collectImageRequests(commands, requests);
+          final images = <Object, ui.Image>{
+            for (final request in requests)
+              if (scene.imageFor(request) case final image?)
+                pdfImageKey(request): image,
+          };
+          final scales =
+              (Platform.environment['PDF_BENCHMARK_SCALES'] ?? '2,4,8')
+                  .split(',')
+                  .map(double.parse);
+          final results = <Object>[];
+          for (final ratio in scales) {
+            final timings = {false: <double>[], true: <double>[]};
+            final rasterTimings = {false: <double>[], true: <double>[]};
+            Uint8List? reference;
+            for (var trial = 0; trial < 8; trial++) {
+              for (final cached
+                  in trial.isEven ? [false, true] : [true, false]) {
+                final clock = Stopwatch()..start();
+                final picture = cached
+                    ? scene.replay(pixelRatio: ratio)
+                    : _uncachedReplay(scene, images, ratio);
+                final replayMs = clock.elapsedMicroseconds / 1000;
+                clock.reset();
+                final image = await picture.toImage(
+                    (scene.pageSize.width * ratio).ceil(),
+                    (scene.pageSize.height * ratio).ceil());
+                try {
+                  final pixels = (await image.toByteData(
+                          format: ui.ImageByteFormat.rawRgba))!
+                      .buffer
+                      .asUint8List();
+                  final rasterMs = clock.elapsedMicroseconds / 1000;
+                  if (trial == 0) {
+                    if (reference == null) {
+                      reference = pixels;
+                    } else {
+                      expect(_sameBytes(reference, pixels), isTrue,
+                          reason: 'cached raster changed pixels at $ratio');
+                      reference = null;
+                    }
+                  } else {
+                    timings[cached]!.add(replayMs);
+                    rasterTimings[cached]!.add(rasterMs);
+                  }
+                } finally {
+                  image.dispose();
+                  picture.dispose();
+                }
+              }
+            }
+            results.add({
+              'scale': ratio,
+              'uncachedReplayMs': _median(timings[false]!),
+              'cachedReplayMs': _median(timings[true]!),
+              'uncachedRasterMs': _median(rasterTimings[false]!),
+              'cachedRasterMs': _median(rasterTimings[true]!),
+              'identicalPixels': true,
+            });
+          }
+          final result = {
+            'commands': commands.length,
+            'results': results,
+            'geometryCaches': [
+              for (final entry in PdfCacheRegistry.instance.snapshot())
+                if (entry.label == 'canvas-paths')
+                  {
+                    'entries': entry.length,
+                    'estimatedBytes': entry.weight,
+                    'hits': entry.hits,
+                    'misses': entry.misses,
+                    'evictions': entry.evictions
+                  },
+            ],
+          };
+          final json = const JsonEncoder.withIndent('  ').convert(result);
+          // ignore: avoid_print
+          print(json);
+          final out = Platform.environment['PDF_BENCHMARK_OUT'];
+          if (out != null) File(out).writeAsStringSync(json);
+        } finally {
+          scene.dispose();
+        }
+      } finally {
+        worker.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}
+
+ui.Picture _uncachedReplay(
+    PdfRetainedScene scene, Map<Object, ui.Image> images, double ratio) {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)..scale(ratio);
+  PdfPageRenderer.preparePageCanvas(canvas, scene.page, scene.plan);
+  replayCommands(scene.commands, CanvasPdfDevice(canvas, images: images));
+  return recorder.endRecording();
+}
+
+double _median(List<double> values) {
+  values.sort();
+  return values[values.length ~/ 2];
+}
+
+bool _sameBytes(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -21,6 +21,37 @@ class _Res {
 
 void main() {
   group('count bound', () {
+    test('repeated full-cache turnovers preserve bounds and eviction order',
+        () {
+      // Native geometry can visit far more paths than its cache admits. Keep
+      // exercising eviction after several complete turnovers, where walking
+      // Map.keys.last and scanning tombstones used to dominate every insert.
+      const capacity = 8192;
+      const total = capacity * 8;
+      final cache = PdfBudgetedCache<int, int>(
+        maxEntries: capacity,
+        maxWeight: capacity,
+        weigher: (_) => 1,
+      );
+      for (var i = 0; i < total; i++) {
+        cache.put(i, i);
+      }
+      expect(cache.length, capacity);
+      expect(cache.weight, capacity);
+      expect(cache.evictions, total - capacity);
+      expect(
+          cache.keys, Iterable.generate(capacity, (i) => total - capacity + i));
+      cache.take(total - capacity);
+      cache.getOrAdd(total - capacity + 1, () => -1);
+      cache.put(total, total);
+      expect(cache.containsKey(total - capacity), isTrue);
+      expect(cache.containsKey(total - capacity + 1), isTrue);
+      expect(cache.containsKey(total - capacity + 2), isFalse);
+      cache.clear();
+      cache.put(0, 0);
+      expect(cache.keys, [0]);
+    });
+
     test('never grows past maxEntries; evicts the LRU, keeps the newest', () {
       final dropped = <int>[];
       final cache = PdfBudgetedCache<int, _Res>(
@@ -75,9 +106,52 @@ void main() {
       expect(cache.weight, 60);
       expect(dropped, isEmpty);
     });
+
+    test('remap collisions preserve touched recency for subsequent eviction',
+        () {
+      final dropped = <int>[];
+      final cache = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 100,
+        disposer: (r) => dropped.add(r.id),
+      );
+      for (var i = 0; i < 4; i++) {
+        cache.put(i, _Res(i));
+      }
+      cache.take(0); // 1, 2, 3, 0; collision winners are 3 and 0.
+      cache.remapKeys((key) => key % 2);
+      expect(cache.keys, [1, 0]);
+      expect(cache.values.map((r) => r.id), [3, 0]);
+      expect(dropped, [1, 2]);
+      expect(cache.weight, 2);
+      cache.take(1);
+      cache.trimToWeight(0);
+      expect(cache.keys, [1]);
+      expect(dropped, [1, 2, 0]);
+      cache.evict(1);
+      cache.put(5, _Res(5));
+      expect(cache.keys, [5]);
+    });
   });
 
   group('weight budget', () {
+    test('a null key participates in weight eviction and MRU protection', () {
+      final cache = PdfBudgetedCache<int?, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 10,
+      );
+      cache.put(null, _Res(0, weight: 10));
+      cache.put(1, _Res(1, weight: 10));
+      expect(cache.keys, [1]);
+      cache.put(null, _Res(2, weight: 20));
+      cache.trimToWeight(0);
+      expect(cache.keys, [null],
+          reason: 'the nullable MRU key stays protected');
+      cache.evict(null);
+      cache.put(3, _Res(3, weight: 10));
+      expect(cache.keys, [3]);
+    });
+
     test('evicts LRU weight-bearing entries down to the budget', () {
       final cache = PdfBudgetedCache<int, _Res>(
         weigher: (r) => r.weight,
@@ -133,7 +207,8 @@ void main() {
       // An oversize value is not stored (contrast the keep-MRU cache above).
       cache.put(1, _Res(1, weight: 500));
       expect(cache.containsKey(1), isFalse);
-      expect(cache.containsKey(0), isTrue, reason: 'the fitting entry survives');
+      expect(cache.containsKey(0), isTrue,
+          reason: 'the fitting entry survives');
       expect(cache.weight, 50);
       // A re-store of an oversize value leaves any existing entry untouched.
       cache.put(0, _Res(100, weight: 500));
@@ -143,7 +218,8 @@ void main() {
   });
 
   group('weight-0 entries', () {
-    test('the weight budget skips them but the count cap still bounds them', () {
+    test('the weight budget skips them but the count cap still bounds them',
+        () {
       // The #283 shape: image-free / vector-first buffers weigh 0, so a byte
       // budget cannot see them; only the entry cap stops one-per-page growth.
       final cache = PdfBudgetedCache<int, _Res>(
@@ -242,6 +318,55 @@ void main() {
   });
 
   group('getOrAdd', () {
+    test('a builder may insert and return the same resource without disposal',
+        () {
+      final dropped = <int>[];
+      final cache = PdfBudgetedCache<int, _Res>(
+        maxEntries: 2,
+        weigher: (r) => r.weight,
+        maxWeight: 10,
+        disposer: (r) => dropped.add(r.id),
+      );
+      final resource = _Res(1, weight: 5);
+      final result = cache.getOrAdd(1, () {
+        cache.put(1, resource);
+        cache.put(2, _Res(2, weight: 5));
+        return resource;
+      });
+      expect(result, same(resource));
+      expect(cache.keys, [2, 1]);
+      expect(cache.weight, 10);
+      expect(dropped, isEmpty);
+      cache.put(3, _Res(3, weight: 5));
+      expect(cache.keys, [1, 3]);
+      expect(dropped, [2]);
+      cache.dispose();
+      expect(dropped, [2, 1, 3]);
+    });
+
+    test('a reentrant insertion is replaced without leaving a stale LRU entry',
+        () {
+      final dropped = <int>[];
+      final cache = PdfBudgetedCache<int, _Res>(
+        maxEntries: 1,
+        weigher: (r) => r.weight,
+        maxWeight: 10,
+        disposer: (r) => dropped.add(r.id),
+      );
+      final result = cache.getOrAdd(0, () {
+        cache.put(0, _Res(1, weight: 5));
+        return _Res(2, weight: 10);
+      });
+      expect(result.id, 2);
+      expect(cache.keys, [0]);
+      expect(cache.weight, 10);
+      expect(dropped, [1]);
+      cache.put(3, _Res(3, weight: 10));
+      expect(cache.keys, [3]);
+      expect(cache.weight, 10);
+      expect(dropped, [1, 2]);
+    });
+
     test('computes once, then serves and refreshes recency without recompute',
         () {
       final cache = PdfBudgetedCache<int, _Res>(maxEntries: 3);
@@ -272,7 +397,8 @@ void main() {
       expect(cache.length, 0);
     });
 
-    test('putAndClone and getOrAdd after dispose return the value uncached', () {
+    test('putAndClone and getOrAdd after dispose return the value uncached',
+        () {
       final cache = PdfBudgetedCache<int, _Res>(
         maxEntries: 2,
         cloner: (r) => r.clone(),
@@ -381,7 +507,8 @@ void main() {
       c.put(0, _Res(0));
       expect(registry.registrationCount, before, reason: 'opted out');
       registry.handleMemoryPressure();
-      expect(c.length, 1, reason: 'pressure does not touch an unregistered cache');
+      expect(c.length, 1,
+          reason: 'pressure does not touch an unregistered cache');
     });
   });
 

--- a/packages/dart_pdf_editor/test/canvas_path_cache_test.dart
+++ b/packages/dart_pdf_editor/test/canvas_path_cache_test.dart
@@ -46,8 +46,8 @@ void main() {
     addTearDown(cache.dispose);
     final a = cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new);
     cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new);
-    expect(
-        cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new), isNot(same(a)));
+    expect(cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new), same(a),
+        reason: 'a full cache retains its reusable subset');
 
     final tiny = PdfCanvasPathCache(maxWeight: 1);
     addTearDown(tiny.dispose);
@@ -55,6 +55,76 @@ void main() {
     expect(tiny.pathFor(path, PdfFillRule.nonzero, ui.Path.new),
         isNot(same(large)),
         reason: 'oversize paths must be returned uncached');
+  });
+
+  test('repeated scans past the entry cap keep admitted paths warm', () {
+    final cache = PdfCanvasPathCache(maxEntries: 2);
+    addTearDown(cache.dispose);
+    final sources = List.generate(4, (_) => PdfPath(path.segments));
+    final builds = List.filled(4, 0);
+    final initial = <ui.Path>[];
+    for (var scan = 0; scan < 3; scan++) {
+      for (var i = 0; i < sources.length; i++) {
+        final result = cache.pathFor(sources[i], PdfFillRule.nonzero, () {
+          builds[i]++;
+          return ui.Path();
+        });
+        if (scan == 0) {
+          initial.add(result);
+        } else {
+          expect(result, i < 2 ? same(initial[i]) : isNot(same(initial[i])));
+        }
+      }
+    }
+    expect(builds, [1, 1, 3, 3]);
+  });
+
+  test('weight admission preserves the subset and fills smaller free slots',
+      () {
+    // The first path weighs 512; the next 320 cannot fit, but the final 224
+    // can. Total retained weight reaches 736 without evicting the first path.
+    final sources = [
+      path,
+      PdfPath(path.segments.take(4).toList()),
+      PdfPath(path.segments.take(1).toList()),
+    ];
+    final cache = PdfCanvasPathCache(maxEntries: 2, maxWeight: 736);
+    addTearDown(cache.dispose);
+    final builds = List.filled(3, 0);
+    for (var scan = 0; scan < 3; scan++) {
+      for (var i = 0; i < sources.length; i++) {
+        cache.pathFor(sources[i], PdfFillRule.nonzero, () {
+          builds[i]++;
+          return ui.Path();
+        });
+      }
+    }
+    expect(builds, [1, 3, 1]);
+    final occupancy = PdfCacheRegistry.instance
+        .snapshot()
+        .singleWhere((entry) => entry.label == 'canvas-paths');
+    expect(occupancy.length, 2);
+    expect(occupancy.weight, 736);
+    expect(occupancy.evictions, 0);
+  });
+
+  test('pressure reopens admission and disposal leaves all paths uncached', () {
+    final cache = PdfCanvasPathCache(maxEntries: 1);
+    addTearDown(cache.dispose);
+    final first = cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new);
+    final declined = cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new);
+    PdfCacheRegistry.instance.handleMemoryPressure();
+    final replacement = cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new);
+    expect(replacement, isNot(same(declined)));
+    expect(cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new),
+        same(replacement));
+    expect(cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new),
+        isNot(same(first)));
+    cache.dispose();
+    final uncached = cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new);
+    expect(uncached, isNot(same(replacement)));
+    expect(cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new),
+        isNot(same(uncached)));
   });
 
   testWidgets('retained paths keep fills, dashes and clips exact across zooms',

--- a/packages/dart_pdf_editor/test/canvas_path_cache_test.dart
+++ b/packages/dart_pdf_editor/test/canvas_path_cache_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/canvas_path_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  const path = PdfPath([
+    PdfMoveTo(20, 20),
+    PdfLineTo(180, 20),
+    PdfLineTo(180, 180),
+    PdfLineTo(20, 180),
+    PdfClosePath(),
+    PdfMoveTo(60, 60),
+    PdfLineTo(140, 60),
+    PdfLineTo(140, 140),
+    PdfLineTo(60, 140),
+    PdfClosePath(),
+  ]);
+
+  test('geometry is reused per fill rule and released under memory pressure',
+      () {
+    final cache = PdfCanvasPathCache();
+    addTearDown(cache.dispose);
+    var builds = 0;
+    ui.Path build() {
+      builds++;
+      return ui.Path();
+    }
+
+    final a = cache.pathFor(path, PdfFillRule.nonzero, build);
+    expect(cache.pathFor(path, PdfFillRule.nonzero, build), same(a));
+    final b = cache.pathFor(path, PdfFillRule.evenOdd, build);
+    expect(b, isNot(same(a)));
+    expect(builds, 2);
+    PdfCacheRegistry.instance.handleMemoryPressure();
+    expect(cache.pathFor(path, PdfFillRule.nonzero, build), isNot(same(a)));
+    expect(builds, 3);
+  });
+
+  test('entry and weight caps bound retained native geometry', () {
+    final cache = PdfCanvasPathCache(maxEntries: 1);
+    addTearDown(cache.dispose);
+    final a = cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new);
+    cache.pathFor(path, PdfFillRule.evenOdd, ui.Path.new);
+    expect(
+        cache.pathFor(path, PdfFillRule.nonzero, ui.Path.new), isNot(same(a)));
+
+    final tiny = PdfCanvasPathCache(maxWeight: 1);
+    addTearDown(tiny.dispose);
+    final large = tiny.pathFor(path, PdfFillRule.nonzero, ui.Path.new);
+    expect(tiny.pathFor(path, PdfFillRule.nonzero, ui.Path.new),
+        isNot(same(large)),
+        reason: 'oversize paths must be returned uncached');
+  });
+
+  testWidgets('retained paths keep fills, dashes and clips exact across zooms',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      // The same geometry appears under both rules, and as both a stroke and
+      // a clip. Caching must never let a fill type or dashed derivative leak
+      // into another use of the path.
+      final commands = <PdfRenderCommand>[
+        const PdfFillPathCommand(
+            path, PdfColor(1, 0, 0), PdfFillRule.nonzero, 1),
+        const PdfFillPathCommand(
+            path, PdfColor(0, 0, 1), PdfFillRule.evenOdd, 1),
+        const PdfStrokePathCommand(path, PdfColor(0, 1, 0),
+            PdfStroke(width: 3, dashArray: [7, 3], dashPhase: 2), 0.7),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(path, PdfFillRule.evenOdd),
+        const PdfFillPathCommand(
+            PdfPath([
+              PdfMoveTo(0, 0),
+              PdfCubicTo(0, 200, 200, 0, 200, 200),
+              PdfLineTo(0, 200),
+              PdfClosePath(),
+            ]),
+            PdfColor(1, 1, 0),
+            PdfFillRule.nonzero,
+            0.5),
+        const PdfRestoreCommand(),
+      ];
+      final scene = await PdfRetainedScene.fromCommands(page, commands);
+      try {
+        for (final ratio in [1.0, 2.5, 1.0]) {
+          final picture =
+              await PdfPageRenderer.pictureFromCommands(page, commands);
+          final direct =
+              await PdfPageRenderer.rasterize(picture, scene.pageSize, ratio);
+          final retained = await scene.rasterize(pixelRatio: ratio);
+          try {
+            expect(await pixels(retained), await pixels(direct),
+                reason: 'ratio $ratio');
+          } finally {
+            direct.dispose();
+            retained.dispose();
+            picture.dispose();
+          }
+        }
+      } finally {
+        scene.dispose();
+      }
+    });
+  });
+}
+
+Future<Uint8List> pixels(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();

--- a/packages/dart_pdf_editor/test/render_worker_sparse_web_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_sparse_web_test.dart
@@ -20,6 +20,30 @@ import 'package:web/web.dart' as web;
 import 'fixtures/sparse_worker_pdf.dart';
 
 void main() {
+  test('web search promotes pending text ahead of queued renders', () async {
+    final oldUrl = pdfRenderWorkerScriptUrl;
+    pdfRenderWorkerScriptUrl = '${Uri.base.origin}'
+        '/packages/dart_pdf_editor/src/sparse_test_worker.js';
+    addTearDown(() => pdfRenderWorkerScriptUrl = oldUrl);
+    final worker = PdfRenderWorker.startUncached(sparseWorkerPdf().bytes);
+    addTearDown(worker.dispose);
+    final order = <String>[];
+    final pending = <Future<void>>[
+      worker.record(0, priority: -1).then((_) => order.add('first')),
+      for (var i = 0; i < 3; i++)
+        worker.record(0, priority: 1).then((_) => order.add('record$i')),
+      worker.extractText(2, priority: 3).then((text) {
+        expect(text!.text, contains('Page 3'));
+        order.add('text');
+      }),
+    ];
+    worker.promoteTextExtraction(2);
+    worker.promoteTextExtraction(2, priority: 9);
+    await Future.wait(pending);
+    expect(order, hasLength(5));
+    expect(order.indexOf('text'), 1);
+  });
+
   for (final shared in [false, true]) {
     test('web worker preserves sparse ranges (shared=$shared)', () async {
       final oldUrl = pdfRenderWorkerScriptUrl;

--- a/packages/dart_pdf_editor/test/render_worker_text_priority_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_text_priority_test.dart
@@ -1,0 +1,43 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  for (final wrapped in [false, true]) {
+    testWidgets(
+        'search promotes queued text without another walk (wrapped=$wrapped)',
+        (tester) async {
+      await tester.runAsync(() async {
+        final backend = PdfRenderWorker.startUncached(buildMultiPagePdf(2));
+        final worker = wrapped
+            ? PdfCachingRenderWorker(
+                PdfPooledRenderWorker.fromWorkers([backend]))
+            : backend;
+        try {
+          // Queue before yielding to any reply. An urgent record occupies the
+          // worker; ordinary records precede a speculative text request.
+          final order = <String>[];
+          final pending = <Future<void>>[
+            worker.record(0, priority: -1).then((_) => order.add('first')),
+            for (var i = 0; i < 3; i++)
+              worker
+                  .record(0, priority: 1, imagePixelRatio: i + 1.0)
+                  .then((_) => order.add('record$i')),
+            worker.extractText(1, priority: 3).then((text) {
+              expect(text!.text, contains('Page 2'));
+              order.add('text');
+            }),
+          ];
+          worker.promoteTextExtraction(1);
+          worker.promoteTextExtraction(1, priority: 9); // never demote
+          await Future.wait(pending);
+          expect(order, hasLength(5));
+          expect(order.indexOf('text'), 1,
+              reason: 'search must precede queued ordinary/background records');
+        } finally {
+          worker.dispose();
+        }
+      });
+    });
+  }
+}

--- a/packages/dart_pdf_editor/test/visible_text_warm_test.dart
+++ b/packages/dart_pdf_editor/test/visible_text_warm_test.dart
@@ -12,6 +12,7 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 class _TextWorker extends PdfRenderWorker {
   final requests =
       <({int page, int priority, Completer<PdfPageText?> reply})>[];
+  final promotions = <({int page, int priority})>[];
 
   @override
   bool get isActive => true;
@@ -21,6 +22,11 @@ class _TextWorker extends PdfRenderWorker {
     final reply = Completer<PdfPageText?>();
     requests.add((page: pageIndex, priority: priority, reply: reply));
     return reply.future;
+  }
+
+  @override
+  void promoteTextExtraction(int pageIndex, {int priority = 0}) {
+    promotions.add((page: pageIndex, priority: priority));
   }
 
   @override
@@ -58,20 +64,21 @@ void main() {
     for (var i = 0; i < 80 && !ready(); i++) {
       await tester.runAsync(
           () => Future<void>.delayed(const Duration(milliseconds: 10)));
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 25));
     }
     expect(ready(), isTrue);
   }
 
   Widget viewer(PdfDocument document, PdfViewerController controller,
           _TextWorker worker,
-          {PdfEditingController? editing}) =>
+          {PdfEditingController? editing, bool active = true}) =>
       MaterialApp(
         home: Scaffold(
           body: PdfViewer(
             document: editing == null ? document : null,
             editing: editing,
             controller: controller,
+            active: active,
             renderWorker: worker,
             autoRenderWorker: false,
             initialFit: PdfViewerFit.width,
@@ -102,6 +109,8 @@ void main() {
     await tester.pump();
     expect(worker.requests, hasLength(1),
         reason: 'foreground search shares the already-pending text warm');
+    expect(worker.promotions, contains((page: 0, priority: 0)),
+        reason: 'sharing a speculative request preserves foreground priority');
     worker.requests.single.reply.complete(result);
     await tester.pump();
     await search;
@@ -116,6 +125,62 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(localExtractions(), 0);
     expect(worker.requests, hasLength(1));
+  });
+
+  testWidgets('text warm waits for a quiet viewport after rendering',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(3));
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(controller.dispose);
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    await tester.pumpWidget(viewer(document, controller, worker));
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+    expect(worker.requests, isEmpty,
+        reason: 'first paint must not immediately start an uncancellable walk');
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(worker.requests, isEmpty);
+
+    // Keep scrolling past the original idle deadline. The timer must be
+    // cancelled, and the settled viewport must get a new quiet window.
+    for (var i = 0; i < 3; i++) {
+      tester.binding.handlePointerEvent(const PointerScrollEvent(
+        position: Offset(450, 400),
+        scrollDelta: Offset(0, 20),
+      ));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(worker.requests, isEmpty);
+    }
+    await pumpUntil(tester, () => worker.requests.isNotEmpty);
+    expect(worker.requests.single.page, controller.currentPage);
+    worker.requests.single.reply.complete(null);
+    await tester.pump(const Duration(seconds: 1));
+    expect(localExtractions(), 0);
+    await tester.pumpWidget(const SizedBox());
+  });
+
+  testWidgets('deactivation and disposal cancel pending text warm timers',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(viewer(document, controller, worker));
+    await pumpUntil(tester,
+        () => controller.isPageRasterReady(0) && !controller.isPageRenderBusy);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester
+        .pumpWidget(viewer(document, controller, worker, active: false));
+    await tester.pump(const Duration(seconds: 1));
+    expect(worker.requests, isEmpty);
+
+    await tester.pumpWidget(viewer(document, controller, worker));
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(worker.requests, isEmpty);
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(seconds: 1));
+    expect(worker.requests, isEmpty);
   });
 
   testWidgets('declined speculative extraction never falls back locally',

--- a/packages/dart_pdf_editor/test/visible_text_warm_test.dart
+++ b/packages/dart_pdf_editor/test/visible_text_warm_test.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/perf.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+class _TextWorker extends PdfRenderWorker {
+  final requests =
+      <({int page, int priority, Completer<PdfPageText?> reply})>[];
+
+  @override
+  bool get isActive => true;
+
+  @override
+  Future<PdfPageText?> extractText(int pageIndex, {int priority = 0}) {
+    final reply = Completer<PdfPageText?>();
+    requests.add((page: pageIndex, priority: priority, reply: reply));
+    return reply.future;
+  }
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
+      null;
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {}
+}
+
+void main() {
+  setUp(() {
+    final threshold = PdfViewer.hoverTextExtractMaxRawContentBytes;
+    PdfViewer.hoverTextExtractMaxRawContentBytes = 0;
+    final perfEnabled = PdfPerf.enabled;
+    PdfPerf.enabled = true;
+    PdfPerf.reset();
+    addTearDown(() {
+      PdfViewer.hoverTextExtractMaxRawContentBytes = threshold;
+      PdfPerf.enabled = perfEnabled;
+    });
+  });
+
+  Future<void> pumpUntil(WidgetTester tester, bool Function() ready) async {
+    for (var i = 0; i < 80 && !ready(); i++) {
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+      await tester.pump();
+    }
+    expect(ready(), isTrue);
+  }
+
+  Widget viewer(PdfDocument document, PdfViewerController controller,
+          _TextWorker worker,
+          {PdfEditingController? editing}) =>
+      MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            document: editing == null ? document : null,
+            editing: editing,
+            controller: controller,
+            renderWorker: worker,
+            autoRenderWorker: false,
+            initialFit: PdfViewerFit.width,
+            pagePreviews: false,
+          ),
+        ),
+      );
+
+  int localExtractions() =>
+      PdfPerf.snapshot().phaseCalls[PdfPerfPhase.textExtract.index];
+
+  testWidgets('ready heavy page warms on worker and search shares its request',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final result = PdfTextExtractor.extract(document, 0);
+    PdfPerf.reset();
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(controller.dispose);
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    await tester.pumpWidget(viewer(document, controller, worker));
+    await pumpUntil(tester, () => worker.requests.isNotEmpty);
+    expect(worker.requests.single.page, 0);
+    expect(worker.requests.single.priority, greaterThan(0));
+    expect(localExtractions(), 0);
+
+    final search = controller.search('Hello');
+    await tester.pump();
+    expect(worker.requests, hasLength(1),
+        reason: 'foreground search shares the already-pending text warm');
+    worker.requests.single.reply.complete(result);
+    await tester.pump();
+    await search;
+    expect(controller.matchCount, 1);
+    expect(localExtractions(), 0);
+
+    // A grab-pan begins by testing text. It must use the warmed text as well.
+    final drag = await tester.startGesture(const Offset(450, 400),
+        kind: PointerDeviceKind.mouse);
+    await drag.moveBy(const Offset(-30, 0));
+    await drag.up();
+    await tester.pump(const Duration(seconds: 1));
+    expect(localExtractions(), 0);
+    expect(worker.requests, hasLength(1));
+  });
+
+  testWidgets('declined speculative extraction never falls back locally',
+      (tester) async {
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(controller.dispose);
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    await tester.pumpWidget(
+        viewer(PdfDocument.open(buildClassicPdf()), controller, worker));
+    await pumpUntil(tester, () => worker.requests.isNotEmpty);
+    worker.requests.single.reply.complete(null);
+    await tester.pump();
+    await tester.pump();
+    expect(localExtractions(), 0);
+    expect(worker.requests, hasLength(1),
+        reason: 'a declining worker must not trigger an idle retry loop');
+  });
+
+  testWidgets('navigation warms only the latest focused page one at a time',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(3));
+    final firstText = PdfTextExtractor.extract(document, 0);
+    final secondText = PdfTextExtractor.extract(document, 1);
+    PdfPerf.reset();
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(controller.dispose);
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    await tester.pumpWidget(viewer(document, controller, worker));
+    await pumpUntil(tester, () => worker.requests.isNotEmpty);
+    unawaited(controller.jumpToPage(1));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await pumpUntil(tester, () => controller.isPageRasterReady(1));
+    expect(controller.currentPage, 1);
+    expect(worker.requests, hasLength(1),
+        reason: 'navigation must not stack speculative extractions');
+
+    worker.requests.first.reply.complete(firstText);
+    await pumpUntil(tester, () => worker.requests.length == 2);
+    expect(worker.requests.last.page, 1);
+    worker.requests.last.reply.complete(secondText);
+    await tester.pump(const Duration(seconds: 1));
+    expect(worker.requests, hasLength(2),
+        reason: 'off-screen pages must not be extracted speculatively');
+    expect(localExtractions(), 0);
+  });
+
+  testWidgets(
+      'text warm from an earlier editing revision cannot fill the cache',
+      (tester) async {
+    final editing = PdfEditingController(buildClassicPdf());
+    final controller = PdfViewerController();
+    final worker = _TextWorker();
+    addTearDown(editing.dispose);
+    addTearDown(controller.dispose);
+    addTearDown(() => tester.pumpWidget(const SizedBox()));
+    final oldText = PdfTextExtractor.extract(editing.document, 0);
+    PdfPerf.reset();
+    await tester.pumpWidget(
+        viewer(editing.document, controller, worker, editing: editing));
+    await pumpUntil(tester, () => worker.requests.isNotEmpty);
+
+    editing.apply((editor) {
+      editor.stampPage(
+          0, (stamp) => stamp.text('Revision marker', x: 72, y: 500));
+    }, pages: const [0]);
+    await tester.pump();
+    final newText = PdfTextExtractor.extract(editing.document, 0);
+    PdfPerf.reset();
+    final search = controller.search('Revision marker');
+    await tester.pump();
+    expect(worker.requests, hasLength(2),
+        reason: 'the new revision must not join an older revision request');
+
+    // Complete the old request first; it must not win putIfAbsent at slot 0.
+    worker.requests.first.reply.complete(oldText);
+    await tester.pump();
+    worker.requests.last.reply.complete(newText);
+    await tester.pump();
+    await search;
+    expect(controller.matchCount, 1);
+    await controller.search('Revision marker');
+    expect(controller.matchCount, 1,
+        reason: 'the current revision text, not the old reply, was cached');
+    expect(localExtractions(), 0);
+    await tester.pump(const Duration(seconds: 1));
+  });
+}

--- a/packages/pdf_cos/lib/src/lexer.dart
+++ b/packages/pdf_cos/lib/src/lexer.dart
@@ -135,17 +135,32 @@ class CosLexer {
   }
 
   CosToken _number(int start, CosTokenBuffer? reuse) {
-    // Content streams are number-dense (every coordinate, colour, index), so
-    // this is the tokenizer's hottest path. Scan the digit/sign/dot run once
-    // and parse straight from the bytes - no per-char StringBuffer.
-    var isReal = false;
-    var p = position;
+    // Accumulate the mantissa while finding the token boundary. CAD exports
+    // contain millions of coordinates; scanning each number again to parse it
+    // needlessly doubles the byte walk on the tokenizer's hottest path.
+    var p = start;
+    final first = bytes[p];
+    final negative = first == 0x2D;
+    if (negative || first == 0x2B) p++;
+    var mantissa = 0;
+    var digits = 0;
+    var dot = -1;
+    var valid = true;
     while (p < bytes.length) {
       final b = bytes[p];
-      if (_isDigit(b) || b == 0x2B || b == 0x2D) {
-        // digit or sign
+      final digit = b - 0x30;
+      if (digit >= 0 && digit <= 9) {
+        // Eighteen decimal digits fit in int64. Longer values use the exact
+        // string fallback below; don't let their unused accumulator overflow.
+        if (digits < 18) mantissa = mantissa * 10 + digit;
+        digits++;
       } else if (b == 0x2E) {
-        isReal = true;
+        if (dot >= 0) valid = false;
+        dot = p;
+      } else if (b == 0x2B || b == 0x2D) {
+        // Embedded signs belong to the same malformed token, matching the
+        // ordinary parser's error boundary ("1-2" must not become 1 and -2).
+        valid = false;
       } else {
         break;
       }
@@ -153,100 +168,44 @@ class CosLexer {
     }
     position = p;
 
-    if (!isReal) {
-      // Parse the integer directly when it can't overflow (≤18 digits); this
-      // is bit-for-bit identical to int.tryParse over the same byte range.
-      final v = _parseIntRange(start, p);
-      if (v != null) return _token(reuse, CosTokenType.integer, start, v);
-      // Overflowing or malformed: fall back to the exact string semantics.
+    if (dot < 0) {
+      if (valid && digits > 0 && digits <= 18) {
+        return _token(reuse, CosTokenType.integer, start,
+            negative ? -mantissa : mantissa);
+      }
       final raw = String.fromCharCodes(bytes, start, p);
-      final iv = int.tryParse(raw);
-      if (iv == null) throw CosParseException('malformed number "$raw"', start);
-      return _token(reuse, CosTokenType.integer, start, iv);
+      final value = int.tryParse(raw);
+      if (value == null) {
+        throw CosParseException('malformed number "$raw"', start);
+      }
+      return _token(reuse, CosTokenType.integer, start, value);
     }
 
-    // PDF reals have no exponent (§7.3.3): sign, digits, one dot. With ≤15
-    // significant digits, digits/10^frac is one exact integer divided by one
-    // exact power of ten - a single correctly-rounded division, bit-for-bit
-    // identical to double.parse - without the string allocation. Content
-    // streams are real-dense (every coordinate), so this is hot.
-    final fast = _parseRealRange(start, p);
-    if (fast != null) return _token(reuse, CosTokenType.real, start, fast);
+    // With at most 15 digits both integers in mantissa / 10^fraction are
+    // exact doubles. One correctly-rounded division matches double.parse,
+    // including a signed zero. Longer or malformed reals retain its string
+    // semantics instead of trading precision for the fast path.
+    if (valid && digits > 0 && digits <= 15) {
+      final value = mantissa / _pow10[p - dot - 1];
+      return _token(reuse, CosTokenType.real, start, negative ? -value : value);
+    }
 
     final raw = String.fromCharCodes(bytes, start, p);
     var s = raw;
     if (s.startsWith('.')) s = '0$s';
     if (s.startsWith('-.')) s = '-0${s.substring(1)}';
     if (s.endsWith('.')) s = '${s}0';
-    final v = double.tryParse(s);
-    if (v == null) throw CosParseException('malformed number "$raw"', start);
-    return _token(reuse, CosTokenType.real, start, v);
+    final value = double.tryParse(s);
+    if (value == null) {
+      throw CosParseException('malformed number "$raw"', start);
+    }
+    return _token(reuse, CosTokenType.real, start, value);
   }
 
   static const List<double> _pow10 = [
     1.0, 10.0, 100.0, 1e3, 1e4, 1e5, 1e6, 1e7, //
     1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
   ];
-
-  /// Parses the real in `bytes[start..end)` when it is a plain
-  /// `sign? digits* ('.' digits*)?` with ≤15 total digits; null otherwise
-  /// (multiple dots, embedded signs, digit-heavy) so the caller can fall
-  /// back to the string path with identical semantics.
-  double? _parseRealRange(int start, int end) {
-    var i = start;
-    var negative = false;
-    final first = bytes[i];
-    if (first == 0x2B || first == 0x2D) {
-      negative = first == 0x2D;
-      i++;
-    }
-    var digits = 0;
-    var nDigits = 0;
-    var fracCount = 0;
-    var sawDot = false;
-    var sawDigit = false;
-    for (; i < end; i++) {
-      final b = bytes[i];
-      if (b == 0x2E) {
-        if (sawDot) return null;
-        sawDot = true;
-      } else {
-        final d = b - 0x30;
-        if (d < 0 || d > 9) return null;
-        digits = digits * 10 + d;
-        nDigits++;
-        if (sawDot) fracCount++;
-        sawDigit = true;
-      }
-    }
-    if (!sawDigit || nDigits > 15) return null;
-    final v = digits / _pow10[fracCount];
-    return negative ? -v : v;
-  }
-
-  /// Parses the integer in `bytes[start..end)` exactly as
-  /// `int.tryParse(String.fromCharCodes(bytes, start, end))` would - an
-  /// optional leading `+`/`-` then digits - but without allocating a string.
-  /// Returns null for malformed input or a mantissa long enough to risk
-  /// 64-bit overflow (≥19 digits), so the caller can fall back to the string
-  /// path with identical semantics.
-  int? _parseIntRange(int start, int end) {
-    var i = start;
-    var negative = false;
-    final first = bytes[i];
-    if (first == 0x2B || first == 0x2D) {
-      negative = first == 0x2D;
-      i++;
-    }
-    if (i >= end || end - i > 18) return null; // empty mantissa, or too long
-    var value = 0;
-    for (; i < end; i++) {
-      final d = bytes[i] - 0x30;
-      if (d < 0 || d > 9) return null; // embedded sign or junk
-      value = value * 10 + d;
-    }
-    return negative ? -value : value;
-  }
 
   CosToken _literalString(int start, CosTokenBuffer? reuse) {
     position++; // (

--- a/packages/pdf_cos/test/lexer_test.dart
+++ b/packages/pdf_cos/test/lexer_test.dart
@@ -60,6 +60,49 @@ void main() {
           double.parse('123456789.0123456789'));
     });
 
+    test('numeric fast and fallback paths preserve token boundaries', () {
+      for (final source in [
+        '.000068328212',
+        '-.0017587801',
+        '999999999999999.', // last exact fast-path real
+        '9999999999999999.', // first fallback real
+        '.000000000000001',
+        '.0000000000000001',
+        '-9223372036854775808', // int64 minimum needs the fallback
+        '+000000000000000017',
+        '00000000000000000017',
+      ]) {
+        final lexer = CosLexer(ascii('$source/Next'));
+        final token = lexer.nextToken();
+        expect(token.value,
+            source.contains('.') ? double.parse(source) : int.parse(source),
+            reason: source);
+        expect(lexer.position, source.length, reason: source);
+        expect(lexer.nextToken().textValue, 'Next', reason: source);
+      }
+    });
+
+    test('real signed zero and permissive bare-dot syntax survive', () {
+      for (final source in ['-0.', '-.0', '-0.0000000000000000', '-.']) {
+        final token = lex(source);
+        expect(token.type, CosTokenType.real, reason: source);
+        expect(token.realValue, 0, reason: source);
+        expect(token.realValue.isNegative, isTrue, reason: source);
+      }
+      expect(lex('.').realValue, 0);
+      expect(lex('+.').realValue, 0);
+    });
+
+    test('malformed numeric tokens consume all signs and dots', () {
+      for (final source in ['1.2.3', '1.-2', '.1+2', '++1', '+', '-']) {
+        final lexer = CosLexer(ascii('$source/Next'));
+        expect(() => lexer.nextToken(), throwsA(isA<CosParseException>()),
+            reason: source);
+        expect(lexer.position, source.length, reason: source);
+        expect(lexer.nextToken().textValue, 'Next', reason: source);
+      }
+    });
+
     test('large integers parse exactly, matching int.tryParse', () {
       // The direct byte parser handles ≤18-digit mantissas; longer ones (incl.
       // the 19-digit int64 max) must fall back to the exact string path.


### PR DESCRIPTION
## Summary

Dense vector sheets pause while opening, zooming, and starting a mouse drag. A local one-page engineering PDF expands to 32 MB of content and over a million operators. This change reduces numeric parsing work, reuses native path geometry during retained-scene replay, and prepares the visible heavy page's text on the render worker after its first raster is ready and the viewport/render scheduler has been idle for 500 ms.

- Parse numeric tokens in one byte pass while retaining existing precision and malformed-input behavior.
- Cache paths by geometry identity and fill rule, bounded to an estimated 32 MiB / 65,536 entries per scene, cleared by memory pressure and scene disposal. Preserve a reusable subset when a page exceeds the limits, avoiding repeated full-cache replacement.
- Track shared-cache recency with a linked list so full-cache touches and ordinary eviction stay constant-time; preserve disposal, weighted eviction, and key-remapping behavior.
- Warm one focused page's text at a time after an idle delay; cancel pending warming during motion, share pending work with search while promoting it to foreground priority, reject stale revision replies, and never fall back to UI-thread extraction during speculative warming.

Final local native measurements: parsing 246.46 → 208.52 ms (15% less), and warm 4× replay plus raster approximately 201 → 152 ms (24% less; replay alone falls 45%). The cached and uncached images are pixel-identical at 2×, 4×, and 8×. An above-cap synthetic replay also stays pixel-identical and retains a useful subset with zero eviction churn. These are controlled renderer measurements, not browser or whole-app latency claims. See the checked-in benchmark notes and opt-in paired benchmark.

## Affected packages

- [x] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

Final validation at `ca8c0b2d`: all 21 CI checks passed; the separate Chromium Patrol lane is intentionally disabled by the workflow (browser tests and web previews passed in other lanes). Android, iOS, macOS, Linux, Windows, native Metal, and web validation are green, and the PR is mergeable. Locally, the complete editor suite passed (2,713 tests, 30 intentional skips), and root analysis is clean. Earlier validation also covered all 376 COS tests and all 225 Ghent/PDF.js interpretation cases; the full editor run includes the rendering corpora, with no baseline changes. Follow-up regressions cover cache bounds and ownership, idle-delay cancellation, and priority promotion through the native and browser worker queues (76 native worker tests and the real Chrome worker integration passed). The remaining workspace suites also passed in CI.

All 4,679,417 tokens in the private input matched the original lexer, and 50,012 numeric cases matched under dart2js -O2 and Node. The before/after 4× worker-rendered PNG is byte-identical.

The final automated web report has mixed scenario elapsed timings (+3.7% to +12.4% for four scenarios, -4.0% for the worker scenario). It compares three samples per scenario from separate runners against the previous day's baseline, so it does not establish a browser latency improvement or regression. Structural work is stable; aggregate measured worker, decode, replay, and raster phases improve approximately 6–7%. The JPEG increase is concentrated in unchanged browser-codec work; the rounded-rung case includes a raster outlier. One attributable extra request is speculative extraction returning empty text on an image-only CAD fixture; skipping known textless transcripts is a follow-up opportunity. See [the web performance run](https://github.com/ben-milanko/dart-pdf/actions/runs/34221284139).

Final Metal validation passed: GPU acceptance/fallback counts and all structural counters match `main` across 227 accelerated corpus pages, with no new fallbacks. All 44 performance comparisons have six samples per side, alternated on the same host after priming both builds; their elapsed medians fall within overlapping run spread. No material regression was identified in [the Metal run](https://github.com/ben-milanko/dart-pdf/actions/runs/34221284165).

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

Measurements cover parser and renderer phases, plus native geometry retention (29.2 MiB estimated for this input). They do not establish whole-app latency or total process memory. A gesture before background text preparation finishes can still pay the existing synchronous extraction cost.

## PDF fixtures and screenshots

The original PDF remains local. Regression fixtures are programmatic; no private PDF or screenshot is included.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The geometry cache relies on the existing immutable retained-transcript contract. Transforms, clipping, dashing, draw order, and raster quality are unchanged. Numeric fallback/error boundaries, memory-pressure eviction, fill-rule isolation, and stale async text results have focused regression coverage.

Further opportunities identified for this input are documented in the development log: index transparency groups as atomic units to enable selective replay/tiles, reuse extraction-ready text from the original recording, and profile soft-mask raster layers. These are follow-up candidates, not claimed gains in this PR.
