### PR TITLE
Reuse recorded text and restore high-zoom tile throughput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,7 @@ jobs:
         run: >-
           flutter test --platform chrome --no-cross-origin-isolation
           test/render_worker_sparse_web_test.dart test/compression_worker_test.dart
+          test/render_worker_text_reuse_test.dart
           --reporter expanded
       - name: Test high-zoom tiles and atomic region replay in Chrome
         working-directory: packages/dart_pdf_editor
@@ -681,6 +682,7 @@ jobs:
           flutter test --platform chrome --no-cross-origin-isolation
           test/high_zoom_tiles_test.dart test/high_zoom_range_test.dart
           test/atomic_region_replay_test.dart test/atomic_tile_budget_test.dart
+          test/tile_pacing_test.dart
           --reporter expanded
 
   # Build the Linux desktop target and validate its desktop-integration files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,13 @@ jobs:
           flutter test --platform chrome --no-cross-origin-isolation
           test/render_worker_sparse_web_test.dart test/compression_worker_test.dart
           --reporter expanded
+      - name: Test high-zoom tiles and atomic region replay in Chrome
+        working-directory: packages/dart_pdf_editor
+        run: >-
+          flutter test --platform chrome --no-cross-origin-isolation
+          test/high_zoom_tiles_test.dart test/high_zoom_range_test.dart
+          test/atomic_region_replay_test.dart test/atomic_tile_budget_test.dart
+          --reporter expanded
 
   # Build the Linux desktop target and validate its desktop-integration files.
   # Mirrors the release-app.yml linux job's build deps (GTK + libsecret for

--- a/doc/dev-log/2026-09-08-extreme-zoom-performance.md
+++ b/doc/dev-log/2026-09-08-extreme-zoom-performance.md
@@ -1,0 +1,96 @@
+# Viewport rendering at 3000–10000%
+
+Follow-up to the [dense-vector parsing and replay work](2026-09-08-dense-vector-pdf-performance.md).
+The local engineering sheet is a single 421 × 269 pt page. Its compact worker
+transcript contains 77,312 commands, including 24 transparency groups and 16
+soft masks. Previously, any group disabled the region index for the entire
+page, so a small zoomed viewport replayed all 77,312 commands and could not use
+the cached tile path.
+
+## Changes
+
+- Balanced compositing groups are indivisible indexed ranges. Selection
+  preserves every command inside a selected group, its entry clips and blend
+  mode, and painter order. Bounds come from source paint coverage; a group's
+  allocation hint or a soft mask's painted footprint cannot safely bound it.
+  Mask transfer functions and backdrop values can reveal source elsewhere.
+- A recursive safety check preserves full replay for malformed state stacks,
+  overprint, seeded non-isolated groups, and cells whose clip or blend state
+  escapes. Shared cells are checked in their incoming blend context. The
+  worker index format carries exclusive range ends and rejects old versions.
+- Dense pages start using the spatial grid at 32,768 commands. The viewer
+  warms that index through its render worker, and worker detail requests reuse
+  the same index and budget. The index is still released on memory pressure.
+- Small groups can use existing cached tiles. Groups exceeding 1,024 command
+  slots, including nested mask/cell commands, retain a single viewport patch
+  to avoid repeating a large indivisible group for every tile. The separate
+  banded-transcript path also keeps its group fallback.
+- The default viewer reaches at least 10000% actual size independently of
+  viewport width. Explicit host zoom caps retain their previous behavior.
+  The shell adds 3000%, 5000%, and 10000% presets; the tile resolution ladder
+  reaches 512 physical pixels per PDF point for high-DPI displays.
+
+## Paired measurements
+
+Native Flutter test engine, 1280 × 800 logical viewport, DPR 2, fixed
+2560 × 1600 output. Each region has one warm-up pair and seven measured pairs,
+alternating full and selective replay on the same retained scene and images.
+These are renderer times, not end-to-end app or browser latency. Readback is
+measured separately and excluded from replay + raster below.
+
+| Drawing region | View zoom | Full replay + raster | Selective replay + raster | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| Centre | 3000% | 71.78 ms | 19.64 ms | 3.65× |
+| Centre | 6000% | 64.77 ms | 10.87 ms | 5.96× |
+| Centre | 10000% | 61.28 ms | 4.94 ms | 12.39× |
+| Lower junction | 3000% | 69.73 ms | 19.13 ms | 3.65× |
+| Lower junction | 6000% | 65.72 ms | 12.44 ms | 5.28× |
+| Lower junction | 10000% | 64.05 ms | 10.76 ms | 5.95× |
+
+At 10000%, the centre selects 405 commands and the lower junction 951.
+The four mask-heavy regions select 28–107 commands: replay takes 0.30–0.40 ms,
+but rasterization remains the larger cost. Their total times improve from
+125–172 ms to 74–119 ms. Cached tiles avoid that cost when returning to a
+previously visited viewport.
+
+All 18 regions (six locations at three zooms) are genuinely selective and
+byte-identical to full replay in every comparison. Grid and linear-index
+outputs also match exactly. The grid retains 71,987 units, estimates 6.75 MB,
+and took 99 ms to build locally; that one-time build belongs on the worker.
+The private input, benchmark JSON and viewport PNGs remain local.
+
+## Reproduction and regression coverage
+
+From `packages/dart_pdf_editor`:
+
+```sh
+PDF_PATH=/absolute/path/to/drawing.pdf \
+PDF_BENCHMARK_REQUIRE_SELECTIVE=1 \
+PDF_BENCHMARK_OUT=/tmp/extreme-zoom.json \
+  fvm flutter test --no-pub test/benchmark_extreme_zoom_test.dart
+```
+
+The benchmark self-skips without `PDF_PATH`. Its header documents viewport,
+DPR, location, zoom and PNG-output overrides. It never allocates a whole-page
+raster at extreme zoom.
+
+Regression coverage includes exact pixels for nested masks, knockout, clip
+and blend combinations at 3000% and 10000%, plus 13 PDF.js fixtures at ordinary
+and extreme zoom. Worker codec and real-isolate tests cover range retention.
+A real Canvas widget test uses a generated grouped PDF at 10000% on DPR 3:
+one-column panning renders only missing edge tiles; returning to the original
+viewport schedules zero new tiles and zero rasterizations. Raster slabs and
+cache memory remain bounded.
+
+## Remaining opportunities
+
+The mask-heavy graphics are now raster-bound. Conservative layer bounds or
+reusable mask surfaces are candidates for a separate measured change; group
+allocation hints must not become clips, and mask backdrop/transfer semantics
+must remain intact. The supplied sheet's drawing areas already benefit from
+selective replay without that additional compositing work.
+
+Text extraction still interprets the page separately from worker recording.
+Sharing extraction-ready text runs could reduce initial preparation time,
+provided character advances, bidi order, invisible text and appearance/mask
+exclusion remain correct.

--- a/doc/dev-log/2026-09-09-worker-text-and-tile-throughput.md
+++ b/doc/dev-log/2026-09-09-worker-text-and-tile-throughput.md
@@ -1,0 +1,101 @@
+# Reusing recorded text and filling high-zoom tiles
+
+Follow-up to [viewport rendering at 3000–10000%](2026-09-08-extreme-zoom-performance.md).
+
+The engineering sheet's render worker already walks roughly 1.1 million
+operators to record the page. Preparing selection and search used to walk them
+again. Complete native and web recordings now retain a text-only snapshot before
+annotation appearances are appended and before the render codec removes exact
+character advances and marked-content ids. Extraction applies the existing
+separator, bidi and geometry logic to that snapshot.
+
+The snapshot discards paths, images and glyph outlines. Text in repeated cells
+stays compact until extraction; nested translations preserve the original
+floating-point evaluation order. Source text inside a masked group remains
+searchable, while text defining the mask is excluded, matching fresh extraction.
+Invisible OCR text and tagged text retain their existing semantics.
+
+Each worker retains at most 32 pages and an estimated 16 MiB of this metadata,
+rejecting a single oversize entry. Repeated image-resolution or annotation
+visibility recordings reuse it. Edits invalidate affected pages; undo/reopen
+clears the cache. Partial and cancelled recordings never supply complete text.
+A miss, including a worker-pool reassignment, uses ordinary extraction.
+
+The earlier spatial-grid change also exposed a scheduling coupling. A page
+with at least 32,768 commands needs its grid built off the UI thread, but that
+does not make every indexed tile expensive. The tile scheduler now reserves
+one-tile-per-paint admission for pages above the original 250,000-command
+ceiling. The supplied 77,312-command transcript can fill the ordinary eight-tile
+batch. The outstanding-work limit, backend limits and strip limits still apply;
+larger pages remain limited to two outstanding tiles.
+
+## Paired measurements
+
+Local Flutter test engine, supplied single-page engineering sheet, one warm-up
+pair followed by seven alternating measured pairs:
+
+| Phase | Previous path | Reuse path |
+| --- | ---: | ---: |
+| Page recording, including metadata capture when enabled | 380.87 ms | 393.82 ms |
+| Text extraction after recording | 372.39 ms | 9.95 ms |
+| Sum of the above phase medians | 753.26 ms | 403.77 ms |
+
+Offset collection and snapshot capture add approximately 13 ms to recording;
+capture alone takes 5.95 ms. Later extraction is about 37 times faster. The
+snapshot estimates 8,151,548 bytes (7.77 MiB), fitting the worker's 16 MiB bound.
+All 13,452 text runs and 14,911 characters match fresh extraction exactly,
+including the 1,672,773-byte text buffer. The 18,206,202-byte render buffer is
+also unchanged.
+
+The actual native worker returned text in 15.49 ms after a completed record.
+Cold extraction on a newly started worker took 399.49 ms; that comparison
+includes startup on the cold side and must not be read as a pure extraction
+speedup. The phase measurements above isolate the extraction work itself.
+
+## Validation and reproduction
+
+Tests compare serialized extracted text exactly, covering Unicode, selection
+advances, MCIDs and geometry. Coverage includes masks, annotations, invisible
+text, nested Type3/pattern cells, Arabic marks, proportional spacing, cancellation,
+resume and revisions, plus representative PDF.js and Ghent documents. Native
+and actual browser workers exercise full, vector-only, progressive, bounded
+prefix and region-index record paths. Tile tests hold raster futures unresolved
+to verify bounded scheduling across repeated paints on native and Chrome.
+
+From `packages/dart_pdf_editor`, the opt-in private-document benchmark is:
+
+```sh
+PDF_PATH=/absolute/path/to/drawing.pdf \
+PDF_TEXT_BENCHMARK_OUT=/tmp/recorded-text.json \
+  fvm flutter test --no-pub test/benchmark_recorded_text_test.dart
+```
+
+It alternates variants, discards one warm-up pair and measures seven pairs.
+It separates initial offset collection/capture from later extraction, compares
+render-command bytes and extracted-text bytes, and also probes the real worker.
+Cold worker extraction includes startup; it is reported separately from local
+phase timings. A sum of phase medians is explicitly labelled, not presented as
+an end-to-end latency measurement. The private input and outputs remain local.
+
+## Mask diagnostic
+
+The new opt-in `benchmark_mask_layers_test.dart` separates replay, raster-image
+readiness and pixel readback. Its baseline manually replays the old unclipped
+Canvas path, so a future production clip cannot change both sides of the oracle.
+Image/layer removal variants deliberately change semantics and are diagnostic
+only. Its software baseline PNGs match the previous benchmark byte for byte.
+
+An explicit output clip made no consistent difference across four masked
+regions at 3000%, 6000% and 10000% in software Skia. Impeller reported image
+readiness much earlier but incurred substantial work during pixel readback;
+neither the readiness time alone nor the readback-inclusive time establishes
+on-screen display latency. No mask or image-sampling change ships here.
+
+The upper and lower logo regions visibly contain masked images. The middle
+region at 10000% is mostly blank despite intersecting the source group's bounds,
+so it measures costly conservative work with little visible content. The masks
+are small alpha images with transfer functions, and their transforms differ
+slightly from those of the source images. Pre-compositing them at matching
+pixel coordinates would therefore be incorrect. A future mask optimization
+needs real presentation timings and checks for mask/source alignment, transfer
+semantics and sampling at fractional positions.

--- a/packages/dart_pdf_editor/lib/src/banded_transcript.dart
+++ b/packages/dart_pdf_editor/lib/src/banded_transcript.dart
@@ -63,6 +63,13 @@ class PdfBandedTranscript {
     final idx = index ??
         PdfRegionReplayIndex.build(commands, maxCommands: commands.length);
     if (!idx.supported) return null;
+    // Bands currently retain one command per unit. Region replay also accepts
+    // atomic group ranges; keep those scenes on its complete-transcript path
+    // until bands can own every command in the range, never just the opener.
+    if (idx.units
+        .any((unit) => unit.endCommandIndex != unit.commandIndex + 1)) {
+      return null;
+    }
 
     final extent = idx.xExtent;
     // A page with no drawable units (blank, or everything clipped away) still

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -5192,7 +5192,14 @@ class _PdfPageViewState extends State<PdfPageView>
         : null;
     final tileDetailScene = _tileDetailScene;
     final sessionCap = scheduling?.maxNewTilesPerPaint;
-    final sceneCap = scene.regionIndexBuildIsHeavy ? 1 : null;
+    // A grid is useful well below the old linear ceiling, but building that
+    // index off-thread does not imply an expensive tile replay. Keep ordinary
+    // slab batching for those medium scenes; reserve one-tile admission for
+    // transcripts that exceed the original linear retention ceiling.
+    final sceneCap =
+        scene.commands.length > PdfRetainedScene.spatialRegionReplayMaxCommands
+            ? 1
+            : null;
     final stripCap = _stripReplayScene(tileDetailScene ?? scene)
         ? PdfPageView.stripTileMaxNewTilesPerPaint
         : null;
@@ -5232,10 +5239,10 @@ class _PdfPageViewState extends State<PdfPageView>
         persistence: _tilePersistence,
         canRasterize: _tileRegionRasterizable,
         batchRasters: scheduling?.batchAdjacentTiles,
-        // A grid-indexed CAD scene can select tens of thousands of commands
-        // across one viewport slab, so it admits one tile per paint. A
-        // strip-routed scene keeps a four-tile batch: eight center-out misses
-        // formed a sparse 4x3 slab and made its oversized readback one UI-frame
+        // A CAD scene above the linear command ceiling can select tens of
+        // thousands of commands across one slab, so it admits one tile per
+        // paint. A strip-routed scene keeps a four-tile batch: eight center-out
+        // misses formed a sparse 4x3 slab and made its readback one UI-frame
         // stall. Tile completion repaints advance both paths center-out;
         // ordinary scenes retain the lower-overhead eight-tile batch.
         maxNewTilesPerPaint: maxNewTiles,

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -4676,8 +4676,8 @@ class _PdfPageViewState extends State<PdfPageView>
 
   /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
   /// detail for this page: the flag is on and the retained scene is
-  /// region-cullable (soft-mask/group spans keep the legacy single-patch
-  /// path).
+  /// region-cullable with bounded atomic groups. Large indivisible compositing
+  /// groups keep a single detail patch to avoid replaying them for every tile.
   ///
   /// A vector-only progressive scene is eligible too - on the dense CAD pages
   /// the pyramid targets, the full image-bearing record may never land during
@@ -4701,11 +4701,14 @@ class _PdfPageViewState extends State<PdfPageView>
     // UI isolate: defer the tile path until the warmed index is resident (built
     // on the render worker when eligible - see [_warmRegionIndexIfNeeded]).
     // Until then the base raster / single detail patch covers the view. Pages
-    // below the grid ceiling keep the cheap synchronous linear build.
+    // below the grid threshold keep the cheap synchronous linear build.
     if (scene.regionIndexBuildIsHeavy && !scene.debugHasRegionReplayIndex) {
       return 'index-warming';
     }
-    return scene.supportsRegionRaster ? 'active' : 'unsupported-scene';
+    if (!scene.supportsRegionRaster) return 'unsupported-scene';
+    return scene.supportsTiledRegionRaster
+        ? 'active'
+        : 'large-compositing-group';
   }
 
   /// Kicks the region-replay index build onto the render worker when the page

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -59,6 +59,7 @@ export 'annotation_tap.dart'
     show PdfAnnotationTapDetails, PdfAnnotationTapHandler;
 
 const double _defaultMaxZoom = 24;
+const double _defaultMaxDisplayZoom = 100;
 
 // Clipboard revisions are shared across viewer windows just like the snapshot
 // holder. Weak keys keep private clipboard lifetimes independent of this cache.
