### PR TITLE
Accelerate high-zoom viewport rendering and enable 10000% zoom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,13 @@ jobs:
           flutter test --platform chrome --no-cross-origin-isolation
           test/render_worker_sparse_web_test.dart test/compression_worker_test.dart
           --reporter expanded
+      - name: Test high-zoom tiles and atomic region replay in Chrome
+        working-directory: packages/dart_pdf_editor
+        run: >-
+          flutter test --platform chrome --no-cross-origin-isolation
+          test/high_zoom_tiles_test.dart test/high_zoom_range_test.dart
+          test/atomic_region_replay_test.dart test/atomic_tile_budget_test.dart
+          --reporter expanded
 
   # Build the Linux desktop target and validate its desktop-integration files.
   # Mirrors the release-app.yml linux job's build deps (GTK + libsecret for

--- a/doc/dev-log/2026-09-08-extreme-zoom-performance.md
+++ b/doc/dev-log/2026-09-08-extreme-zoom-performance.md
@@ -1,0 +1,96 @@
+# Viewport rendering at 3000–10000%
+
+Follow-up to the [dense-vector parsing and replay work](2026-09-08-dense-vector-pdf-performance.md).
+The local engineering sheet is a single 421 × 269 pt page. Its compact worker
+transcript contains 77,312 commands, including 24 transparency groups and 16
+soft masks. Previously, any group disabled the region index for the entire
+page, so a small zoomed viewport replayed all 77,312 commands and could not use
+the cached tile path.
+
+## Changes
+
+- Balanced compositing groups are indivisible indexed ranges. Selection
+  preserves every command inside a selected group, its entry clips and blend
+  mode, and painter order. Bounds come from source paint coverage; a group's
+  allocation hint or a soft mask's painted footprint cannot safely bound it.
+  Mask transfer functions and backdrop values can reveal source elsewhere.
+- A recursive safety check preserves full replay for malformed state stacks,
+  overprint, seeded non-isolated groups, and cells whose clip or blend state
+  escapes. Shared cells are checked in their incoming blend context. The
+  worker index format carries exclusive range ends and rejects old versions.
+- Dense pages start using the spatial grid at 32,768 commands. The viewer
+  warms that index through its render worker, and worker detail requests reuse
+  the same index and budget. The index is still released on memory pressure.
+- Small groups can use existing cached tiles. Groups exceeding 1,024 command
+  slots, including nested mask/cell commands, retain a single viewport patch
+  to avoid repeating a large indivisible group for every tile. The separate
+  banded-transcript path also keeps its group fallback.
+- The default viewer reaches at least 10000% actual size independently of
+  viewport width. Explicit host zoom caps retain their previous behavior.
+  The shell adds 3000%, 5000%, and 10000% presets; the tile resolution ladder
+  reaches 512 physical pixels per PDF point for high-DPI displays.
+
+## Paired measurements
+
+Native Flutter test engine, 1280 × 800 logical viewport, DPR 2, fixed
+2560 × 1600 output. Each region has one warm-up pair and seven measured pairs,
+alternating full and selective replay on the same retained scene and images.
+These are renderer times, not end-to-end app or browser latency. Readback is
+measured separately and excluded from replay + raster below.
+
+| Drawing region | View zoom | Full replay + raster | Selective replay + raster | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| Centre | 3000% | 71.78 ms | 19.64 ms | 3.65× |
+| Centre | 6000% | 64.77 ms | 10.87 ms | 5.96× |
+| Centre | 10000% | 61.28 ms | 4.94 ms | 12.39× |
+| Lower junction | 3000% | 69.73 ms | 19.13 ms | 3.65× |
+| Lower junction | 6000% | 65.72 ms | 12.44 ms | 5.28× |
+| Lower junction | 10000% | 64.05 ms | 10.76 ms | 5.95× |
+
+At 10000%, the centre selects 405 commands and the lower junction 951.
+The four mask-heavy regions select 28–107 commands: replay takes 0.30–0.40 ms,
+but rasterization remains the larger cost. Their total times improve from
+125–172 ms to 74–119 ms. Cached tiles avoid that cost when returning to a
+previously visited viewport.
+
+All 18 regions (six locations at three zooms) are genuinely selective and
+byte-identical to full replay in every comparison. Grid and linear-index
+outputs also match exactly. The grid retains 71,987 units, estimates 6.75 MB,
+and took 99 ms to build locally; that one-time build belongs on the worker.
+The private input, benchmark JSON and viewport PNGs remain local.
+
+## Reproduction and regression coverage
+
+From `packages/dart_pdf_editor`:
+
+```sh
+PDF_PATH=/absolute/path/to/drawing.pdf \
+PDF_BENCHMARK_REQUIRE_SELECTIVE=1 \
+PDF_BENCHMARK_OUT=/tmp/extreme-zoom.json \
+  fvm flutter test --no-pub test/benchmark_extreme_zoom_test.dart
+```
+
+The benchmark self-skips without `PDF_PATH`. Its header documents viewport,
+DPR, location, zoom and PNG-output overrides. It never allocates a whole-page
+raster at extreme zoom.
+
+Regression coverage includes exact pixels for nested masks, knockout, clip
+and blend combinations at 3000% and 10000%, plus 13 PDF.js fixtures at ordinary
+and extreme zoom. Worker codec and real-isolate tests cover range retention.
+A real Canvas widget test uses a generated grouped PDF at 10000% on DPR 3:
+one-column panning renders only missing edge tiles; returning to the original
+viewport schedules zero new tiles and zero rasterizations. Raster slabs and
+cache memory remain bounded.
+
+## Remaining opportunities
+
+The mask-heavy graphics are now raster-bound. Conservative layer bounds or
+reusable mask surfaces are candidates for a separate measured change; group
+allocation hints must not become clips, and mask backdrop/transfer semantics
+must remain intact. The supplied sheet's drawing areas already benefit from
+selective replay without that additional compositing work.
+
+Text extraction still interprets the page separately from worker recording.
+Sharing extraction-ready text runs could reduce initial preparation time,
+provided character advances, bidi order, invisible text and appearance/mask
+exclusion remain correct.

--- a/packages/dart_pdf_editor/lib/src/banded_transcript.dart
+++ b/packages/dart_pdf_editor/lib/src/banded_transcript.dart
@@ -63,6 +63,13 @@ class PdfBandedTranscript {
     final idx = index ??
         PdfRegionReplayIndex.build(commands, maxCommands: commands.length);
     if (!idx.supported) return null;
+    // Bands currently retain one command per unit. Region replay also accepts
+    // atomic group ranges; keep those scenes on its complete-transcript path
+    // until bands can own every command in the range, never just the opener.
+    if (idx.units
+        .any((unit) => unit.endCommandIndex != unit.commandIndex + 1)) {
+      return null;
+    }
 
     final extent = idx.xExtent;
     // A page with no drawable units (blank, or everything clipped away) still

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -4676,8 +4676,8 @@ class _PdfPageViewState extends State<PdfPageView>
 
   /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
   /// detail for this page: the flag is on and the retained scene is
-  /// region-cullable (soft-mask/group spans keep the legacy single-patch
-  /// path).
+  /// region-cullable with bounded atomic groups. Large indivisible compositing
+  /// groups keep a single detail patch to avoid replaying them for every tile.
   ///
   /// A vector-only progressive scene is eligible too - on the dense CAD pages
   /// the pyramid targets, the full image-bearing record may never land during
@@ -4701,11 +4701,14 @@ class _PdfPageViewState extends State<PdfPageView>
     // UI isolate: defer the tile path until the warmed index is resident (built
     // on the render worker when eligible - see [_warmRegionIndexIfNeeded]).
     // Until then the base raster / single detail patch covers the view. Pages
-    // below the grid ceiling keep the cheap synchronous linear build.
+    // below the grid threshold keep the cheap synchronous linear build.
     if (scene.regionIndexBuildIsHeavy && !scene.debugHasRegionReplayIndex) {
       return 'index-warming';
     }
-    return scene.supportsRegionRaster ? 'active' : 'unsupported-scene';
+    if (!scene.supportsRegionRaster) return 'unsupported-scene';
+    return scene.supportsTiledRegionRaster
+        ? 'active'
+        : 'large-compositing-group';
   }
 
   /// Kicks the region-replay index build onto the render worker when the page

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -59,6 +59,7 @@ export 'annotation_tap.dart'
     show PdfAnnotationTapDetails, PdfAnnotationTapHandler;
 
 const double _defaultMaxZoom = 24;
+const double _defaultMaxDisplayZoom = 100;
 
 // Clipboard revisions are shared across viewer windows just like the snapshot
 // holder. Weak keys keep private clipboard lifetimes independent of this cache.