@@ -1320,7 +1321,7 @@ class PdfViewer extends StatefulWidget {
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
     this.minZoom = 0.25,
-    this.maxZoom = _defaultMaxZoom,
+    double? maxZoom,
     this.doubleTapZoom = 2.5,
     this.backgroundColor,
     this.pageColor = const Color(0xFFFFFFFF),
@@ -1344,7 +1345,9 @@ class PdfViewer extends StatefulWidget {
     this.textCache,
     this.documentId,
     this.active = true,
-  }) : assert(
+  })  : maxZoom = maxZoom ?? _defaultMaxZoom,
+        _hasCustomMaxZoom = maxZoom != null,
+        assert(
             document != null ||
                 editing != null ||
                 (formController != null && interactiveForms),
@@ -1711,10 +1714,13 @@ class PdfViewer extends StatefulWidget {
   /// each PDF point tiny on screen, and the deep-zoom detail patch keeps the
   /// visible slice sharp without forcing a full-page raster at this scale.
   ///
-  /// When the default is used on a narrow viewport, the viewer may lift the
-  /// internal fit-width multiplier so the actual-size cap still reaches at
-  /// least 2400%. Custom [maxZoom] values are respected exactly.
+  /// When omitted, the viewer lifts the internal fit-width multiplier as
+  /// needed so the actual-size cap reaches at least 10000%, independently of
+  /// the viewport width or open side panels. Explicit values retain their
+  /// existing fit-width limits: 24 keeps its minimum actual-size cap of 2400%,
+  /// and all other values are respected exactly as fit-width multiples.
   final double maxZoom;
+  final bool _hasCustomMaxZoom;
   final double doubleTapZoom;
 
   /// The canvas color around and between the pages. Defaults to a
@@ -5118,17 +5124,20 @@ class _PdfViewerState extends State<PdfViewer>
       ? 1
       : _crossView / _maxCrossPoint;
 
-  /// Gesture/controller zoom clamps are expressed as fit multiples. On small
-  /// viewports the fit scale is less than actual size, so the stock 24x cap
-  /// used to top out below 2400% actual size. Keep the default generous
-  /// there without changing explicit host caps.
+  /// Gesture/controller zoom clamps are expressed as fit multiples. Keep
+  /// 10000% actual size reachable at the default on any viewport, including
+  /// when side panels reduce its width, without changing explicit host caps.
   double get _effectiveMaxZoom {
-    if (widget.maxZoom != _defaultMaxZoom) return widget.maxZoom;
-    final fit = _fitScale;
-    if (!fit.isFinite || fit <= 0 || fit >= 1) {
+    if (widget._hasCustomMaxZoom && widget.maxZoom != _defaultMaxZoom) {
       return widget.maxZoom;
     }
-    return math.max(widget.maxZoom, _defaultMaxZoom / fit);
+    final fit = _fitScale;
+    if (!fit.isFinite || fit <= 0) {
+      return widget.maxZoom;
+    }
+    final minimumDisplayZoom =
+        widget._hasCustomMaxZoom ? _defaultMaxZoom : _defaultMaxDisplayZoom;
+    return math.max(widget.maxZoom, minimumDisplayZoom / fit);
   }
 
   /// The on-screen scale the user sees, in logical pixels per PDF point,

--- a/packages/dart_pdf_editor/lib/src/region_replay_index.dart
+++ b/packages/dart_pdf_editor/lib/src/region_replay_index.dart
@@ -5,8 +5,8 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 /// Serialized-index format version. Producer and consumer are the same build,
-/// shipped together, so a mismatch is a programming error (asserted on read).
-const int _regionIndexFormatVersion = 1;
+/// shipped together; older cached indices are declined in every build mode.
+const int _regionIndexFormatVersion = 2;
 
 /// Region-index policy for worker detail transcripts.
 ///
@@ -17,14 +17,15 @@ const int _regionIndexFormatVersion = 1;
 /// ordinary linear/grid escalation without importing the Flutter-facing scene
 /// into worker code.
 const int pdfDetailRegionLinearMaxCommands = 250000;
+const int pdfDetailRegionGridMinCommands = 32768;
 const int pdfDetailRegionGridMaxCommands = 4000000;
 
 /// Bounded, painter-order-preserving index for retained region replay.
 ///
-/// Each entry is one independent paint operation plus a persistent snapshot
-/// of the clips and blend mode active at that point in the command stream.
-/// Transparency/soft-mask groups remain on the full-replay path: splitting a
-/// group would change its isolated compositing semantics.
+/// Each entry is an independent paint operation or a complete balanced
+/// compositing group, plus the clips and blend mode active at its entry.
+/// Group contents stay indivisible: selecting their full command range keeps
+/// nested transparency, knockout and soft-mask compositing in painter order.
 class PdfRegionReplayIndex {
   PdfRegionReplayIndex._({
     required this.supported,
@@ -47,32 +48,48 @@ class PdfRegionReplayIndex {
       );
     }
 
+    final safety = _ReplaySafety(maxStateDepth);
+    if (!safety.supports(commands)) {
+      return PdfRegionReplayIndex._(
+        supported: false,
+        units: const [],
+        clipNodeCount: 0,
+      );
+    }
+
     final units = <PdfRegionReplayUnit>[];
     final savedClips = <PdfRegionClipState?>[];
+    final groups = <_RegionGroupFrame>[];
     PdfRegionClipState? clips;
     var blendMode = PdfBlendMode.normal;
     var clipNodes = 0;
+
+    void addBounds(int start, int end, PdfRect? bounds,
+        PdfRegionClipState? entryClips, PdfBlendMode entryBlend) {
+      if (bounds == null) return;
+      if (groups.isNotEmpty) {
+        final group = groups.last;
+        group.bounds =
+            group.bounds == null ? bounds : _union(group.bounds!, bounds);
+        return;
+      }
+      units.add(PdfRegionReplayUnit(
+        commandIndex: start,
+        endCommandIndex: end,
+        bounds: bounds,
+        clips: entryClips,
+        blendMode: entryBlend,
+      ));
+    }
 
     for (var i = 0; i < commands.length; i++) {
       final command = commands[i];
       switch (command) {
         case PdfSaveCommand():
-          if (savedClips.length >= maxStateDepth) {
-            return PdfRegionReplayIndex._(
-              supported: false,
-              units: const [],
-              clipNodeCount: clipNodes,
-            );
-          }
           savedClips.add(clips);
         case PdfRestoreCommand():
-          if (savedClips.isEmpty) {
-            return PdfRegionReplayIndex._(
-              supported: false,
-              units: const [],
-              clipNodeCount: clipNodes,
-            );
-          }
+          // The safety pass rejects restores crossing a layer boundary.
+          // Canvas save/restore does not save the device's blend-mode field.
           clips = savedClips.removeLast();
         case PdfClipPathCommand(:final path):
           final bounds = pdfRenderPathBounds(path);
@@ -88,28 +105,29 @@ class PdfRegionReplayIndex {
           clipNodes++;
         case PdfSetBlendModeCommand(:final mode):
           blendMode = mode;
+        case PdfBeginGroupCommand() || PdfBeginSoftMaskedCommand():
+          groups.add(_RegionGroupFrame(i, clips, blendMode));
+          if (command is PdfBeginSoftMaskedCommand) {
+            blendMode = PdfBlendMode.normal;
+          }
+        case PdfEndGroupCommand() || PdfEndSoftMaskedCommand():
+          final group = groups.removeLast();
+          // Both layer kinds implicitly restore their entry canvas clip.
+          // Ordinary groups leave the device blend alone; soft masks restore
+          // the blend captured before their source was reset to Normal.
+          clips = group.clips;
+          if (command is PdfEndSoftMaskedCommand) {
+            blendMode = group.blendMode;
+          }
+          addBounds(group.commandIndex, i + 1, group.bounds, group.clips,
+              group.blendMode);
         case PdfSetOverprintCommand():
-          // Unlike blend mode, the region index does not yet snapshot the
-          // three overprint fields on each unit. Selective replay would lose
-          // that persistent device state, so keep these pages on the exact
-          // full-transcript fallback.
-          return PdfRegionReplayIndex._(
-            supported: false,
-            units: const [],
-            clipNodeCount: clipNodes,
-          );
-        case PdfBeginGroupCommand() ||
-              PdfEndGroupCommand() ||
-              PdfBeginSoftMaskedCommand() ||
-              PdfEndSoftMaskedCommand():
-          return PdfRegionReplayIndex._(
-            supported: false,
-            units: const [],
-            clipNodeCount: clipNodes,
-          );
+          // Declined recursively by the safety pass; units do not snapshot
+          // persistent overprint fields, including those in mask/cell lists.
+          throw StateError('Overprint passed region replay safety validation');
         default:
           if (clips?.empty ?? false) continue;
-          var bounds = pdfRenderCommandBounds(command);
+          var bounds = safety.commandBounds(command);
           if (bounds == null) continue;
           // Raster coverage and filtered image edges can extend just beyond
           // mathematical geometry. Two page points conservatively cover a
@@ -120,20 +138,11 @@ class PdfRegionReplayIndex {
             bounds = _intersection(bounds, clipBounds);
             if (bounds == null) continue;
           }
-          units.add(PdfRegionReplayUnit(
-            commandIndex: i,
-            bounds: bounds,
-            clips: clips,
-            blendMode: blendMode,
-          ));
+          // A group's allocation BBox is not a clip. Its bounds must include
+          // all source paint, even outside the BBox or painted mask geometry:
+          // /BC and /TR can reveal source where the mask itself never painted.
+          addBounds(i, i + 1, bounds, clips, blendMode);
       }
-    }
-    if (savedClips.isNotEmpty) {
-      return PdfRegionReplayIndex._(
-        supported: false,
-        units: const [],
-        clipNodeCount: clipNodes,
-      );
     }
     final unitList = List<PdfRegionReplayUnit>.unmodifiable(units);
     return PdfRegionReplayIndex._(
@@ -157,7 +166,15 @@ class PdfRegionReplayIndex {
   /// Conservative retained-index estimate. The command geometry itself is
   /// borrowed from the scene and is not counted twice.
   int get estimatedBytes =>
-      units.length * 48 + clipNodeCount * 40 + (grid?.estimatedBytes ?? 0);
+      units.length * 56 + clipNodeCount * 40 + (grid?.estimatedBytes ?? 0);
+
+  /// Largest indivisible top-level command range selected by a region query.
+  /// A large compositing group may remain useful for single-patch culling,
+  /// while repeating the whole range for every small tile would be expensive.
+  late final int maxAtomicCommandSpan = units.fold<int>(
+      0,
+      (largest, unit) =>
+          math.max(largest, unit.endCommandIndex - unit.commandIndex));
 
   /// Page-space X span [min, max] covered by the indexed paint units, or null
   /// when nothing is drawable. This is the axis an X-strip band decomposition
@@ -222,10 +239,10 @@ class PdfRegionReplayIndex {
         commands,
         device,
         start: unit.commandIndex,
-        end: unit.commandIndex + 1,
+        end: unit.endCommandIndex,
       );
       device.restore();
-      replayed++;
+      replayed += unit.endCommandIndex - unit.commandIndex;
     }
     return replayed;
   }
@@ -273,7 +290,8 @@ class PdfRegionReplayIndex {
   ) {
     if (!supported) return commands;
     final selected = select(region);
-    if (selected.isNotEmpty && selected.last.commandIndex >= commands.length) {
+    if (selected.isNotEmpty &&
+        selected.last.endCommandIndex > commands.length) {
       return commands;
     }
     final out = <PdfRenderCommand>[];
@@ -281,7 +299,7 @@ class PdfRegionReplayIndex {
       out.add(const PdfSaveCommand());
       out.add(PdfSetBlendModeCommand(unit.blendMode));
       unit.clips?.appendCommands(out);
-      out.add(commands[unit.commandIndex]);
+      out.addAll(commands.getRange(unit.commandIndex, unit.endCommandIndex));
       out.add(const PdfRestoreCommand());
       if (out.length >= commands.length) return commands;
     }
@@ -437,10 +455,10 @@ class PdfRegionReplayGrid {
         commands,
         device,
         start: unit.commandIndex,
-        end: unit.commandIndex + 1,
+        end: unit.endCommandIndex,
       );
       device.restore();
-      replayed++;
+      replayed += unit.endCommandIndex - unit.commandIndex;
     }
     return replayed;
   }
@@ -486,12 +504,16 @@ class PdfRegionReplayGrid {
 class PdfRegionReplayUnit {
   const PdfRegionReplayUnit({
     required this.commandIndex,
+    int? endCommandIndex,
     required this.bounds,
     required this.clips,
     required this.blendMode,
-  });
+  }) : endCommandIndex = endCommandIndex ?? commandIndex + 1;
 
   final int commandIndex;
+
+  /// Exclusive end of the indivisible paint/compositing command range.
+  final int endCommandIndex;
   final PdfRect bounds;
   final PdfRegionClipState? clips;
   final PdfBlendMode blendMode;
@@ -519,6 +541,170 @@ class PdfRegionClipState {
     parent?.appendCommands(commands);
     commands.add(command);
   }
+}
+
+class _RegionGroupFrame {
+  _RegionGroupFrame(this.commandIndex, this.clips, this.blendMode);
+
+  final int commandIndex;
+  final PdfRegionClipState? clips;
+  final PdfBlendMode blendMode;
+  PdfRect? bounds;
+}
+
+/// Validate each shared command list once before exposing independent ranges.
+/// In particular, a save outside a layer cannot be restored inside it: canvas
+/// restores share one stack, while group bookkeeping uses a separate stack.
+/// Mask/cell lists are checked too, even though their paint stays indivisible.
+class _ReplaySafety {
+  _ReplaySafety(this.maxStateDepth);
+
+  final int maxStateDepth;
+  final _summaries = Map<List<PdfRenderCommand>,
+      Map<PdfBlendMode, _ReplaySafetySummary?>>.identity();
+  final _visiting = Set<List<PdfRenderCommand>>.identity();
+  final _bounds = Map<List<PdfRenderCommand>, PdfRect?>.identity();
+
+  bool supports(List<PdfRenderCommand> commands) =>
+      _summarize(commands, PdfBlendMode.normal) != null;
+
+  _ReplaySafetySummary? _summarize(
+      List<PdfRenderCommand> commands, PdfBlendMode incomingBlend) {
+    final modes = _summaries.putIfAbsent(commands, () => {});
+    if (modes.containsKey(incomingBlend)) return modes[incomingBlend];
+    // Shared lists are ordinary; cycles and excessive nested-list recursion
+    // are not. Decline before recursing so malformed input cannot overflow.
+    if (_visiting.length > maxStateDepth || !_visiting.add(commands)) {
+      return null;
+    }
+    final summary = _scan(commands, incomingBlend);
+    _visiting.remove(commands);
+    modes[incomingBlend] = summary;
+    return summary;
+  }
+
+  _ReplaySafetySummary? _scan(
+      List<PdfRenderCommand> commands, PdfBlendMode incomingBlend) {
+    final savedClips = <bool>[];
+    final groups = <_ReplaySafetyFrame>[];
+    var clipped = false;
+    // Canvas save/restore does not restore device blend, but the interpreter
+    // can emit an explicit reset after q/Q. That is safe when it matches the
+    // actual incoming mode. A shared cell may be used in several modes, so
+    // summaries include that context instead of rejecting every explicit reset.
+    var blend = incomingBlend;
+    var depth = 0;
+
+    bool includeNested(_ReplaySafetySummary? child) {
+      if (child == null) return false;
+      depth = math.max(
+          depth, savedClips.length + groups.length + 1 + child.maxDepth);
+      return depth <= maxStateDepth;
+    }
+
+    for (final command in commands) {
+      switch (command) {
+        case PdfSaveCommand():
+          savedClips.add(clipped);
+        case PdfRestoreCommand():
+          if (savedClips.isEmpty ||
+              (groups.isNotEmpty &&
+                  savedClips.length <= groups.last.saveDepth)) {
+            return null;
+          }
+          clipped = savedClips.removeLast();
+        case PdfClipPathCommand():
+          clipped = true;
+        case PdfSetBlendModeCommand(:final mode):
+          blend = mode;
+        case PdfSetOverprintCommand():
+          return null;
+        case PdfBeginGroupCommand(:final isolated, :final backdropColor):
+          // Seeded non-isolated groups clip before saving their layer and
+          // replace its backdrop. Even without a BBox here, a seed can pass
+          // through a knockout parent to a bounded child, so decline it.
+          if (!isolated && backdropColor != null) return null;
+          groups.add(
+              _ReplaySafetyFrame(false, savedClips.length, clipped, blend));
+        case PdfBeginSoftMaskedCommand():
+          groups
+              .add(_ReplaySafetyFrame(true, savedClips.length, clipped, blend));
+          blend = PdfBlendMode.normal;
+        case PdfEndGroupCommand() || PdfEndSoftMaskedCommand():
+          final masked = command is PdfEndSoftMaskedCommand;
+          if (groups.isEmpty ||
+              groups.last.masked != masked ||
+              savedClips.length != groups.last.saveDepth) {
+            return null;
+          }
+          if (command is PdfEndSoftMaskedCommand &&
+              !includeNested(
+                  _summarize(command.maskCommands, PdfBlendMode.normal))) {
+            return null;
+          }
+          final group = groups.removeLast();
+          clipped = group.clipped;
+          if (masked) blend = group.blend;
+        case PdfDrawTiledCellCommand(
+            :final cellCommands,
+            :final originsX,
+            :final originsY
+          ):
+          if (originsX.length != originsY.length) return null;
+          final cell = _summarize(cellCommands, blend);
+          if (!includeNested(cell)) return null;
+          // Canvas may expand cells directly into the parent device when a
+          // blend/knockout is active. Only cells whose state cannot escape
+          // are independent paint units in both replay paths.
+          if (cell!.clipped || cell.blend != blend) return null;
+        default:
+          break;
+      }
+      depth = math.max(depth, savedClips.length + groups.length);
+      if (depth > maxStateDepth) return null;
+    }
+    if (savedClips.isNotEmpty || groups.isNotEmpty) return null;
+    return _ReplaySafetySummary(depth, clipped, blend);
+  }
+
+  PdfRect? commandBounds(PdfRenderCommand command) {
+    if (command is! PdfDrawTiledCellCommand) {
+      return pdfRenderCommandBounds(command);
+    }
+    final cell = _listBounds(command.cellCommands);
+    return _tiledCellBounds(command, cell);
+  }
+
+  PdfRect? _listBounds(List<PdfRenderCommand> commands) {
+    if (_bounds.containsKey(commands)) return _bounds[commands];
+    PdfRect? bounds;
+    for (final command in commands) {
+      // Mask geometry does not bound source coverage: /BC or /TR can reveal
+      // the source beyond it. Group allocation hints are not clips either.
+      final next = commandBounds(command);
+      if (next != null) bounds = bounds == null ? next : _union(bounds, next);
+    }
+    _bounds[commands] = bounds;
+    return bounds;
+  }
+}
+
+class _ReplaySafetyFrame {
+  const _ReplaySafetyFrame(
+      this.masked, this.saveDepth, this.clipped, this.blend);
+
+  final bool masked;
+  final int saveDepth;
+  final bool clipped;
+  final PdfBlendMode blend;
+}
+
+class _ReplaySafetySummary {
+  const _ReplaySafetySummary(this.maxDepth, this.clipped, this.blend);
+
+  final int maxDepth;
+  final bool clipped;
+  final PdfBlendMode blend;
 }
 
 PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
@@ -554,11 +740,7 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
       return bounds;
     case PdfDrawImageCommand(:final request):
       return _matrixBounds(request.transform, 0, 0, 1, 1);
-    case PdfDrawTiledCellCommand(
-        :final cellCommands,
-        :final originsX,
-        :final originsY
-      ):
+    case PdfDrawTiledCellCommand(:final cellCommands):
       // Conservative: the cell's painted bounds (clip commands inside the
       // cell contribute nothing, so overrunning content is included - safe
       // for culling) swept across the origin extent. One rect for the whole
@@ -568,17 +750,7 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
         final b = pdfRenderCommandBounds(c);
         if (b != null) cell = cell == null ? b : _union(cell, b);
       }
-      if (cell == null || originsX.isEmpty) return null;
-      var minX = originsX[0], maxX = originsX[0];
-      var minY = originsY[0], maxY = originsY[0];
-      for (var t = 1; t < originsX.length; t++) {
-        minX = math.min(minX, originsX[t]);
-        maxX = math.max(maxX, originsX[t]);
-        minY = math.min(minY, originsY[t]);
-        maxY = math.max(maxY, originsY[t]);
-      }
-      return PdfRect(cell.left + minX, cell.bottom + minY, cell.right + maxX,
-          cell.top + maxY);
+      return _tiledCellBounds(command, cell);
     case PdfSaveCommand() ||
           PdfRestoreCommand() ||
           PdfClipPathCommand() ||
@@ -590,6 +762,22 @@ PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
           PdfEndSoftMaskedCommand():
       return null;
   }
+}
+
+PdfRect? _tiledCellBounds(PdfDrawTiledCellCommand command, PdfRect? cell) {
+  final originsX = command.originsX;
+  final originsY = command.originsY;
+  if (cell == null || originsX.isEmpty) return null;
+  var minX = originsX[0], maxX = originsX[0];
+  var minY = originsY[0], maxY = originsY[0];
+  for (var t = 1; t < originsX.length; t++) {
+    minX = math.min(minX, originsX[t]);
+    maxX = math.max(maxX, originsX[t]);
+    minY = math.min(minY, originsY[t]);
+    maxY = math.max(maxY, originsY[t]);
+  }
+  return PdfRect(
+      cell.left + minX, cell.bottom + minY, cell.right + maxX, cell.top + maxY);
 }
 
 PdfRect? _textBounds(PdfTextRun run) {
@@ -735,8 +923,8 @@ bool pdfRenderRectsIntersect(PdfRect a, PdfRect b) =>
 
 /// Serializes [index] to a portable byte buffer, or returns null when it holds
 /// content the codec declines (a clip path that fails to serialize — never in
-/// practice, clip paths carry no images). An unsupported index (a
-/// transparency/soft-mask group spanned the page, or the build hit its bounds)
+/// practice, clip paths carry no images). An unsupported index (unsafe
+/// persistent state or malformed groups, or a build that hit its bounds)
 /// serializes to a tiny "unsupported" marker so the consumer learns the worker
 /// examined the page and it is not region-cullable.
 Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
@@ -783,6 +971,7 @@ Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
   for (var i = 0; i < index.units.length; i++) {
     final unit = index.units[i];
     w.u32(unit.commandIndex);
+    w.u32(unit.endCommandIndex);
     _idxWriteRect(w, unit.bounds);
     w.i32(unitClipIndices[i]);
     w.u8(unit.blendMode.index);
@@ -810,8 +999,9 @@ Uint8List? serializeRegionReplayIndex(PdfRegionReplayIndex index) {
 PdfRegionReplayIndex deserializeRegionReplayIndex(Uint8List bytes) {
   final r = _IdxReader(bytes);
   final version = r.u8();
-  assert(version == _regionIndexFormatVersion,
-      'region index format version mismatch');
+  if (version != _regionIndexFormatVersion) {
+    throw const FormatException('Region index format version mismatch');
+  }
   final supported = r.boolean();
   final clipNodeCount = r.u32();
   if (!supported) {
@@ -845,11 +1035,16 @@ PdfRegionReplayIndex deserializeRegionReplayIndex(Uint8List bytes) {
   final unitCount = r.u32();
   final units = List<PdfRegionReplayUnit>.generate(unitCount, (_) {
     final commandIndex = r.u32();
+    final endCommandIndex = r.u32();
+    if (endCommandIndex <= commandIndex) {
+      throw const FormatException('Invalid region replay command range');
+    }
     final bounds = _idxReadRect(r);
     final clipIndex = r.i32();
     final blendMode = PdfBlendMode.values[r.u8()];
     return PdfRegionReplayUnit(
       commandIndex: commandIndex,
+      endCommandIndex: endCommandIndex,
       bounds: bounds,
       clips: clipIndex < 0 ? null : nodes[clipIndex],
       blendMode: blendMode,

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -18,6 +18,7 @@ import 'region_replay_index.dart';
 import 'jpeg_accelerator.dart';
 import 'render_worker.dart';
 import 'render_worker_ranges.dart';
+import 'render_worker_text_cache.dart';
 import 'render_worker_transcript_cache.dart'
     show compactTranscriptSourceCommands, retainedCommandGraphsWeight;
 
@@ -818,7 +819,8 @@ void _workerMain(_WorkerInit init) {
     document = null; // a broken document fails every page → all local renders
   }
 
-  final binCommands = _BinCommandCache();
+  final textCache = PdfWorkerTextCache();
+  final binCommands = _BinCommandCache(textCache);
   final suspendedRecord = _SuspendedRecordCache();
 
   PdfCancellationToken? activeToken;
@@ -908,6 +910,7 @@ void _workerMain(_WorkerInit init) {
         // old document too, so it follows the same eviction.
         binCommands.evictPages(incremental ? changed : null);
         suspendedRecord.evict(incremental ? changed : null);
+        textCache.evictPages(incremental ? changed : null);
       } catch (_) {
         // Malformed update: leave the document and buffer as they were and just
         // free the worker slot below so it keeps serving other pages.
@@ -971,7 +974,7 @@ void _workerMain(_WorkerInit init) {
           buffer = await _buildRegionIndexAsync(doc, binCommands, pageIndex,
               annotations, request[4] as int, request[5] as bool, token);
         } else if (kind == 'extractText') {
-          buffer = _extractTextForWorker(doc, pageIndex);
+          buffer = _extractTextForWorker(doc, textCache, pageIndex);
         } else {
           final imagePixelRatio = request[4] as double?;
           final decodeImages = request[5] as bool;
@@ -1003,6 +1006,7 @@ void _workerMain(_WorkerInit init) {
               doc,
               imageCache,
               suspendedRecord,
+              textCache,
               pageIndex,
               annotations,
               imagePixelRatio,
@@ -1040,13 +1044,14 @@ void _workerMain(_WorkerInit init) {
 }
 
 /// Extracts one page's text off the UI isolate and serializes it for the wire
-/// (#396). Synchronous - [PdfTextExtractor.extract] is a single content walk
-/// with no cancellation seam - but it runs on the worker isolate, so a heavy
-/// page's extraction no longer freezes the frame; a superseded search just
-/// discards the result. Null (a bad index) declines to a local extraction.
-Uint8List? _extractTextForWorker(PdfDocument document, int pageIndex) {
+/// (#396). A complete render supplies exact text metadata, avoiding another
+/// content walk. Cache misses still extract synchronously off the UI isolate.
+/// Null (a bad index) declines to a local extraction.
+Uint8List? _extractTextForWorker(
+    PdfDocument document, PdfWorkerTextCache textCache, int pageIndex) {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
-  return serializePageText(PdfTextExtractor.extract(document, pageIndex));
+  return serializePageText(textCache.extract(pageIndex) ??
+      PdfTextExtractor.extract(document, pageIndex));
 }
 
 /// Records one page into a serialized command buffer, yielding periodically
@@ -1062,6 +1067,7 @@ Future<Uint8List?> _recordPageAsync(
     PdfDocument document,
     PdfImageDecodeCache imageCache,
     _SuspendedRecordCache suspended,
+    PdfWorkerTextCache textCache,
     int pageIndex,
     bool annotations,
     double? imagePixelRatio,
@@ -1078,17 +1084,33 @@ Future<Uint8List?> _recordPageAsync(
   // record builds (#564 pt4). A bounded prefix (commandLimit set) stays on the
   // simple one-shot path; it is already cheap and does not stream.
   if (decodeImages || (onPartial != null && commandLimit == null)) {
-    return _recordResumablePage(document, imageCache, suspended, pageIndex,
-        annotations, imagePixelRatio, commandLimit, imageDecodeRegion, token,
-        decodeImages: decodeImages, onPartial: onPartial);
+    return _recordResumablePage(
+        document,
+        imageCache,
+        suspended,
+        textCache,
+        pageIndex,
+        annotations,
+        imagePixelRatio,
+        commandLimit,
+        imageDecodeRegion,
+        token,
+        decodeImages: decodeImages,
+        onPartial: onPartial);
   }
 
   final page = document.page(pageIndex);
   final recorder = RecordingPdfDevice();
-  final interpreter =
-      PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
+  final interpreter = PdfInterpreter(
+    cos: document.cos,
+    device: recorder,
+    cancellation: token,
+    collectCharOffsets: commandLimit == null,
+  );
   await interpreter.drawPageContentAsync(page, page.contentBytes(),
       operationLimit: commandLimit);
+  if (token.cancelled) throw const PdfCancelledException();
+  if (commandLimit == null) textCache.record(pageIndex, recorder.commands);
   if (annotations) interpreter.drawAnnotations(page);
   return serializeCommands(recorder.commands,
       cos: document.cos,
@@ -1134,6 +1156,7 @@ Future<Uint8List?> _recordResumablePage(
     PdfDocument document,
     PdfImageDecodeCache imageCache,
     _SuspendedRecordCache suspended,
+    PdfWorkerTextCache textCache,
     int pageIndex,
     bool annotations,
     double? imagePixelRatio,
@@ -1152,7 +1175,11 @@ Future<Uint8List?> _recordResumablePage(
   if (entry == null) {
     final page = document.page(pageIndex);
     final recorder = RecordingPdfDevice();
-    final interpreter = PdfInterpreter(cos: document.cos, device: recorder);
+    final interpreter = PdfInterpreter(
+      cos: document.cos,
+      device: recorder,
+      collectCharOffsets: true,
+    );
     final walk = interpreter.beginPageContent(page, page.contentBytes());
     entry = _SuspendedRecord(
         pageIndex, annotations, page, recorder, interpreter, walk);
@@ -1206,6 +1233,8 @@ Future<Uint8List?> _recordResumablePage(
     if (partial != null) onPartial(partial);
   }
 
+  if (token.cancelled) throw const PdfCancelledException();
+  textCache.record(pageIndex, entry.recorder.commands);
   if (annotations) entry.interpreter.drawAnnotations(entry.page);
   // A fused progressive full record uses the same content walk for first ink
   // and final pixels. Ship the complete image-free transcript before the
@@ -1480,6 +1509,9 @@ Future<Uint8List?> _buildRegionIndexAsync(
 /// and never ask for worker plans anyway. A command-slot budget supplements
 /// the two-entry cap while always retaining the most recently used page.
 class _BinCommandCache {
+  _BinCommandCache(this.textCache);
+
+  final PdfWorkerTextCache textCache;
   final _entries = <(int, bool), _BinCommandEntry>{};
   static const int _capacity = 2;
   static const int _maxRetainedCommands = 250000;
@@ -1539,8 +1571,14 @@ class _BinCommandCache {
     final page = document.page(pageIndex);
     final recorder = RecordingPdfDevice();
     final interpreter = PdfInterpreter(
-        cos: document.cos, device: recorder, cancellation: token);
+      cos: document.cos,
+      device: recorder,
+      cancellation: token,
+      collectCharOffsets: true,
+    );
     await interpreter.drawPageContentAsync(page, page.contentBytes());
+    if (token.cancelled) throw const PdfCancelledException();
+    textCache.record(pageIndex, recorder.commands);
     if (annotations) interpreter.drawAnnotations(page);
     final buffer = serializeCommands(recorder.commands,
         cos: document.cos,

--- a/packages/dart_pdf_editor/lib/src/render_worker_text_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_text_cache.dart
@@ -1,0 +1,51 @@
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'budgeted_cache.dart';
+
+/// Text metadata from complete page recordings, local to one render worker.
+///
+/// Capture before drawing annotations and before the render codec drops exact
+/// advances and marked-content ids. A miss still uses ordinary extraction: a
+/// pool can assign extraction to a different worker, and large entries may be
+/// declined or evicted. No command graph, glyph outline or document is retained.
+class PdfWorkerTextCache {
+  PdfWorkerTextCache({int maxBytes = 16 * 1024 * 1024, int maxPages = 32})
+      : _entries = PdfBudgetedCache<int, PdfRecordedText>(
+          weigher: (text) => text.estimatedBytes,
+          maxWeight: maxBytes,
+          maxEntries: maxPages,
+          rejectOversize: true,
+          debugLabel: 'worker-recorded-text',
+        );
+
+  final PdfBudgetedCache<int, PdfRecordedText> _entries;
+
+  int get hits => _entries.hits;
+  int get retainedBytes => _entries.weight;
+  int get length => _entries.length;
+
+  /// [commands] must contain the complete page content, recorded with
+  /// `collectCharOffsets: true`, and must exclude annotation appearances.
+  /// Call [evictPages] when the worker receives a document revision.
+  void record(int pageIndex, List<PdfRenderCommand> commands) {
+    // Image resolutions and annotation visibility can trigger another full
+    // recording without changing searchable page content.
+    if (_entries.containsKey(pageIndex)) return;
+    _entries.put(pageIndex, PdfRecordedText.capture(commands));
+  }
+
+  PdfPageText? extract(int pageIndex) {
+    final recorded = _entries.take(pageIndex);
+    return recorded == null
+        ? null
+        : PdfTextExtractor.fromRecordedText(recorded, pageIndex);
+  }
+
+  void evictPages(Set<int>? pages) {
+    if (pages == null) {
+      _entries.clear();
+    } else {
+      _entries.evictWhere(pages.contains);
+    }
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -45,9 +45,9 @@ class PdfWorkerTranscript {
 
   /// Selects a compact, document-backed transcript for one detail region.
   List<PdfRenderCommand> commandsForDetail(PdfRect region) {
-    final buildGrid = wireCommands.length > pdfDetailRegionLinearMaxCommands;
+    final buildGrid = wireCommands.length >= pdfDetailRegionGridMinCommands;
     final index = regionIndex(
-      maxCommands: buildGrid
+      maxCommands: wireCommands.length > pdfDetailRegionLinearMaxCommands
           ? pdfDetailRegionGridMaxCommands
           : pdfDetailRegionLinearMaxCommands,
       buildGrid: buildGrid,

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -6,6 +6,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'budgeted_cache.dart';
 import 'region_replay_index.dart';
 import 'render_trace.dart';
+import 'render_worker_text_cache.dart';
 
 // The worker fills its half of the unified [PdfRenderTrace]; re-exported so
 // callers importing this file keep seeing [PdfWorkerPhaseTimings] (now an alias
@@ -211,11 +212,15 @@ class PdfWorkerTranscriptCache {
     this.capacity = 4,
     this.maxRetainedCommands = 250000,
     this.deduplicateCommands = true,
+    PdfWorkerTextCache? textCache,
     int? resumeChunkOperations,
   })  : assert(capacity > 0),
         assert(maxRetainedCommands > 0),
         assert(resumeChunkOperations == null || resumeChunkOperations > 0),
-        _resumeChunk = resumeChunkOperations ?? _resumeRecordChunkOperations;
+        _resumeChunk = resumeChunkOperations ?? _resumeRecordChunkOperations,
+        textCache = textCache ?? PdfWorkerTextCache();
+
+  final PdfWorkerTextCache textCache;
 
   final int capacity;
   final int maxRetainedCommands;
@@ -287,7 +292,11 @@ class PdfWorkerTranscriptCache {
     if (entry == null) {
       final page = document.page(pageIndex);
       final recorder = RecordingPdfDevice();
-      final interpreter = PdfInterpreter(cos: document.cos, device: recorder);
+      final interpreter = PdfInterpreter(
+        cos: document.cos,
+        device: recorder,
+        collectCharOffsets: true,
+      );
       final walk = interpreter.beginPageContent(page, page.contentBytes());
       entry = _SuspendedTranscriptWalk(
           pageIndex, annotations, page, recorder, interpreter, walk);
@@ -344,7 +353,9 @@ class PdfWorkerTranscriptCache {
       streamClock.stop();
       timings!.streamUs += streamClock.elapsedMicroseconds;
     }
+    if (token.cancelled) throw const PdfCancelledException();
     final interpretClock = timings == null ? null : (Stopwatch()..start());
+    textCache.record(pageIndex, entry.recorder.commands);
     if (annotations) entry.interpreter.drawAnnotations(entry.page);
     if (interpretClock != null) {
       interpretClock.stop();
@@ -390,6 +401,7 @@ class PdfWorkerTranscriptCache {
 
   void clear() {
     _entries.clear();
+    textCache.evictPages(null);
     _evictSuspended(null);
   }
 
@@ -399,6 +411,7 @@ class PdfWorkerTranscriptCache {
   /// every other page's stays warm across the edit boundary. A suspended record
   /// walks the old document too, so it follows the same eviction (#530).
   void evictPages(Set<int>? pages) {
+    textCache.evictPages(pages);
     if (pages == null) {
       _entries.clear();
     } else {

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -779,8 +779,8 @@ void runPdfRenderWorker() {
     if (kind == 'extractText') {
       final id = (data.getProperty('id'.toJS) as JSNumber).toDartInt;
       final page = (data.getProperty('page'.toJS) as JSNumber).toDartInt;
-      // Text extraction has no cancellation seam and runs synchronously; it
-      // still lands off the UI thread here, which is the point (#396).
+      // Reuse exact metadata captured during a complete page recording. A miss
+      // still extracts synchronously off the UI thread (#396).
       activeToken = null;
       activeRequestId = id;
       () async {
@@ -791,7 +791,8 @@ void runPdfRenderWorker() {
         final doc = document;
         try {
           if (doc != null && page >= 0 && page < doc.pageCount) {
-            out = serializePageText(PdfTextExtractor.extract(doc, page));
+            out = serializePageText(transcriptCache.textCache.extract(page) ??
+                PdfTextExtractor.extract(doc, page));
           }
         } catch (e, st) {
           out = null;
@@ -1055,6 +1056,7 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       device: recorder,
       cancellation: token,
+      collectCharOffsets: previewOperationLimit == null,
     );
     final streamClock = timings == null ? null : (Stopwatch()..start());
     await interpreter.drawPageContentAsync(
@@ -1067,7 +1069,11 @@ Future<Uint8List?> _recordPageAsync(
       streamClock.stop();
       timings!.streamUs += streamClock.elapsedMicroseconds;
     }
+    if (token.cancelled) throw const PdfCancelledException();
     final interpretClock = timings == null ? null : (Stopwatch()..start());
+    if (previewOperationLimit == null) {
+      cache.textCache.record(pageIndex, recorder.commands);
+    }
     if (annotations) interpreter.drawAnnotations(page);
     if (interpretClock != null) {
       interpretClock.stop();

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -172,16 +172,12 @@ class PdfRetainedScene {
   /// a huge unit count would cost O(N) per tile.
   static int spatialRegionReplayMaxCommands = 250000;
 
-  /// Escalate to a uniform-grid spatial index for transcripts ABOVE the linear
-  /// [spatialRegionReplayMaxCommands] ceiling, up to [spatialGridReplayMaxCommands].
-  ///
-  /// Below the linear ceiling nothing changes: the flat per-op scan is cheap
-  /// enough. Above it, the historical behaviour was to give up on culling and
-  /// full-replay the whole transcript into every tile — catastrophic on a dense
-  /// CAD page (a 256px tile replaying ~850k commands, ~260ms, on the UI
-  /// isolate). The grid makes region replay O(candidates) instead, so those
-  /// pages become pannable. On by default because it only ever REPLACES the
-  /// full-transcript fallback — it never changes a page that already culled.
+  /// Use a uniform-grid spatial index on dense transcripts, starting at
+  /// [pdfDetailRegionGridMinCommands]. It avoids scanning every paint for tiny
+  /// high-zoom tiles. Above [spatialRegionReplayMaxCommands], the grid also
+  /// extends the supported transcript size to [spatialGridReplayMaxCommands].
+  /// Turning this off retains the linear index below its ceiling and full
+  /// replay above it.
   static bool spatialGridReplay = true;
   static int spatialGridReplayMaxCommands = 4000000;
 
@@ -242,11 +238,60 @@ class PdfRetainedScene {
   }
 
   /// Whether region rasters ([rasterizeRegion]) can be spatially culled to the
-  /// requested bounds rather than replaying the whole transcript. False when a
-  /// transparency group or soft mask spans the page (splitting one would change
-  /// its isolated compositing) - the [PdfTileStore] tile path leaves such pages
-  /// on the legacy full-page raster to avoid per-tile full-transcript replays.
+  /// requested bounds rather than replaying the whole transcript. Balanced
+  /// compositing groups remain atomic. Unsupported state stays on the legacy
+  /// detail path to avoid per-tile full-transcript replays.
   bool get supportsRegionRaster => _ensureRegionIndex().supported;
+
+  /// Whether small cached tiles can replay this scene without repeatedly
+  /// walking a large indivisible compositing group. Such groups can still use
+  /// selective [rasterizeRegion] for one viewport-sized detail patch. The
+  /// per-group budget includes nested masks and repeated tiled-cell work.
+  bool get supportsTiledRegionRaster {
+    final index = _ensureRegionIndex();
+    if (!index.supported) return false;
+    return _atomicGroupsFitTileBudget ??= _checkAtomicTileBudget(index);
+  }
+
+  bool? _atomicGroupsFitTileBudget;
+  static const _maxAtomicTileCommands = 1024;
+
+  bool _checkAtomicTileBudget(PdfRegionReplayIndex index) {
+    if (index.maxAtomicCommandSpan > _maxAtomicTileCommands) return false;
+    final nestedCosts = Map<List<PdfRenderCommand>, int>.identity();
+    late int Function(PdfRenderCommand command) commandCost;
+    int listCost(List<PdfRenderCommand> commands) =>
+        nestedCosts.putIfAbsent(commands, () {
+          var cost = 0;
+          for (final command in commands) {
+            cost += commandCost(command);
+            if (cost > _maxAtomicTileCommands) break;
+          }
+          return cost;
+        });
+    commandCost = (command) => switch (command) {
+          PdfEndSoftMaskedCommand(:final maskCommands) =>
+            1 + listCost(maskCommands),
+          PdfDrawTiledCellCommand(:final cellCommands, :final originsX) =>
+            originsX.isEmpty
+                ? 1
+                : 1 +
+                    math.min(_maxAtomicTileCommands + 1,
+                        originsX.length * math.max(1, listCost(cellCommands))),
+          _ => 1,
+        };
+    for (final unit in index.units) {
+      // Only compositing ranges gain tile eligibility here; ordinary paint
+      // units (including single tiled cells) keep their existing policy.
+      if (unit.endCommandIndex == unit.commandIndex + 1) continue;
+      var cost = 0;
+      for (var i = unit.commandIndex; i < unit.endCommandIndex; i++) {
+        cost += commandCost(commands[i]);
+        if (cost > _maxAtomicTileCommands) return false;
+      }
+    }
+    return true;
+  }
 
   /// Approximate bytes of the decoded images this scene retains for replay
   /// (RGBA, width*height*4). Counted against the live-raster budget (#405): a
@@ -737,11 +782,10 @@ class PdfRetainedScene {
   ///
   /// [rasterRegion] uses the same page-point, y-down space as
   /// [rasterizeRegion]. Each returned unit carries its command index plus the
-  /// clip and blend state active at that command. Null means the scene cannot
-  /// be split safely (for example, it contains an isolated group or soft
-  /// mask), so a backend must decline the scene and let the Canvas fallback
-  /// render it whole. An empty list means the supported region is genuinely
-  /// blank.
+  /// clip and blend state active at that command. A group is a complete command
+  /// range and must remain indivisible. Null means the scene cannot be indexed
+  /// safely, so a backend must decline it and use full replay. An empty list
+  /// means the supported region is genuinely blank.
   List<PdfRegionReplayUnit>? selectRegion(Rect rasterRegion) {
     assert(!_disposed, 'selectRegion after dispose');
     final index = _ensureRegionIndex();
@@ -752,18 +796,20 @@ class PdfRetainedScene {
   }
 
   /// The `(maxCommands, buildGrid)` the region index builds under for this
-  /// transcript, given the current escalation policy. Below the linear ceiling:
-  /// the flat per-op scan (unchanged). Above it: escalate to the grid rather
-  /// than falling back to full-transcript replay. Shared by the in-isolate
+  /// transcript, given the current escalation policy. Dense transcripts use
+  /// the grid before reaching the linear retention ceiling: at extreme zoom a
+  /// tile covers only a few page points, so scanning tens of thousands of units
+  /// per tile wastes most of the query work. Shared by the in-isolate
   /// build ([_ensureRegionIndex]) and the worker request ([warmRegionIndex]) so
   /// both bin the transcript identically — the worker re-records a byte-for-byte
   /// identical transcript, so the same parameters produce an index whose unit
   /// indices line up with this scene's [commands].
   ({int maxCommands, bool buildGrid}) get _regionIndexBuildParams {
     final overLinear = commands.length > spatialRegionReplayMaxCommands;
-    final useGrid = spatialGridReplay && overLinear;
+    final useGrid = spatialGridReplay &&
+        (overLinear || commands.length >= pdfDetailRegionGridMinCommands);
     return (
-      maxCommands: useGrid
+      maxCommands: overLinear && useGrid
           ? spatialGridReplayMaxCommands
           : spatialRegionReplayMaxCommands,
       buildGrid: useGrid,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1179,7 +1179,19 @@ class PdfShellZoomControl extends StatefulWidget {
 }
 
 class _PdfShellZoomControlState extends State<PdfShellZoomControl> {
-  static const List<double> _presets = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+  static const List<double> _presets = [
+    0.5,
+    0.75,
+    1,
+    1.25,
+    1.5,
+    2,
+    3,
+    4,
+    30,
+    50,
+    100,
+  ];
 
   @override
   void initState() {

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -77,7 +77,7 @@ class PdfTileZoomLadder {
   const PdfTileZoomLadder({
     this.stepsPerOctave = 2,
     this.minRung = -8,
-    this.maxRung = 16,
+    this.maxRung = 18,
   })  : assert(stepsPerOctave >= 1),
         assert(minRung <= 0 && maxRung >= 0);
 
@@ -87,6 +87,9 @@ class PdfTileZoomLadder {
   /// Clamp bounds so a degenerate desired ratio can't select an absurd bucket
   /// (ratio floor 0.05 / a huge accidental zoom). minRung ratio ≈ 2^(min/steps).
   final int minRung;
+
+  /// Highest resolution bucket. The default is 512 physical pixels per PDF
+  /// point, keeping a 10000% view sharp at device pixel ratios up to 5.
   final int maxRung;
 
   /// The rung whose ratio is nearest [ratio] (in log space), clamped.

--- a/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
@@ -1,0 +1,269 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+PdfPath _rect(double l, double b, double r, double t) => PdfPath([
+      PdfMoveTo(l, b),
+      PdfLineTo(r, b),
+      PdfLineTo(r, t),
+      PdfLineTo(l, t),
+      const PdfClosePath(),
+    ]);
+
+PdfFillPathCommand _fill(double l, double b, double r, double t,
+        [PdfColor color = const PdfColor(1, 0, 0)]) =>
+    PdfFillPathCommand(_rect(l, b, r, t), color, PdfFillRule.nonzero, 1);
+
+const _maskEnd = PdfEndSoftMaskedCommand(
+  luminosity: false,
+  backdrop: PdfRect(0, 0, 612, 792),
+  maskCommands: [],
+  transferScale: 0,
+  transferOffset: 1,
+);
+
+void main() {
+  test('selects complete groups and source outside a transferred soft mask',
+      () {
+    final commands = <PdfRenderCommand>[
+      _fill(300, 300, 320, 320),
+      const PdfBeginGroupCommand(.7,
+          isolated: true, bounds: PdfRect(0, 0, 1, 1)),
+      const PdfBeginSoftMaskedCommand(),
+      _fill(40, 40, 70, 70),
+      _maskEnd,
+      const PdfEndGroupCommand(),
+      _fill(400, 400, 420, 420),
+    ];
+    for (final grid in [false, true]) {
+      final index = PdfRegionReplayIndex.build(commands,
+          maxCommands: 100, buildGrid: grid);
+      expect(index.supported, isTrue);
+      final selected = index.select(const PdfRect(60, 60, 65, 65));
+      expect(selected, hasLength(1));
+      expect(selected.single.commandIndex, 1);
+      expect(selected.single.endCommandIndex, 6);
+      // The allocation hint and empty mask never bound the visible source.
+      expect(selected.single.bounds.left, lessThanOrEqualTo(40));
+      expect(selected.single.bounds.right, greaterThanOrEqualTo(70));
+      expect(index.select(const PdfRect(200, 200, 210, 210)), isEmpty);
+      final restored =
+          deserializeRegionReplayIndex(serializeRegionReplayIndex(index)!);
+      expect(
+          restored.select(const PdfRect(60, 60, 65, 65)).single.endCommandIndex,
+          6);
+    }
+  });
+
+  test('groups restore clips; only soft masks restore their entry blend', () {
+    final commands = <PdfRenderCommand>[
+      const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+      const PdfBeginGroupCommand(.5, isolated: true),
+      PdfClipPathCommand(_rect(10, 10, 20, 20), PdfFillRule.nonzero),
+      _fill(10, 10, 20, 20),
+      const PdfSetBlendModeCommand(PdfBlendMode.screen),
+      const PdfEndGroupCommand(),
+      _fill(100, 100, 120, 120),
+      const PdfBeginSoftMaskedCommand(),
+      const PdfSetBlendModeCommand(PdfBlendMode.darken),
+      _fill(150, 150, 170, 170),
+      _maskEnd,
+      _fill(200, 200, 220, 220),
+    ];
+    final index = PdfRegionReplayIndex.build(commands, maxCommands: 100);
+    expect(index.supported, isTrue);
+    final afterGroup = index.select(const PdfRect(105, 105, 110, 110)).single;
+    expect(afterGroup.clips, isNull);
+    expect(afterGroup.blendMode, PdfBlendMode.screen);
+    final afterMask = index.select(const PdfRect(205, 205, 210, 210)).single;
+    expect(afterMask.blendMode, PdfBlendMode.screen);
+  });
+
+  test('unsafe compositing and state crossings retain full-replay fallback',
+      () {
+    const begin = PdfBeginGroupCommand(1, isolated: true);
+    const end = PdfEndGroupCommand();
+    const save = PdfSaveCommand();
+    const restore = PdfRestoreCommand();
+    const overprint =
+        PdfSetOverprintCommand(fill: true, stroke: false, mode: 1);
+    final unsafe = <List<PdfRenderCommand>>[
+      [begin, _fill(0, 0, 10, 10)],
+      [end],
+      [begin, _maskEnd],
+      [const PdfBeginSoftMaskedCommand(), end],
+      [save, begin, restore, end],
+      [begin, save, end, restore],
+      [begin, overprint, _fill(0, 0, 10, 10), end],
+      [const PdfBeginGroupCommand(1, backdropColor: PdfColor(1, 1, 1)), end],
+      [
+        const PdfBeginSoftMaskedCommand(),
+        _fill(0, 0, 10, 10),
+        const PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: PdfRect(0, 0, 10, 10),
+            maskCommands: [overprint])
+      ],
+      [
+        PdfDrawTiledCellCommand([begin, overprint, end],
+            Float64List.fromList([0]), Float64List.fromList([0]))
+      ],
+    ];
+    for (var i = 0; i < unsafe.length; i++) {
+      final index = PdfRegionReplayIndex.build(unsafe[i], maxCommands: 100);
+      expect(index.supported, isFalse, reason: 'unsafe case $i');
+      expect(index.commandsForRegion(const PdfRect(0, 0, 10, 10), unsafe[i]),
+          same(unsafe[i]));
+    }
+    expect(
+        PdfRegionReplayIndex.build([begin, begin, end, end],
+                maxCommands: 100, maxStateDepth: 1)
+            .supported,
+        isFalse);
+  });
+
+  test('shared cells preserve the blend mode of each invocation', () {
+    const normal = PdfSetBlendModeCommand(PdfBlendMode.normal);
+    const multiply = PdfSetBlendModeCommand(PdfBlendMode.multiply);
+    const screen = PdfSetBlendModeCommand(PdfBlendMode.screen);
+    PdfDrawTiledCellCommand cell(List<PdfRenderCommand> commands) =>
+        PdfDrawTiledCellCommand(
+            commands, Float64List.fromList([0]), Float64List.fromList([0]));
+    final resetNormal = cell([multiply, _fill(0, 0, 10, 10), normal]);
+    final cases = <(List<PdfRenderCommand>, bool)>[
+      ([resetNormal], true),
+      (
+        [
+          multiply,
+          cell([screen, _fill(0, 0, 10, 10), multiply])
+        ],
+        true
+      ),
+      (
+        [
+          cell([multiply, _fill(0, 0, 10, 10)])
+        ],
+        false
+      ),
+      // An identity-only safety cache would accept the second invocation.
+      ([resetNormal, multiply, resetNormal], false),
+      (
+        [
+          cell([PdfClipPathCommand(_rect(0, 0, 10, 10), PdfFillRule.nonzero)])
+        ],
+        false
+      ),
+      (
+        [
+          multiply,
+          const PdfBeginSoftMaskedCommand(),
+          resetNormal,
+          PdfEndSoftMaskedCommand(
+              luminosity: false,
+              backdrop: const PdfRect(0, 0, 10, 10),
+              maskCommands: [resetNormal])
+        ],
+        true
+      ),
+    ];
+    for (var i = 0; i < cases.length; i++) {
+      expect(
+          PdfRegionReplayIndex.build(cases[i].$1, maxCommands: 100).supported,
+          cases[i].$2,
+          reason: 'cell context $i');
+    }
+  });
+
+  testWidgets('nested masks, knockout and clips retain exact high-zoom pixels',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[
+        _fill(0, 0, 612, 792, const PdfColor(.7, .85, 1)),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(40, 700, 100, 760), PdfFillRule.nonzero),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        const PdfBeginGroupCommand(.7, isolated: true, knockout: true),
+        _fill(45, 715, 80, 750),
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rect(50, 720, 75, 747), PdfFillRule.nonzero),
+        const PdfBeginSoftMaskedCommand(),
+        _fill(53, 722, 78, 748, const PdfColor(0, 1, 0)),
+        const PdfBeginGroupCommand(.5, isolated: true),
+        _fill(57, 728, 70, 746, const PdfColor(0, 0, 1)),
+        const PdfEndGroupCommand(),
+        PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: const PdfRect(0, 0, 612, 792),
+            maskCommands: [_fill(56, 726, 62, 731, const PdfColor(1, 1, 1))],
+            transferScale: .65,
+            transferOffset: .35),
+        const PdfRestoreCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.screen),
+        const PdfEndGroupCommand(),
+        const PdfRestoreCommand(),
+        _fill(85, 725, 95, 740, const PdfColor(1, 0, 1)),
+        const PdfSetBlendModeCommand(PdfBlendMode.normal),
+        _fill(300, 300, 320, 320),
+        _fill(400, 400, 420, 420),
+        for (var i = 0; i < 32; i++)
+          _fill(300 + i * 3.0, 300, 301 + i * 3.0, 301),
+      ];
+      for (final useGrid in [false, true]) {
+        final index = deserializeRegionReplayIndex(serializeRegionReplayIndex(
+            PdfRegionReplayIndex.build(commands,
+                maxCommands: 100, buildGrid: useGrid))!);
+        expect(index.supported, isTrue);
+        for (final ratio in [30.0, 100.0]) {
+          for (final region in [
+            const ui.Rect.fromLTWH(50.137, 45.271, 12, 9),
+            const ui.Rect.fromLTWH(60.129, 61.331, 12, 9),
+            const ui.Rect.fromLTWH(84.137, 52.271, 12, 9),
+          ]) {
+            final pageRegion = PdfRect(region.left, 792 - region.bottom,
+                region.right, 792 - region.top);
+            final source = await _raster(page, commands, region, ratio);
+            final selected = index.commandsForRegion(pageRegion, commands);
+            expect(selected.length, lessThan(commands.length));
+            final actual = await _raster(page, selected, region, ratio);
+            try {
+              expect(await _pixels(actual), await _pixels(source),
+                  reason: 'grid=$useGrid ratio=$ratio region=$region');
+            } finally {
+              source.dispose();
+              actual.dispose();
+            }
+          }
+        }
+      }
+    });
+  });
+}
+
+Future<ui.Image> _raster(PdfPage page, List<PdfRenderCommand> commands,
+    ui.Rect region, double ratio) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..scale(ratio)
+    ..translate(-region.left, -region.top);
+  PdfPageRenderer.preparePageCanvas(canvas, page, const PdfPageRenderPlan());
+  replayCommands(commands, CanvasPdfDevice(canvas, images: const {}));
+  final picture = recorder.endRecording();
+  try {
+    return await picture.toImage(
+        (region.width * ratio).ceil(), (region.height * ratio).ceil());
+  } finally {
+    picture.dispose();
+  }
+}
+
+Future<Uint8List> _pixels(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();

--- a/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_region_replay_test.dart
@@ -6,7 +6,8 @@ import 'package:dart_pdf_editor/src/region_replay_index.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 PdfPath _rect(double l, double b, double r, double t) => PdfPath([
       PdfMoveTo(l, b),
@@ -183,7 +184,7 @@ void main() {
   testWidgets('nested masks, knockout and clips retain exact high-zoom pixels',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       final commands = <PdfRenderCommand>[
         _fill(0, 0, 612, 792, const PdfColor(.7, .85, 1)),
         const PdfSaveCommand(),

--- a/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
@@ -6,7 +6,8 @@ import 'package:dart_pdf_editor/src/region_replay_index.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 const _paint = PdfFillPathCommand(
     PdfPath([
@@ -38,7 +39,7 @@ void main() {
   testWidgets('large groups keep selective patches without enabling tiles',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       for (final (paints, tiled) in [(40, true), (1022, true), (1023, false)]) {
         final scene = await PdfRetainedScene.fromCommands(page, _group(paints),
             includeImages: false);
@@ -66,7 +67,7 @@ void main() {
   testWidgets('tile budget counts nested mask and cell commands',
       (tester) async {
     await tester.runAsync(() async {
-      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
       final mask = List<PdfRenderCommand>.filled(1024, _paint);
       final cases = <List<PdfRenderCommand>>[
         [

--- a/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
+++ b/packages/dart_pdf_editor/test/atomic_tile_budget_test.dart
@@ -1,0 +1,108 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+const _paint = PdfFillPathCommand(
+    PdfPath([
+      PdfMoveTo(10, 10),
+      PdfLineTo(20, 10),
+      PdfLineTo(20, 20),
+      PdfLineTo(10, 20),
+      PdfClosePath(),
+    ]),
+    PdfColor(1, 0, 0),
+    PdfFillRule.nonzero,
+    1);
+
+List<PdfRenderCommand> _group(int paints) => [
+      const PdfBeginGroupCommand(1, isolated: true),
+      for (var i = 0; i < paints; i++) _paint,
+      const PdfEndGroupCommand(),
+    ];
+
+void main() {
+  test('atomic span survives the worker index codec', () {
+    final index = PdfRegionReplayIndex.build(_group(1023), maxCommands: 2000);
+    expect(index.maxAtomicCommandSpan, 1025);
+    final restored =
+        deserializeRegionReplayIndex(serializeRegionReplayIndex(index)!);
+    expect(restored.maxAtomicCommandSpan, 1025);
+  });
+
+  testWidgets('large groups keep selective patches without enabling tiles',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      for (final (paints, tiled) in [(40, true), (1022, true), (1023, false)]) {
+        final scene = await PdfRetainedScene.fromCommands(page, _group(paints),
+            includeImages: false);
+        try {
+          expect(scene.supportsRegionRaster, isTrue);
+          expect(scene.supportsTiledRegionRaster, tiled,
+              reason: '$paints paints in one indivisible group');
+          final selected =
+              scene.selectRegion(const ui.Rect.fromLTWH(12, 774, 2, 2));
+          expect(selected, hasLength(1));
+          expect(selected!.single.endCommandIndex, paints + 2);
+          expect(scene.selectRegion(const ui.Rect.fromLTWH(100, 100, 10, 10)),
+              isEmpty,
+              reason: 'single-patch culling remains available');
+          scene.dropRegionIndex();
+          expect(scene.supportsTiledRegionRaster, tiled,
+              reason: 'memory-pressure rebuild keeps the same tile verdict');
+        } finally {
+          scene.dispose();
+        }
+      }
+    });
+  });
+
+  testWidgets('tile budget counts nested mask and cell commands',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final mask = List<PdfRenderCommand>.filled(1024, _paint);
+      final cases = <List<PdfRenderCommand>>[
+        [
+          const PdfBeginSoftMaskedCommand(),
+          _paint,
+          PdfEndSoftMaskedCommand(
+            luminosity: false,
+            backdrop: const PdfRect(0, 0, 612, 792),
+            maskCommands: mask,
+          ),
+        ],
+        [
+          const PdfBeginGroupCommand(1, isolated: true),
+          PdfDrawTiledCellCommand(
+              mask, Float64List.fromList([0]), Float64List.fromList([0])),
+          const PdfEndGroupCommand(),
+        ],
+        [
+          const PdfBeginGroupCommand(1, isolated: true),
+          PdfDrawTiledCellCommand(
+              const [_paint], Float64List(1024), Float64List(1024)),
+          const PdfEndGroupCommand(),
+        ],
+      ];
+      for (final commands in cases) {
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            includeImages: false);
+        try {
+          expect(scene.commands, hasLength(3));
+          expect(scene.supportsRegionRaster, isTrue);
+          expect(scene.supportsTiledRegionRaster, isFalse,
+              reason: 'nested work must not hide behind a three-slot range');
+        } finally {
+          scene.dispose();
+        }
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/banded_transcript_test.dart
+++ b/packages/dart_pdf_editor/test/banded_transcript_test.dart
@@ -113,10 +113,23 @@ PdfRect _pageSpaceRegion(PdfPage page, PdfPageRenderPlan plan, Rect region) {
 }
 
 void main() {
+  test('bands decline atomic groups instead of retaining only their opener',
+      () {
+    final commands = <PdfRenderCommand>[
+      const PdfBeginGroupCommand(.5, isolated: true),
+      _box(0, 400, 80, 480, const PdfColor(1, 0, 0)),
+      const PdfEndGroupCommand(),
+    ];
+    final index = PdfRegionReplayIndex.build(commands, maxCommands: 100);
+    expect(index.supported, isTrue);
+    expect(PdfBandedTranscript.build(commands, bandCount: 2, index: index),
+        isNull);
+  });
+
   testWidgets('bands partition the transcript along the X pan axis',
       (tester) async {
-    final index = PdfRegionReplayIndex.build(_wideTranscript(),
-        maxCommands: 1 << 20);
+    final index =
+        PdfRegionReplayIndex.build(_wideTranscript(), maxCommands: 1 << 20);
     expect(index.supported, isTrue);
 
     // 10 strips over the 0..1000 X extent. The histogram counts each unit once
@@ -131,8 +144,7 @@ void main() {
     expect(bands.residentBandCount, 10);
     // The wide stroke is retained by every strip it spans, so summed strip
     // lengths exceed the distinct unit count - but the byte estimate dedupes.
-    final summedUnits =
-        bands.bands.fold<int>(0, (n, b) => n + b.unitCount);
+    final summedUnits = bands.bands.fold<int>(0, (n, b) => n + b.unitCount);
     expect(summedUnits, greaterThan(index.units.length));
   });
 
@@ -141,8 +153,8 @@ void main() {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final commands = _wideTranscript();
-      final scene =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: false);
+      final scene = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: false);
       addTearDown(scene.dispose);
       final bands = PdfBandedTranscript.build(commands, bandCount: 10)!;
 
@@ -178,7 +190,8 @@ void main() {
         reason: 'evicting offscreen strips must lower retained bytes');
 
     // A viewport that pans into an evicted strip is reported as incomplete.
-    final missing = bands.missingBandsForRegion(const PdfRect(600, 0, 900, 1000));
+    final missing =
+        bands.missingBandsForRegion(const PdfRect(600, 0, 900, 1000));
     expect(missing, isNotEmpty);
   });
 
@@ -187,8 +200,8 @@ void main() {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       final commands = _wideTranscript();
-      final scene =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: false);
+      final scene = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: false);
       addTearDown(scene.dispose);
       final size = const PdfPageRenderPlan().pageSize(page);
 
@@ -250,7 +263,8 @@ void main() {
     expect(bands.residentBandCount, 0);
     expect(bands.estimatedResidentBytes, 0);
     // Every strip the page covers is now missing.
-    expect(bands.missingBandsForRegion(PdfRect(bands.xMin, 0, bands.xMax, 1000)),
+    expect(
+        bands.missingBandsForRegion(PdfRect(bands.xMin, 0, bands.xMax, 1000)),
         isNotEmpty);
   });
 
@@ -285,8 +299,7 @@ void main() {
       (tester) async {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
-      final scene = await PdfRetainedScene.fromCommands(
-          page, _wideTranscript(),
+      final scene = await PdfRetainedScene.fromCommands(page, _wideTranscript(),
           includeImages: false);
       addTearDown(scene.dispose);
 

--- a/packages/dart_pdf_editor/test/benchmark_extreme_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_extreme_zoom_test.dart
@@ -1,0 +1,288 @@
+// Opt-in, paired visible-region benchmark. Never rasterizes the whole page at
+// extreme zoom: a 1280x800 logical viewport at DPR 2 is always 2560x1600 pixels.
+// PDF_PATH=/path/to/drawing.pdf PDF_BENCHMARK_OUT=/tmp/extreme-zoom.json \
+//   fvm flutter test --no-pub test/benchmark_extreme_zoom_test.dart
+// Optional: PDF_BENCHMARK_SCALES=30,60,100 (3000%, 6000%, 10000%),
+// PDF_BENCHMARK_SCENARIOS=center,lower,upper-right, PDF_BENCHMARK_TRIALS=7,
+// PDF_BENCHMARK_DPR=2, PDF_BENCHMARK_VIEWPORT=1280x800,
+// PDF_BENCHMARK_PNG_DIR=/tmp/extreme-zoom-crops,
+// PDF_BENCHMARK_REQUIRE_SELECTIVE=1 (fail instead of measuring a fallback).
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+// Fractions of the displayed page, with y down. The right-hand locations
+// exercise small transparency islands on the local engineering drawing that
+// motivated this benchmark, without bundling that private document.
+const _locations = <String, ui.Offset>{
+  'center': ui.Offset(0.5, 0.5),
+  'lower': ui.Offset(0.5, 2 / 3),
+  'upper-right': ui.Offset(400 / 421, 18 / 269),
+  'middle-right': ui.Offset(405 / 421, 84 / 269),
+  'lower-right': ui.Offset(345 / 421, 169 / 269),
+  'bottom-right': ui.Offset(345 / 421, 214 / 269),
+};
+
+void main() {
+  testWidgets('paired visible-region replay at extreme zoom', (tester) async {
+    final path = Platform.environment['PDF_PATH'];
+    if (path == null) {
+      markTestSkipped('set PDF_PATH');
+      return;
+    }
+    final oldRegion = PdfRetainedScene.spatialRegionReplay;
+    final oldGrid = PdfRetainedScene.spatialGridReplay;
+    addTearDown(() {
+      PdfRetainedScene.spatialRegionReplay = oldRegion;
+      PdfRetainedScene.spatialGridReplay = oldGrid;
+    });
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final env = Platform.environment;
+      final scales = (env['PDF_BENCHMARK_SCALES'] ?? '30,60,100')
+          .split(',')
+          .map(double.parse)
+          .toList();
+      final names = (env['PDF_BENCHMARK_SCENARIOS'] ??
+              'center,lower,upper-right,middle-right,lower-right,bottom-right')
+          .split(',');
+      final trials = int.parse(env['PDF_BENCHMARK_TRIALS'] ?? '7');
+      final dpr = double.parse(env['PDF_BENCHMARK_DPR'] ?? '2');
+      final viewport = (env['PDF_BENCHMARK_VIEWPORT'] ?? '1280x800')
+          .split('x')
+          .map(double.parse)
+          .toList();
+      expect(viewport, hasLength(2));
+      expect(trials, greaterThan(0));
+      expect(dpr, greaterThan(0));
+      for (final scale in scales) {
+        expect(scale, greaterThan(0));
+      }
+      final width = (viewport[0] * dpr).round();
+      final height = (viewport[1] * dpr).round();
+      expect(width, inInclusiveRange(1, 1 << 14));
+      expect(height, inInclusiveRange(1, 1 << 14));
+      final pngDir = env['PDF_BENCHMARK_PNG_DIR'];
+      if (pngDir != null) Directory(pngDir).createSync(recursive: true);
+      final bytes = File(path).readAsBytesSync();
+      final pageIndex = int.parse(env['PDF_PAGE'] ?? '0');
+      final page = PdfDocument.open(bytes).page(pageIndex);
+      final worker = PdfRenderWorker.start(bytes);
+      try {
+        final maxRatio = scales.reduce(math.max) * dpr;
+        final recordClock = Stopwatch()..start();
+        final commands =
+            (await worker.record(pageIndex, imagePixelRatio: maxRatio))!;
+        final recordMs = recordClock.elapsedMicroseconds / 1000;
+        recordClock.reset();
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            maxImagePixelRatio: maxRatio);
+        final sceneMs = recordClock.elapsedMicroseconds / 1000;
+        try {
+          final results = <Map<String, Object>>[];
+          final failures = <String>[];
+          final indexClock = Stopwatch()..start();
+          final indexSupported = scene.debugRegionReplaySupported;
+          final indexBuildMs = indexClock.elapsedMicroseconds / 1000;
+          if (env['PDF_BENCHMARK_REQUIRE_SELECTIVE'] == '1') {
+            expect(indexSupported, isTrue,
+                reason: 'this run must exercise selective region replay');
+          }
+          for (final name in names) {
+            final location = _locations[name];
+            expect(location, isNotNull, reason: 'unknown scenario $name');
+            for (final scale in scales) {
+              final ratio = scale * dpr;
+              final regionWidth = width / ratio;
+              final regionHeight = height / ratio;
+              final region = ui.Rect.fromLTWH(
+                (scene.pageSize.width * location!.dx - regionWidth / 2).clamp(
+                    0.0, math.max(0.0, scene.pageSize.width - regionWidth)),
+                (scene.pageSize.height * location.dy - regionHeight / 2).clamp(
+                    0.0, math.max(0.0, scene.pageSize.height - regionHeight)),
+                regionWidth,
+                regionHeight,
+              );
+              final measurements = {
+                false: <_Measurement>[],
+                true: <_Measurement>[]
+              };
+              var maxChangedPixels = 0;
+              var maxChannelDifference = 0;
+              var maxMeanChannelDifference = 0.0;
+              var wasSelective = false;
+              var selectedCommands = 0;
+              // The initial pair warms BOTH modes and compares their pixels;
+              // seven further measured pairs alternate their execution order.
+              for (var trial = 0; trial <= trials; trial++) {
+                Uint8List? reference;
+                for (final selective
+                    in trial.isEven ? [false, true] : [true, false]) {
+                  PdfRetainedScene.spatialRegionReplay = selective;
+                  PdfRetainedScene.spatialGridReplay = selective;
+                  final clock = Stopwatch()..start();
+                  final picture = scene.replayRegion(region, pixelRatio: ratio);
+                  final replayMs = clock.elapsedMicroseconds / 1000;
+                  if (selective) {
+                    wasSelective = scene.debugLastRegionReplayWasSelective;
+                    selectedCommands = scene.debugLastRegionReplayCommandCount;
+                  }
+                  clock.reset();
+                  final image = await picture.toImage(width, height);
+                  final rasterMs = clock.elapsedMicroseconds / 1000;
+                  try {
+                    clock.reset();
+                    final data = (await image.toByteData(
+                        format: ui.ImageByteFormat.rawRgba))!;
+                    final pixels = data.buffer
+                        .asUint8List(data.offsetInBytes, data.lengthInBytes);
+                    final readbackMs = clock.elapsedMicroseconds / 1000;
+                    if (reference == null) {
+                      reference = pixels;
+                    } else {
+                      final diff = _pixelDiff(reference, pixels);
+                      maxChangedPixels = math.max(maxChangedPixels, diff.$1);
+                      maxChannelDifference =
+                          math.max(maxChannelDifference, diff.$2);
+                      maxMeanChannelDifference =
+                          math.max(maxMeanChannelDifference, diff.$3);
+                    }
+                    if (trial > 0) {
+                      measurements[selective]!
+                          .add(_Measurement(replayMs, rasterMs, readbackMs));
+                    } else if (pngDir != null) {
+                      final png = (await image.toByteData(
+                          format: ui.ImageByteFormat.png))!;
+                      File('$pngDir/$name-${scale.toInt()}x-'
+                              '${selective ? 'selective' : 'full'}.png')
+                          .writeAsBytesSync(png.buffer.asUint8List(
+                              png.offsetInBytes, png.lengthInBytes));
+                    }
+                  } finally {
+                    image.dispose();
+                    picture.dispose();
+                  }
+                }
+              }
+              results.add({
+                'scenario': name,
+                'viewPercent': scale * 100,
+                'logicalZoom': scale,
+                'physicalPixelsPerPoint': ratio,
+                'rasterRegionPoints': [
+                  region.left,
+                  region.top,
+                  region.width,
+                  region.height
+                ],
+                'full': _summarize(measurements[false]!),
+                'selective': _summarize(measurements[true]!),
+                'wasSelective': wasSelective,
+                'selectedCommands': selectedCommands,
+                'identicalPixels': maxChangedPixels == 0,
+                'maxChangedPixels': maxChangedPixels,
+                'maxChangedPixelFraction': maxChangedPixels / (width * height),
+                'maxChannelDifference': maxChannelDifference,
+                'maxMeanChannelDifference': maxMeanChannelDifference,
+              });
+              if (env['PDF_BENCHMARK_REQUIRE_SELECTIVE'] == '1' &&
+                  !wasSelective) {
+                failures.add('$name ${scale}x fell back to full replay');
+              }
+              if (maxChangedPixels > 0) {
+                failures.add('$name ${scale}x: $maxChangedPixels pixels, '
+                    'maximum channel difference $maxChannelDifference');
+              }
+              // ignore: avoid_print
+              print(
+                  'measured $name ${scale}x: $selectedCommands/${commands.length} '
+                  'commands; changed pixels=$maxChangedPixels');
+            }
+          }
+          final result = {
+            'pageIndex': pageIndex,
+            'pageSizePoints': [scene.pageSize.width, scene.pageSize.height],
+            'viewportLogicalPixels': viewport,
+            'devicePixelRatio': dpr,
+            'imagePhysicalPixels': [width, height],
+            'commands': commands.length,
+            'warmupPairs': 1,
+            'measuredPairs': trials,
+            'workerRecordMs': recordMs,
+            'sceneBuildMs': sceneMs,
+            'indexSupported': indexSupported,
+            'tileEligible': scene.supportsTiledRegionRaster,
+            'indexBuildMs': indexBuildMs,
+            'indexUnits': scene.debugRegionReplayUnitCount,
+            'indexEstimatedBytes': scene.debugRegionReplayEstimatedBytes,
+            'results': results,
+          };
+          final json = const JsonEncoder.withIndent('  ').convert(result);
+          final out = env['PDF_BENCHMARK_OUT'];
+          if (out != null) File(out).writeAsStringSync(json);
+          // ignore: avoid_print
+          print(json);
+          expect(failures, isEmpty,
+              reason: 'selective replay must preserve every RGBA pixel');
+        } finally {
+          scene.dispose();
+        }
+      } finally {
+        worker.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 15)));
+}
+
+class _Measurement {
+  const _Measurement(this.replayMs, this.rasterMs, this.readbackMs);
+  final double replayMs;
+  final double rasterMs;
+  final double readbackMs;
+}
+
+Map<String, Object> _summarize(List<_Measurement> measurements) => {
+      'medianReplayMs': _median(measurements.map((m) => m.replayMs)),
+      'medianRasterMs': _median(measurements.map((m) => m.rasterMs)),
+      'medianReplayAndRasterMs':
+          _median(measurements.map((m) => m.replayMs + m.rasterMs)),
+      'medianReadbackMs': _median(measurements.map((m) => m.readbackMs)),
+      'samples': [
+        for (final m in measurements)
+          {
+            'replayMs': m.replayMs,
+            'rasterMs': m.rasterMs,
+            'readbackMs': m.readbackMs
+          }
+      ],
+    };
+
+double _median(Iterable<double> values) {
+  final sorted = values.toList()..sort();
+  return sorted[sorted.length ~/ 2];
+}
+
+(int, int, double) _pixelDiff(Uint8List a, Uint8List b) {
+  expect(a.length, b.length);
+  var changedPixels = 0;
+  var maxDifference = 0;
+  var sumDifference = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    var changed = false;
+    for (var channel = 0; channel < 4; channel++) {
+      final delta = (a[i + channel] - b[i + channel]).abs();
+      changed |= delta != 0;
+      maxDifference = math.max(maxDifference, delta);
+      sumDifference += delta;
+    }
+    if (changed) changedPixels++;
+  }
+  return (changedPixels, maxDifference, sumDifference / a.length);
+}

--- a/packages/dart_pdf_editor/test/benchmark_mask_layers_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_mask_layers_test.dart
@@ -1,0 +1,381 @@
+// Local masked-graphics diagnosis. No PDF or raster is checked into the repo.
+// PDF_PATH=/path/to/drawing.pdf PDF_MASK_BENCHMARK_OUT=/tmp/mask-phases.json \
+//   fvm flutter test --no-pub test/benchmark_mask_layers_test.dart
+// Optional: PDF_MASK_SCALES=30,60,100, PDF_MASK_SCENARIOS=middle-right,
+// PDF_MASK_TRIALS=7, PDF_MASK_PNG_DIR=/tmp/mask-phases.
+// Only the explicit output clip is expected to preserve pixels. Image and
+// layer ablations deliberately change the rendering; their costs are not
+// additive estimates of production phases (raster optimizers can elide work).
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/canvas_path_cache.dart';
+import 'package:dart_pdf_editor/src/image_decoder.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfPage;
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+const _locations = {
+  'upper-right': ui.Offset(400 / 421, 18 / 269),
+  'middle-right': ui.Offset(405 / 421, 84 / 269),
+  'lower-right': ui.Offset(345 / 421, 169 / 269),
+  'bottom-right': ui.Offset(345 / 421, 214 / 269),
+};
+
+enum _Variant { stock, outputClip, flatImages, noLayers, elideOpaqueGroups }
+
+void main() {
+  testWidgets('masked image scaling and layer phase diagnostics',
+      (tester) async {
+    final env = Platform.environment;
+    final path = env['PDF_PATH'];
+    if (path == null) {
+      markTestSkipped('set PDF_PATH');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final scales = (env['PDF_MASK_SCALES'] ?? '30,60,100')
+          .split(',')
+          .map(double.parse)
+          .toList();
+      final scenarios =
+          (env['PDF_MASK_SCENARIOS'] ?? 'middle-right').split(',');
+      final trials = int.parse(env['PDF_MASK_TRIALS'] ?? '7');
+      final pngDir = env['PDF_MASK_PNG_DIR'];
+      if (pngDir != null) Directory(pngDir).createSync(recursive: true);
+      const width = 2560, height = 1600, dpr = 2.0;
+      final bytes = File(path).readAsBytesSync();
+      final pageIndex = int.parse(env['PDF_PAGE'] ?? '0');
+      final page = PdfDocument.open(bytes).page(pageIndex);
+      final worker = PdfRenderWorker.start(bytes);
+      final paths = PdfCanvasPathCache();
+      try {
+        final commands = (await worker.record(pageIndex,
+            imagePixelRatio: scales.reduce(math.max) * dpr))!;
+        final scene = await PdfRetainedScene.fromCommands(page, commands,
+            maxImagePixelRatio: scales.reduce(math.max) * dpr);
+        try {
+          final requests = <PdfImageRequest>[];
+          PdfPageRenderer.collectImageRequests(commands, requests);
+          final images = <Object, ui.Image>{
+            for (final request in requests)
+              if (scene.imageFor(request) case final image?)
+                pdfImageKey(request): image,
+          };
+          final results = <Object>[];
+          var clipChanged = 0;
+          for (final name in scenarios) {
+            final location = _locations[name]!;
+            for (final zoom in scales) {
+              final ratio = zoom * dpr;
+              final rw = width / ratio, rh = height / ratio;
+              final region = ui.Rect.fromLTWH(
+                  (scene.pageSize.width * location.dx - rw / 2)
+                      .clamp(0.0, math.max(0.0, scene.pageSize.width - rw)),
+                  (scene.pageSize.height * location.dy - rh / 2)
+                      .clamp(0.0, math.max(0.0, scene.pageSize.height - rh)),
+                  rw,
+                  rh);
+              final units = scene.selectRegion(region)!;
+              final selected = <PdfRenderCommand>[];
+              for (final unit in units) {
+                selected.add(const PdfSaveCommand());
+                selected.add(PdfSetBlendModeCommand(unit.blendMode));
+                unit.clips?.appendCommands(selected);
+                selected.addAll(
+                    commands.getRange(unit.commandIndex, unit.endCommandIndex));
+                selected.add(const PdfRestoreCommand());
+              }
+              final variants = {
+                for (final variant in _Variant.values)
+                  variant: _transform(selected, variant),
+              };
+              final times = {
+                for (final v in _Variant.values) v: <List<double>>[]
+              };
+              final differences = {for (final v in _Variant.values) v: (0, 0)};
+              Uint8List? oracle;
+              for (var trial = 0; trial <= trials; trial++) {
+                // Rotate the order each trial: every variant sees warm and
+                // cold neighbours without always following the stock run.
+                final order = [
+                  for (var n = 0; n < _Variant.values.length; n++)
+                    _Variant.values[(n + trial) % _Variant.values.length],
+                ];
+                for (final variant in order) {
+                  final clock = Stopwatch()..start();
+                  final picture = _picture(scene, variants[variant]!, images,
+                      paths, region, ratio, width, height,
+                      clip: variant == _Variant.outputClip);
+                  final replayMs = clock.elapsedMicroseconds / 1000;
+                  clock.reset();
+                  final image = await picture.toImage(width, height);
+                  final rasterMs = clock.elapsedMicroseconds / 1000;
+                  try {
+                    clock.reset();
+                    final data = (await image.toByteData(
+                        format: ui.ImageByteFormat.rawRgba))!;
+                    final pixels = data.buffer
+                        .asUint8List(data.offsetInBytes, data.lengthInBytes);
+                    final readbackMs = clock.elapsedMicroseconds / 1000;
+                    if (trial == 0 && variant == _Variant.stock) {
+                      oracle = pixels;
+                    }
+                    final difference = _diff(oracle!, pixels);
+                    final previous = differences[variant]!;
+                    differences[variant] = (
+                      math.max(previous.$1, difference.$1),
+                      math.max(previous.$2, difference.$2)
+                    );
+                    if (trial > 0) {
+                      times[variant]!.add([replayMs, rasterMs, readbackMs]);
+                    }
+                    if (trial == 0 && pngDir != null) {
+                      final png = (await image.toByteData(
+                          format: ui.ImageByteFormat.png))!;
+                      File('$pngDir/$name-${zoom.toInt()}x-${variant.name}.png')
+                          .writeAsBytesSync(png.buffer.asUint8List(
+                              png.offsetInBytes, png.lengthInBytes));
+                    }
+                  } finally {
+                    image.dispose();
+                    picture.dispose();
+                  }
+                }
+              }
+              clipChanged += differences[_Variant.outputClip]!.$1;
+              results.add({
+                'scenario': name,
+                'viewPercent': zoom * 100,
+                'regionPoints': [
+                  region.left,
+                  region.top,
+                  region.width,
+                  region.height
+                ],
+                'selectedCommands': selected.length,
+                'structure': _structure(selected, images, page),
+                'variants': {
+                  for (final v in _Variant.values)
+                    v.name: {
+                      'productionEquivalentCandidate':
+                          v == _Variant.stock || v == _Variant.outputClip,
+                      'medianReplayMs': _median(times[v]!.map((s) => s[0])),
+                      'medianRasterMs': _median(times[v]!.map((s) => s[1])),
+                      'medianReadbackMs': _median(times[v]!.map((s) => s[2])),
+                      'medianReplayAndRasterMs':
+                          _median(times[v]!.map((s) => s[0] + s[1])),
+                      'medianReplayRasterReadbackMs':
+                          _median(times[v]!.map((s) => s[0] + s[1] + s[2])),
+                      'maxChangedPixels': differences[v]!.$1,
+                      'maxChannelDifference': differences[v]!.$2,
+                      'samples': times[v],
+                    },
+                },
+              });
+              // ignore: avoid_print
+              print('$name ${zoom}x: ${[
+                for (final v in _Variant.values)
+                  '${v.name}=${_median(times[v]!.map((s) => s[1])).toStringAsFixed(2)}ms/${differences[v]!.$1}px'
+              ]}');
+            }
+          }
+          final result = const JsonEncoder.withIndent('  ').convert({
+            'note':
+                'Flat-image/layer ablations intentionally change pixels; costs are not additive phase estimates.',
+            'readbackCaution':
+                'Impeller toImage may precede GPU completion. Readback waits for completion and adds transfer cost; the inclusive total is not viewer frame latency.',
+            'imagePixels': [width, height],
+            'dpr': dpr,
+            'warmupTrials': 1,
+            'measuredTrials': trials,
+            'results': results,
+          });
+          final out = env['PDF_MASK_BENCHMARK_OUT'];
+          if (out != null) File(out).writeAsStringSync(result);
+          expect(clipChanged, 0,
+              reason: 'a physical output clip must preserve every pixel');
+        } finally {
+          scene.dispose();
+        }
+      } finally {
+        paths.dispose();
+        worker.dispose();
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}
+
+ui.Picture _picture(
+    PdfRetainedScene scene,
+    List<PdfRenderCommand> commands,
+    Map<Object, ui.Image> images,
+    PdfCanvasPathCache paths,
+    ui.Rect region,
+    double ratio,
+    int width,
+    int height,
+    {required bool clip}) {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder);
+  // Clip physical output pixels before transformation; clipping the logical
+  // ROI instead loses the rounded fringe of non-integral raster dimensions.
+  if (clip) {
+    canvas.clipRect(ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+        doAntiAlias: false);
+  }
+  canvas.scale(ratio);
+  canvas.translate(-region.left, -region.top);
+  PdfPageRenderer.preparePageCanvas(canvas, scene.page, scene.plan);
+  replayCommands(
+      commands, CanvasPdfDevice(canvas, images: images, pathCache: paths));
+  return recorder.endRecording();
+}
+
+List<PdfRenderCommand> _transform(
+    List<PdfRenderCommand> commands, _Variant variant) {
+  final out = <PdfRenderCommand>[];
+  final groupElided = <bool>[];
+  for (final command in commands) {
+    if (command is PdfDrawImageCommand && variant == _Variant.flatImages) {
+      final m = command.request.transform;
+      final corners = [
+        m.apply(0, 0),
+        m.apply(1, 0),
+        m.apply(1, 1),
+        m.apply(0, 1)
+      ];
+      out.add(PdfFillPathCommand(
+          PdfPath([
+            PdfMoveTo(corners.first.$1, corners.first.$2),
+            for (final p in corners.skip(1)) PdfLineTo(p.$1, p.$2),
+            const PdfClosePath(),
+          ]),
+          const PdfColor(1, 1, 1),
+          PdfFillRule.nonzero,
+          command.request.alpha));
+    } else if (command is PdfBeginGroupCommand) {
+      final elide = variant == _Variant.noLayers ||
+          (variant == _Variant.elideOpaqueGroups &&
+              command.alpha == 1 &&
+              command.isolated &&
+              !command.knockout);
+      groupElided.add(elide);
+      out.add(elide ? const PdfSaveCommand() : command);
+    } else if (command is PdfEndGroupCommand) {
+      out.add(groupElided.removeLast() ? const PdfRestoreCommand() : command);
+    } else if (command is PdfBeginSoftMaskedCommand &&
+        variant == _Variant.noLayers) {
+      out.add(const PdfSaveCommand());
+    } else if (command is PdfEndSoftMaskedCommand) {
+      final mask = _transform(command.maskCommands, variant);
+      if (variant == _Variant.noLayers) {
+        out.addAll(mask);
+        out.add(const PdfRestoreCommand());
+      } else {
+        out.add(PdfEndSoftMaskedCommand(
+            luminosity: command.luminosity,
+            backdrop: command.backdrop,
+            maskCommands: mask,
+            backdropLuminance: command.backdropLuminance,
+            transferScale: command.transferScale,
+            transferOffset: command.transferOffset));
+      }
+    } else if (command is PdfDrawTiledCellCommand) {
+      out.add(PdfDrawTiledCellCommand(_transform(command.cellCommands, variant),
+          command.originsX, command.originsY));
+    } else {
+      out.add(command);
+    }
+  }
+  return out;
+}
+
+Map<String, Object> _structure(List<PdfRenderCommand> commands,
+    Map<Object, ui.Image> images, PdfPage page) {
+  final counts = <String, int>{};
+  final draws = <Object>[];
+  void visit(List<PdfRenderCommand> list, String prefix) {
+    for (var i = 0; i < list.length; i++) {
+      final c = list[i], path = '$prefix$i';
+      counts.update(c.runtimeType.toString(), (n) => n + 1, ifAbsent: () => 1);
+      if (c is PdfDrawImageCommand) {
+        final r = c.request, image = images[pdfImageKey(r)];
+        final source = r.sourceReference == null
+            ? r.stream
+            : page.document.cos.resolve(r.sourceReference);
+        final dict =
+            source is CosStream ? source.dictionary : r.stream.dictionary;
+        draws.add({
+          'path': path,
+          'imagePixels': image == null ? null : [image.width, image.height],
+          'nativeWidth': dict['Width'].toString(),
+          'nativeHeight': dict['Height'].toString(),
+          'transform': r.transform.toList(),
+          'alpha': r.alpha,
+          'stencil': r.isStencil,
+          'luminosityImage': r.isLuminosityMask,
+          'companionMask': image != null && pdfGpuSoftMaskOf(image) != null
+        });
+      } else if (c is PdfBeginGroupCommand) {
+        draws.add({
+          'path': path,
+          'groupAlpha': c.alpha,
+          'isolated': c.isolated,
+          'knockout': c.knockout,
+          'bounds': c.bounds.toString(),
+          'backdropColor': c.backdropColor.toString()
+        });
+      } else if (c is PdfSetBlendModeCommand) {
+        draws.add({'path': path, 'blend': c.mode.name});
+      } else if (c is PdfEndSoftMaskedCommand) {
+        draws.add({
+          'path': path,
+          'luminosity': c.luminosity,
+          'backdrop': c.backdrop.toString(),
+          'backdropLuminance': c.backdropLuminance,
+          'transfer': [c.transferScale, c.transferOffset],
+          'maskCommands': c.maskCommands.length
+        });
+        visit(c.maskCommands, '$path.mask.');
+      } else if (c is PdfDrawTiledCellCommand) {
+        draws.add({
+          'path': path,
+          'cellCommands': c.cellCommands.length,
+          'instances': c.originsX.length
+        });
+        visit(c.cellCommands, '$path.cell.');
+      }
+    }
+  }
+
+  visit(commands, '');
+  return {'counts': counts, 'details': draws};
+}
+
+double _median(Iterable<double> values) {
+  final sorted = values.toList()..sort();
+  return sorted[sorted.length ~/ 2];
+}
+
+(int, int) _diff(Uint8List a, Uint8List b) {
+  var pixels = 0, maxDifference = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    var changed = false;
+    for (var c = 0; c < 4; c++) {
+      final delta = (a[i + c] - b[i + c]).abs();
+      changed |= delta != 0;
+      maxDifference = math.max(maxDifference, delta);
+    }
+    if (changed) pixels++;
+  }
+  return (pixels, maxDifference);
+}

--- a/packages/dart_pdf_editor/test/benchmark_recorded_text_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_recorded_text_test.dart
@@ -1,0 +1,186 @@
+// Opt-in text-reuse benchmark; the document stays local.
+// PDF_PATH=/path/to/drawing.pdf PDF_TEXT_BENCHMARK_OUT=/tmp/text-reuse.json \
+//   fvm flutter test --no-pub test/benchmark_recorded_text_test.dart
+// Optional PDF_TEXT_BENCHMARK_TRIALS=7. One warmup pair is excluded.
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  testWidgets('paired recorded-text reuse on a local PDF', (tester) async {
+    final path = Platform.environment['PDF_PATH'];
+    if (path == null) {
+      markTestSkipped('set PDF_PATH');
+      return;
+    }
+    await tester.runAsync(() async {
+      final bytes = File(path).readAsBytesSync();
+      final pageIndex = int.parse(Platform.environment['PDF_PAGE'] ?? '0');
+      final trials =
+          int.parse(Platform.environment['PDF_TEXT_BENCHMARK_TRIALS'] ?? '7');
+      expect(trials, greaterThan(0));
+      final recordTimes = {false: <double>[], true: <double>[]};
+      final captureTimes = <double>[];
+      final recordAndCaptureTimes = <double>[];
+      PdfRecordedText? metadata;
+      Uint8List? renderOracle;
+      var commandsCount = 0;
+      var renderWireBytes = 0;
+      for (var trial = 0; trial <= trials; trial++) {
+        for (final collect in trial.isEven ? [false, true] : [true, false]) {
+          // Both variants start from a fresh COS/font cache. File IO and
+          // opening the document/page are outside the recording clock.
+          final document = PdfDocument.open(bytes);
+          final page = document.page(pageIndex);
+          final recorder = RecordingPdfDevice();
+          final clock = Stopwatch()..start();
+          PdfInterpreter(
+                  cos: document.cos,
+                  device: recorder,
+                  collectCharOffsets: collect)
+              .drawPage(page);
+          final recordMs = clock.elapsedMicroseconds / 1000;
+          clock.reset();
+          if (collect) metadata = PdfRecordedText.capture(recorder.commands);
+          final captureMs = clock.elapsedMicroseconds / 1000;
+          commandsCount = recorder.commands.length;
+          if (trial > 0) {
+            recordTimes[collect]!.add(recordMs);
+            if (collect) {
+              captureTimes.add(captureMs);
+              recordAndCaptureTimes.add(recordMs + captureMs);
+            }
+          } else {
+            // Render serialization intentionally omits extraction-only
+            // metadata; exact byte equality catches any visible-wire drift.
+            final wire = serializeCommands(recorder.commands,
+                cos: document.cos, compactStateScopes: true)!;
+            if (renderOracle == null) {
+              renderOracle = wire;
+            } else {
+              expect(_sameBytes(renderOracle, wire), isTrue,
+                  reason: 'capturing text must not change render wire bytes');
+              renderWireBytes = wire.length;
+              renderOracle = null;
+            }
+          }
+        }
+      }
+      final captured = metadata!;
+      final freshTimes = <double>[];
+      final reuseTimes = <double>[];
+      final extractionDocument = PdfDocument.open(bytes);
+      Uint8List? textOracle;
+      var runCount = 0, textCharacters = 0;
+      for (var trial = 0; trial <= trials; trial++) {
+        for (final reuse in trial.isEven ? [false, true] : [true, false]) {
+          final clock = Stopwatch()..start();
+          final text = reuse
+              ? PdfTextExtractor.fromRecordedText(captured, pageIndex)
+              : PdfTextExtractor.extract(extractionDocument, pageIndex);
+          final elapsed = clock.elapsedMicroseconds / 1000;
+          runCount = text.runs.length;
+          textCharacters = text.text.length;
+          final serialized = serializePageText(text);
+          textOracle ??= serialized;
+          expect(_sameBytes(textOracle, serialized), isTrue,
+              reason: 'reused text must preserve exact extraction bytes');
+          if (trial > 0) (reuse ? reuseTimes : freshTimes).add(elapsed);
+        }
+      }
+      // Separate uncached workers rule out the UI wrapper's extraction cache.
+      // Recording is complete (with images), and only the immediate extraction
+      // after it benefits from metadata published inside that worker.
+      final workerFreshTimes = <double>[];
+      final workerRecordTimes = <double>[];
+      final workerReuseTimes = <double>[];
+      for (var trial = 0; trial <= trials; trial++) {
+        for (final reuse in trial.isEven ? [false, true] : [true, false]) {
+          final worker = PdfRenderWorker.startUncached(bytes);
+          try {
+            var recordMs = 0.0;
+            if (reuse) {
+              final clock = Stopwatch()..start();
+              final commands = await worker.record(pageIndex,
+                  imagePixelRatio: 2, annotations: false);
+              expect(commands, isNotNull);
+              recordMs = clock.elapsedMicroseconds / 1000;
+            }
+            final clock = Stopwatch()..start();
+            final text = await worker.extractText(pageIndex);
+            final elapsed = clock.elapsedMicroseconds / 1000;
+            expect(text, isNotNull);
+            expect(_sameBytes(textOracle!, serializePageText(text!)), isTrue,
+                reason: 'the real worker must preserve exact extraction bytes');
+            if (trial > 0) {
+              if (reuse) {
+                workerRecordTimes.add(recordMs);
+                workerReuseTimes.add(elapsed);
+              } else {
+                workerFreshTimes.add(elapsed);
+              }
+            }
+          } finally {
+            worker.dispose();
+          }
+        }
+      }
+      final result = {
+        'pageIndex': pageIndex,
+        'commands': commandsCount,
+        'textRuns': runCount,
+        'textCharacters': textCharacters,
+        'warmupPairs': 1,
+        'measuredPairs': trials,
+        'renderWireIdentical': true,
+        'renderWireBytes': renderWireBytes,
+        'textBytesIdentical': true,
+        'textWireBytes': textOracle!.length,
+        'recordedTextEstimatedBytes': captured.estimatedBytes,
+        'recordWithoutOffsetsMs': _stats(recordTimes[false]!),
+        'recordWithOffsetsMs': _stats(recordTimes[true]!),
+        'captureMs': _stats(captureTimes),
+        'recordWithOffsetsAndCaptureMs': _stats(recordAndCaptureTimes),
+        'freshExtractionMs': _stats(freshTimes),
+        'reusedExtractionMs': _stats(reuseTimes),
+        'workerColdExtractionMs': _stats(workerFreshTimes),
+        'workerRecordMs': _stats(workerRecordTimes),
+        'workerExtractionAfterRecordMs': _stats(workerReuseTimes),
+        'estimatedRecordPlusTextMs': {
+          'before': _median(recordTimes[false]!) + _median(freshTimes),
+          'after': _median(recordAndCaptureTimes) + _median(reuseTimes),
+          'note':
+              'Sum of separately measured phase medians, not an end-to-end elapsed sample.',
+        },
+        'workerTimingNote':
+            'Cold extraction includes worker startup. Record includes startup, image decoding and wire transfer; extraction after record uses the already-running worker.',
+      };
+      final json = const JsonEncoder.withIndent('  ').convert(result);
+      final out = Platform.environment['PDF_TEXT_BENCHMARK_OUT'];
+      if (out != null) File(out).writeAsStringSync(json);
+      // ignore: avoid_print
+      print(json);
+    });
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}
+
+Map<String, Object> _stats(List<double> values) {
+  return {'median': _median(values), 'samples': values};
+}
+
+double _median(List<double> values) {
+  final sorted = values.toList()..sort();
+  return sorted[sorted.length ~/ 2];
+}
+
+bool _sameBytes(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
+++ b/packages/dart_pdf_editor/test/editing_caret_zoom_test.dart
@@ -28,8 +28,10 @@ void main() {
   // A box centred in the viewport at fit-width, so it stays on screen when
   // the transform magnifies about the viewport centre: an 800x800 logical
   // viewport over a 612x792 page shows the top 612pt, centred on (306, 486).
-  const rect = PdfRect(291, 477, 321, 494.7585);
-  const rectWidth = 321 - 291.0;
+  // Keep both line ends inside the window at the requested 40 px/pt. The
+  // former 30pt box relied on the viewer silently clamping that request.
+  const rect = PdfRect(294, 477, 318, 494.7585);
+  const rectWidth = 318 - 294.0;
   const fontSize = 8.0;
   const text = 'UB';
 
@@ -40,6 +42,9 @@ void main() {
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
     addTearDown(viewer.dispose);
+    addTearDown(() async {
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: RepaintBoundary(
@@ -164,6 +169,7 @@ void main() {
     await tester.pump();
     viewer.setZoom(zoom);
     await tester.pump();
+    expect(viewer.zoom, closeTo(zoom, .001));
     expect(editing.requestEditSelectedTextInline(), isTrue);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 16));
@@ -185,14 +191,15 @@ void main() {
     // everything is read inside the box and inside the window, clear of the
     // chrome border and of the viewer's scrollbar gutter
     final view = tester.view;
-    final screen = Rect.fromLTWH(0, 0,
+    final screen = Rect.fromLTWH(
+        0,
+        0,
         view.physicalSize.width / view.devicePixelRatio - 20,
         view.physicalSize.height / view.devicePixelRatio);
     // the box interior, for the wash colour
     final wash = box.deflate(4).intersect(screen);
     // the line's own band, for the ink
-    final region = Rect.fromPoints(
-            render.localToGlobal(Offset.zero),
+    final region = Rect.fromPoints(render.localToGlobal(Offset.zero),
             render.localToGlobal(render.size.bottomRight(Offset.zero)))
         .intersect(wash);
 
@@ -226,10 +233,10 @@ void main() {
 
   group('the inline free-text caret at deep zoom', () {
     for (final align in PdfTextAlign.values) {
-      // 4 px/pt is an ordinary reading zoom; the deep one is the viewer's
-      // ceiling, where a constant in layout pixels turns into a visible gap
+      // At 40 px/pt a constant in layout pixels becomes a visible gap.
       for (final zoom in const <double>[4, 40]) {
-        testWidgets('$align free text: painted caret hugs the glyphs at '
+        testWidgets(
+            '$align free text: painted caret hugs the glyphs at '
             '${zoom.toInt()} px/pt', (tester) async {
           tester.view.physicalSize = const Size(1600, 1600);
           tester.view.devicePixelRatio = 2;

--- a/packages/dart_pdf_editor/test/fixtures/high_zoom_pdf.dart
+++ b/packages/dart_pdf_editor/test/fixtures/high_zoom_pdf.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+
+/// Browser-safe geometry for high-zoom tests. The general fixture package
+/// also exports native CAD generators with 64-bit random-number arithmetic.
+Uint8List buildHighZoomPagePdf() {
+  final builder = CosDocumentBuilder();
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final font = builder.add(CosDictionary({
+    'Type': const CosName('Font'),
+    'Subtype': const CosName('Type1'),
+    'BaseFont': const CosName('Helvetica'),
+  }));
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': CosArray([0, 0, 612, 792].map(CosInteger.new).toList()),
+    'Resources': CosDictionary({
+      'Font': CosDictionary({'F1': font}),
+    }),
+    'Contents': builder.add(CosStream(
+      CosDictionary(),
+      Uint8List.fromList('BT /F1 12 Tf 72 720 Td (High zoom) Tj ET'.codeUnits),
+    )),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  return builder.build(
+      root: builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef})));
+}

--- a/packages/dart_pdf_editor/test/high_zoom_range_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_range_test.dart
@@ -1,0 +1,77 @@
+import 'dart:math' as math;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  testWidgets('default zoom reaches 10000% with desktop side panels',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(1));
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    Widget build(double panelWidth) => MaterialApp(
+          home: Scaffold(
+            body: Row(children: [
+              SizedBox(width: panelWidth),
+              Expanded(
+                child: PdfViewer(
+                  key: const ValueKey('viewer'),
+                  document: document,
+                  controller: controller,
+                  pagePreviews: false,
+                ),
+              ),
+            ]),
+          ),
+        );
+
+    for (final panelWidth in [0.0, 400.0]) {
+      await tester.pumpWidget(build(panelWidth));
+      await tester.pump();
+      controller.setZoom(100);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.zoom, closeTo(100, 0.01));
+
+      // These viewports used to cap below 10000%. Larger requests still
+      // clamp instead of growing a page or its tile demand without bound.
+      controller.setZoom(1000);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(controller.zoom, closeTo(100, 0.01));
+    }
+  });
+
+  for (final width in [360.0, 800.0]) {
+    for (final maxZoom in [6.0, 24.0]) {
+      testWidgets('explicit maxZoom $maxZoom keeps its limit at width $width',
+          (tester) async {
+        tester.view.physicalSize = Size(width, 640);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+        final controller = PdfViewerController();
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+            body: PdfViewer(
+              document: PdfDocument.open(buildMultiPagePdf(1)),
+              controller: controller,
+              maxZoom: maxZoom,
+              pagePreviews: false,
+            ),
+          ),
+        ));
+        await tester.pump();
+
+        final fitWidth = width / 612;
+        final expected = maxZoom == 24
+            ? math.max(24.0, maxZoom * fitWidth)
+            : maxZoom * fitWidth;
+        controller.setZoom(100);
+        await tester.pumpAndSettle(const Duration(milliseconds: 300));
+        expect(controller.zoom, closeTo(expected, 0.01));
+      });
+    }
+  }
+}

--- a/packages/dart_pdf_editor/test/high_zoom_range_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_range_test.dart
@@ -3,12 +3,13 @@ import 'dart:math' as math;
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
 
 void main() {
   testWidgets('default zoom reaches 10000% with desktop side panels',
       (tester) async {
-    final document = PdfDocument.open(buildMultiPagePdf(1));
+    final document = PdfDocument.open(buildHighZoomPagePdf());
     final controller = PdfViewerController();
     addTearDown(controller.dispose);
 
@@ -55,7 +56,7 @@ void main() {
         await tester.pumpWidget(MaterialApp(
           home: Scaffold(
             body: PdfViewer(
-              document: PdfDocument.open(buildMultiPagePdf(1)),
+              document: PdfDocument.open(buildHighZoomPagePdf()),
               controller: controller,
               maxZoom: maxZoom,
               pagePreviews: false,

--- a/packages/dart_pdf_editor/test/high_zoom_tiles_test.dart
+++ b/packages/dart_pdf_editor/test/high_zoom_tiles_test.dart
@@ -1,0 +1,247 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  testWidgets('grouped PDF reuses sharp tiles while panning at 10000%',
+      (tester) async {
+    tester.view.physicalSize = const ui.Size(768, 576);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+
+    final store = PdfTileStore(
+      tilePixels: 256,
+      maxBytes: 16 << 20,
+      prefetchRing: 0,
+      registerForMemoryPressure: false,
+    );
+    final backend = _CountingCanvasBackend();
+    final oldTiles = PdfPageView.tileStoreDetail;
+    final oldStore = PdfPageView.debugTileStoreOverride;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = oldTiles;
+      PdfPageView.debugTileStoreOverride = oldStore;
+      store.dispose();
+    });
+
+    final page = PdfDocument.open(_groupedSheet()).page(0);
+    const pagePoints = 64.0;
+    const zoom = 100.0;
+    const desiredRatio = zoom * 3;
+    final rung = store.ladder.rungAtOrAbove(desiredRatio);
+    final ratio = store.ladder.ratioFor(rung);
+    // Translate by exactly one tile column, in logical display pixels.
+    final pan = store.tilePixels / ratio * zoom;
+
+    Widget build(double dx, int generation) => MediaQuery.fromView(
+          view: tester.view,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: Transform.translate(
+                offset: Offset(dx, 0),
+                child: OverflowBox(
+                  maxWidth: double.infinity,
+                  maxHeight: double.infinity,
+                  child: SizedBox(
+                    width: pagePoints * zoom,
+                    child: PdfPageView(
+                      page: page,
+                      settleGeneration: generation,
+                      tileRasterBackend: backend,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(0, 0));
+    await _waitForTiles(tester, store);
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget,
+        reason: 'a small transparency group must not veto tiling the page');
+    expect(tester.getSize(find.byType(PdfPageView)).width / pagePoints, zoom);
+    expect(
+        backend.scene!.commands.whereType<PdfBeginGroupCommand>(), isNotEmpty);
+    expect(backend.scene!.commands.whereType<PdfBeginSoftMaskedCommand>(),
+        isNotEmpty);
+    expect(ratio, greaterThanOrEqualTo(desiredRatio),
+        reason: '10000% must stay sharp on a DPR3 display');
+    expect(backend.ratios, everyElement(ratio));
+    expect(store.debugTileFractionsForPage(0).map((tile) => tile.rung),
+        everyElement(rung));
+    final originalFraction = _tileFraction(tester);
+    final initialTiles = store.debugTilesScheduled;
+    final initialRasters = backend.rasterizations;
+    final initialPixels = backend.rasterPixels;
+    expect(initialTiles, greaterThan(1));
+    expect(initialRasters, greaterThan(0));
+    expect(store.debugTilesLanded, initialTiles);
+    expect(backend.largestRasterPixels, lessThan(2 << 20),
+        reason: 'sharpness must come from viewport slabs, not a giant page');
+
+    await tester.pumpWidget(build(-pan, 1));
+    await _waitForTiles(tester, store);
+    expect(_tileFraction(tester).left, greaterThan(originalFraction.left));
+    final newEdgeTiles = store.debugTilesScheduled - initialTiles;
+    expect(newEdgeTiles, greaterThan(0),
+        reason: 'the pan must reveal genuinely uncached content');
+    expect(newEdgeTiles, lessThan(initialTiles),
+        reason: 'the overlapping viewport must reuse its existing tiles');
+    expect(backend.rasterizations, greaterThan(initialRasters));
+    expect(backend.rasterPixels - initialPixels, lessThan(initialPixels));
+
+    final afterPanTiles = store.debugTilesScheduled;
+    final afterPanRasters = backend.rasterizations;
+    await tester.pumpWidget(build(0, 2));
+    await _waitForTiles(tester, store);
+    expect(_tileFraction(tester), originalFraction);
+    expect(store.debugTilesScheduled, afterPanTiles,
+        reason: 'returning to a cached viewport needs no new tiles');
+    expect(backend.rasterizations, afterPanRasters,
+        reason: 'returning to a cached viewport needs no Canvas replay');
+    expect(store.debugTilesDiscarded, 0);
+    expect(store.retainedBytes, lessThanOrEqualTo(store.maxBytes));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 300));
+  });
+}
+
+ui.Rect _tileFraction(WidgetTester tester) => (tester
+        .widget<CustomPaint>(find.byKey(const ValueKey('pdf-page-tile-layer')))
+        .painter as dynamic)
+    .visibleFraction as ui.Rect;
+
+Future<void> _waitForTiles(WidgetTester tester, PdfTileStore store) async {
+  for (var i = 0; i < 300; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+    final exception = tester.takeException();
+    if (exception != null) fail('high-zoom tile rendering failed: $exception');
+    final found = find.byKey(const ValueKey('pdf-page-tile-layer'));
+    if (found.evaluate().isNotEmpty) {
+      final painter = tester.widget<CustomPaint>(found).painter as dynamic;
+      final ui.Rect fraction = painter.visibleFraction;
+      final ui.Size size = painter.pageSize;
+      final view = store.viewFor(
+        id: painter.identity,
+        pageSize: size,
+        desiredRatio: painter.desiredRatio,
+        visiblePageRect: ui.Rect.fromLTRB(
+          fraction.left * size.width,
+          fraction.top * size.height,
+          fraction.right * size.width,
+          fraction.bottom * size.height,
+        ),
+        rasterize: painter.rasterize,
+        scheduleMissing: false,
+        allowCoarserFallback: false,
+      );
+      if (view.complete && !view.isEmpty && store.inFlightCount == 0) return;
+    }
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('grouped page did not present a complete high-zoom tile layer');
+}
+
+class _CountingCanvasBackend extends PdfCanvasTileRasterBackend {
+  PdfRetainedScene? scene;
+  final ratios = <double>[];
+  int rasterizations = 0;
+  int rasterPixels = 0;
+  int largestRasterPixels = 0;
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) {
+    this.scene = scene;
+    return _CountingCanvasSession(this, scene);
+  }
+}
+
+class _CountingCanvasSession implements PdfTileRasterSession {
+  _CountingCanvasSession(this.backend, this.scene);
+
+  final _CountingCanvasBackend backend;
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(ui.Rect region,
+      {required double pixelRatio, int? tracePage}) async {
+    backend.rasterizations++;
+    backend.ratios.add(pixelRatio);
+    final image = await scene.rasterizeRegion(region,
+        pixelRatio: pixelRatio, tracePage: tracePage);
+    final pixels = image.width * image.height;
+    backend.rasterPixels += pixels;
+    if (pixels > backend.largestRasterPixels) {
+      backend.largestRasterPixels = pixels;
+    }
+    return image;
+  }
+
+  @override
+  void dispose() {}
+}
+
+Uint8List _groupedSheet() {
+  final builder = CosDocumentBuilder();
+  CosArray box() => CosArray([0, 0, 64, 64].map(CosInteger.new).toList());
+  CosDictionary group() => CosDictionary({
+        'S': const CosName('Transparency'),
+        'I': const CosBoolean(true),
+        'CS': const CosName('DeviceRGB'),
+      });
+  CosReference stream(String content, CosDictionary dictionary) =>
+      builder.add(CosStream(dictionary, Uint8List.fromList(content.codeUnits)));
+  final mask = stream(
+      '0.8 g 0 0 64 64 re f',
+      CosDictionary({
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Form'),
+        'BBox': box(),
+        'Group': group(),
+      }));
+  final form = stream(
+    'q /Masked gs 1 0 0 rg 29 29 6 6 re f Q '
+    '0 0 0 RG 0.01 w 31.5 29 m 31.5 35 l S',
+    CosDictionary({
+      'Type': const CosName('XObject'),
+      'Subtype': const CosName('Form'),
+      'BBox': box(),
+      'Group': group(),
+      'Resources': CosDictionary({
+        'ExtGState': CosDictionary({
+          'Masked': CosDictionary({
+            'SMask': CosDictionary({'S': const CosName('Alpha'), 'G': mask}),
+          }),
+        }),
+      }),
+    }),
+  );
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': box(),
+    'Resources': CosDictionary({
+      'XObject': CosDictionary({'Group': form}),
+    }),
+    'Contents':
+        stream('0.7 0.8 1 rg 0 0 64 64 re f /Group Do', CosDictionary()),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  return builder.build(
+      root: builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef})));
+}

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -125,6 +125,24 @@ void main() {
       expect(find.text('100%'), findsOneWidget);
     });
 
+    testWidgets('zoom menu reaches 10000% for detailed drawing inspection',
+        (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(1), controller: viewer));
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-menu')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      final target = find.byKey(const ValueKey('pdf-shell-zoom-10000'));
+      await tester.ensureVisible(target);
+      await tester.pumpAndSettle();
+      await tester.tap(target, kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(100, 0.01));
+      expect(find.text('10000%'), findsOneWidget);
+    });
+
     testWidgets('PdfReaderFeatures.none leaves just the pages', (tester) async {
       await pump(
         tester,

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1066,7 +1066,7 @@ void main() {
     expect(controller.zoom, greaterThan(6));
   });
 
-  testWidgets('default max zoom keeps 2400% available on phone-width views',
+  testWidgets('default max zoom keeps 10000% available on phone-width views',
       (tester) async {
     tester.view.physicalSize = const Size(360, 640);
     tester.view.devicePixelRatio = 1;
@@ -1078,11 +1078,11 @@ void main() {
 
     final interactiveViewer =
         tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
-    expect(interactiveViewer.maxScale, closeTo(24 / phoneFitWidth, 0.001));
+    expect(interactiveViewer.maxScale, closeTo(100 / phoneFitWidth, 0.001));
 
-    controller.setZoom(24);
+    controller.setZoom(100);
     await tester.pumpAndSettle(const Duration(milliseconds: 300));
-    expect(controller.zoom, closeTo(24, 0.01));
+    expect(controller.zoom, closeTo(100, 0.01));
   });
 
   testWidgets('controller zoom settles page rendering immediately',

--- a/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
+++ b/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
@@ -17,6 +17,7 @@ import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:dart_pdf_editor/src/render_worker_transcript_cache.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -54,7 +55,8 @@ class _RoundTripIndexWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override
@@ -101,13 +103,37 @@ void main() {
     PdfRetainedScene.spatialRegionReplayMaxCommands = prevCeil;
   });
 
+  test('dense detail selection reuses the worker grid at the scene budget', () {
+    final commands = List<PdfRenderCommand>.generate(
+        pdfDetailRegionGridMinCommands,
+        (i) => PdfFillPathCommand(
+            PdfPath([
+              PdfMoveTo(i.toDouble(), 0),
+              PdfLineTo(i + 1.0, 0),
+              PdfLineTo(i + 1.0, 1),
+              const PdfClosePath()
+            ]),
+            const PdfColor(1, 0, 0),
+            PdfFillRule.nonzero,
+            1));
+    final transcript = PdfWorkerTranscript(commands, commands);
+    final index = transcript.regionIndex(
+        maxCommands: pdfDetailRegionLinearMaxCommands, buildGrid: true);
+    expect(index.grid, isNotNull);
+    final selected = transcript.commandsForDetail(const PdfRect(0, 0, 5, 5));
+    expect(selected.length, lessThan(100));
+    expect(
+        transcript.regionIndex(
+            maxCommands: pdfDetailRegionLinearMaxCommands, buildGrid: true),
+        same(index));
+  });
+
   testWidgets('serialized region index rasters identically to in-isolate build',
       (tester) async {
     await tester.runAsync(() async {
       var offloaded = 0;
       for (final name in _fixtures) {
-        final bytes =
-            File('../../test_corpora/pdfjs/$name').readAsBytesSync();
+        final bytes = File('../../test_corpora/pdfjs/$name').readAsBytesSync();
         final document = PdfDocument.open(Uint8List.fromList(bytes));
         if (document.pageCount == 0) continue;
         final page = document.page(0);
@@ -130,8 +156,8 @@ void main() {
             Rect.fromLTWH(0, 0, size.width * .33, size.height * .33),
             Rect.fromLTWH(size.width * .55, size.height * .1, size.width * .4,
                 size.height * .5),
-            Rect.fromLTWH(size.width * .45, size.height * .45,
-                size.width * .12, size.height * .12),
+            Rect.fromLTWH(size.width * .45, size.height * .45, size.width * .12,
+                size.height * .12),
           ];
           for (final region in regions) {
             final expected =
@@ -180,11 +206,11 @@ void main() {
         return;
       }
 
-      final local =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: true);
+      final local = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: true);
       await local.warmRegionIndex(null, pageIndex: 0); // in-isolate build
-      final offload =
-          await PdfRetainedScene.fromCommands(page, commands, includeImages: true);
+      final offload = await PdfRetainedScene.fromCommands(page, commands,
+          includeImages: true);
       await offload.warmRegionIndex(worker, pageIndex: 0); // worker build
       addTearDown(local.dispose);
       addTearDown(offload.dispose);
@@ -193,8 +219,8 @@ void main() {
           reason: 'a worker index must reconstruct as supported');
 
       final size = local.pageSize;
-      final region = Rect.fromLTWH(
-          size.width * .15, size.height * .15, size.width * .5, size.height * .5);
+      final region = Rect.fromLTWH(size.width * .15, size.height * .15,
+          size.width * .5, size.height * .5);
       final expected = await local.rasterizeRegion(region, pixelRatio: 2);
       final actual = await offload.rasterizeRegion(region, pixelRatio: 2);
       expect(offload.debugLastRegionReplayWasSelective, isTrue);
@@ -209,7 +235,7 @@ void main() {
     });
   });
 
-  testWidgets('unsupported (grouped) index round-trips its verdict',
+  testWidgets('atomic group command ranges round-trip through the worker codec',
       (tester) async {
     await tester.runAsync(() async {
       final commands = <PdfRenderCommand>[
@@ -228,11 +254,13 @@ void main() {
         const PdfEndGroupCommand(),
       ];
       final index = PdfRegionReplayIndex.build(commands, maxCommands: 1 << 20);
-      expect(index.supported, isFalse);
+      expect(index.supported, isTrue);
       final bytes = serializeRegionReplayIndex(index)!;
       final restored = deserializeRegionReplayIndex(bytes);
-      expect(restored.supported, isFalse);
-      expect(restored.units, isEmpty);
+      expect(restored.supported, isTrue);
+      expect(restored.units, hasLength(1));
+      expect(restored.units.single.commandIndex, 0);
+      expect(restored.units.single.endCommandIndex, commands.length);
     });
   });
 
@@ -255,9 +283,8 @@ void main() {
           reason: 'warm after drop rebuilds the index');
       scene.dropRegionIndex();
       // The next region raster silently rebuilds it too.
-      final image = await scene.rasterizeRegion(
-          const Rect.fromLTWH(0, 0, 100, 100),
-          pixelRatio: 1);
+      final image = await scene
+          .rasterizeRegion(const Rect.fromLTWH(0, 0, 100, 100), pixelRatio: 1);
       image.dispose();
       expect(scene.debugHasRegionReplayIndex, isTrue);
     });

--- a/packages/dart_pdf_editor/test/render_worker_text_reuse_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_text_reuse_test.dart
@@ -1,0 +1,202 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/render_worker_text_cache.dart';
+import 'package:dart_pdf_editor/src/render_worker_transcript_cache.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+// Browser integration uses the same real bundle as render_worker_sparse_web_test:
+// dart run dart_pdf_editor:build_web_worker --out lib/src/sparse_test_worker.js
+void main() {
+  test('complete transcript retains exact page text before annotations',
+      () async {
+    final doc = PdfDocument.open(_pdf());
+    final cache = PdfWorkerTranscriptCache();
+    final transcript =
+        await cache.transcriptFor(doc, 0, true, PdfCancellationToken());
+    expect(transcript, isNotNull);
+    expect(
+        transcript!.wireCommands
+            .whereType<PdfDrawTextCommand>()
+            .any((c) => c.run.text.contains('Annotation only')),
+        isTrue);
+    final text = cache.textCache.extract(0);
+    expect(text, isNotNull);
+    expect(cache.textCache.hits, 1,
+        reason: 'the complete recording must populate the text cache');
+    _expectSame(text!, PdfTextExtractor.extract(doc, 0));
+    expect(text.text, contains('OCR text'));
+    expect(text.text, isNot(contains('Annotation only')));
+    expect(text.runs.any((r) => r.mcid == 3), isTrue);
+
+    cache.evictPages({1});
+    expect(cache.textCache.extract(0), isNotNull);
+    cache.evictPages({0});
+    expect(cache.textCache.extract(0), isNull);
+    await cache.transcriptFor(doc, 0, false, PdfCancellationToken());
+    expect(cache.textCache.extract(0), isNotNull);
+    cache.clear();
+    expect(cache.textCache.length, 0);
+  });
+
+  test('preempted partial text is published only after a resumed full walk',
+      () async {
+    final doc = PdfDocument.open(_pdf(lines: 1000));
+    final cache = PdfWorkerTranscriptCache(resumeChunkOperations: 32);
+    final token = PdfCancellationToken();
+    var partials = 0;
+    await expectLater(
+      cache.transcriptFor(doc, 0, true, token, onPartial: (_) {
+        partials++;
+        token.cancelled = true;
+      }),
+      throwsA(isA<PdfCancelledException>()),
+    );
+    expect(partials, greaterThan(0));
+    expect(cache.textCache.extract(0), isNull);
+    await cache.transcriptFor(doc, 0, true, PdfCancellationToken());
+    _expectSame(cache.textCache.extract(0)!, PdfTextExtractor.extract(doc, 0));
+  });
+
+  test('text cache bounds metadata and entries, with strict oversize rejection',
+      () {
+    final doc = PdfDocument.open(_pdf());
+    final recorder = RecordingPdfDevice();
+    PdfInterpreter(cos: doc.cos, device: recorder, collectCharOffsets: true)
+        .drawPage(doc.page(0));
+    final bytes = PdfRecordedText.capture(recorder.commands).estimatedBytes;
+    expect(bytes, greaterThan(0));
+    final cache = PdfWorkerTextCache(maxBytes: bytes * 2, maxPages: 2);
+    cache.record(0, recorder.commands);
+    cache.record(1, recorder.commands);
+    expect(cache.extract(0), isNotNull); // Page 1 is least recently used.
+    cache.record(2, recorder.commands);
+    expect(cache.extract(1), isNull);
+    expect(cache.extract(0), isNotNull);
+    expect(cache.extract(2), isNotNull);
+    expect(cache.retainedBytes, lessThanOrEqualTo(bytes * 2));
+    cache.evictPages(null);
+    expect(cache.retainedBytes, 0);
+    final tiny = PdfWorkerTextCache(maxBytes: bytes - 1);
+    tiny.record(0, recorder.commands);
+    expect(tiny.length, 0);
+    expect(tiny.retainedBytes, 0);
+  });
+
+  for (final path in ['full', 'vector', 'progressive', 'prefix', 'index']) {
+    testWidgets('real worker preserves text after $path recording',
+        (tester) async {
+      await tester.runAsync(() async {
+        final oldUrl = pdfRenderWorkerScriptUrl;
+        if (kIsWeb) {
+          pdfRenderWorkerScriptUrl = '${Uri.base.origin}'
+              '/packages/dart_pdf_editor/src/sparse_test_worker.js';
+        }
+        addTearDown(() => pdfRenderWorkerScriptUrl = oldUrl);
+        final bytes = _pdf(lines: path == 'prefix' ? 1000 : 0);
+        final worker = PdfRenderWorker.startUncached(bytes);
+        addTearDown(worker.dispose);
+        if (path == 'index') {
+          expect(
+              await worker.buildRegionIndex(0,
+                  annotations: true, maxCommands: 10000, buildGrid: true),
+              isNotNull);
+        } else {
+          expect(
+              await worker.record(0,
+                  decodeImages: path == 'full',
+                  commandLimit: path == 'prefix' ? 16 : null,
+                  onPartial: path == 'progressive' ? (_) {} : null),
+              isNotNull);
+        }
+        final text = await worker.extractText(0);
+        expect(text, isNotNull);
+        _expectSame(
+            text!, PdfTextExtractor.extract(PdfDocument.open(bytes), 0));
+        expect(text.text, contains('OCR text'),
+            reason: 'a bounded prefix must fall back to complete extraction');
+      });
+    });
+  }
+
+  testWidgets('worker text invalidates on edit and undo', (tester) async {
+    await tester.runAsync(() async {
+      final original = _pdf();
+      final worker = PdfRenderWorker.startUncached(original);
+      addTearDown(worker.dispose);
+      expect(worker.supportsRevisionUpdate, isTrue);
+      expect(await worker.record(0), isNotNull);
+      final editor = PdfEditor(PdfDocument.open(original))
+        ..stampPage(0, (stamp) => stamp.text('New content', x: 50, y: 300));
+      final updated = editor.save();
+      worker.updateRevision(original.length,
+          Uint8List.sublistView(updated, original.length), updated.length, {0});
+      final text = await worker.extractText(0);
+      _expectSame(
+          text!, PdfTextExtractor.extract(PdfDocument.open(updated), 0));
+      expect(text.text, contains('New content'));
+      expect(await worker.record(0), isNotNull);
+      worker
+          .updateRevision(original.length, Uint8List(0), original.length, {0});
+      final undone = await worker.extractText(0);
+      _expectSame(
+          undone!, PdfTextExtractor.extract(PdfDocument.open(original), 0));
+      expect(undone.text, isNot(contains('New content')));
+    });
+  }, skip: kIsWeb); // Web revisions replace the worker instead of updating it.
+}
+
+void _expectSame(PdfPageText actual, PdfPageText expected) {
+  expect(serializePageText(actual), serializePageText(expected),
+      reason: 'Unicode, exact advances, MCIDs and geometry must all survive');
+  for (final word in ['AV', 'OCR']) {
+    expect(actual.findAll(word).map((m) => m.quads.map((q) => q.corners)),
+        expected.findAll(word).map((m) => m.quads.map((q) => q.corners)));
+  }
+  final run = expected.runs.first;
+  final x = (run.bounds.left + run.bounds.right) / 2;
+  final y = (run.bounds.bottom + run.bounds.top) / 2;
+  expect(actual.positionNear(x, y), expected.positionNear(x, y));
+}
+
+Uint8List _pdf({int lines = 0}) {
+  final builder = CosDocumentBuilder();
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final font = builder.add(CosDictionary({
+    'Type': const CosName('Font'),
+    'Subtype': const CosName('Type1'),
+    'BaseFont': const CosName('Helvetica'),
+  }));
+  final content =
+      StringBuffer('BT /F1 12 Tf 1 Tc 2 Tw 72 720 Td (AV fi) Tj ET\n');
+  for (var i = 0; i < lines; i++) {
+    content.writeln('10 10 m 20 20 l S');
+  }
+  content.write('/P << /MCID 3 >> BDC BT /F1 12 Tf 3 Tr 72 680 Td '
+      '(OCR text) Tj ET EMC');
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': CosArray([0, 0, 612, 792].map(CosInteger.new).toList()),
+    'Resources': CosDictionary({
+      'Font': CosDictionary({'F1': font})
+    }),
+    'Contents': builder.add(CosStream(
+        CosDictionary(), Uint8List.fromList(content.toString().codeUnits))),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  final bytes = builder.build(
+      root: builder.add(CosDictionary({
+    'Type': const CosName('Catalog'),
+    'Pages': pagesRef,
+  })));
+  return (PdfEditor(PdfDocument.open(bytes))
+        ..addFreeText(0, const PdfRect(50, 400, 300, 450), 'Annotation only'))
+      .save();
+}

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -305,7 +305,7 @@ void main() {
     });
   });
 
-  testWidgets('groups and over-budget transcripts fall back to full replay',
+  testWidgets('atomic groups are selective; over-budget transcripts fall back',
       (tester) async {
     await tester.runAsync(() async {
       final previousMax = PdfRetainedScene.spatialRegionReplayMaxCommands;
@@ -335,8 +335,10 @@ void main() {
         pixelRatio: 2,
       );
       image.dispose();
-      expect(grouped.debugLastRegionReplayWasSelective, isFalse);
-      expect(grouped.debugRegionReplaySupported, isFalse);
+      expect(grouped.debugLastRegionReplayWasSelective, isTrue);
+      expect(grouped.debugRegionReplaySupported, isTrue);
+      expect(grouped.debugLastRegionReplayCommandCount, 3,
+          reason: 'the complete group is replayed as one atomic unit');
 
       // Over BOTH ceilings (linear and grid): genuine full-replay fallback.
       PdfRetainedScene.spatialRegionReplayMaxCommands = 1;

--- a/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
+++ b/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
@@ -15,6 +15,11 @@ const _fixtures = <String>[
   'blendmode.pdf',
   'smaskdim.pdf',
   'knockout_isolated_overlap.pdf',
+  'smask_luminosity_oob_transfer.pdf',
+  'smask_alpha_oob_transfer.pdf',
+  'smask_alpha_oob.pdf',
+  'smask_alpha_bc.pdf',
+  'knockout_smask.pdf',
 ];
 
 void main() {
@@ -32,32 +37,46 @@ void main() {
         final scene = await PdfRetainedScene.record(document.page(0));
         try {
           final size = scene.pageSize;
-          final region = Rect.fromLTWH(
-            size.width * .2,
-            size.height * .2,
-            size.width * .6,
-            size.height * .6,
-          );
-          PdfRetainedScene.spatialRegionReplay = false;
-          final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
-          PdfRetainedScene.spatialRegionReplay = true;
-          final actual = await scene.rasterizeRegion(region, pixelRatio: 1.5);
-          try {
-            expect(actual.width, expected.width, reason: name);
-            expect(actual.height, expected.height, reason: name);
-            expect(
-              await _bytes(actual),
-              await _bytes(expected),
-              reason: '$name region pixels',
-            );
-          } finally {
-            expected.dispose();
-            actual.dispose();
-          }
-          if (scene.debugLastRegionReplayWasSelective) {
-            selective++;
-          } else {
-            fallback++;
+          final regions = <(Rect, double)>[
+            (
+              Rect.fromLTWH(
+                size.width * .2,
+                size.height * .2,
+                size.width * .6,
+                size.height * .6,
+              ),
+              1.5
+            ),
+            (
+              Rect.fromLTWH(
+                  size.width * .5 + .137, size.height * .5 + .271, 8, 6),
+              100
+            ),
+          ];
+          for (final (region, ratio) in regions) {
+            PdfRetainedScene.spatialRegionReplay = false;
+            final expected =
+                await scene.rasterizeRegion(region, pixelRatio: ratio);
+            PdfRetainedScene.spatialRegionReplay = true;
+            final actual =
+                await scene.rasterizeRegion(region, pixelRatio: ratio);
+            try {
+              expect(actual.width, expected.width, reason: name);
+              expect(actual.height, expected.height, reason: name);
+              expect(
+                await _bytes(actual),
+                await _bytes(expected),
+                reason: '$name region pixels',
+              );
+            } finally {
+              expected.dispose();
+              actual.dispose();
+            }
+            if (scene.debugLastRegionReplayWasSelective) {
+              selective++;
+            } else {
+              fallback++;
+            }
           }
         } finally {
           scene.dispose();
@@ -65,7 +84,7 @@ void main() {
       }
       expect(selective, greaterThanOrEqualTo(3));
       expect(fallback, greaterThanOrEqualTo(1),
-          reason: 'transparency groups exercise conservative full replay');
+          reason: 'unsafe state retains conservative full replay');
     });
   });
 }

--- a/packages/dart_pdf_editor/test/tile_pacing_test.dart
+++ b/packages/dart_pdf_editor/test/tile_pacing_test.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'fixtures/high_zoom_pdf.dart';
+
+void main() {
+  for (final (commandCount, expectedInFlight) in [(77312, 8), (250001, 2)]) {
+    testWidgets('$commandCount commands use bounded tile admission',
+        (tester) async {
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final oldTiles = PdfPageView.tileStoreDetail;
+      final oldStore = PdfPageView.debugTileStoreOverride;
+      final oldDirect = PdfPageView.directPicturePresentation;
+      final oldSlug = PdfPageView.webSlugGlyphLayer;
+      final oldStrips = PdfPageView.stripZoomReplay;
+      final oldProgressive = PdfPageView.progressiveStreamingPaint;
+      final oldLocalFirstPaint =
+          PdfPageView.debugWebLocalFirstPaintBackendOverride;
+      final store = PdfTileStore(
+          tilePixels: 128, prefetchRing: 0, registerForMemoryPressure: false);
+      final worker = _TranscriptWorker(commandCount);
+      final backend = _PendingTileBackend();
+      PdfPageView.tileStoreDetail = true;
+      PdfPageView.debugTileStoreOverride = store;
+      PdfPageView.directPicturePresentation = false;
+      PdfPageView.webSlugGlyphLayer = false;
+      PdfPageView.stripZoomReplay = false;
+      PdfPageView.progressiveStreamingPaint = false;
+      // The count belongs to the supplied worker transcript; the tiny PDF
+      // exists only to provide geometry, so the web local shortcut must wait.
+      PdfPageView.debugWebLocalFirstPaintBackendOverride = false;
+      addTearDown(() {
+        PdfPageView.tileStoreDetail = oldTiles;
+        PdfPageView.debugTileStoreOverride = oldStore;
+        PdfPageView.directPicturePresentation = oldDirect;
+        PdfPageView.webSlugGlyphLayer = oldSlug;
+        PdfPageView.stripZoomReplay = oldStrips;
+        PdfPageView.progressiveStreamingPaint = oldProgressive;
+        PdfPageView.debugWebLocalFirstPaintBackendOverride = oldLocalFirstPaint;
+        worker.dispose();
+        store.dispose();
+      });
+
+      final page = PdfDocument.open(buildHighZoomPagePdf()).page(0);
+      await tester.pumpWidget(MediaQuery.fromView(
+        view: tester.view,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: OverflowBox(
+              maxWidth: double.infinity,
+              maxHeight: double.infinity,
+              child: SizedBox(
+                width: 6120,
+                child: PdfPageView(
+                  page: page,
+                  renderWorker: worker,
+                  tileRasterBackend: backend,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+      for (var i = 0; i < 300 && backend.requests.isEmpty; i++) {
+        await tester.pump();
+        final exception = tester.takeException();
+        if (exception != null) fail('tile pacing setup failed: $exception');
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 5)));
+      }
+      expect(backend.requests, isNotEmpty,
+          reason: 'the page must enter the actual tile scheduler');
+      expect(worker.indexRequests, greaterThan(0));
+      expect(backend.scene!.commands, hasLength(commandCount));
+      expect(backend.scene!.regionIndexBuildIsHeavy, isTrue,
+          reason: 'both transcripts should warm their grids off-thread');
+
+      final painter = tester
+          .widget<CustomPaint>(
+              find.byKey(const ValueKey('pdf-page-tile-layer')))
+          .painter as dynamic;
+      expect(painter.maxNewTilesPerPaint, commandCount > 250000 ? 1 : isNull);
+      expect(painter.maxInFlightTiles, expectedInFlight);
+      // Keep every raster unresolved and force further paints. Medium pages
+      // may fill an eight-tile slab; very large pages retain one-at-a-time
+      // admission. Neither may grow an unbounded queue across repaints.
+      for (var i = 0; i < 5; i++) {
+        tester
+            .renderObject<RenderObject>(
+                find.byKey(const ValueKey('pdf-page-tile-layer')))
+            .markNeedsPaint();
+        await tester.pump();
+      }
+      expect(store.debugTilesScheduled, expectedInFlight);
+      expect(store.debugTilesLanded, 0,
+          reason: 'the queue bound must hold before any tile completes');
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      backend.completeAll();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+    });
+  }
+}
+
+class _TranscriptWorker extends PdfRenderWorker {
+  _TranscriptWorker(int count)
+      : commands = List<PdfRenderCommand>.unmodifiable([
+          // Many cheap state slots model a dense transcript whose indexed
+          // viewport work is small; drawing them requires no giant fixture.
+          for (var i = 0; i < count - 1; i++)
+            const PdfSetBlendModeCommand(PdfBlendMode.normal),
+          const PdfFillPathCommand(
+            PdfPath([
+              PdfMoveTo(300, 390),
+              PdfLineTo(312, 390),
+              PdfLineTo(312, 402),
+              PdfLineTo(300, 402),
+              PdfClosePath(),
+            ]),
+            PdfColor(0, 0, 1),
+            PdfFillRule.nonzero,
+            1,
+          ),
+        ]);
+
+  final List<PdfRenderCommand> commands;
+  int indexRequests = 0;
+  bool _active = true;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
+      commands;
+
+  @override
+  Future<PdfRegionReplayIndex?> buildRegionIndex(int pageIndex,
+      {required bool annotations,
+      required int maxCommands,
+      required bool buildGrid,
+      int priority = 0}) async {
+    indexRequests++;
+    return PdfRegionReplayIndex.build(commands,
+        maxCommands: maxCommands, buildGrid: buildGrid);
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _active = false;
+}
+
+class _PendingTileBackend extends PdfCanvasTileRasterBackend {
+  PdfRetainedScene? scene;
+  final requests = <(Completer<ui.Image>, int, int)>[];
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) {
+    this.scene = scene;
+    return _PendingTileSession(this, scene);
+  }
+
+  void completeAll() {
+    for (final (completer, width, height) in requests) {
+      final recorder = ui.PictureRecorder();
+      ui.Canvas(recorder);
+      final picture = recorder.endRecording();
+      completer.complete(picture.toImageSync(width, height));
+      picture.dispose();
+    }
+    requests.clear();
+  }
+}
+
+class _PendingTileSession implements PdfTileRasterSession {
+  _PendingTileSession(this.backend, this.scene);
+  final _PendingTileBackend backend;
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(ui.Rect region,
+      {required double pixelRatio, int? tracePage}) {
+    final completer = Completer<ui.Image>();
+    backend.requests.add((
+      completer,
+      (region.width * pixelRatio).ceil(),
+      (region.height * pixelRatio).ceil()
+    ));
+    return completer.future;
+  }
+
+  @override
+  void dispose() {}
+}

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -153,6 +153,16 @@ void main() {
         expect(ladder.rungAtOrAbove(ladder.ratioFor(rung)), rung);
       }
     });
+
+    test('default ladder keeps 10000% sharp on high-density displays', () {
+      const ladder = PdfTileZoomLadder();
+      for (final devicePixelRatio in [1.0, 2.0, 3.0, 4.0, 5.0]) {
+        final desiredRatio = 100 * devicePixelRatio;
+        final ratio = ladder.ratioFor(ladder.rungAtOrAbove(desiredRatio));
+        expect(ratio, greaterThanOrEqualTo(desiredRatio));
+        expect(ratio, lessThan(desiredRatio * math.sqrt(2)));
+      }
+    });
   });
 
   group('PdfTileStore.viewFor', () {

--- a/packages/pdf_graphics/lib/pdf_graphics.dart
+++ b/packages/pdf_graphics/lib/pdf_graphics.dart
@@ -28,6 +28,7 @@ export 'src/matrix.dart';
 export 'src/mesh.dart';
 export 'src/path.dart';
 export 'src/recording_device.dart';
+export 'src/recorded_text.dart';
 export 'src/render_command.dart';
 export 'src/translating_device.dart';
 export 'src/render_command_codec.dart';

--- a/packages/pdf_graphics/lib/src/recorded_text.dart
+++ b/packages/pdf_graphics/lib/src/recorded_text.dart
@@ -1,0 +1,193 @@
+import 'dart:typed_data';
+
+import 'color.dart';
+import 'device.dart';
+import 'matrix.dart';
+import 'render_command.dart';
+
+/// Text metadata captured from a complete, in-memory page recording.
+///
+/// Capture after the page content walk finishes and before drawing annotations:
+/// `PdfTextExtractor` searches page content, not annotation appearances. The
+/// recording interpreter must use `collectCharOffsets: true` for exact
+/// selection geometry. Capture before serializing render commands, whose wire
+/// format omits marked-content ids and embedded-font character offsets.
+///
+/// Graphics, glyph outlines and soft-mask definitions are discarded. Text in
+/// Type3 and tiling cells stays compact and expands only when [runs] is read.
+/// Invisible text and text inside masked source groups remain searchable, just
+/// as in a fresh extraction. The snapshot does not retain the input graph and
+/// is unaffected by subsequently clearing or extending its command lists.
+class PdfRecordedText {
+  PdfRecordedText._(this._sequence, this.estimatedBytes);
+
+  factory PdfRecordedText.capture(List<PdfRenderCommand> commands) {
+    final builder = _RecordedTextBuilder();
+    final sequence = builder.capture(commands);
+    return PdfRecordedText._(sequence, builder.estimatedBytes);
+  }
+
+  final _RecordedTextSequence _sequence;
+
+  /// Approximate retained bytes for cache budgeting, including object/list
+  /// overhead, UTF-16 strings, glyph metadata and copied numeric buffers.
+  /// Shared cells and runs count once. This is a portable estimate, not a heap
+  /// measurement, and excludes the expanded extraction produced from [runs].
+  final int estimatedBytes;
+
+  bool get isEmpty => _sequence.nodes.isEmpty;
+
+  /// Positioned source text in the interpreter's original encounter order.
+  ///
+  /// Repeated cells expand lazily. Runs retain extraction geometry, Unicode,
+  /// invisibility and marked-content ids; their painting properties and glyph
+  /// outlines have intentionally been removed. Use `PdfTextExtractor` to
+  /// reconstruct logical text, separators, and bidirectional selection data.
+  Iterable<PdfTextRun> get runs => _sequence.runs;
+}
+
+sealed class _RecordedTextNode {}
+
+class _RecordedTextRun extends _RecordedTextNode {
+  _RecordedTextRun(this.run);
+
+  final PdfTextRun run;
+}
+
+class _RecordedTextCell extends _RecordedTextNode {
+  _RecordedTextCell(this.sequence, this.originsX, this.originsY);
+
+  final _RecordedTextSequence sequence;
+  final Float64List originsX;
+  final Float64List originsY;
+}
+
+class _RecordedTextSequence {
+  _RecordedTextSequence(this.nodes);
+
+  final List<_RecordedTextNode> nodes;
+
+  Iterable<PdfTextRun> get runs sync* {
+    for (final node in nodes) {
+      switch (node) {
+        case _RecordedTextRun(:final run):
+          yield run;
+        case _RecordedTextCell(
+            :final sequence,
+            :final originsX,
+            :final originsY
+          ):
+          for (var i = 0; i < originsX.length; i++) {
+            final dx = originsX[i], dy = originsY[i];
+            for (final run in sequence.runs) {
+              // Match TranslatingPdfDevice's inner-to-outer additions exactly.
+              // Summing nested translations first can change rounding and move
+              // a search quad relative to a fresh extraction at extreme zoom.
+              yield dx == 0 && dy == 0
+                  ? run
+                  : _textRun(run,
+                      transform: PdfMatrix(
+                        run.transform.a,
+                        run.transform.b,
+                        run.transform.c,
+                        run.transform.d,
+                        run.transform.e + dx,
+                        run.transform.f + dy,
+                      ));
+            }
+          }
+      }
+    }
+  }
+}
+
+class _RecordedTextBuilder {
+  final _sequences =
+      Map<List<PdfRenderCommand>, _RecordedTextSequence>.identity();
+  final _active = Set<List<PdfRenderCommand>>.identity();
+  final _runs = Map<PdfTextRun, PdfTextRun>.identity();
+  int estimatedBytes = 32;
+
+  _RecordedTextSequence capture(List<PdfRenderCommand> commands) {
+    final existing = _sequences[commands];
+    if (existing != null) return existing;
+    if (!_active.add(commands)) {
+      throw ArgumentError('Recorded text contains a cyclic tiled cell');
+    }
+    final nodes = <_RecordedTextNode>[];
+    for (final command in commands) {
+      if (command is PdfDrawTextCommand) {
+        final run =
+            _runs.putIfAbsent(command.run, () => _captureRun(command.run));
+        nodes.add(_RecordedTextRun(run));
+        estimatedBytes += 32;
+      } else if (command is PdfDrawTiledCellCommand &&
+          command.originsX.isNotEmpty) {
+        final cell = capture(command.cellCommands);
+        if (cell.nodes.isNotEmpty) {
+          nodes.add(_RecordedTextCell(
+            cell,
+            Float64List.fromList(command.originsX).asUnmodifiableView(),
+            Float64List.fromList(command.originsY).asUnmodifiableView(),
+          ));
+          estimatedBytes += 112 + command.originsX.length * 16;
+        }
+      }
+      // Mask commands live inside PdfEndSoftMaskedCommand. Never visit them:
+      // the extraction device deliberately does not execute drawMask either.
+    }
+    _active.remove(commands);
+    final sequence = _RecordedTextSequence(List.unmodifiable(nodes));
+    _sequences[commands] = sequence;
+    estimatedBytes += 48 + nodes.length * 8;
+    return sequence;
+  }
+
+  PdfTextRun _captureRun(PdfTextRun source) {
+    final glyphs = source.glyphs;
+    final offsets = source.charOffsets;
+    estimatedBytes += 384 + source.text.length * 2;
+    if (glyphs != null) {
+      estimatedBytes += 32;
+      for (final glyph in glyphs) {
+        estimatedBytes += 96 + (glyph.text?.length ?? 0) * 2;
+      }
+    }
+    if (offsets != null) estimatedBytes += 32 + offsets.length * 8;
+    return PdfTextRun(
+      text: source.text,
+      transform: source.transform,
+      color: PdfColor.black,
+      width: source.width,
+      // Null vs non-null distinguishes substituted logical text from the
+      // positioned visual glyph order of embedded fonts in the bidi pipeline.
+      glyphs: glyphs == null
+          ? null
+          : List.unmodifiable([
+              for (final glyph in glyphs)
+                PdfGlyphPlacement(
+                  offset: glyph.offset,
+                  offsetY: glyph.offsetY,
+                  text: glyph.text,
+                ),
+            ]),
+      charOffsets: offsets == null
+          ? null
+          : Float64List.fromList(offsets).asUnmodifiableView(),
+      invisible: source.invisible,
+      mcid: source.mcid,
+    );
+  }
+}
+
+PdfTextRun _textRun(PdfTextRun source, {required PdfMatrix transform}) =>
+    PdfTextRun(
+      text: source.text,
+      transform: transform,
+      color: PdfColor.black,
+      width: source.width,
+      glyphs: source.glyphs,
+      charOffsets: source.charOffsets,
+      invisible: source.invisible,
+      mcid: source.mcid,
+    );

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -10,6 +10,7 @@ import 'interpreter.dart';
 import 'matrix.dart';
 import 'mesh.dart';
 import 'path.dart';
+import 'recorded_text.dart';
 import 'shading.dart';
 
 final _bidiFormattingControls =
@@ -501,6 +502,20 @@ class PdfTextExtractor {
     }
   }
 
+  /// Reuses text from a completed page recording without interpreting again.
+  ///
+  /// Applies the same separators, bidirectional ordering, and selection
+  /// geometry as [extract]. See [PdfRecordedText.capture] for the recording
+  /// requirements and the page-content-only capture boundary.
+  static PdfPageText fromRecordedText(PdfRecordedText recorded, int pageIndex) {
+    final t0 = PdfPerf.begin();
+    try {
+      return _pageTextFrom(pageIndex, recorded.runs);
+    } finally {
+      PdfPerf.end(PdfPerfPhase.textExtract, t0);
+    }
+  }
+
   static _ExtractionDevice _interpret(PdfDocument document, int pageIndex) {
     final device = _ExtractionDevice();
     // Extraction reads geometry and Unicode, never colour, so the overprint
@@ -516,7 +531,8 @@ class PdfTextExtractor {
     return device;
   }
 
-  static PdfPageText _pageTextFrom(int pageIndex, List<PdfTextRun> deviceRuns) {
+  static PdfPageText _pageTextFrom(
+      int pageIndex, Iterable<PdfTextRun> deviceRuns) {
     final buffer = StringBuffer();
     final runs = <PdfExtractedRun>[];
     final line = <_SourceRun>[];

--- a/packages/pdf_graphics/test/recorded_text_corpus_test.dart
+++ b/packages/pdf_graphics/test/recorded_text_corpus_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // A bounded sample of the checked-in corpora targets differences between a
+  // recording device and extraction: embedded/substitute/vertical fonts,
+  // recursive Type3 cells, optional content, OCR and text-bearing soft masks.
+  const files = [
+    'pdfjs/arial_unicode_ab_cidfont.pdf',
+    'pdfjs/bug1011159.pdf',
+    'pdfjs/bug898853.pdf',
+    'pdfjs/bug946506.pdf',
+    'pdfjs/cid_cff.pdf',
+    'pdfjs/complex_ttf_font.pdf',
+    'pdfjs/ContentStreamCycleType3insideType3.pdf',
+    'pdfjs/ContentStreamNoCycleType3insideType3.pdf',
+    'pdfjs/helloworld-bad.pdf',
+    'pdfjs/issue4684.pdf',
+    'pdfjs/operator-in-TJ-array.pdf',
+    'pdfjs/vertical.pdf',
+    'ghent/1-CMYK/GWG050_Font_Substitution_x3.pdf',
+    'ghent/1-CMYK/GWG090_Font-Support_x3.pdf',
+    'ghent/1-CMYK/GWG091_FontSupport-OpenType_X4.pdf',
+    'ghent/1-CMYK/GWG150_OptionalContent-OCCD_X4.pdf',
+    'ghent/1-CMYK/GWG161_Transp_Basic_BM_DeviceCMYK_Knockout_X4.pdf',
+    'ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf',
+    'ghent/1-CMYK/GWG1611_Softmasks_Text_part2_X4.pdf',
+    'ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf',
+  ];
+
+  for (final name in files) {
+    final file = File('../../test_corpora/$name');
+    test('recorded text matches fresh extraction: $name', () {
+      final document = PdfDocument.open(file.readAsBytesSync());
+      final pages =
+          name == 'pdfjs/vertical.pdf' ? math.min(3, document.pageCount) : 1;
+      var textLength = 0;
+      for (var page = 0; page < pages; page++) {
+        final recorder = RecordingPdfDevice();
+        PdfInterpreter(
+          cos: document.cos,
+          device: recorder,
+          collectCharOffsets: true,
+        ).drawPage(document.page(page));
+        final snapshot = PdfRecordedText.capture(recorder.commands);
+        recorder.commands.clear();
+        final reused = PdfTextExtractor.fromRecordedText(snapshot, page);
+        final fresh = PdfTextExtractor.extract(document, page);
+        expect(serializePageText(reused), serializePageText(fresh),
+            reason:
+                'page $page: text, bidi, MCIDs and exact selection geometry');
+        textLength += reused.text.length;
+      }
+      // Some vertical.pdf pages use currently unsupported CMaps and extract
+      // no text. Compare that existing behavior too, while requiring actual
+      // text in every document so no file's parity passes wholly vacuously.
+      expect(textLength, greaterThan(0));
+    }, skip: file.existsSync() ? false : 'checked-in corpus unavailable');
+  }
+}

--- a/packages/pdf_graphics/test/recorded_text_test.dart
+++ b/packages/pdf_graphics/test/recorded_text_test.dart
@@ -1,0 +1,340 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('recorded page preserves advances, tagged text and rotated search quads',
+      () {
+    final document = _document('''
+/Span << /MCID 7 >> BDC
+BT /F1 24 Tf 2 Tc 12 Tw 72 720 Td (IIII WWWW) Tj ET
+EMC
+q 0 1 -1 0 300 400 cm
+BT /F1 18 Tf 0 0 Td (Rotated text) Tj ET
+Q
+''');
+    final recorded = _record(document);
+    final extracted = _expectEquivalent(document, recorded);
+    expect(extracted.runs.first.mcid, 7);
+    expect(extracted.runs.first.charOffsets, hasLength(10));
+    final matches = extracted.findAll('WWWW');
+    expect(matches, hasLength(1));
+    expect(
+        matches.single.quads.single.corners,
+        PdfTextExtractor.extract(document, 0)
+            .findAll('WWWW')
+            .single
+            .quads
+            .single
+            .corners);
+    final center = matches.single.rects.single;
+    expect(
+      extracted.positionNear(center.left + 1, center.bottom + 1),
+      PdfTextExtractor.extract(document, 0)
+          .positionNear(center.left + 1, center.bottom + 1),
+    );
+  });
+
+  test('capture excludes masks and annotations but includes invisible sources',
+      () {
+    final document = _document('''
+q /Masked gs
+BT /F1 12 Tf 72 720 Td (Masked source) Tj ET
+Q
+BT /F1 12 Tf 72 680 Td 3 Tr (OCR text) Tj ET
+BT /F1 12 Tf 72 640 Td 7 Tr (Clip text) Tj ET
+''');
+    final recorder = RecordingPdfDevice();
+    final interpreter = PdfInterpreter(
+        cos: document.cos, device: recorder, collectCharOffsets: true);
+    interpreter.drawPage(document.page(0));
+    expect(recorder.commands.whereType<PdfEndSoftMaskedCommand>(), isNotEmpty);
+    final recorded = PdfRecordedText.capture(recorder.commands);
+    interpreter.drawAnnotations(document.page(0));
+    expect(
+        recorder.commands
+            .whereType<PdfDrawTextCommand>()
+            .map((c) => c.run.text),
+        contains('ANNOTATION_ONLY'));
+    recorder.commands.clear();
+
+    final extracted = _expectEquivalent(document, recorded);
+    expect(extracted.text, 'Masked source\nOCR text\nClip text');
+    expect(extracted.text, isNot(contains('MASK_ONLY')));
+    expect(recorded.runs.where((run) => run.invisible), hasLength(2));
+  });
+
+  test('Type3 and text-bearing pattern cells match fresh extraction', () {
+    final document = _document('''
+BT /T3 24 Tf 72 720 Td (AA) Tj ET
+q /Pattern cs /PatternText scn 80 80 30 30 re f Q
+''');
+    final recorder = RecordingPdfDevice();
+    PdfInterpreter(
+            cos: document.cos, device: recorder, collectCharOffsets: true)
+        .drawPage(document.page(0));
+    final cells = recorder.commands.whereType<PdfDrawTiledCellCommand>();
+    expect(cells.length, greaterThanOrEqualTo(3));
+    expect(cells.any((cell) => cell.originsX.length > 1), isTrue);
+    final recorded = PdfRecordedText.capture(recorder.commands);
+    final extracted = _expectEquivalent(document, recorded);
+    expect(extracted.text, contains('TYPE3_TEXT'));
+    expect(extracted.text, contains('PATTERN_TEXT'));
+    expect(
+        extracted.runs.where((run) => run.text == 'TYPE3_TEXT'), hasLength(2));
+  });
+
+  test('embedded RTL glyphs and positioned combining marks retain logical text',
+      () {
+    for (final bytes in [
+      buildPositionedTashkilPdf(),
+      buildRtlTextPdf(lines: const ['اهلا وسهلا', 'كيف حالك', 'خوش آمدید']),
+    ]) {
+      final document = PdfDocument.open(bytes);
+      final recorded = _record(document);
+      final extracted = _expectEquivalent(document, recorded);
+      expect(extracted.text, isNotEmpty);
+      expect(recorded.runs.any((run) => run.glyphs != null), isTrue);
+      expect(extracted.runs.any((run) => run.isRightToLeft), isTrue);
+    }
+  });
+
+  test('projection snapshots metrics, strips outlines and retains glyph kind',
+      () {
+    final offsets = <double>[0, 0.2, 0.8];
+    final glyphs = <PdfGlyphPlacement>[
+      PdfGlyphPlacement(
+        offset: 0,
+        offsetY: -0.3,
+        text: 'fi',
+        outline: PdfPath(const [PdfMoveTo(0, 0), PdfLineTo(100, 100)]),
+      ),
+    ];
+    final commands = <PdfRenderCommand>[
+      PdfDrawTextCommand(_run('fi', glyphs: glyphs, offsets: offsets)),
+      PdfDrawTextCommand(_run('مرحبا', y: 40)),
+      PdfDrawTextCommand(_run('', y: 80, glyphs: [])),
+    ];
+    final recorded = PdfRecordedText.capture(commands);
+    offsets[1] = 999;
+    glyphs.clear();
+    commands.clear();
+
+    final runs = recorded.runs.toList();
+    expect(runs[0].charOffsets, [0, 0.2, 0.8]);
+    expect(runs[0].glyphs!.single.text, 'fi');
+    expect(runs[0].glyphs!.single.offsetY, -0.3);
+    expect(runs[0].glyphs!.single.outline, isNull);
+    expect(runs[0].mcid, 12);
+    expect(runs[1].glyphs, isNull);
+    expect(runs[2].glyphs, isEmpty);
+    expect(
+        PdfTextExtractor.fromRecordedText(recorded, 0).text, contains('مرحبا'));
+    expect(() => runs[0].charOffsets![0] = 1, throwsUnsupportedError);
+    expect(() => runs[0].glyphs!.clear(), throwsUnsupportedError);
+  });
+
+  test('nested cells retain exact translated positions and stay compact', () {
+    final original = _run('Repeated', x: 1e16, y: 50);
+    final innerX = Float64List.fromList([-1e16]);
+    final outerX = Float64List.fromList([1, 5]);
+    final leaf = <PdfRenderCommand>[PdfDrawTextCommand(original)];
+    final commands = <PdfRenderCommand>[
+      PdfDrawTiledCellCommand([
+        PdfDrawTiledCellCommand(leaf, innerX, Float64List(1)),
+      ], outerX, Float64List(2)),
+    ];
+    final reference = _TextDevice();
+    replayCommands(commands, reference);
+    final recorded = PdfRecordedText.capture(commands);
+    final positions = recorded.runs.map((run) => run.transform.e).toList();
+    expect(positions, [1, 5]);
+    expect(positions, reference.runs.map((run) => run.transform.e));
+    innerX[0] = 0;
+    outerX[0] = 0;
+    leaf.clear();
+    commands.clear();
+    expect(recorded.runs.map((run) => run.transform.e), [1, 5]);
+
+    final shared = [PdfDrawTextCommand(_run('Shared'))];
+    PdfRecordedText repeated(int count) => PdfRecordedText.capture([
+          PdfDrawTiledCellCommand(
+              shared, Float64List(count), Float64List(count)),
+        ]);
+    final once = repeated(1);
+    final many = repeated(1000);
+    expect(many.estimatedBytes - once.estimatedBytes, 999 * 16);
+    expect(many.runs.length, 1000);
+    expect(many.estimatedBytes, lessThan(20000));
+  });
+
+  test('shared cell metadata is retained once and graphics do not add weight',
+      () {
+    final cell = [PdfDrawTextCommand(_run('Shared'))];
+    PdfDrawTiledCellCommand stamp(List<PdfRenderCommand> source) =>
+        PdfDrawTiledCellCommand(source, Float64List(1), Float64List(1));
+    final shared = PdfRecordedText.capture([stamp(cell), stamp(cell)]);
+    final distinct = PdfRecordedText.capture([
+      stamp(cell),
+      stamp([PdfDrawTextCommand(_run('Shared'))]),
+    ]);
+    expect(shared.estimatedBytes, lessThan(distinct.estimatedBytes));
+    final plain = PdfRecordedText.capture(cell);
+    final decorated = PdfRecordedText.capture([
+      PdfFillPathCommand(
+          PdfPath(List.generate(1000, (i) => PdfLineTo(i.toDouble(), 1))),
+          PdfColor.black,
+          PdfFillRule.nonzero,
+          1),
+      ...cell,
+    ]);
+    expect(decorated.estimatedBytes, plain.estimatedBytes);
+  });
+
+  test('empty graphs stay empty and malformed cell cycles are rejected', () {
+    final empty = PdfRecordedText.capture([const PdfSaveCommand()]);
+    expect(empty.isEmpty, isTrue);
+    expect(PdfTextExtractor.fromRecordedText(empty, 9).pageIndex, 9);
+    expect(PdfTextExtractor.fromRecordedText(empty, 9).text, isEmpty);
+    final cyclic = <PdfRenderCommand>[];
+    cyclic.add(PdfDrawTiledCellCommand(cyclic, Float64List(1), Float64List(1)));
+    expect(() => PdfRecordedText.capture(cyclic), throwsArgumentError);
+  });
+}
+
+PdfTextRun _run(String text,
+        {double x = 10,
+        double y = 20,
+        List<PdfGlyphPlacement>? glyphs,
+        List<double>? offsets}) =>
+    PdfTextRun(
+      text: text,
+      transform: PdfMatrix(12, 0, 0, 12, x, y),
+      color: PdfColor.black,
+      width: offsets?.last ?? text.length * 0.5,
+      glyphs: glyphs,
+      charOffsets: offsets,
+      mcid: 12,
+    );
+
+class _TextDevice implements PdfDevice {
+  final runs = <PdfTextRun>[];
+
+  @override
+  void drawText(PdfTextRun run) => runs.add(run);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {}
+}
+
+PdfRecordedText _record(PdfDocument document) {
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: document.cos, device: recorder, collectCharOffsets: true)
+      .drawPage(document.page(0));
+  return PdfRecordedText.capture(recorder.commands);
+}
+
+PdfPageText _expectEquivalent(PdfDocument document, PdfRecordedText recorded) {
+  final expected = PdfTextExtractor.extract(document, 0);
+  final actual = PdfTextExtractor.fromRecordedText(recorded, 0);
+  // The extraction wire includes text, bidi flags, every character offset,
+  // MCIDs, matrices and bounds. Exact bytes guard all of them together.
+  expect(serializePageText(actual), serializePageText(expected));
+  return actual;
+}
+
+PdfDocument _document(String content) {
+  final builder = CosDocumentBuilder();
+  CosArray numbers(List<num> values) => CosArray([
+        for (final value in values)
+          if (value is int) CosInteger(value) else CosReal(value.toDouble()),
+      ]);
+  final pages = CosDictionary({'Type': const CosName('Pages')});
+  final pagesRef = builder.add(pages);
+  final font = builder.add(CosDictionary({
+    'Type': const CosName('Font'),
+    'Subtype': const CosName('Type1'),
+    'BaseFont': const CosName('Helvetica'),
+  }));
+  final fonts = CosDictionary({'F1': font});
+  final resources = CosDictionary({'Font': fonts});
+  final cellResources = CosDictionary({
+    'Font': CosDictionary({'F1': font}),
+  });
+  CosReference stream(String content, [Map<String, CosObject>? fields]) =>
+      builder.add(CosStream(
+          CosDictionary(fields ?? {}), Uint8List.fromList(content.codeUnits)));
+  CosReference form(String content, {bool group = false}) => stream(content, {
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Form'),
+        'BBox': numbers([0, 0, 612, 792]),
+        'Resources': cellResources,
+        if (group)
+          'Group': CosDictionary({
+            'S': const CosName('Transparency'),
+            'CS': const CosName('DeviceGray'),
+          }),
+      });
+  resources['ExtGState'] = CosDictionary({
+    'Masked': CosDictionary({
+      'Type': const CosName('ExtGState'),
+      'SMask': CosDictionary({
+        'S': const CosName('Luminosity'),
+        'G': form('BT /F1 12 Tf 72 720 Td (MASK_ONLY) Tj ET', group: true),
+      }),
+    }),
+  });
+  fonts['T3'] = builder.add(CosDictionary({
+    'Type': const CosName('Font'),
+    'Subtype': const CosName('Type3'),
+    'FontBBox': numbers([0, 0, 1000, 1000]),
+    'FontMatrix': numbers([0.001, 0, 0, 0.001, 0, 0]),
+    'FirstChar': const CosInteger(65),
+    'LastChar': const CosInteger(65),
+    'Widths': numbers([1000]),
+    'Encoding': CosDictionary({
+      'Differences': CosArray([const CosInteger(65), const CosName('A')]),
+    }),
+    'Resources': cellResources,
+    'CharProcs': CosDictionary({
+      'A': stream('1000 0 d0 BT /F1 20 Tf 0 0 Td (TYPE3_TEXT) Tj ET'),
+    }),
+  }));
+  resources['Pattern'] = CosDictionary({
+    'PatternText': stream('BT /F1 4 Tf 0 0 Td (PATTERN_TEXT) Tj ET', {
+      'Type': const CosName('Pattern'),
+      'PatternType': const CosInteger(1),
+      'PaintType': const CosInteger(1),
+      'TilingType': const CosInteger(1),
+      'BBox': numbers([0, 0, 20, 20]),
+      'XStep': const CosInteger(20),
+      'YStep': const CosInteger(20),
+      'Resources': cellResources,
+    }),
+  });
+  final annotation = builder.add(CosDictionary({
+    'Type': const CosName('Annot'),
+    'Subtype': const CosName('FreeText'),
+    'Rect': numbers([50, 100, 200, 200]),
+    'AP': CosDictionary({
+      'N': form('BT /F1 12 Tf 72 720 Td (ANNOTATION_ONLY) Tj ET'),
+    }),
+  }));
+  final page = builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': pagesRef,
+    'MediaBox': numbers([0, 0, 612, 792]),
+    'Resources': resources,
+    'Contents': stream(content),
+    'Annots': CosArray([annotation]),
+  }));
+  pages['Kids'] = CosArray([page]);
+  pages['Count'] = const CosInteger(1);
+  return PdfDocument.open(builder.build(
+      root: builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef}))));
+}


### PR DESCRIPTION
Dense pages were interpreted again when preparing selection/search after rendering, and the spatial-grid threshold also restricted medium-size pages to one new high-zoom tile per paint. Reuse bounded, exact text metadata from completed worker recordings and separate tile admission from grid construction cost. Partial recordings retain fresh-extraction fallback; edits/undo invalidate metadata; large-page, backend and in-flight tile limits remain enforced.

On the local engineering sheet, text extraction falls from 372.39 ms to 9.95 ms. Recording plus metadata capture adds 12.96 ms (3.4%) and retains an estimated 7.77 MiB within a strict 16 MiB worker bound. Render and extracted-text buffers match byte for byte. The 77,312-command page regains ordinary eight-tile batching, while pages above 250,000 commands keep stricter admission.

A same-machine Chrome comparison of base `92f361d` and this head used fresh old/new workers, one warm-up and seven alternating measured pairs on the same private PDF. Recording stayed essentially unchanged (1422.4 → 1426.9 ms); extraction after recording fell from 740.2 → 45.4 ms. Directly measured record-plus-extraction time fell from 2159.6 → 1472.0 ms (31.8%). Every render and text result matched byte for byte. A 6,000-path/one-title control had unchanged stream time and no combined-time regression.

Stacked on #902. The private PDF and output images remain local. Opt-in benchmarks and a development note document reproduction and the separate masked-image investigation; image sampling and compositing are unchanged.

Validation:

- 67 focused graphics tests, including exact extraction parity across 20 PDF.js/Ghent documents (22 pages).
- Native worker reuse, partial/resume, bounded cache, edit/undo and tile scheduling regressions pass.
- Real Chrome worker reuse and tile scheduling regressions pass; added to CI.
- Exact private-file render/text equality and seven alternating benchmark pairs pass.
- Full suites pass: 2,742 editor tests and 1,093 graphics tests; repository analyzer and formatting are clean.
- CI is green at `f10662b`: 21 successful checks and one pre-existing standalone Web Patrol skip. The separate Chrome regression steps ran and passed. No actionable review findings remain.

Performance-report limits: cross-run web samples were slower than the preceding PR across several scenarios, including image-only work; the same-machine worker comparison above did not reproduce a substantial recording regression. Cross-run iOS simulator GPU timings also worsened, while their measured windows bypass the changed worker and viewer scheduling paths. Same-host Metal comparison has unchanged corpus support/work counts and overlapping visible-tile timing ranges, with two small warm-up regressions. These observations do not establish an iOS speedup or isolate a code-caused GPU regression; the claimed gains are the targeted measurements above.