@@ -1320,7 +1321,7 @@ class PdfViewer extends StatefulWidget {
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
     this.minZoom = 0.25,
-    this.maxZoom = _defaultMaxZoom,
+    double? maxZoom,
     this.doubleTapZoom = 2.5,
     this.backgroundColor,
     this.pageColor = const Color(0xFFFFFFFF),
@@ -1344,7 +1345,9 @@ class PdfViewer extends StatefulWidget {
     this.textCache,
     this.documentId,
     this.active = true,
-  }) : assert(
+  })  : maxZoom = maxZoom ?? _defaultMaxZoom,
+        _hasCustomMaxZoom = maxZoom != null,
+        assert(
             document != null ||
                 editing != null ||
                 (formController != null && interactiveForms),
@@ -1711,10 +1714,13 @@ class PdfViewer extends StatefulWidget {
   /// each PDF point tiny on screen, and the deep-zoom detail patch keeps the
   /// visible slice sharp without forcing a full-page raster at this scale.
   ///
-  /// When the default is used on a narrow viewport, the viewer may lift the
-  /// internal fit-width multiplier so the actual-size cap still reaches at
-  /// least 2400%. Custom [maxZoom] values are respected exactly.
+  /// When omitted, the viewer lifts the internal fit-width multiplier as
+  /// needed so the actual-size cap reaches at least 10000%, independently of
+  /// the viewport width or open side panels. Explicit values retain their
+  /// existing fit-width limits: 24 keeps its minimum actual-size cap of 2400%,
+  /// and all other values are respected exactly as fit-width multiples.
   final double maxZoom;
+  final bool _hasCustomMaxZoom;
   final double doubleTapZoom;
 
   /// The canvas color around and between the pages. Defaults to a
@@ -5118,17 +5124,20 @@ class _PdfViewerState extends State<PdfViewer>
       ? 1
       : _crossView / _maxCrossPoint;
 
-  /// Gesture/controller zoom clamps are expressed as fit multiples. On small
-  /// viewports the fit scale is less than actual size, so the stock 24x cap
-  /// used to top out below 2400% actual size. Keep the default generous
-  /// there without changing explicit host caps.
+  /// Gesture/controller zoom clamps are expressed as fit multiples. Keep
+  /// 10000% actual size reachable at the default on any viewport, including
+  /// when side panels reduce its width, without changing explicit host caps.
   double get _effectiveMaxZoom {
-    if (widget.maxZoom != _defaultMaxZoom) return widget.maxZoom;
-    final fit = _fitScale;
-    if (!fit.isFinite || fit <= 0 || fit >= 1) {
+    if (widget._hasCustomMaxZoom && widget.maxZoom != _defaultMaxZoom) {
       return widget.maxZoom;
     }
-    return math.max(widget.maxZoom, _defaultMaxZoom / fit);
+    final fit = _fitScale;
+    if (!fit.isFinite || fit <= 0) {
+      return widget.maxZoom;
+    }
+    final minimumDisplayZoom =
+        widget._hasCustomMaxZoom ? _defaultMaxZoom : _defaultMaxDisplayZoom;
+    return math.max(widget.maxZoom, minimumDisplayZoom / fit);
   }
 
   /// The on-screen scale the user sees, in logical pixels per PDF point,

--- a/packages/dart_pdf_editor/lib/src/region_replay_index.dart
+++ b/packages/dart_pdf_editor/lib/src/region_replay_index.dart
@@ -5,8 +5,8 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 /// Serialized-index format version. Producer and consumer are the same build,
-/// shipped together, so a mismatch is a programming error (asserted on read).
-const int _regionIndexFormatVersion = 1;
+/// shipped together; older cached indices are declined in every build mode.
+const int _regionIndexFormatVersion = 2;
 
 /// Region-index policy for worker detail transcripts.
 ///
@@ -17,14 +17,15 @@ const int _regionIndexFormatVersion = 1;
 /// ordinary linear/grid escalation without importing the Flutter-facing scene
 /// into worker code.
 const int pdfDetailRegionLinearMaxCommands = 250000;
+const int pdfDetailRegionGridMinCommands = 32768;
 const int pdfDetailRegionGridMaxCommands = 4000000;
 
 /// Bounded, painter-order-preserving index for retained region replay.
 ///
-/// Each entry is one independent paint operation plus a persistent snapshot
-/// of the clips and blend mode active at that point in the command stream.
-/// Transparency/soft-mask groups remain on the full-replay path: splitting a
-/// group would change its isolated compositing semantics.
+/// Each entry is an independent paint operation or a complete balanced
+/// compositing group, plus the clips and blend mode active at its entry.
+/// Group contents stay indivisible: selecting their full command range keeps
+/// nested transparency, knockout and soft-mask compositing in painter order.
 class PdfRegionReplayIndex {
   PdfRegionReplayIndex._({
     required this.supported,
@@ -47,32 +48,48 @@ class PdfRegionReplayIndex {
       );
     }
 
+    final safety = _ReplaySafety(maxStateDepth);
+    if (!safety.supports(commands)) {
+      return PdfRegionReplayIndex._(
+        supported: false,
+        units: const [],
+        clipNodeCount: 0,
+      );
+    }
+
     final units = <PdfRegionReplayUnit>[];
     final savedClips = <PdfRegionClipState?>[];
+    final groups = <_RegionGroupFrame>[];
     PdfRegionClipState? clips;
     var blendMode = PdfBlendMode.normal;
     var clipNodes = 0;
+
+    void addBounds(int start, int end, PdfRect? bounds,
+        PdfRegionClipState? entryClips, PdfBlendMode entryBlend) {
+      if (bounds == null) return;
+      if (groups.isNotEmpty) {
+        final group = groups.last;
+        group.bounds =
+            group.bounds == null ? bounds : _union(group.bounds!, bounds);
+        return;
+      }
+      units.add(PdfRegionReplayUnit(
+        commandIndex: start,
+        endCommandIndex: end,
+        bounds: bounds,
+        clips: entryClips,
+        blendMode: entryBlend,
+      ));
+    }
 
     for (var i = 0; i < commands.length; i++) {
       final command = commands[i];
       switch (command) {
         case PdfSaveCommand():
-          if (savedClips.length >= maxStateDepth) {
-            return PdfRegionReplayIndex._(
-              supported: false,
-              units: const [],
-              clipNodeCount: clipNodes,
-            );
-          }
           savedClips.add(clips);
         case PdfRestoreCommand():
-          if (savedClips.isEmpty) {
-            return PdfRegionReplayIndex._(
-              supported: false,
-              units: const [],
-              clipNodeCount: clipNodes,
-            );
-          }
+          // The safety pass rejects restores crossing a layer boundary.
+          // Canvas save/restore does not save the device's blend-mode field.
           clips = savedClips.removeLast();
         case PdfClipPathCommand(:final path):
           final bounds = pdfRenderPathBounds(path);
@@ -88,28 +105,29 @@ class PdfRegionReplayIndex {
           clipNodes++;
         case PdfSetBlendModeCommand(:final mode):
           blendMode = mode;
+        case PdfBeginGroupCommand() || PdfBeginSoftMaskedCommand():
+          groups.add(_RegionGroupFrame(i, clips, blendMode));
+          if (command is PdfBeginSoftMaskedCommand) {
+            blendMode = PdfBlendMode.normal;
+          }
+        case PdfEndGroupCommand() || PdfEndSoftMaskedCommand():
+          final group = groups.removeLast();
+          // Both layer kinds implicitly restore their entry canvas clip.
+          // Ordinary groups leave the device blend alone; soft masks restore
+          // the blend captured before their source was reset to Normal.
+          clips = group.clips;
+          if (command is PdfEndSoftMaskedCommand) {
+            blendMode = group.blendMode;
+          }
+          addBounds(group.commandIndex, i + 1, group.bounds, group.clips,
+              group.blendMode);
         case PdfSetOverprintCommand():
-          // Unlike blend mode, the region index does not yet snapshot the
-          // three overprint fields on each unit. Selective replay would lose
-          // that persistent device state, so keep these pages on the exact
-          // full-transcript fallback.
-          return PdfRegionReplayIndex._(
-            supported: false,
-            units: const [],
-            clipNodeCount: clipNodes,
-          );
-        case PdfBeginGroupCommand() ||
-              PdfEndGroupCommand() ||
-              PdfBeginSoftMaskedCommand() ||
-              PdfEndSoftMaskedCommand():
-          return PdfRegionReplayIndex._(
-            supported: false,
-            units: const [],
-            clipNodeCount: clipNodes,
-          );
+          // Declined recursively by the safety pass; units do not snapshot
+          // persistent overprint fields, including those in mask/cell lists.
+          throw StateError('Overprint passed region replay safety validation');
         default:
           if (clips?.empty ?? false) continue;
-          var bounds = pdfRenderCommandBounds(command);
+          var bounds = safety.commandBounds(command);
           if (bounds == null) continue;
           // Raster coverage and filtered image edges can extend just beyond
           // mathematical geometry. Two page points conservatively cover a
@@ -120,20 +138,11 @@ class PdfRegionReplayIndex {
             bounds = _intersection(bounds, clipBounds);
             if (bounds == null) continue;
           }
-          units.add(PdfRegionReplayUnit(
-            commandIndex: i,
-            bounds: bounds,
-            clips: clips,
-            blendMode: blendMode,
-          ));
+          // A group's allocation BBox is not a clip. Its bounds must include
+          // all source paint, even outside the BBox or painted mask geometry:
+          // /BC and /TR can reveal source where the mask itself never painted.
+          addBounds(i, i + 1, bounds, clips, blendMode);
       }
-    }
-    if (savedClips.isNotEmpty) {
-      return PdfRegionReplayIndex._(
-        supported: false,
-        units: const [],
-        clipNodeCount: clipNodes,
-      );
     }
     final unitList = List<PdfRegionReplayUnit>.unmodifiable(units);
     return PdfRegionReplayIndex._(
@@ -157,7 +166,15 @@ class PdfRegionReplayIndex {
   /// Conservative retained-index estimate. The command geometry itself is
   /// borrowed from the scene and is not counted twice.
   int get estimatedBytes =>
-      units.length * 48 + clipNodeCount * 40 + (grid?.estimatedBytes ?? 0);
+      units.length * 56 + clipNodeCount * 40 + (grid?.estimatedBytes ?? 0);
+
+  /// Largest indivisible top-level command range selected by a region query.
+  /// A large compositing group may remain useful for single-patch culling,
+  /// while repeating the whole range for every small tile would be expensive.
+  late final int maxAtomicCommandSpan = units.fold<int>(
+      0,
+      (largest, unit) =>
+          math.max(largest, unit.endCommandIndex - unit.commandIndex));
 
   /// Page-space X span [min, max] covered by the indexed paint units, or null
   /// when nothing is drawable. This is the axis an X-strip band decomposition
@@ -222,10 +239,10 @@ class PdfRegionReplayIndex {
         commands,
         device,
         start: unit.commandIndex,
-        end: unit.commandIndex + 1,
+        end: unit.endCommandIndex,
       );
       device.restore();
-      replayed++;
+      replayed += unit.endCommandIndex - unit.commandIndex;
     }
     return replayed;
   }
@@ -273,7 +290,8 @@ class PdfRegionReplayIndex {
   ) {
     if (!supported) return commands;
     final selected = select(region);
-    if (selected.isNotEmpty && selected.last.commandIndex >= commands.length) {
+    if (selected.isNotEmpty &&
+        selected.last.endCommandIndex > commands.length) {
       return commands;
     }
     final out = <PdfRenderCommand>[];
@@ -281,7 +299,7 @@ class PdfRegionReplayIndex {
       out.add(const PdfSaveCommand());
       out.add(PdfSetBlendModeCommand(unit.blendMode));
       unit.clips?.appendCommands(out);
-      out.add(commands[unit.commandIndex]);
+      out.addAll(commands.getRange(unit.commandIndex, unit.endCommandIndex));
       out.add(const PdfRestoreCommand());
       if (out.length >= commands.length) return commands;
     }
@@ -437,10 +455,10 @@ class PdfRegionReplayGrid {
         commands,
         device,
         start: unit.commandIndex,
-        end: unit.commandIndex + 1,
+        end: unit.endCommandIndex,
       );
       device.restore();
-      replayed++;
+      replayed += unit.endCommandIndex - unit.commandIndex;
     }
     return replayed;
   }
@@ -486,12 +504,16 @@ class PdfRegionReplayGrid {
 class PdfRegionReplayUnit {
   const PdfRegionReplayUnit({
     required this.commandIndex,
+    int? endCommandIndex,
     required this.bounds,
     required this.clips,
     required this.blendMode,
-  });
+  }) : endCommandIndex = endCommandIndex ?? commandIndex + 1;
 
   final int commandIndex;
+
+  /// Exclusive end of the indivisible paint/compositing command range.
+  final int endCommandIndex;
   final PdfRect bounds;
   final PdfRegionClipState? clips;
   final PdfBlendMode blendMode;
@@ -519,6 +541,170 @@ class PdfRegionClipState {
     parent?.appendCommands(commands);
     commands.add(command);
   }
+}
+
+class _RegionGroupFrame {
+  _RegionGroupFrame(this.commandIndex, this.clips, this.blendMode);
+
+  final int commandIndex;
+  final PdfRegionClipState? clips;
+  final PdfBlendMode blendMode;
+  PdfRect? bounds;
+}
+
+/// Validate each shared command list once before exposing independent ranges.
+/// In particular, a save outside a layer cannot be restored inside it: canvas
+/// restores share one stack, while group bookkeeping uses a separate stack.
+/// Mask/cell lists are checked too, even though their paint stays indivisible.
+class _ReplaySafety {
+  _ReplaySafety(this.maxStateDepth);
+
+  final int maxStateDepth;
+  final _summaries = Map<List<PdfRenderCommand>,
+      Map<PdfBlendMode, _ReplaySafetySummary?>>.identity();
+  final _visiting = Set<List<PdfRenderCommand>>.identity();
+  final _bounds = Map<List<PdfRenderCommand>, PdfRect?>.identity();
+
+  bool supports(List<PdfRenderCommand> commands) =>
+      _summarize(commands, PdfBlendMode.normal) != null;
+
+  _ReplaySafetySummary? _summarize(
+      List<PdfRenderCommand> commands, PdfBlendMode incomingBlend) {
+    final modes = _summaries.putIfAbsent(commands, () => {});
+    if (modes.containsKey(incomingBlend)) return modes[incomingBlend];
+    // Shared lists are ordinary; cycles and excessive nested-list recursion
+    // are not. Decline before recursing so malformed input cannot overflow.
+    if (_visiting.length > maxStateDepth || !_visiting.add(commands)) {
+      return null;
+    }
+    final summary = _scan(commands, incomingBlend);
+    _visiting.remove(commands);
+    modes[incomingBlend] = summary;
+    return summary;
+  }
+
+  _ReplaySafetySummary? _scan(
+      List<PdfRenderCommand> commands, PdfBlendMode incomingBlend) {
+    final savedClips = <bool>[];
+    final groups = <_ReplaySafetyFrame>[];
+    var clipped = false;
+    // Canvas save/restore does not restore device blend, but the interpreter
+    // can emit an explicit reset after q/Q. That is safe when it matches the
+    // actual incoming mode. A shared cell may be used in several modes, so
+    // summaries include that context instead of rejecting every explicit reset.
+    var blend = incomingBlend;
+    var depth = 0;
+
+    bool includeNested(_ReplaySafetySummary? child) {
+      if (child == null) return false;
+      depth = math.max(
+          depth, savedClips.length + groups.length + 1 + child.maxDepth);
+      return depth <= maxStateDepth;
+    }
+
+    for (final command in commands) {
+      switch (command) {
+        case PdfSaveCommand():
+          savedClips.add(clipped);
+        case PdfRestoreCommand():
+          if (savedClips.isEmpty ||
+              (groups.isNotEmpty &&
+                  savedClips.length <= groups.last.saveDepth)) {
+            return null;
+          }
+          clipped = savedClips.removeLast();
+        case PdfClipPathCommand():
+          clipped = true;
+        case PdfSetBlendModeCommand(:final mode):
+          blend = mode;
+        case PdfSetOverprintCommand():
+          return null;
+        case PdfBeginGroupCommand(:final isolated, :final backdropColor):
+          // Seeded non-isolated groups clip before saving their layer and
+          // replace its backdrop. Even without a BBox here, a seed can pass
+          // through a knockout parent to a bounded child, so decline it.
+          if (!isolated && backdropColor != null) return null;
+          groups.add(
+              _ReplaySafetyFrame(false, savedClips.length, clipped, blend));
+        case PdfBeginSoftMaskedCommand():
+          groups
+              .add(_ReplaySafetyFrame(true, savedClips.length, clipped, blend));
+          blend = PdfBlendMode.normal;
+        case PdfEndGroupCommand() || PdfEndSoftMaskedCommand():
+          final masked = command is PdfEndSoftMaskedCommand;
+          if (groups.isEmpty ||
+              groups.last.masked != masked ||
+              savedClips.length != groups.last.saveDepth) {
+            return null;
+          }
+          if (command is PdfEndSoftMaskedCommand &&
+              !includeNested(
+                  _summarize(command.maskCommands, PdfBlendMode.normal))) {
+            return null;
+          }
+          final group = groups.removeLast();
+          clipped = group.clipped;
+          if (masked) blend = group.blend;
+        case PdfDrawTiledCellCommand(
+            :final cellCommands,
+            :final originsX,
+            :final originsY
+          ):
+          if (originsX.length != originsY.length) return null;
+          final cell = _summarize(cellCommands, blend);
+          if (!includeNested(cell)) return null;
+          // Canvas may expand cells directly into the parent device when a
+          // blend/knockout is active. Only cells whose state cannot escape
+          // are independent paint units in both replay paths.
+          if (cell!.clipped || cell.blend != blend) return null;
+        default:
+          break;
+      }
+      depth = math.max(depth, savedClips.length + groups.length);
+      if (depth > maxStateDepth) return null;
+    }
+    if (savedClips.isNotEmpty || groups.isNotEmpty) return null;
+    return _ReplaySafetySummary(depth, clipped, blend);
+  }
+
+  PdfRect? commandBounds(PdfRenderCommand command) {
+    if (command is! PdfDrawTiledCellCommand) {
+      return pdfRenderCommandBounds(command);
+    }
+    final cell = _listBounds(command.cellCommands);
+    return _tiledCellBounds(command, cell);
+  }
+
+  PdfRect? _listBounds(List<PdfRenderCommand> commands) {
+    if (_bounds.containsKey(commands)) return _bounds[commands];
+    PdfRect? bounds;
+    for (final command in commands) {
+      // Mask geometry does not bound source coverage: /BC or /TR can reveal
+      // the source beyond it. Group allocation hints are not clips either.
+      final next = commandBounds(command);
+      if (next != null) bounds = bounds == null ? next : _union(bounds, next);
+    }
+    _bounds[commands] = bounds;
+    return bounds;
+  }
+}
+
+class _ReplaySafetyFrame {
+  const _ReplaySafetyFrame(
+      this.masked, this.saveDepth, this.clipped, this.blend);
+
+  final bool masked;
+  final int saveDepth;
+  final bool clipped;
+  final PdfBlendMode blend;
+}
+
+class _ReplaySafetySummary {
+  const _ReplaySafetySummary(this.maxDepth, this.clipped, this.blend);
+
+  final int maxDepth;
+  final bool clipped;
+  final PdfBlendMode blend;
 }
 
 PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
@@ -554,11 +740,7 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
       return bounds;
     case PdfDrawImageCommand(:final request):
       return _matrixBounds(request.transform, 0, 0, 1, 1);
-    case PdfDrawTiledCellCommand(
-        :final cellCommands,
-        :final originsX,
-        :final originsY
-      ):
+    case PdfDrawTiledCellCommand(:final cellCommands):
       // Conservative: the cell's painted bounds (clip commands inside the
       // cell contribute nothing, so overrunning content is included - safe
       // for culling) swept across the origin extent. One rect for the whole
@@ -568,17 +750,7 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
         final b = pdfRenderCommandBounds(c);
         if (b != null) cell = cell == null ? b : _union(cell, b);
       }
-      if (cell == null || originsX.isEmpty) return null;
-      var minX = originsX[0], maxX = originsX[0];
-      var minY = originsY[0], maxY = originsY[0];
-      for (var t = 1; t < originsX.length; t++) {
-        minX = math.min(minX, originsX[t]);
-        maxX = math.max(maxX, originsX[t]);
-        minY = math.min(minY, originsY[t]);
-        maxY = math.max(maxY, originsY[t]);
-      }
-      return PdfRect(cell.left + minX, cell.bottom + minY, cell.right + maxX,
-          cell.top + maxY);
+      return _tiledCellBounds(command, cell);
     case PdfSaveCommand() ||
           PdfRestoreCommand() ||
           PdfClipPathCommand() ||
@@ -590,6 +762,22 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
           PdfEndSoftMaskedCommand():
       return null;
   }
+}
+
+PdfRect? _tiledCellBounds(PdfDrawTiledCellCommand command, PdfRect? cell) {
+  final originsX = command.originsX;
+  final originsY = command.originsY;
+  if (cell == null || originsX.isEmpty) return null;
+  var minX = originsX[0], maxX = originsX[0];
+  var minY = originsY[0], maxY = originsY[0];
+  for (var t = 1; t < originsX.length; t++) {
+    minX = math.min(minX, originsX[t]);
+    maxX = math.max(maxX, originsX[t]);
+    minY = math.min(minY, originsY[t]);
+    maxY = math.max(maxY, originsY[t]);
+  }
+  return PdfRect(
+      cell.left + minX, cell.bottom + minY, cell.right + maxX, cell.top + maxY);
 }
 
 PdfRect? _textBounds(PdfTextRun run) {
@@ -735,8 +923,8 @@ bool pdfRenderRectsIntersect(PdfRect a, PdfRect b) =>
 
 /// Serializes [index] to a portable byte buffer, or returns null when it holds
 /// content the codec declines (a clip path that fails to serialize — never in
-/// practice, clip paths carry no images). An unsupported index (a
-/// transparency/soft-mask group spanned the page, or the build hit its bounds)
+/// practice, clip paths carry no images). An unsupported index (unsafe
+/// persistent state or malformed groups, or a build that hit its bounds)
 /// serializes to a tiny "unsupported" marker so the consumer learns the worker
 /// examined the page and it is not region-cullable.
 Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
@@ -783,6 +971,7 @@ Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
   for (var i = 0; i < index.units.length; i++) {
     final unit = index.units[i];
     w.u32(unit.commandIndex);
+    w.u32(unit.endCommandIndex);
     _idxWriteRect(w, unit.bounds);
     w.i32(unitClipIndices[i]);
     w.u8(unit.blendMode.index);
@@ -810,8 +999,9 @@ Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
 PdfRegionReplayIndex deserializeRegionReplayIndex(Uint8List bytes) {
   final r = _IdxReader(bytes);
   final version = r.u8();
-  assert(version == _regionIndexFormatVersion,
-      'region index format version mismatch');
+  if (version != _regionIndexFormatVersion) {
+    throw const FormatException('Region index format version mismatch');
+  }
   final supported = r.boolean();
   final clipNodeCount = r.u32();
   if (!supported) {
@@ -845,11 +1035,16 @@ PdfRegionReplayIndex deserializeRegionReplayIndex(Uint8List bytes) {
   final unitCount = r.u32();
   final units = List<PdfRegionReplayUnit>.generate(unitCount, (_) {
     final commandIndex = r.u32();
+    final endCommandIndex = r.u32();
+    if (endCommandIndex <= commandIndex) {
+      throw const FormatException('Invalid region replay command range');
+    }
     final bounds = _idxReadRect(r);
     final clipIndex = r.i32();
     final blendMode = PdfBlendMode.values[r.u8()];
     return PdfRegionReplayUnit(
       commandIndex: commandIndex,
+      endCommandIndex: endCommandIndex,
       bounds: bounds,
       clips: clipIndex < 0 ? null : nodes[clipIndex],
       blendMode: blendMode,

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -45,9 +45,9 @@ class PdfWorkerTranscript {
 
   /// Selects a compact, document-backed transcript for one detail region.
   List<PdfRenderCommand> commandsForDetail(PdfRect region) {
-    final buildGrid = wireCommands.length > pdfDetailRegionLinearMaxCommands;
+    final buildGrid = wireCommands.length >= pdfDetailRegionGridMinCommands;
     final index = regionIndex(
-      maxCommands: buildGrid
+      maxCommands: wireCommands.length > pdfDetailRegionLinearMaxCommands
           ? pdfDetailRegionGridMaxCommands
           : pdfDetailRegionLinearMaxCommands,
       buildGrid: buildGrid,

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -172,16 +172,12 @@ class PdfRetainedScene {
   /// a huge unit count would cost O(N) per tile.
   static int spatialRegionReplayMaxCommands = 250000;
 
-  /// Escalate to a uniform-grid spatial index for transcripts ABOVE the linear
-  /// [spatialRegionReplayMaxCommands] ceiling, up to [spatialGridReplayMaxCommands].
-  ///
-  /// Below the linear ceiling nothing changes: the flat per-op scan is cheap
-  /// enough. Above it, the historical behaviour was to give up on culling and
-  /// full-replay the whole transcript into every tile — catastrophic on a dense
-  /// CAD page (a 256px tile replaying ~850k commands, ~260ms, on the UI
-  /// isolate). The grid makes region replay O(candidates) instead, so those
-  /// pages become pannable. On by default because it only ever REPLACES the
-  /// full-transcript fallback — it never changes a page that already culled.
+  /// Use a uniform-grid spatial index on dense transcripts, starting at
+  /// [pdfDetailRegionGridMinCommands]. It avoids scanning every paint for tiny
+  /// high-zoom tiles. Above [spatialRegionReplayMaxCommands], the grid also
+  /// extends the supported transcript size to [spatialGridReplayMaxCommands].
+  /// Turning this off retains the linear index below its ceiling and full
+  /// replay above it.
   static bool spatialGridReplay = true;
   static int spatialGridReplayMaxCommands = 4000000;
 
@@ -242,11 +238,60 @@ class PdfRetainedScene {
   }
 
   /// Whether region rasters ([rasterizeRegion]) can be spatially culled to the
-  /// requested bounds rather than replaying the whole transcript. False when a
-  /// transparency group or soft mask spans the page (splitting one would change
-  /// its isolated compositing) - the [PdfTileStore] tile path leaves such pages
-  /// on the legacy full-page raster to avoid per-tile full-transcript replays.
+  /// requested bounds rather than replaying the whole transcript. Balanced
+  /// compositing groups remain atomic. Unsupported state stays on the legacy
+  /// detail path to avoid per-tile full-transcript replays.
   bool get supportsRegionRaster => _ensureRegionIndex().supported;
+
+  /// Whether small cached tiles can replay this scene without repeatedly
+  /// walking a large indivisible compositing group. Such groups can still use
+  /// selective [rasterizeRegion] for one viewport-sized detail patch. The
+  /// per-group budget includes nested masks and repeated tiled-cell work.
+  bool get supportsTiledRegionRaster {
+    final index = _ensureRegionIndex();
+    if (!index.supported) return false;
+    return _atomicGroupsFitTileBudget ??= _checkAtomicTileBudget(index);
+  }
+
+  bool? _atomicGroupsFitTileBudget;
+  static const _maxAtomicTileCommands = 1024;
+
+  bool _checkAtomicTileBudget(PdfRegionReplayIndex index) {
+    if (index.maxAtomicCommandSpan > _maxAtomicTileCommands) return false;
+    final nestedCosts = Map<List<PdfRenderCommand>, int>.identity();
+    late int Function(PdfRenderCommand command) commandCost;
+    int listCost(List<PdfRenderCommand> commands) =>
+        nestedCosts.putIfAbsent(commands, () {
+          var cost = 0;
+          for (final command in commands) {
+            cost += commandCost(command);
+            if (cost > _maxAtomicTileCommands) break;
+          }
+          return cost;
+        });
+    commandCost = (command) => switch (command) {
+          PdfEndSoftMaskedCommand(:final maskCommands) =>
+            1 + listCost(maskCommands),
+          PdfDrawTiledCellCommand(:final cellCommands, :final originsX) =>
+            originsX.isEmpty
+                ? 1
+                : 1 +
+                    math.min(_maxAtomicTileCommands + 1,
+                        originsX.length * math.max(1, listCost(cellCommands))),
+          _ => 1,
+        };
+    for (final unit in index.units) {
+      // Only compositing ranges gain tile eligibility here; ordinary paint
+      // units (including single tiled cells) keep their existing policy.
+      if (unit.endCommandIndex == unit.commandIndex + 1) continue;
+      var cost = 0;
+      for (var i = unit.commandIndex; i < unit.endCommandIndex; i++) {
+        cost += commandCost(commands[i]);
+        if (cost > _maxAtomicTileCommands) return false;
+      }
+    }
+    return true;
+  }
 
   /// Approximate bytes of the decoded images this scene retains for replay
   /// (RGBA, width*height*4). Counted against the live-raster budget (#405): a
@@ -737,11 +782,10 @@ class PdfRetainedScene {
   ///
   /// [rasterRegion] uses the same page-point, y-down space as
   /// [rasterizeRegion]. Each returned unit carries its command index plus the
-  /// clip and blend state active at that command. Null means the scene cannot
-  /// be split safely (for example, it contains an isolated group or soft
-  /// mask), so a backend must decline the scene and let the Canvas fallback
-  /// render it whole. An empty list means the supported region is genuinely
-  /// blank.
+  /// clip and blend state active at that command. A group is a complete command
+  /// range and must remain indivisible. Null means the scene cannot be indexed
+  /// safely, so a backend must decline it and use full replay. An empty list
+  /// means the supported region is genuinely blank.
   List<PdfRegionReplayUnit>? selectRegion(Rect rasterRegion) {
     assert(!_disposed, 'selectRegion after dispose');
     final index = _ensureRegionIndex();
@@ -752,18 +796,20 @@ class PdfRetainedScene {
   }
 
   /// The `(maxCommands, buildGrid)` the region index builds under for this
-  /// transcript, given the current escalation policy. Below the linear ceiling:
-  /// the flat per-op scan (unchanged). Above it: escalate to the grid rather
-  /// than falling back to full-transcript replay. Shared by the in-isolate
+  /// transcript, given the current escalation policy. Dense transcripts use
+  /// the grid before reaching the linear retention ceiling: at extreme zoom a
+  /// tile covers only a few page points, so scanning tens of thousands of units
+  /// per tile wastes most of the query work. Shared by the in-isolate
   /// build ([_ensureRegionIndex]) and the worker request ([warmRegionIndex]) so
   /// both bin the transcript identically — the worker re-records a byte-for-byte
   /// identical transcript, so the same parameters produce an index whose unit
   /// indices line up with this scene's [commands].
   ({int maxCommands, bool buildGrid}) get _regionIndexBuildParams {
     final overLinear = commands.length > spatialRegionReplayMaxCommands;
-    final useGrid = spatialGridReplay && overLinear;
+    final useGrid = spatialGridReplay &&
+        (overLinear || commands.length >= pdfDetailRegionGridMinCommands);
     return (
-      maxCommands: useGrid
+      maxCommands: overLinear && useGrid
           ? spatialGridReplayMaxCommands
           : spatialRegionReplayMaxCommands,
       buildGrid: useGrid,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1179,7 +1179,19 @@ class PdfShellZoomControl extends StatefulWidget {
 }
 
 class _PdfShellZoomControlState extends State<PdfShellZoomControl> {
-  static const List<double> _presets = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+  static const List<double> _presets = [
+    0.5,
+    0.75,
+    1,
+    1.25,
+    1.5,
+    2,
+    3,
+    4,
+    30,
+    50,
+    100,
+  ];
 
   @override
   void initState() {

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -77,7 +77,7 @@ class PdfTileZoomLadder {
   const PdfTileZoomLadder({
     this.stepsPerOctave = 2,
     this.minRung = -8,
-    this.maxRung = 16,
+    this.maxRung = 18,
   })  : assert(stepsPerOctave >= 1),
         assert(minRung <= 0 && maxRung >= 0);
 
@@ -87,6 +87,9 @@ class PdfTileZoomLadder {
   /// Clamp bounds so a degenerate desired ratio can't select an absurd bucket
   /// (ratio floor 0.05 / a huge accidental zoom). minRung ratio ≈ 2^(min/steps).
   final int minRung;
+
+  /// Highest resolution bucket. The default is 512 physical pixels per PDF
+  /// point, keeping a 10000% view sharp at device pixel ratios up to 5.
   final int maxRung;
 
   /// The rung whose ratio is nearest [ratio] (in log space), clamped.

--- a/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
@@ -1,0 +1,269 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+PdfPath _rect(double l, double b, double r, double t) => PdfPath([
+      PdfMoveTo(l, b),
+      PdfLineTo(r, b),
+      PdfLineTo(r, t),
+      PdfLineTo(l, t),
+      const PdfClosePath(),
+    ]);
+
+PdfFillPathCommand _fill(double l, double b, double r, double t,
+        [PdfColor color = const PdfColor(1, 0, 0)]) =>
+    PdfFillPathCommand(_rect(l, b, r, t), color, PdfFillRule.nonzero, 1);
+
+const _maskEnd = PdfEndSoftMaskedCommand(
+  luminosity: false,
+  backdrop: PdfRect(0, 0, 612, 792),
+  maskCommands: [],
+  transferScale: 0,
+  transferOffset: 1,
+);
+
+void main() {
+  test('selects complete groups and source outside a transferred soft mask',
+      () {
+    final commands = <PdfRenderCommand>[
+      _fill(300, 300, 320, 320),
+      const PdfBeginGroupCommand(.7,
+          isolated: true, bounds: PdfRect(0, 0, 1, 1)),
+      const PdfBeginSoftMaskedCommand(),
+      _fill(40, 40, 70, 70),
+      _maskEnd,
+      const PdfEndGroupCommand(),
+      _fill(400, 400, 420, 420),
+    ];
+    for (final grid in [false, true]) {
+      final index = PdfRegionReplayIndex.build(commands,
+          maxCommands: 100, buildGrid: grid);
+      expect(index.supported, isTrue);
+      final selected = index.select(const PdfRect(60, 60, 65, 65));
+      expect(selected, hasLength(1));
+      expect(selected.single.commandIndex, 1);
+      expect(selected.single.endCommandIndex, 6);
+      // The allocation hint and empty mask never bound the visible source.
+      expect(selected.single.bounds.left, lessThanOrEqualTo(40));
+      expect(selected.single.bounds.right, greaterThanOrEqualTo(70));
+      expect(index.select(const PdfRect(200, 200, 210, 210)), isEmpty);
+      final restored =
+          deserializeRegionReplayIndex(serializeRegionReplayIndex(index)!);
+      expect(
+          restored.select(const PdfRect(60, 60, 65, 65)).single.endCommandIndex,
+          6);
+    }
+  });
+
+  test('groups restore clips; only soft masks restore their entry blend', () {
+    final commands = <PdfRenderCommand>[
+      const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+      const PdfBeginGroupCommand(.5, isolated: true),
+      PdfClipPathCommand(_rect(10, 10, 20, 20), PdfFillRule.nonzero),
+      _fill(10, 10, 20, 20),
+      const PdfSetBlendModeCommand(PdfBlendMode.screen),
+      const PdfEndGroupCommand(),
+      _fill(100, 100, 120, 120),
+      const PdfBeginSoftMaskedCommand(),
+      const PdfSetBlendModeCommand(PdfBlendMode.darken),
+      _fill(150, 150, 170, 170),
+      _maskEnd,
+      _fill(200, 200, 220, 220),
+    ];
+    final index = PdfRegionReplayIndex.build(commands, maxCommands: 100);
+    expect(index.supported, isTrue);
+    final afterGroup = index.select(const PdfRect(105, 105, 110, 110)).single;
+    expect(afterGroup.clips, isNull);
+    expect(afterGroup.blendMode, PdfBlendMode.screen);
+    final afterMask = index.select(const PdfRect(205, 205, 210, 210)).single;
+    expect(afterMask.blendMode, PdfBlendMode.screen);
+  });
+
+  test('unsafe compositing and state crossings retain full-replay fallback',
+      () {
+    const begin = PdfBeginGroupCommand(1, isolated: true);
+    const end = PdfEndGroupCommand();
+    const save = PdfSaveCommand();
+    const restore = PdfRestoreCommand();
+    const overprint =
+        PdfSetOverprintCommand(fill: true, stroke: false, mode: 1);
+    final unsafe = <List<PdfRenderCommand>>[
+      [begin, _fill(0, 0, 10, 10)],
+      [end],
+      [begin, _maskEnd],
+      [const PdfBeginSoftMaskedCommand(), end],
+      [save, begin, restore, end],
+      [begin, save, end, restore],
+      [begin, overprint, _fill(0, 0, 10, 10), end],
+      [const PdfBeginGroupCommand(1, backdropColor: PdfColor(1, 1, 1)), end],
+      [
+        const PdfBeginSoftMaskedCommand(),
+        _fill(0, 0, 10, 10),
+        const PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: PdfRect(0, 0, 10, 10),
+            maskCommands: [overprint])
+      ],
+      [
+        PdfDrawTiledCellCommand([begin, overprint, end],
+            Float64List.fromList([0]), Float64List.fromList([0]))
+      ],
+    ];
+    for (var i = 0; i < unsafe.length; i++) {
+      final index = PdfRegionReplayIndex.build(unsafe[i], maxCommands: 100);
+      expect(index.supported, isFalse, reason: 'unsafe case $i');
+      expect(index.commandsForRegion(const PdfRect(0, 0, 10, 10), unsafe[i]),
+          same(unsafe[i]));
+    }
+    expect(
+        PdfRegionReplayIndex.build([begin, begin, end, end],
+                maxCommands: 100, maxStateDepth: 1)
+            .supported,
+        isFalse);
+  });
+
+  test('shared cells preserve the blend mode of each invocation', () {
+    const normal = PdfSetBlendModeCommand(PdfBlendMode.normal);
+    const multiply = PdfSetBlendModeCommand(PdfBlendMode.multiply);
+    const screen = PdfSetBlendModeCommand(PdfBlendMode.screen);
+    PdfDrawTiledCellCommand cell(List<PdfRenderCommand> commands) =>
+        PdfDrawTiledCellCommand(
+            commands, Float64List.fromList([0]), Float64List.fromList([0]));
+    final resetNormal = cell([multiply, _fill(0, 0, 10, 10), normal]);
+    final cases = <(List<PdfRenderCommand>, bool)>[
+      ([resetNormal], true),
+      (
+        [
+          multiply,
+          cell([screen, _fill(0, 0, 10, 10), multiply])
+        ],
+        true
+      ),
+      (
+        [
+          cell([multiply, _fill(0, 0, 10, 10)])
+        ],
+        false
+      ),
+      // An identity-only safety cache would accept the second invocation.
+      ([resetNormal, multiply, resetNormal], false),
+      (
+        [
+          cell([PdfClipPathCommand(_rect(0, 0, 10, 10), PdfFillRule.nonzero)])
+        ],
+        false
+      ),
+      (
+        [
+          multiply,
+          const PdfBeginSoftMaskedCommand(),
+          resetNormal,
+          PdfEndSoftMaskedCommand(
+              luminosity: false,
+              backdrop: const PdfRect(0, 0, 10, 10),
+              maskCommands: [resetNormal])
+        ],
+        true
+      ),
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      expect(
+          PdfRegionReplayIndex.build(cases[i].$1, maxCommands: 100).supported,
+          cases[i].$2,
+          reason: 'cell context $i');
+    }
+  });
+
+  testWidgets('nested masks, knockout and clips retain exact high-zoom pixels',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[
+        _fill(0, 0, 612, 792, const PdfColor(.7, .85, 1)),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(40, 700, 100, 760), PdfFillRule.nonzero),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(.7, isolated: true, knockout: true),
+        _fill(45, 715, 80, 750),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(50, 720, 75, 747), PdfFillRule.nonzero),
+        const PdfBeginSoftMaskedCommand(),
+        _fill(53, 722, 78, 748, const PdfColor(0, 1, 0)),
+        const PdfBeginGroupCommand(.5, isolated: true),
+        _fill(57, 728, 70, 746, const PdfColor(0, 0, 1)),
+        const PdfEndGroupCommand(),
+        PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: const PdfRect(0, 0, 612, 792),
+            maskCommands: [_fill(56, 726, 62, 731, const PdfColor(1, 1, 1))],
+            transferScale: .65,
+            transferOffset: .35),
+        const PdfRestoreCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.screen),
+        const PdfEndGroupCommand(),
+        const PdfRestoreCommand(),
+        _fill(85, 725, 95, 740, const PdfColor(1, 0, 1)),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        _fill(300, 300, 320, 320),
+        _fill(400, 400, 420, 420),
+        for (var i = 0; i < 32; i++)
+          _fill(300 + i * 3.0, 300, 301 + i * 3.0, 301),
+      ];
+      for (final useGrid in [false, true]) {
+        final index = deserializeRegionReplayIndex(serializeRegionReplayIndex(
+            PdfRegionReplayIndex.build(commands,
+                maxCommands: 100, buildGrid: useGrid))!);
+        expect(index.supported, isTrue);
+        for (final ratio in [30.0, 100.0]) {
+          for (final region in [
+            const ui.Rect.fromLTWH(50.137, 45.271, 12, 9),
+            const ui.Rect.fromLTWH(60.129, 61.331, 12, 9),
+            const ui.Rect.fromLTWH(84.137, 52.271, 12, 9),
+          ]) {
+            final pageRegion = PdfRect(region.left, 792 - region.bottom,
+                region.right, 792 - region.top);
+            final source = await _raster(page, commands, region, ratio);
+            final selected = index.commandsForRegion(pageRegion, commands);
+            expect(selected.length, lessThan(commands.length));
+            final actual = await _raster(page, selected, region, ratio);
+            try {
+              expect(await _pixels(actual), await _pixels(source),
+                  reason: 'grid=$useGrid ratio=$ratio region=$region');
+            } finally {
+              source.dispose();
+              actual.dispose();
+            }
+          }
+        }
+      }
+    });
+  });
+}
+
+Future<ui.Image> _raster(PdfPage page, List<PdfRenderCommand> commands,
+    ui.Rect region, double ratio) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..scale(ratio)
+    ..translate(-region.left, -region.top);
+  PdfPageRenderer.preparePageCanvas(canvas, page, const PdfPageRenderPlan());
+  replayCommands(commands, CanvasPdfDevice(canvas, images: const {}));
+  final picture = recorder.endRecording();
+  try {
+    return await picture.toImage(
+        (region.width * ratio).ceil(), (region.height * ratio).ceil());
+  } finally {
+    picture.dispose();
+  }
+}
+
+Future<Uint8List> _pixels(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();

--- a/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
@@ -6,7 +6,8 @@ import 'package:dart_pdf_editor/src/region_replay_index.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 PdfPath _rect(double l, double b, double r, double t) => PdfPath([
       PdfMoveTo(l, b),
@@ -183,7 +184,7 @@ void main() {
   testWidgets('nested masks, knockout and clips retain exact high-zoom pixels',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       final commands = <PdfRenderCommand>[
         _fill(0, 0, 612, 792, const PdfColor(.7, .85, 1)),
         const PdfSaveCommand(),

--- a/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
@@ -6,7 +6,8 @@ import 'package:dart_pdf_editor/src/region_replay_index.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 const _paint = PdfFillPathCommand(
     PdfPath([
@@ -38,7 +39,7 @@ void main() {
   testWidgets('large groups keep selective patches without enabling tiles',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       for (final (paints, tiled) in [(40, true), (1022, true), (1023, false)]) {
         final scene = await PdfRetainedScene.fromCommands(page, _group(paints),
             includeImages: false);
@@ -66,7 +67,7 @@ void main() {
   testWidgets('tile budget counts nested mask and cell commands',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       final mask = List<PdfRenderCommand>.filled(1024, _paint);
       final cases = <List<PdfRenderCommand>>[
         [

--- a/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
@@ -1,0 +1,108 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+const _paint = PdfFillPathCommand(
+    PdfPath([
+      PdfMoveTo(10, 10),
+      PdfLineTo(20, 10),
+      PdfLineTo(20, 20),
+      PdfLineTo(10, 20),
+      PdfClosePath(),
+    ]),
+    PdfColor(1, 0, 0),
+    PdfFillRule.nonzero,
+    1);
+
+List<PdfRenderCommand> _group(int paints) => [
+      const PdfBeginGroupCommand(1, isolated: true),
+      for (var i = 0; i < paints; i++) _paint,
+      const PdfEndGroupCommand(),
+    ];
+
+void main() {
+  test('atomic span survives the worker index codec', () {
+    final index = PdfRegionReplayIndex.build(_group(1023), maxCommands: 2000);
+    expect(index.maxAtomicCommandSpan, 1025);
+    final restored =
+        deserializeRegionReplayIndex(serializeRegionReplayIndex(index)!);
+    expect(restored.maxAtomicCommandSpan, 1025);
+  });
+
+  testWidgets('large groups keep selective patches without enabling tiles',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      for (final (paints, tiled) in [(40, true), (1022, true), (1023, false)]) {
+        final scene = await PdfRetainedScene.fromCommands(page, _group(paints),
+            includeImages: false);
+        try {
+          expect(scene.supportsRegionRaster, isTrue);
+          expect(scene.supportsTiledRegionRaster, tiled,
+              reason: '$paints paints in one indivisible group');
+          final selected =
+              scene.selectRegion(const ui.Rect.fromLTWH(12, 774, 2, 2));
+          expect(selected, hasLength(1));
+          expect(selected!.single.endCommandIndex, paints + 2);
+          expect(scene.selectRegion(const ui.Rect.fromLTWH(100, 100, 10, 10)),
+              isEmpty,
+              reason: 'single-patch culling remains available');
+          scene.dropRegionIndex();
+          expect(scene.supportsTiledRegionRaster, tiled,
+              reason: 'memory-pressure rebuild keeps the same tile verdict');
+        } finally {
+          scene.dispose();
+        }
+      }
+    });
+  });
+
+  testWidgets('tile budget counts nested mask and cell commands',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final mask = List<PdfRenderCommand>.filled(1024, _paint);
+      final cases = <List<PdfRenderCommand>>[
+        [
+          const PdfBeginSoftMaskedCommand(),
+          _paint,
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: const PdfRect(0, 0, 612, 792),
+            maskCommands: mask,
+          ),
+        ],
+        [
+          const PdfBeginGroupCommand(1, isolated: true),
+          PdfDrawTiledCellCommand(
+              mask, Float64List.fromList([0]), Float64List.fromList([0])),
+          const PdfEndGroupCommand(),
+        ],
+        [
+          const PdfBeginGroupCommand(1, isolated: true),
+          PdfDrawTiledCellCommand(
+              const [_paint], Float64List(1024), Float64List(1024)),
+          const PdfEndGroupCommand(),
+        ],
+      ];
+      for (final commands in cases) {
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            includeImages: false);
+        try {
+          expect(scene.commands, hasLength(3));
+          expect(scene.supportsRegionRaster, isTrue);
+          expect(scene.supportsTiledRegionRaster, isFalse,
+              reason: 'nested work must not hide behind a three-slot range');
+        } finally {
+          scene.dispose();
+        }
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/banded_transcript_test.dart
+++ b/packages/dart_pdf_editor/test/banded_transcript_test.dart
@@ -113,10 +113,23 @@ PdfRect _pageSpaceRegion(PdfPage page, PdfPageRenderPlan plan, Rect region) {
 }
 
 void main() {
+  test('bands decline atomic groups instead of retaining only their opener',
+      () {
+    final commands = <PdfRenderCommand>[
+      const PdfBeginGroupCommand(.5, isolated: true),
+      _box(0, 400, 80, 480, const PdfColor(1, 0, 0)),
+      const PdfEndGroupCommand(),
+    ];
+    final index = PdfRegionReplayIndex.build(commands, maxCommands: 100);
+    expect(index.supported, isTrue);
+    expect(PdfBandedTranscript.build(commands, bandCount: 2, index: index),
+        isNull);
+  });
+
   testWidgets('bands partition the transcript along the X pan axis',
       (tester) async {
-    final index = PdfRegionReplayIndex.build(_wideTranscript(),
-        maxCommands: 1 << 20);
+    final index =
+        PdfRegionReplayIndex.build(_wideTranscript(), maxCommands: 1 << 20);
     expect(index.supported, isTrue);
 
     // 10 strips over the 0..1000 X extent. The histogram counts each unit once
@@ -131,8 +144,7 @@ void main() {
     expect(bands.residentBandCount, 10);
     // The wide stroke is retained by every strip it spans, so summed strip
     // lengths exceed the distinct unit count - but the byte estimate dedupes.
-    final summedUnits =
-        bands.bands.fold<int>(0, (n, b) => n + b.unitCount);
+    final summedUnits = bands.bands.fold<int>(0, (n, b) => n + b.unitCount);
     expect(summedUnits, greaterThan(index.units.length));
   });
 
@@ -141,8 +153,8 @@ void main() {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final commands = _wideTranscript();
-      final scene =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: false);
+      final scene = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: false);
       addTearDown(scene.dispose);
       final bands = PdfBandedTranscript.build(commands, bandCount: 10)!;
 
@@ -178,7 +190,8 @@ void main() {
         reason: 'evicting offscreen strips must lower retained bytes');
 
     // A viewport that pans into an evicted strip is reported as incomplete.
-    final missing = bands.missingBandsForRegion(const PdfRect(600, 0, 900, 1000));
+    final missing =
+        bands.missingBandsForRegion(const PdfRect(600, 0, 900, 1000));
     expect(missing, isNotEmpty);
   });
 
@@ -187,8 +200,8 @@ void main() {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final commands = _wideTranscript();
-      final scene =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: false);
+      final scene = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: false);
       addTearDown(scene.dispose);
       final size = const PdfPageRenderPlan().pageSize(page);
 
@@ -250,7 +263,8 @@ void main() {
     expect(bands.residentBandCount, 0);
     expect(bands.estimatedResidentBytes, 0);
     // Every strip the page covers is now missing.
-    expect(bands.missingBandsForRegion(PdfRect(bands.xMin, 0, bands.xMax, 1000)),
+    expect(
+        bands.missingBandsForRegion(PdfRect(bands.xMin, 0, bands.xMax, 1000)),
         isNotEmpty);
   });
 
@@ -285,8 +299,7 @@ void main() {
       (tester) async {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
-      final scene = await PdfRetainedScene.fromCommands(
-          page, _wideTranscript(),
+      final scene = await PdfRetainedScene.fromCommands(page, _wideTranscript(),
           includeImages: false);
       addTearDown(scene.dispose);
 

--- a/packages/dart_pdf_editor/test/benchmark_extreme_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_extreme_zoom_test.dart
@@ -1,0 +1,288 @@
+// Opt-in, paired visible-region benchmark. Never rasterizes the whole page at
+// extreme zoom: a 1280x800 logical viewport at DPR 2 is always 2560x1600 pixels.
+// PDF_PATH=/path/to/drawing.pdf PDF_BENCHMARK_OUT=/tmp/extreme-zoom.json \
+//   fvm flutter test --no-pub test/benchmark_extreme_zoom_test.dart
+// Optional: PDF_BENCHMARK_SCALES=30,60,100 (3000%, 6000%, 10000%),
+// PDF_BENCHMARK_SCENARIOS=center,lower,upper-right, PDF_BENCHMARK_TRIALS=7,
+// PDF_BENCHMARK_DPR=2, PDF_BENCHMARK_VIEWPORT=1280x800,
+// PDF_BENCHMARK_PNG_DIR=/tmp/extreme-zoom-crops,
+// PDF_BENCHMARK_REQUIRE_SELECTIVE=1 (fail instead of measuring a fallback).
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+// Fractions of the displayed page, with y down. The right-hand locations
+// exercise small transparency islands on the local engineering drawing that
+// motivated this benchmark, without bundling that private document.
+const _locations = <String, ui.Offset>{
+  'center': ui.Offset(0.5, 0.5),
+  'lower': ui.Offset(0.5, 2 / 3),
+  'upper-right': ui.Offset(400 / 421, 18 / 269),
+  'middle-right': ui.Offset(405 / 421, 84 / 269),
+  'lower-right': ui.Offset(345 / 421, 169 / 269),
+  'bottom-right': ui.Offset(345 / 421, 214 / 269),
+};
+
+void main() {
+  testWidgets('paired visible-region replay at extreme zoom', (tester) async {
+    final path = Platform.environment['PDF_PATH'];
+    if (path == null) {
+      markTestSkipped('set PDF_PATH');
+      return;
+    }
+    final oldRegion = PdfRetainedScene.spatialRegionReplay;
+    final oldGrid = PdfRetainedScene.spatialGridReplay;
+    addTearDown(() {
+      PdfRetainedScene.spatialRegionReplay = oldRegion;
+      PdfRetainedScene.spatialGridReplay = oldGrid;
+    });
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final env = Platform.environment;
+      final scales = (env['PDF_BENCHMARK_SCALES'] ?? '30,60,100')
+          .split(',')
+          .map(double.parse)
+          .toList();
+      final names = (env['PDF_BENCHMARK_SCENARIOS'] ??
+              'center,lower,upper-right,middle-right,lower-right,bottom-right')
+          .split(',');
+      final trials = int.parse(env['PDF_BENCHMARK_TRIALS'] ?? '7');
+      final dpr = double.parse(env['PDF_BENCHMARK_DPR'] ?? '2');
+      final viewport = (env['PDF_BENCHMARK_VIEWPORT'] ?? '1280x800')
+          .split('x')
+          .map(double.parse)
+          .toList();
+      expect(viewport, hasLength(2));
+      expect(trials, greaterThan(0));
+      expect(dpr, greaterThan(0));
+      for (final scale in scales) {
+        expect(scale, greaterThan(0));
+      }
+      final width = (viewport[0] * dpr).round();
+      final height = (viewport[1] * dpr).round();
+      expect(width, inInclusiveRange(1, 1 << 14));
+      expect(height, inInclusiveRange(1, 1 << 14));
+      final pngDir = env['PDF_BENCHMARK_PNG_DIR'];
+      if (pngDir != null) Directory(pngDir).createSync(recursive: true);
+      final bytes = File(path).readAsBytesSync();
+      final pageIndex = int.parse(env['PDF_PAGE'] ?? '0');
+      final page = PdfDocument.open(bytes).page(pageIndex);
+      final worker = PdfRenderWorker.start(bytes);
+      try {
+        final maxRatio = scales.reduce(math.max) * dpr;
+        final recordClock = Stopwatch()..start();
+        final commands =
+            (await worker.record(pageIndex, imagePixelRatio: maxRatio))!;
+        final recordMs = recordClock.elapsedMicroseconds / 1000;
+        recordClock.reset();
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            maxImagePixelRatio: maxRatio);
+        final sceneMs = recordClock.elapsedMicroseconds / 1000;
+        try {
+          final results = <Map<String, Object>>[];
+          final failures = <String>[];
+          final indexClock = Stopwatch()..start();
+          final indexSupported = scene.debugRegionReplaySupported;
+          final indexBuildMs = indexClock.elapsedMicroseconds / 1000;
+          if (env['PDF_BENCHMARK_REQUIRE_SELECTIVE'] == '1') {
+            expect(indexSupported, isTrue,
+                reason: 'this run must exercise selective region replay');
+          }
+          for (final name in names) {
+            final location = _locations[name];
+            expect(location, isNotNull, reason: 'unknown scenario $name');
+            for (final scale in scales) {
+              final ratio = scale * dpr;
+              final regionWidth = width / ratio;
+              final regionHeight = height / ratio;
+              final region = ui.Rect.fromLTWH(
+                (scene.pageSize.width * location!.dx - regionWidth / 2).clamp(
+                    0.0, math.max(0.0, scene.pageSize.width - regionWidth)),
+                (scene.pageSize.height * location.dy - regionHeight / 2).clamp(
+                    0.0, math.max(0.0, scene.pageSize.height - regionHeight)),
+                regionWidth,
+                regionHeight,
+              );
+              final measurements = {
+                false: <_Measurement>[],
+                true: <_Measurement>[]
+              };
+              var maxChangedPixels = 0;
+              var maxChannelDifference = 0;
+              var maxMeanChannelDifference = 0.0;
+              var wasSelective = false;
+              var selectedCommands = 0;
+              // The initial pair warms BOTH modes and compares their pixels;
+              // seven further measured pairs alternate their execution order.
+              for (var trial = 0; trial <= trials; trial++) {
+                Uint8List? reference;
+                for (final selective
+                    in trial.isEven ? [false, true] : [true, false]) {
+                  PdfRetainedScene.spatialRegionReplay = selective;
+                  PdfRetainedScene.spatialGridReplay = selective;
+                  final clock = Stopwatch()..start();
+                  final picture = scene.replayRegion(region, pixelRatio: ratio);
+                  final replayMs = clock.elapsedMicroseconds / 1000;
+                  if (selective) {
+                    wasSelective = scene.debugLastRegionReplayWasSelective;
+                    selectedCommands = scene.debugLastRegionReplayCommandCount;
+                  }
+                  clock.reset();
+                  final image = await picture.toImage(width, height);
+                  final rasterMs = clock.elapsedMicroseconds / 1000;
+                  try {
+                    clock.reset();
+                    final data = (await image.toByteData(
+                        format: ui.ImageByteFormat.rawRgba))!;
+                    final pixels = data.buffer
+                        .asUint8List(data.offsetInBytes, data.lengthInBytes);
+                    final readbackMs = clock.elapsedMicroseconds / 1000;
+                    if (reference == null) {
+                      reference = pixels;
+                    } else {
+                      final diff = _pixelDiff(reference, pixels);
+                      maxChangedPixels = math.max(maxChangedPixels, diff.$1);
+                      maxChannelDifference =
+                          math.max(maxChannelDifference, diff.$2);
+                      maxMeanChannelDifference =
+                          math.max(maxMeanChannelDifference, diff.$3);
+                    }
+                    if (trial > 0) {
+                      measurements[selective]!
+                          .add(_Measurement(replayMs, rasterMs, readbackMs));
+                    } else if (pngDir != null) {
+                      final png = (await image.toByteData(
+                          format: ui.ImageByteFormat.png))!;
+                      File('$pngDir/$name-${scale.toInt()}x-'
+                              '${selective ? 'selective' : 'full'}.png')
+                          .writeAsBytesSync(png.buffer.asUint8List(
+                              png.offsetInBytes, png.lengthInBytes));
+                    }
+                  } finally {
+                    image.dispose();
+                    picture.dispose();
+                  }
+                }
+              }
+              results.add({
+                'scenario': name,
+                'viewPercent': scale * 100,
+                'logicalZoom': scale,
+                'physicalPixelsPerPoint': ratio,
+                'rasterRegionPoints': [
+                  region.left,
+                  region.top,
+                  region.width,
+                  region.height
+                ],
+                'full': _summarize(measurements[false]!),
+                'selective': _summarize(measurements[true]!),
+                'wasSelective': wasSelective,
+                'selectedCommands': selectedCommands,
+                'identicalPixels': maxChangedPixels == 0,
+                'maxChangedPixels': maxChangedPixels,
+                'maxChangedPixelFraction': maxChangedPixels / (width * height),
+                'maxChannelDifference': maxChannelDifference,
+                'maxMeanChannelDifference': maxMeanChannelDifference,
+              });
+              if (env['PDF_BENCHMARK_REQUIRE_SELECTIVE'] == '1' &&
+                  !wasSelective) {
+                failures.add('$name ${scale}x fell back to full replay');
+              }
+              if (maxChangedPixels > 0) {
+                failures.add('$name ${scale}x: $maxChangedPixels pixels, '
+                    'maximum channel difference $maxChannelDifference');
+              }
+              // ignore: avoid_print
+              print(
+                  'measured $name ${scale}x: $selectedCommands/${commands.length} '
+                  'commands; changed pixels=$maxChangedPixels');
+            }
+          }
+          final result = {
+            'pageIndex': pageIndex,
+            'pageSizePoints': [scene.pageSize.width, scene.pageSize.height],
+            'viewportLogicalPixels': viewport,
+            'devicePixelRatio': dpr,
+            'imagePhysicalPixels': [width, height],
+            'commands': commands.length,
+            'warmupPairs': 1,
+            'measuredPairs': trials,
+            'workerRecordMs': recordMs,
+            'sceneBuildMs': sceneMs,
+            'indexSupported': indexSupported,
+            'tileEligible': scene.supportsTiledRegionRaster,
+            'indexBuildMs': indexBuildMs,
+            'indexUnits': scene.debugRegionReplayUnitCount,
+            'indexEstimatedBytes': scene.debugRegionReplayEstimatedBytes,
+            'results': results,
+          };
+          final json = const JsonEncoder.withIndent('  ').convert(result);
+          final out = env['PDF_BENCHMARK_OUT'];
+          if (out != null) File(out).writeAsStringSync(json);
+          // ignore: avoid_print
+          print(json);
+          expect(failures, isEmpty,
+              reason: 'selective replay must preserve every RGBA pixel');
+        } finally {
+          scene.dispose();
+        }
+      } finally {
+        worker.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 15)));
+}
+
+class _Measurement {
+  const _Measurement(this.replayMs, this.rasterMs, this.readbackMs);
+  final double replayMs;
+  final double rasterMs;
+  final double readbackMs;
+}
+
+Map<String, Object> _summarize(List<_Measurement> measurements) => {
+      'medianReplayMs': _median(measurements.map((m) => m.replayMs)),
+      'medianRasterMs': _median(measurements.map((m) => m.rasterMs)),
+      'medianReplayAndRasterMs':
+          _median(measurements.map((m) => m.replayMs + m.rasterMs)),
+      'medianReadbackMs': _median(measurements.map((m) => m.readbackMs)),
+      'samples': [
+        for (final m in measurements)
+          {
+            'replayMs': m.replayMs,
+            'rasterMs': m.rasterMs,
+            'readbackMs': m.readbackMs
+          }
+      ],
+    };
+
+double _median(Iterable<double> values) {
+  final sorted = values.toList()..sort();
+  return sorted[sorted.length ~/ 2];
+}
+
+(int, int, double) _pixelDiff(Uint8List a, Uint8List b) {
+  expect(a.length, b.length);
+  var changedPixels = 0;
+  var maxDifference = 0;
+  var sumDifference = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    var changed = false;
+    for (var channel = 0; channel < 4; channel++) {
+      final delta = (a[i + channel] - b[i + channel]).abs();
+      changed |= delta != 0;
+      maxDifference = math.max(maxDifference, delta);
+      sumDifference += delta;
+    }
+    if (changed) changedPixels++;
+  }
+  return (changedPixels, maxDifference, sumDifference / a.length);
+}

--- a/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
@@ -28,8 +28,10 @@ void main() {
   // A box centred in the viewport at fit-width, so it stays on screen when
   // the transform magnifies about the viewport centre: an 800x800 logical
   // viewport over a 612x792 page shows the top 612pt, centred on (306, 486).
-  const rect = PdfRect(291, 477, 321, 494.7585);
-  const rectWidth = 321 - 291.0;
+  // Keep both line ends inside the window at the requested 40 px/pt. The
+  // former 30pt box relied on the viewer silently clamping that request.
+  const rect = PdfRect(294, 477, 318, 494.7585);
+  const rectWidth = 318 - 294.0;
   const fontSize = 8.0;
   const text = 'UB';
 
@@ -40,6 +42,9 @@ void main() {
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
     addTearDown(viewer.dispose);
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: RepaintBoundary(
@@ -164,6 +169,7 @@ void main() {
     await tester.pump();
     viewer.setZoom(zoom);
     await tester.pump();
+    expect(viewer.zoom, closeTo(zoom, .001));
     expect(editing.requestEditSelectedTextInline(), isTrue);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 16));
@@ -185,14 +191,15 @@ void main() {
     // everything is read inside the box and inside the window, clear of the
     // chrome border and of the viewer's scrollbar gutter
     final view = tester.view;
-    final screen = Rect.fromLTWH(0, 0,
+    final screen = Rect.fromLTWH(
+        0,
+        0,
         view.physicalSize.width / view.devicePixelRatio - 20,
         view.physicalSize.height / view.devicePixelRatio);
     // the box interior, for the wash colour
     final wash = box.deflate(4).intersect(screen);
     // the line's own band, for the ink
-    final region = Rect.fromPoints(
-            render.localToGlobal(Offset.zero),
+    final region = Rect.fromPoints(render.localToGlobal(Offset.zero),
             render.localToGlobal(render.size.bottomRight(Offset.zero)))
         .intersect(wash);
 
@@ -226,10 +233,10 @@ void main() {
 
   group('the inline free-text caret at deep zoom', () {
     for (final align in PdfTextAlign.values) {
-      // 4 px/pt is an ordinary reading zoom; the deep one is the viewer's
-      // ceiling, where a constant in layout pixels turns into a visible gap
+      // At 40 px/pt a constant in layout pixels becomes a visible gap.
       for (final zoom in const <double>[4, 40]) {
-        testWidgets('$align free text: painted caret hugs the glyphs at '
+        testWidgets(
+            '$align free text: painted caret hugs the glyphs at '
             '${zoom.toInt()} px/pt', (tester) async {
           tester.view.physicalSize = const Size(1600, 1600);
           tester.view.devicePixelRatio = 2;

--- a/packages/dart_pdf_editor/test/fixtures/high_zoom_pdf.dart
+++ b/packages/dart_pdf_editor/test/fixtures/high_zoom_pdf.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+
+/// Browser-safe geometry for high-zoom tests. The general fixture package
+/// also exports native CAD generators with 64-bit random-number arithmetic.
+Uint8List buildHighZoomPagePdf() {
+  final builder = CosDocumentBuilder();
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final font = builder.add(CosDictionary({
+    'Type': const CosName('Font'),
+    'Subtype': const CosName('Type1'),
+    'BaseFont': const CosName('Helvetica'),
+  }));
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': CosArray([0, 0, 612, 792].map(CosInteger.new).toList()),
+    'Resources': CosDictionary({
+      'Font': CosDictionary({'F1': font}),
+    }),
+    'Contents': builder.add(CosStream(
+      CosDictionary(),
+      Uint8List.fromList('BT /F1 12 Tf 72 720 Td (High zoom) Tj ET'.codeUnits),
+    )),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  return builder.build(
+      root: builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef})));
+}

--- a/packages/dart_pdf_editor/test/high_zoom_range_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_range_test.dart
@@ -1,0 +1,77 @@
+import 'dart:math' as math;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  testWidgets('default zoom reaches 10000% with desktop side panels',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(1));
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    Widget build(double panelWidth) => MaterialApp(
+          home: Scaffold(
+            body: Row(children: [
+              SizedBox(width: panelWidth),
+              Expanded(
+                child: PdfViewer(
+                  key: const ValueKey('viewer'),
+                  document: document,
+                  controller: controller,
+                  pagePreviews: false,
+                ),
+              ),
+            ]),
+          ),
+        );
+
+    for (final panelWidth in [0.0, 400.0]) {
+      await tester.pumpWidget(build(panelWidth));
+      await tester.pump();
+      controller.setZoom(100);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.zoom, closeTo(100, 0.01));
+
+      // These viewports used to cap below 10000%. Larger requests still
+      // clamp instead of growing a page or its tile demand without bound.
+      controller.setZoom(1000);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.zoom, closeTo(100, 0.01));
+    }
+  });
+
+  for (final width in [360.0, 800.0]) {
+    for (final maxZoom in [6.0, 24.0]) {
+      testWidgets('explicit maxZoom $maxZoom keeps its limit at width $width',
+          (tester) async {
+        tester.view.physicalSize = Size(width, 640);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final controller = PdfViewerController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: PdfViewer(
+              document: PdfDocument.open(buildMultiPagePdf(1)),
+              controller: controller,
+              maxZoom: maxZoom,
+              pagePreviews: false,
+            ),
+          ),
+        ));
+        await tester.pump();
+
+        final fitWidth = width / 612;
+        final expected = maxZoom == 24
+            ? math.max(24.0, maxZoom * fitWidth)
+            : maxZoom * fitWidth;
+        controller.setZoom(100);
+        await tester.pumpAndSettle(const Duration(milliseconds: 300));
+        expect(controller.zoom, closeTo(expected, 0.01));
+      });
+    }
+  }
+}

--- a/packages/dart_pdf_editor/test/high_zoom_range_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_range_test.dart
@@ -3,12 +3,13 @@ import 'dart:math' as math;
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 void main() {
   testWidgets('default zoom reaches 10000% with desktop side panels',
       (tester) async {
-    final document = PdfDocument.open(buildMultiPagePdf(1));
+    final document = PdfDocument.open(buildHighZoomPagePdf());
     final controller = PdfViewerController();
     addTearDown(controller.dispose);
 
@@ -55,7 +56,7 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: PdfViewer(
-              document: PdfDocument.open(buildMultiPagePdf(1)),
+              document: PdfDocument.open(buildHighZoomPagePdf()),
               controller: controller,
               maxZoom: maxZoom,
               pagePreviews: false,

--- a/packages/dart_pdf_editor/test/high_zoom_tiles_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_tiles_test.dart
@@ -1,0 +1,247 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  testWidgets('grouped PDF reuses sharp tiles while panning at 10000%',
+      (tester) async {
+    tester.view.physicalSize = const ui.Size(768, 576);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+
+    final store = PdfTileStore(
+      tilePixels: 256,
+      maxBytes: 16 << 20,
+      prefetchRing: 0,
+      registerForMemoryPressure: false,
+    );
+    final backend = _CountingCanvasBackend();
+    final oldTiles = PdfPageView.tileStoreDetail;
+    final oldStore = PdfPageView.debugTileStoreOverride;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = oldTiles;
+      PdfPageView.debugTileStoreOverride = oldStore;
+      store.dispose();
+    });
+
+    final page = PdfDocument.open(_groupedSheet()).page(0);
+    const pagePoints = 64.0;
+    const zoom = 100.0;
+    const desiredRatio = zoom * 3;
+    final rung = store.ladder.rungAtOrAbove(desiredRatio);
+    final ratio = store.ladder.ratioFor(rung);
+    // Translate by exactly one tile column, in logical display pixels.
+    final pan = store.tilePixels / ratio * zoom;
+
+    Widget build(double dx, int generation) => MediaQuery.fromView(
+          view: tester.view,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: Transform.translate(
+                offset: Offset(dx, 0),
+                child: OverflowBox(
+                  maxWidth: double.infinity,
+                  maxHeight: double.infinity,
+                  child: SizedBox(
+                    width: pagePoints * zoom,
+                    child: PdfPageView(
+                      page: page,
+                      settleGeneration: generation,
+                      tileRasterBackend: backend,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(0, 0));
+    await _waitForTiles(tester, store);
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget,
+        reason: 'a small transparency group must not veto tiling the page');
+    expect(tester.getSize(find.byType(PdfPageView)).width / pagePoints, zoom);
+    expect(
+        backend.scene!.commands.whereType<PdfBeginGroupCommand>(), isNotEmpty);
+    expect(backend.scene!.commands.whereType<PdfBeginSoftMaskedCommand>(),
+        isNotEmpty);
+    expect(ratio, greaterThanOrEqualTo(desiredRatio),
+        reason: '10000% must stay sharp on a DPR3 display');
+    expect(backend.ratios, everyElement(ratio));
+    expect(store.debugTileFractionsForPage(0).map((tile) => tile.rung),
+        everyElement(rung));
+    final originalFraction = _tileFraction(tester);
+    final initialTiles = store.debugTilesScheduled;
+    final initialRasters = backend.rasterizations;
+    final initialPixels = backend.rasterPixels;
+    expect(initialTiles, greaterThan(1));
+    expect(initialRasters, greaterThan(0));
+    expect(store.debugTilesLanded, initialTiles);
+    expect(backend.largestRasterPixels, lessThan(2 << 20),
+        reason: 'sharpness must come from viewport slabs, not a giant page');
+
+    await tester.pumpWidget(build(-pan, 1));
+    await _waitForTiles(tester, store);
+    expect(_tileFraction(tester).left, greaterThan(originalFraction.left));
+    final newEdgeTiles = store.debugTilesScheduled - initialTiles;
+    expect(newEdgeTiles, greaterThan(0),
+        reason: 'the pan must reveal genuinely uncached content');
+    expect(newEdgeTiles, lessThan(initialTiles),
+        reason: 'the overlapping viewport must reuse its existing tiles');
+    expect(backend.rasterizations, greaterThan(initialRasters));
+    expect(backend.rasterPixels - initialPixels, lessThan(initialPixels));
+
+    final afterPanTiles = store.debugTilesScheduled;
+    final afterPanRasters = backend.rasterizations;
+    await tester.pumpWidget(build(0, 2));
+    await _waitForTiles(tester, store);
+    expect(_tileFraction(tester), originalFraction);
+    expect(store.debugTilesScheduled, afterPanTiles,
+        reason: 'returning to a cached viewport needs no new tiles');
+    expect(backend.rasterizations, afterPanRasters,
+        reason: 'returning to a cached viewport needs no Canvas replay');
+    expect(store.debugTilesDiscarded, 0);
+    expect(store.retainedBytes, lessThanOrEqualTo(store.maxBytes));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+}
+
+ui.Rect _tileFraction(WidgetTester tester) => (tester
+        .widget<CustomPaint>(find.byKey(const ValueKey('pdf-page-tile-layer')))
+        .painter as dynamic)
+    .visibleFraction as ui.Rect;
+
+Future<void> _waitForTiles(WidgetTester tester, PdfTileStore store) async {
+  for (var i = 0; i < 300; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+    final exception = tester.takeException();
+    if (exception != null) fail('high-zoom tile rendering failed: $exception');
+    final found = find.byKey(const ValueKey('pdf-page-tile-layer'));
+    if (found.evaluate().isNotEmpty) {
+      final painter = tester.widget<CustomPaint>(found).painter as dynamic;
+      final ui.Rect fraction = painter.visibleFraction;
+      final ui.Size size = painter.pageSize;
+      final view = store.viewFor(
+        id: painter.identity,
+        pageSize: size,
+        desiredRatio: painter.desiredRatio,
+        visiblePageRect: ui.Rect.fromLTRB(
+          fraction.left * size.width,
+          fraction.top * size.height,
+          fraction.right * size.width,
+          fraction.bottom * size.height,
+        ),
+        rasterize: painter.rasterize,
+        scheduleMissing: false,
+        allowCoarserFallback: false,
+      );
+      if (view.complete && !view.isEmpty && store.inFlightCount == 0) return;
+    }
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('grouped page did not present a complete high-zoom tile layer');
+}
+
+class _CountingCanvasBackend extends PdfCanvasTileRasterBackend {
+  PdfRetainedScene? scene;
+  final ratios = <double>[];
+  int rasterizations = 0;
+  int rasterPixels = 0;
+  int largestRasterPixels = 0;
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) {
+    this.scene = scene;
+    return _CountingCanvasSession(this, scene);
+  }
+}
+
+class _CountingCanvasSession implements PdfTileRasterSession {
+  _CountingCanvasSession(this.backend, this.scene);
+
+  final _CountingCanvasBackend backend;
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(ui.Rect region,
+      {required double pixelRatio, int? tracePage}) async {
+    backend.rasterizations++;
+    backend.ratios.add(pixelRatio);
+    final image = await scene.rasterizeRegion(region,
+        pixelRatio: pixelRatio, tracePage: tracePage);
+    final pixels = image.width * image.height;
+    backend.rasterPixels += pixels;
+    if (pixels > backend.largestRasterPixels) {
+      backend.largestRasterPixels = pixels;
+    }
+    return image;
+  }
+
+  @override
+  void dispose() {}
+}
+
+Uint8List _groupedSheet() {
+  final builder = CosDocumentBuilder();
+  CosArray box() => CosArray([0, 0, 64, 64].map(CosInteger.new).toList());
+  CosDictionary group() => CosDictionary({
+        'S': const CosName('Transparency'),
+        'I': const CosBoolean(true),
+        'CS': const CosName('DeviceRGB'),
+      });
+  CosReference stream(String content, CosDictionary dictionary) =>
+      builder.add(CosStream(dictionary, Uint8List.fromList(content.codeUnits)));
+  final mask = stream(
+      '0.8 g 0 0 64 64 re f',
+      CosDictionary({
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Form'),
+        'BBox': box(),
+        'Group': group(),
+      }));
+  final form = stream(
+    'q /Masked gs 1 0 0 rg 29 29 6 6 re f Q '
+    '0 0 0 RG 0.01 w 31.5 29 m 31.5 35 l S',
+    CosDictionary({
+      'Type': const CosName('XObject'),
+      'Subtype': const CosName('Form'),
+      'BBox': box(),
+      'Group': group(),
+      'Resources': CosDictionary({
+        'ExtGState': CosDictionary({
+          'Masked': CosDictionary({
+            'SMask': CosDictionary({'S': const CosName('Alpha'), 'G': mask}),
+          }),
+        }),
+      }),
+    }),
+  );
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': box(),
+    'Resources': CosDictionary({
+      'XObject': CosDictionary({'Group': form}),
+    }),
+    'Contents':
+        stream('0.7 0.8 1 rg 0 0 64 64 re f /Group Do', CosDictionary()),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  return builder.build(
+      root: builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef})));
+}

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -125,6 +125,24 @@ void main() {
       expect(find.text('100%'), findsOneWidget);
     });
 
+    testWidgets('zoom menu reaches 10000% for detailed drawing inspection',
+        (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(1), controller: viewer));
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-menu')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      final target = find.byKey(const ValueKey('pdf-shell-zoom-10000'));
+      await tester.ensureVisible(target);
+      await tester.pumpAndSettle();
+      await tester.tap(target, kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(100, 0.01));
+      expect(find.text('10000%'), findsOneWidget);
+    });
+
     testWidgets('PdfReaderFeatures.none leaves just the pages', (tester) async {
       await pump(
         tester,

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1066,7 +1066,7 @@ void main() {
     expect(controller.zoom, greaterThan(6));
   });
 
-  testWidgets('default max zoom keeps 2400% available on phone-width views',
+  testWidgets('default max zoom keeps 10000% available on phone-width views',
       (tester) async {
     tester.view.physicalSize = const Size(360, 640);
     tester.view.devicePixelRatio = 1;
@@ -1078,11 +1078,11 @@ void main() {
 
     final interactiveViewer =
         tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
-    expect(interactiveViewer.maxScale, closeTo(24 / phoneFitWidth, 0.001));
+    expect(interactiveViewer.maxScale, closeTo(100 / phoneFitWidth, 0.001));
 
-    controller.setZoom(24);
+    controller.setZoom(100);
     await tester.pumpAndSettle(const Duration(milliseconds: 300));
-    expect(controller.zoom, closeTo(24, 0.01));
+    expect(controller.zoom, closeTo(100, 0.01));
   });
 
   testWidgets('controller zoom settles page rendering immediately',

--- a/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
+++ b/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
@@ -17,6 +17,7 @@ import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:dart_pdf_editor/src/render_worker_transcript_cache.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -54,7 +55,8 @@ class _RoundTripIndexWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override
@@ -101,13 +103,37 @@ void main() {
     PdfRetainedScene.spatialRegionReplayMaxCommands = prevCeil;
   });
 
+  test('dense detail selection reuses the worker grid at the scene budget', () {
+    final commands = List<PdfRenderCommand>.generate(
+        pdfDetailRegionGridMinCommands,
+        (i) => PdfFillPathCommand(
+            PdfPath([
+              PdfMoveTo(i.toDouble(), 0),
+              PdfLineTo(i + 1.0, 0),
+              PdfLineTo(i + 1.0, 1),
+              const PdfClosePath()
+            ]),
+            const PdfColor(1, 0, 0),
+            PdfFillRule.nonzero,
+            1));
+    final transcript = PdfWorkerTranscript(commands, commands);
+    final index = transcript.regionIndex(
+        maxCommands: pdfDetailRegionLinearMaxCommands, buildGrid: true);
+    expect(index.grid, isNotNull);
+    final selected = transcript.commandsForDetail(const PdfRect(0, 0, 5, 5));
+    expect(selected.length, lessThan(100));
+    expect(
+        transcript.regionIndex(
+            maxCommands: pdfDetailRegionLinearMaxCommands, buildGrid: true),
+        same(index));
+  });
+
   testWidgets('serialized region index rasters identically to in-isolate build',
       (tester) async {
     await tester.runAsync(() async {
       var offloaded = 0;
       for (final name in _fixtures) {
-        final bytes =
-            File('../../test_corpora/pdfjs/$name').readAsBytesSync();
+        final bytes = File('../../test_corpora/pdfjs/$name').readAsBytesSync();
         final document = PdfDocument.open(Uint8List.fromList(bytes));
         if (document.pageCount == 0) continue;
         final page = document.page(0);
@@ -130,8 +156,8 @@ void main() {
             Rect.fromLTWH(0, 0, size.width * .33, size.height * .33),
             Rect.fromLTWH(size.width * .55, size.height * .1, size.width * .4,
                 size.height * .5),
-            Rect.fromLTWH(size.width * .45, size.height * .45,
-                size.width * .12, size.height * .12),
+            Rect.fromLTWH(size.width * .45, size.height * .45, size.width * .12,
+                size.height * .12),
           ];
           for (final region in regions) {
             final expected =
@@ -180,11 +206,11 @@ void main() {
         return;
       }
 
-      final local =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: true);
+      final local = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: true);
       await local.warmRegionIndex(null, pageIndex: 0); // in-isolate build
-      final offload =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: true);
+      final offload = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: true);
       await offload.warmRegionIndex(worker, pageIndex: 0); // worker build
       addTearDown(local.dispose);
       addTearDown(offload.dispose);
@@ -193,8 +219,8 @@ void main() {
           reason: 'a worker index must reconstruct as supported');
 
       final size = local.pageSize;
-      final region = Rect.fromLTWH(
-          size.width * .15, size.height * .15, size.width * .5, size.height * .5);
+      final region = Rect.fromLTWH(size.width * .15, size.height * .15,
+          size.width * .5, size.height * .5);
       final expected = await local.rasterizeRegion(region, pixelRatio: 2);
       final actual = await offload.rasterizeRegion(region, pixelRatio: 2);
       expect(offload.debugLastRegionReplayWasSelective, isTrue);
@@ -209,7 +235,7 @@ void main() {
     });
   });
 
-  testWidgets('unsupported (grouped) index round-trips its verdict',
+  testWidgets('atomic group command ranges round-trip through the worker codec',
       (tester) async {
     await tester.runAsync(() async {
       final commands = <PdfRenderCommand>[
@@ -228,11 +254,13 @@ void main() {
         const PdfEndGroupCommand(),
       ];
       final index = PdfRegionReplayIndex.build(commands, maxCommands: 1 << 20);
-      expect(index.supported, isFalse);
+      expect(index.supported, isTrue);
       final bytes = serializeRegionReplayIndex(index)!;
       final restored = deserializeRegionReplayIndex(bytes);
-      expect(restored.supported, isFalse);
-      expect(restored.units, isEmpty);
+      expect(restored.supported, isTrue);
+      expect(restored.units, hasLength(1));
+      expect(restored.units.single.commandIndex, 0);
+      expect(restored.units.single.endCommandIndex, commands.length);
     });
   });
 
@@ -255,9 +283,8 @@ void main() {
           reason: 'warm after drop rebuilds the index');
       scene.dropRegionIndex();
       // The next region raster silently rebuilds it too.
-      final image = await scene.rasterizeRegion(
-          const Rect.fromLTWH(0, 0, 100, 100),
-          pixelRatio: 1);
+      final image = await scene
+          .rasterizeRegion(const Rect.fromLTWH(0, 0, 100, 100), pixelRatio: 1);
       image.dispose();
       expect(scene.debugHasRegionReplayIndex, isTrue);
     });

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -305,7 +305,7 @@ void main() {
     });
   });
 
-  testWidgets('groups and over-budget transcripts fall back to full replay',
+  testWidgets('atomic groups are selective; over-budget transcripts fall back',
       (tester) async {
     await tester.runAsync(() async {
       final previousMax = PdfRetainedScene.spatialRegionReplayMaxCommands;
@@ -335,8 +335,10 @@ void main() {
         pixelRatio: 2,
       );
       image.dispose();
-      expect(grouped.debugLastRegionReplayWasSelective, isFalse);
-      expect(grouped.debugRegionReplaySupported, isFalse);
+      expect(grouped.debugLastRegionReplayWasSelective, isTrue);
+      expect(grouped.debugRegionReplaySupported, isTrue);
+      expect(grouped.debugLastRegionReplayCommandCount, 3,
+          reason: 'the complete group is replayed as one atomic unit');
 
       // Over BOTH ceilings (linear and grid): genuine full-replay fallback.
       PdfRetainedScene.spatialRegionReplayMaxCommands = 1;

--- a/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
+++ b/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
@@ -15,6 +15,11 @@ const _fixtures = <String>[
   'blendmode.pdf',
   'smaskdim.pdf',
   'knockout_isolated_overlap.pdf',
+  'smask_luminosity_oob_transfer.pdf',
+  'smask_alpha_oob_transfer.pdf',
+  'smask_alpha_oob.pdf',
+  'smask_alpha_bc.pdf',
+  'knockout_smask.pdf',
 ];
 
 void main() {
@@ -32,32 +37,46 @@ void main() {
         final scene = await PdfRetainedScene.record(document.page(0));
         try {
           final size = scene.pageSize;
-          final region = Rect.fromLTWH(
-            size.width * .2,
-            size.height * .2,
-            size.width * .6,
-            size.height * .6,
-          );
-          PdfRetainedScene.spatialRegionReplay = false;
-          final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
-          PdfRetainedScene.spatialRegionReplay = true;
-          final actual = await scene.rasterizeRegion(region, pixelRatio: 1.5);
-          try {
-            expect(actual.width, expected.width, reason: name);
-            expect(actual.height, expected.height, reason: name);
-            expect(
-              await _bytes(actual),
-              await _bytes(expected),
-              reason: '$name region pixels',
-            );
-          } finally {
-            expected.dispose();
-            actual.dispose();
-          }
-          if (scene.debugLastRegionReplayWasSelective) {
-            selective++;
-          } else {
-            fallback++;
+          final regions = <(Rect, double)>[
+            (
+              Rect.fromLTWH(
+                size.width * .2,
+                size.height * .2,
+                size.width * .6,
+                size.height * .6,
+              ),
+              1.5
+            ),
+            (
+              Rect.fromLTWH(
+                  size.width * .5 + .137, size.height * .5 + .271, 8, 6),
+              100
+            ),
+          ];
+          for (final (region, ratio) in regions) {
+            PdfRetainedScene.spatialRegionReplay = false;
+            final expected =
+                await scene.rasterizeRegion(region, pixelRatio: ratio);
+            PdfRetainedScene.spatialRegionReplay = true;
+            final actual =
+                await scene.rasterizeRegion(region, pixelRatio: ratio);
+            try {
+              expect(actual.width, expected.width, reason: name);
+              expect(actual.height, expected.height, reason: name);
+              expect(
+                await _bytes(actual),
+                await _bytes(expected),
+                reason: '$name region pixels',
+              );
+            } finally {
+              expected.dispose();
+              actual.dispose();
+            }
+            if (scene.debugLastRegionReplayWasSelective) {
+              selective++;
+            } else {
+              fallback++;
+            }
           }
         } finally {
           scene.dispose();
@@ -65,7 +84,7 @@ void main() {
       }
       expect(selective, greaterThanOrEqualTo(3));
       expect(fallback, greaterThanOrEqualTo(1),
-          reason: 'transparency groups exercise conservative full replay');
+          reason: 'unsafe state retains conservative full replay');
     });
   });
 }

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -153,6 +153,16 @@ void main() {
         expect(ladder.rungAtOrAbove(ladder.ratioFor(rung)), rung);
       }
     });
+
+    test('default ladder keeps 10000% sharp on high-density displays', () {
+      const ladder = PdfTileZoomLadder();
+      for (final devicePixelRatio in [1.0, 2.0, 3.0, 4.0, 5.0]) {
+        final desiredRatio = 100 * devicePixelRatio;
+        final ratio = ladder.ratioFor(ladder.rungAtOrAbove(desiredRatio));
+        expect(ratio, greaterThanOrEqualTo(desiredRatio));
+        expect(ratio, lessThan(desiredRatio * math.sqrt(2)));
+      }
+    });
   });
 
   group('PdfTileStore.viewFor', () {


### PR DESCRIPTION
At 3000–10000% zoom, small transparency groups in a dense engineering drawing forced every viewport to replay all 77,312 commands and disabled cached tiles. Balanced groups now remain intact as indexed ranges, allowing nearby content to render independently. Dense pages use a worker-built spatial grid, and panning reuses existing sharp tiles.

The default viewer now reaches 10000% actual size, with matching zoom presets and sufficient tile resolution for high-DPI displays. Explicit host zoom caps retain their behavior. Unsupported compositing retains full replay; large indivisible groups retain one viewport patch to avoid multiplying their cost across tiles.

On the private input, paired native measurements at a 1280×800 logical viewport/DPR2 show:

| Region | 3000% | 6000% | 10000% |
| --- | ---: | ---: | ---: |
| Centre, replay + raster | 71.78 → 19.64 ms | 64.77 → 10.87 ms | 61.28 → 4.94 ms |
| Dense junction, replay + raster | 69.73 → 19.13 ms | 65.72 → 12.44 ms | 64.05 → 10.76 ms |

All 18 measured viewports are byte-identical to full replay across seven alternating measured pairs after warmup. Mask-heavy graphics still take 74–119 ms to rasterize at 10000%, although their replay drops below 0.5 ms. These are renderer measurements, not browser or whole-app latency. The private PDF and its images are not included.

Validation includes exact high-zoom pixels across compositing fixtures and 13 PDF.js files, worker codec/native-isolate and real Chrome worker checks, a DPR3 widget test proving edge-only tile work and zero rerasterization on return, native GPU corpus tests, and viewer/host-app suites. Benchmark reproduction and remaining optimization opportunities are documented in `doc/dev-log/2026-09-08-extreme-zoom-performance.md`.

Local validation: analyzer clean; editor 2,731 passed (31 opt-in/platform skips); native GPU 334 passed (4 expected skips); host app 661 passed; example 63 passed; Chrome worker tests 10 passed (one isolation skip). The final browser-safe fixture follow-up passes all 14 high-zoom regressions both natively and in Chrome, with a dedicated CI step added. No corpus baselines changed.
