### PR TITLE
Ship the changelog with the app

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Ship the release notes with the app: **What's new** (Settings > About, or the
+  command palette) reads the bundled `CHANGELOG.md` and marks the section the
+  running build came from, so the notes can't drift from the binary and need no
+  network call.
+
 ## 4.4.0
 
 - Print directly on Windows from the app's own preview: choose the printer,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -51,6 +51,7 @@ import 'update_installer.dart';
 import 'update_platform.dart';
 import 'web_launch.dart';
 import 'welcome_screen.dart';
+import 'whats_new.dart';
 import 'window_support.dart';
 import 'windows_drop_target.dart';
 
@@ -3433,6 +3434,17 @@ class _EditorScreenState extends State<EditorScreen>
         run: action.run,
       ));
     }
+
+    // Reachable from Settings > About rather than the menu itself, so it
+    // names Settings as its source instead of claiming a menu row it has not
+    // got.
+    commands.add(AppCommand(
+      id: 'whats-new',
+      label: l.whatsNew,
+      icon: Icons.new_releases_outlined,
+      source: l.settingsTitle,
+      run: () => unawaited(showWhatsNew(context)),
+    ));
 
     if (hasDocument) {
       commands.add(AppCommand(

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "الخطوط المضمنة",
   "reduceSizeImages": "الصور",
   "reduceSizeDuplicates": "الكائنات المكررة",
-  "reduceSizeCustom": "إعدادات مخصصة"
+  "reduceSizeCustom": "إعدادات مخصصة",
+  "whatsNew": "ما الجديد",
+  "whatsNewInstalled": "مثبَّتة",
+  "whatsNewUnavailable": "ملاحظات الإصدار غير متوفرة في هذه النسخة."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Eingebettete Schriftarten",
   "reduceSizeImages": "Bilder",
   "reduceSizeDuplicates": "Doppelte Objekte",
-  "reduceSizeCustom": "Benutzerdefinierte Einstellungen"
+  "reduceSizeCustom": "Benutzerdefinierte Einstellungen",
+  "whatsNew": "Neuerungen",
+  "whatsNewInstalled": "Installiert",
+  "whatsNewUnavailable": "In diesem Build sind keine Versionshinweise verfügbar."
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1602,5 +1602,17 @@
   "reduceSizeCustom": "Custom settings",
   "@reduceSizeCustom": {
     "description": "Preset label shown after any individual compression setting is changed."
+  },
+  "whatsNew": "What's new",
+  "@whatsNew": {
+    "description": "Title of the release-notes dialog, and the label of every entry point that opens it."
+  },
+  "whatsNewInstalled": "Installed",
+  "@whatsNewInstalled": {
+    "description": "Badge marking the changelog section that matches the running build's version."
+  },
+  "whatsNewUnavailable": "Release notes aren't available in this build.",
+  "@whatsNewUnavailable": {
+    "description": "Shown when the bundled changelog is missing or empty."
   }
 }

--- a/app/lib/l10n/app_en_AU.arb
+++ b/app/lib/l10n/app_en_AU.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Embedded fonts",
   "reduceSizeImages": "Images",
   "reduceSizeDuplicates": "Duplicate objects",
-  "reduceSizeCustom": "Custom settings"
+  "reduceSizeCustom": "Custom settings",
+  "whatsNew": "What's new",
+  "whatsNewInstalled": "Installed",
+  "whatsNewUnavailable": "Release notes aren't available in this build."
 }

--- a/app/lib/l10n/app_en_GB.arb
+++ b/app/lib/l10n/app_en_GB.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Embedded fonts",
   "reduceSizeImages": "Images",
   "reduceSizeDuplicates": "Duplicate objects",
-  "reduceSizeCustom": "Custom settings"
+  "reduceSizeCustom": "Custom settings",
+  "whatsNew": "What's new",
+  "whatsNewInstalled": "Installed",
+  "whatsNewUnavailable": "Release notes aren't available in this build."
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Fuentes incrustadas",
   "reduceSizeImages": "Imágenes",
   "reduceSizeDuplicates": "Objetos duplicados",
-  "reduceSizeCustom": "Ajustes personalizados"
+  "reduceSizeCustom": "Ajustes personalizados",
+  "whatsNew": "Novedades",
+  "whatsNewInstalled": "Instalada",
+  "whatsNewUnavailable": "Las notas de la versión no están disponibles en esta compilación."
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Polices intégrées",
   "reduceSizeImages": "Images",
   "reduceSizeDuplicates": "Objets en double",
-  "reduceSizeCustom": "Paramètres personnalisés"
+  "reduceSizeCustom": "Paramètres personnalisés",
+  "whatsNew": "Nouveautés",
+  "whatsNewInstalled": "Installée",
+  "whatsNewUnavailable": "Les notes de version ne sont pas disponibles dans cette version."
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "एम्बेड किए गए फ़ॉन्ट",
   "reduceSizeImages": "छवियाँ",
   "reduceSizeDuplicates": "डुप्लिकेट ऑब्जेक्ट",
-  "reduceSizeCustom": "कस्टम सेटिंग"
+  "reduceSizeCustom": "कस्टम सेटिंग",
+  "whatsNew": "नया क्या है",
+  "whatsNewInstalled": "इंस्टॉल किया गया",
+  "whatsNewUnavailable": "इस बिल्ड में रिलीज़ नोट्स उपलब्ध नहीं हैं।"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Font tertanam",
   "reduceSizeImages": "Gambar",
   "reduceSizeDuplicates": "Objek duplikat",
-  "reduceSizeCustom": "Pengaturan khusus"
+  "reduceSizeCustom": "Pengaturan khusus",
+  "whatsNew": "Yang baru",
+  "whatsNewInstalled": "Terpasang",
+  "whatsNewUnavailable": "Catatan rilis tidak tersedia di build ini."
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Font incorporati",
   "reduceSizeImages": "Immagini",
   "reduceSizeDuplicates": "Oggetti duplicati",
-  "reduceSizeCustom": "Impostazioni personalizzate"
+  "reduceSizeCustom": "Impostazioni personalizzate",
+  "whatsNew": "Novità",
+  "whatsNewInstalled": "Installata",
+  "whatsNewUnavailable": "Le note di rilascio non sono disponibili in questa build."
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "埋め込みフォント",
   "reduceSizeImages": "画像",
   "reduceSizeDuplicates": "重複するオブジェクト",
-  "reduceSizeCustom": "カスタム設定"
+  "reduceSizeCustom": "カスタム設定",
+  "whatsNew": "新機能",
+  "whatsNewInstalled": "インストール済み",
+  "whatsNewUnavailable": "このビルドにはリリースノートがありません。"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "내장 글꼴",
   "reduceSizeImages": "이미지",
   "reduceSizeDuplicates": "중복 객체",
-  "reduceSizeCustom": "사용자 지정 설정"
+  "reduceSizeCustom": "사용자 지정 설정",
+  "whatsNew": "새로운 기능",
+  "whatsNewInstalled": "설치됨",
+  "whatsNewUnavailable": "이 빌드에서는 릴리스 정보를 사용할 수 없습니다."
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2000,6 +2000,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Custom settings'**
   String get reduceSizeCustom;
+
+  /// Title of the release-notes dialog, and the label of every entry point that opens it.
+  ///
+  /// In en, this message translates to:
+  /// **'What\'s new'**
+  String get whatsNew;
+
+  /// Badge marking the changelog section that matches the running build's version.
+  ///
+  /// In en, this message translates to:
+  /// **'Installed'**
+  String get whatsNewInstalled;
+
+  /// Shown when the bundled changelog is missing or empty.
+  ///
+  /// In en, this message translates to:
+  /// **'Release notes aren\'t available in this build.'**
+  String get whatsNewUnavailable;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -1232,4 +1232,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'إعدادات مخصصة';
+
+  @override
+  String get whatsNew => 'ما الجديد';
+
+  @override
+  String get whatsNewInstalled => 'مثبَّتة';
+
+  @override
+  String get whatsNewUnavailable => 'ملاحظات الإصدار غير متوفرة في هذه النسخة.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -1228,4 +1228,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Benutzerdefinierte Einstellungen';
+
+  @override
+  String get whatsNew => 'Neuerungen';
+
+  @override
+  String get whatsNewInstalled => 'Installiert';
+
+  @override
+  String get whatsNewUnavailable =>
+      'In diesem Build sind keine Versionshinweise verfügbar.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1205,6 +1205,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Custom settings';
+
+  @override
+  String get whatsNew => 'What\'s new';
+
+  @override
+  String get whatsNewInstalled => 'Installed';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Release notes aren\'t available in this build.';
 }
 
 /// The translations for English, as used in Australia (`en_AU`).
@@ -2408,6 +2418,16 @@ class AppLocalizationsEnAu extends AppLocalizationsEn {
 
   @override
   String get reduceSizeCustom => 'Custom settings';
+
+  @override
+  String get whatsNew => 'What\'s new';
+
+  @override
+  String get whatsNewInstalled => 'Installed';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Release notes aren\'t available in this build.';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).
@@ -3611,4 +3631,14 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get reduceSizeCustom => 'Custom settings';
+
+  @override
+  String get whatsNew => 'What\'s new';
+
+  @override
+  String get whatsNewInstalled => 'Installed';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Release notes aren\'t available in this build.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -1224,4 +1224,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Ajustes personalizados';
+
+  @override
+  String get whatsNew => 'Novedades';
+
+  @override
+  String get whatsNewInstalled => 'Instalada';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Las notas de la versión no están disponibles en esta compilación.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1229,4 +1229,14 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Paramètres personnalisés';
+
+  @override
+  String get whatsNew => 'Nouveautés';
+
+  @override
+  String get whatsNewInstalled => 'Installée';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Les notes de version ne sont pas disponibles dans cette version.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -1209,4 +1209,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'कस्टम सेटिंग';
+
+  @override
+  String get whatsNew => 'नया क्या है';
+
+  @override
+  String get whatsNewInstalled => 'इंस्टॉल किया गया';
+
+  @override
+  String get whatsNewUnavailable =>
+      'इस बिल्ड में रिलीज़ नोट्स उपलब्ध नहीं हैं।';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -1216,4 +1216,14 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Pengaturan khusus';
+
+  @override
+  String get whatsNew => 'Yang baru';
+
+  @override
+  String get whatsNewInstalled => 'Terpasang';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Catatan rilis tidak tersedia di build ini.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -1224,4 +1224,14 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Impostazioni personalizzate';
+
+  @override
+  String get whatsNew => 'Novità';
+
+  @override
+  String get whatsNewInstalled => 'Installata';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Le note di rilascio non sono disponibili in questa build.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -1182,4 +1182,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'カスタム設定';
+
+  @override
+  String get whatsNew => '新機能';
+
+  @override
+  String get whatsNewInstalled => 'インストール済み';
+
+  @override
+  String get whatsNewUnavailable => 'このビルドにはリリースノートがありません。';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1182,4 +1182,13 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => '사용자 지정 설정';
+
+  @override
+  String get whatsNew => '새로운 기능';
+
+  @override
+  String get whatsNewInstalled => '설치됨';
+
+  @override
+  String get whatsNewUnavailable => '이 빌드에서는 릴리스 정보를 사용할 수 없습니다.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -1222,4 +1222,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Aangepaste instellingen';
+
+  @override
+  String get whatsNew => 'Wat is er nieuw';
+
+  @override
+  String get whatsNewInstalled => 'Geïnstalleerd';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Release-opmerkingen zijn niet beschikbaar in deze build.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -1247,4 +1247,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Ustawienia niestandardowe';
+
+  @override
+  String get whatsNew => 'Co nowego';
+
+  @override
+  String get whatsNewInstalled => 'Zainstalowana';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Informacje o wydaniu są niedostępne w tej kompilacji.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -1222,4 +1222,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Definições personalizadas';
+
+  @override
+  String get whatsNew => 'Novidades';
+
+  @override
+  String get whatsNewInstalled => 'Instalada';
+
+  @override
+  String get whatsNewUnavailable =>
+      'As notas de versão não estão disponíveis nesta compilação.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -1228,4 +1228,14 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Пользовательские настройки';
+
+  @override
+  String get whatsNew => 'Что нового';
+
+  @override
+  String get whatsNewInstalled => 'Установлена';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Примечания к выпуску недоступны в этой сборке.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -1201,4 +1201,13 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'การตั้งค่าแบบกำหนดเอง';
+
+  @override
+  String get whatsNew => 'มีอะไรใหม่';
+
+  @override
+  String get whatsNewInstalled => 'ติดตั้งแล้ว';
+
+  @override
+  String get whatsNewUnavailable => 'ไม่มีบันทึกประจำรุ่นในบิลด์นี้';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -1209,4 +1209,13 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Özel ayarlar';
+
+  @override
+  String get whatsNew => 'Yenilikler';
+
+  @override
+  String get whatsNewInstalled => 'Yüklü';
+
+  @override
+  String get whatsNewUnavailable => 'Bu sürümde sürüm notları kullanılamıyor.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -1230,4 +1230,14 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Власні налаштування';
+
+  @override
+  String get whatsNew => 'Що нового';
+
+  @override
+  String get whatsNewInstalled => 'Встановлено';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Примітки до випуску недоступні в цій збірці.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -1210,4 +1210,14 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => 'Cài đặt tùy chỉnh';
+
+  @override
+  String get whatsNew => 'Có gì mới';
+
+  @override
+  String get whatsNewInstalled => 'Đã cài đặt';
+
+  @override
+  String get whatsNewUnavailable =>
+      'Ghi chú phát hành không có sẵn trong bản dựng này.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -1174,6 +1174,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get reduceSizeCustom => '自定义设置';
+
+  @override
+  String get whatsNew => '新增功能';
+
+  @override
+  String get whatsNewInstalled => '已安装';
+
+  @override
+  String get whatsNewUnavailable => '此版本不提供发行说明。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -2347,4 +2356,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get reduceSizeCustom => '自訂設定';
+
+  @override
+  String get whatsNew => '新功能';
+
+  @override
+  String get whatsNewInstalled => '已安裝';
+
+  @override
+  String get whatsNewUnavailable => '此版本未提供版本資訊。';
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Ingesloten lettertypen",
   "reduceSizeImages": "Afbeeldingen",
   "reduceSizeDuplicates": "Dubbele objecten",
-  "reduceSizeCustom": "Aangepaste instellingen"
+  "reduceSizeCustom": "Aangepaste instellingen",
+  "whatsNew": "Wat is er nieuw",
+  "whatsNewInstalled": "Geïnstalleerd",
+  "whatsNewUnavailable": "Release-opmerkingen zijn niet beschikbaar in deze build."
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Osadzone czcionki",
   "reduceSizeImages": "Obrazy",
   "reduceSizeDuplicates": "Zduplikowane obiekty",
-  "reduceSizeCustom": "Ustawienia niestandardowe"
+  "reduceSizeCustom": "Ustawienia niestandardowe",
+  "whatsNew": "Co nowego",
+  "whatsNewInstalled": "Zainstalowana",
+  "whatsNewUnavailable": "Informacje o wydaniu są niedostępne w tej kompilacji."
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Fontes incorporadas",
   "reduceSizeImages": "Imagens",
   "reduceSizeDuplicates": "Objetos duplicados",
-  "reduceSizeCustom": "Definições personalizadas"
+  "reduceSizeCustom": "Definições personalizadas",
+  "whatsNew": "Novidades",
+  "whatsNewInstalled": "Instalada",
+  "whatsNewUnavailable": "As notas de versão não estão disponíveis nesta compilação."
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Встроенные шрифты",
   "reduceSizeImages": "Изображения",
   "reduceSizeDuplicates": "Дублирующиеся объекты",
-  "reduceSizeCustom": "Пользовательские настройки"
+  "reduceSizeCustom": "Пользовательские настройки",
+  "whatsNew": "Что нового",
+  "whatsNewInstalled": "Установлена",
+  "whatsNewUnavailable": "Примечания к выпуску недоступны в этой сборке."
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "ฟอนต์ที่ฝังไว้",
   "reduceSizeImages": "ภาพ",
   "reduceSizeDuplicates": "วัตถุที่ซ้ำกัน",
-  "reduceSizeCustom": "การตั้งค่าแบบกำหนดเอง"
+  "reduceSizeCustom": "การตั้งค่าแบบกำหนดเอง",
+  "whatsNew": "มีอะไรใหม่",
+  "whatsNewInstalled": "ติดตั้งแล้ว",
+  "whatsNewUnavailable": "ไม่มีบันทึกประจำรุ่นในบิลด์นี้"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Gömülü yazı tipleri",
   "reduceSizeImages": "Görüntüler",
   "reduceSizeDuplicates": "Yinelenen nesneler",
-  "reduceSizeCustom": "Özel ayarlar"
+  "reduceSizeCustom": "Özel ayarlar",
+  "whatsNew": "Yenilikler",
+  "whatsNewInstalled": "Yüklü",
+  "whatsNewUnavailable": "Bu sürümde sürüm notları kullanılamıyor."
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Вбудовані шрифти",
   "reduceSizeImages": "Зображення",
   "reduceSizeDuplicates": "Дубльовані об’єкти",
-  "reduceSizeCustom": "Власні налаштування"
+  "reduceSizeCustom": "Власні налаштування",
+  "whatsNew": "Що нового",
+  "whatsNewInstalled": "Встановлено",
+  "whatsNewUnavailable": "Примітки до випуску недоступні в цій збірці."
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "Phông chữ nhúng",
   "reduceSizeImages": "Ảnh",
   "reduceSizeDuplicates": "Đối tượng trùng lặp",
-  "reduceSizeCustom": "Cài đặt tùy chỉnh"
+  "reduceSizeCustom": "Cài đặt tùy chỉnh",
+  "whatsNew": "Có gì mới",
+  "whatsNewInstalled": "Đã cài đặt",
+  "whatsNewUnavailable": "Ghi chú phát hành không có sẵn trong bản dựng này."
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "嵌入字体",
   "reduceSizeImages": "图像",
   "reduceSizeDuplicates": "重复对象",
-  "reduceSizeCustom": "自定义设置"
+  "reduceSizeCustom": "自定义设置",
+  "whatsNew": "新增功能",
+  "whatsNewInstalled": "已安装",
+  "whatsNewUnavailable": "此版本不提供发行说明。"
 }

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -310,5 +310,8 @@
   "reduceSizeFonts": "嵌入字型",
   "reduceSizeImages": "影像",
   "reduceSizeDuplicates": "重複物件",
-  "reduceSizeCustom": "自訂設定"
+  "reduceSizeCustom": "自訂設定",
+  "whatsNew": "新功能",
+  "whatsNewInstalled": "已安裝",
+  "whatsNewUnavailable": "此版本未提供版本資訊。"
 }

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -13,6 +13,7 @@ import 'recents.dart';
 import 'update.dart';
 import 'update_install_flow.dart';
 import 'update_installer.dart';
+import 'whats_new.dart';
 
 // The platform-specific default-app help lives in the ARB as one ICU `select`
 // key each (branches: web/windows/macos/linux/android/ios/other), resolved from
@@ -291,6 +292,14 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                   label: Text(appL10n(context).settingsViewSource),
                   onPressed: () => launchUrl(Uri.parse(AppInfo.sourceUrl),
                       mode: LaunchMode.externalApplication),
+                ),
+                ListTile(
+                  key: const ValueKey('settings-whats-new'),
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.new_releases_outlined),
+                  title: Text(appL10n(context).whatsNew),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => showWhatsNew(context),
                 ),
                 ListTile(
                   key: const ValueKey('settings-licenses'),

--- a/app/lib/whats_new.dart
+++ b/app/lib/whats_new.dart
@@ -1,0 +1,288 @@
+// Ships the app's own release notes inside the build.
+//
+// `app/CHANGELOG.md` is declared as a Flutter asset (see app/pubspec.yaml), so
+// the notes a user reads are always the ones that were written for the binary
+// they are running - no network call, and nothing to keep in step with the
+// GitHub release page. The parser below is deliberately small: the changelog
+// is written to one shape (`## <version>` headings over `- ` bullets that wrap
+// across lines, with `**bold**` and `` `code` `` inline), and a whole markdown
+// package would be a dependency for four rules.
+import 'dart:convert' show LineSplitter;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+
+import 'app_info.dart';
+import 'l10n/app_l10n.dart';
+
+/// Asset key for the bundled changelog, relative to the app package root.
+const appChangelogAsset = 'CHANGELOG.md';
+
+/// Leading whitespace marks a wrapped continuation of the bullet above.
+final _indented = RegExp(r'^\s');
+
+/// One `## <version>` section of the changelog.
+class ChangelogRelease {
+  const ChangelogRelease({required this.version, required this.notes});
+
+  /// The heading text as written - a version (`4.4.0`) in a released build,
+  /// or `Unreleased` in a build cut before the section was rolled over.
+  final String version;
+
+  /// The section's bullets, each unwrapped back into a single line.
+  final List<String> notes;
+}
+
+/// Parses the subset of markdown `app/CHANGELOG.md` is written in.
+///
+/// Anything above the first `## ` heading (the `# Changelog` title) is skipped.
+/// A bullet runs until the next bullet, heading, or blank line, so the source's
+/// hard-wrapped lines rejoin into one paragraph.
+List<ChangelogRelease> parseChangelog(String source) {
+  final releases = <ChangelogRelease>[];
+  var notes = <String>[];
+  String? version;
+
+  void flush() {
+    final heading = version;
+    if (heading != null) {
+      releases.add(ChangelogRelease(version: heading, notes: notes));
+    }
+    notes = <String>[];
+  }
+
+  for (final line in const LineSplitter().convert(source)) {
+    final trimmed = line.trim();
+    if (trimmed.startsWith('## ')) {
+      flush();
+      version = trimmed.substring(3).trim();
+      continue;
+    }
+    if (version == null) continue;
+    if (trimmed.isEmpty) {
+      continue;
+    }
+    if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      notes.add(trimmed.substring(2).trim());
+    } else if (notes.isNotEmpty && line.startsWith(_indented)) {
+      // A continuation of the wrapped bullet above it.
+      notes[notes.length - 1] = '${notes.last} $trimmed';
+    }
+  }
+  flush();
+
+  return releases;
+}
+
+/// Splits a bullet into `**bold**` / `` `code` `` runs.
+///
+/// Returned in source order; an unterminated marker stays literal text rather
+/// than swallowing the rest of the line.
+List<InlineSpan> changelogSpans(
+  String text, {
+  required TextStyle? bold,
+  required TextStyle? code,
+}) {
+  final spans = <InlineSpan>[];
+  final buffer = StringBuffer();
+
+  void flushPlain() {
+    if (buffer.isEmpty) return;
+    spans.add(TextSpan(text: buffer.toString()));
+    buffer.clear();
+  }
+
+  var i = 0;
+  while (i < text.length) {
+    if (text.startsWith('**', i)) {
+      final end = text.indexOf('**', i + 2);
+      if (end > i + 2) {
+        flushPlain();
+        spans.add(TextSpan(text: text.substring(i + 2, end), style: bold));
+        i = end + 2;
+        continue;
+      }
+    } else if (text[i] == '`') {
+      final end = text.indexOf('`', i + 1);
+      if (end > i + 1) {
+        flushPlain();
+        spans.add(TextSpan(text: text.substring(i + 1, end), style: code));
+        i = end + 1;
+        continue;
+      }
+    }
+    buffer.write(text[i]);
+    i++;
+  }
+  flushPlain();
+
+  return spans;
+}
+
+Future<List<ChangelogRelease>>? _cached;
+
+/// Reads and parses the bundled changelog.
+///
+/// The result is cached for the default bundle, because the dialog is opened
+/// from three places and the file never changes under a running build. A test
+/// passing its own [bundle] always gets a fresh read.
+Future<List<ChangelogRelease>> loadAppChangelog({AssetBundle? bundle}) {
+  if (bundle != null) {
+    return bundle.loadString(appChangelogAsset).then(parseChangelog);
+  }
+  return _cached ??=
+      rootBundle.loadString(appChangelogAsset).then(parseChangelog);
+}
+
+@visibleForTesting
+void debugResetChangelogCache() => _cached = null;
+
+/// Opens the "What's new" dialog over [context].
+Future<void> showWhatsNew(BuildContext context, {AssetBundle? bundle}) =>
+    showPdfDialog<void>(
+      context: context,
+      builder: (context) => _WhatsNewDialog(bundle: bundle),
+    );
+
+/// The bundled release notes, newest first, with the running build's own
+/// section badged so a reader can tell what they already have.
+class _WhatsNewDialog extends StatefulWidget {
+  const _WhatsNewDialog({this.bundle});
+
+  final AssetBundle? bundle;
+
+  @override
+  State<_WhatsNewDialog> createState() => _WhatsNewDialogState();
+}
+
+class _WhatsNewDialogState extends State<_WhatsNewDialog> {
+  late final Future<List<ChangelogRelease>> _releases =
+      loadAppChangelog(bundle: widget.bundle);
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('whats-new-dialog'),
+      title: Text(appL10n(context).whatsNew),
+      content: SizedBox(
+        width: 360,
+        child: FutureBuilder<List<ChangelogRelease>>(
+          future: _releases,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              );
+            }
+            final releases = snapshot.data ?? const <ChangelogRelease>[];
+            if (releases.isEmpty) {
+              return Text(
+                appL10n(context).whatsNewUnavailable,
+                key: const ValueKey('whats-new-unavailable'),
+              );
+            }
+            return SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final (index, release) in releases.indexed) ...[
+                    if (index > 0) const SizedBox(height: 20),
+                    _ReleaseSection(release: release),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+      actions: [
+        PdfDialogSubmit(
+            child: TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(appL10n(context).close),
+        )),
+      ],
+    );
+  }
+}
+
+class _ReleaseSection extends StatelessWidget {
+  const _ReleaseSection({required this.release});
+
+  final ChangelogRelease release;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final body = theme.textTheme.bodySmall;
+    final code = body?.copyWith(
+      fontFamily: 'monospace',
+      fontFamilyFallback: const ['Courier'],
+      color: scheme.onSurfaceVariant,
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Flexible(
+              child: Text(release.version, style: theme.textTheme.titleSmall),
+            ),
+            if (release.version == AppInfo.version) ...[
+              const SizedBox(width: 8),
+              // The running build's own section, so a reader can place
+              // themselves in the list without checking About first.
+              Container(
+                key: const ValueKey('whats-new-installed'),
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: scheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  appL10n(context).whatsNewInstalled,
+                  style: theme.textTheme.labelSmall
+                      ?.copyWith(color: scheme.onSecondaryContainer),
+                ),
+              ),
+            ],
+          ],
+        ),
+        const SizedBox(height: 6),
+        for (final note in release.notes)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('• ', style: body),
+                Expanded(
+                  child: Text.rich(
+                    TextSpan(
+                      children: changelogSpans(
+                        note,
+                        bold: body?.copyWith(fontWeight: FontWeight.w600),
+                        code: code,
+                      ),
+                    ),
+                    style: body,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -136,5 +136,9 @@ flutter:
   # generated Dart is checked in so builds/CI need no extra codegen step.
   generate: true
   assets:
+    # The release notes the "What's new" dialog reads (lib/whats_new.dart).
+    # Bundling the file the release was cut from is what keeps the notes and
+    # the binary from drifting apart.
+    - CHANGELOG.md
     - web/favicon.png
     - web/icons/Icon-512.png

--- a/app/test/whats_new_test.dart
+++ b/app/test/whats_new_test.dart
@@ -1,0 +1,237 @@
+// The app ships its own CHANGELOG.md as an asset and reads it back in the
+// "What's new" dialog, so these cover both halves: the markdown subset the
+// changelog is written in, and the dialog reaching the real bundled asset
+// (which also guards the pubspec asset declaration - drop it and the last
+// group fails).
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/app_info.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/whats_new.dart';
+
+/// An [AssetBundle] that serves one string for the changelog key.
+class _FakeBundle extends CachingAssetBundle {
+  _FakeBundle(this.contents);
+
+  final String contents;
+
+  @override
+  Future<ByteData> load(String key) async {
+    if (key != appChangelogAsset) throw FlutterError('unexpected asset $key');
+    return ByteData.sublistView(Uint8List.fromList(contents.codeUnits));
+  }
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    if (key != appChangelogAsset) throw FlutterError('unexpected asset $key');
+    return contents;
+  }
+}
+
+void main() {
+  group('parseChangelog', () {
+    test('reads sections newest first and skips the document title', () {
+      final releases = parseChangelog('''
+# Changelog
+
+## 4.5.0
+
+- Ship the changelog with the app.
+
+## 4.4.0
+
+- Print directly on Windows.
+- Zoom to 10000%.
+''');
+
+      expect(releases.map((r) => r.version), ['4.5.0', '4.4.0']);
+      expect(releases.first.notes, ['Ship the changelog with the app.']);
+      expect(releases.last.notes,
+          ['Print directly on Windows.', 'Zoom to 10000%.']);
+    });
+
+    test('rejoins a bullet that wraps across lines', () {
+      final releases = parseChangelog('''
+## 1.0.0
+
+- Open and scroll dense vector drawings faster, and prepare text for
+  selection and search from the render worker's own pass over the page
+  rather than a second one.
+- A second entry.
+''');
+
+      expect(releases.single.notes, [
+        "Open and scroll dense vector drawings faster, and prepare text for "
+            "selection and search from the render worker's own pass over the "
+            "page rather than a second one.",
+        'A second entry.',
+      ]);
+    });
+
+    test('a blank line between bullets does not join them', () {
+      final releases = parseChangelog('''
+## 1.0.0
+
+- First.
+
+- Second.
+''');
+
+      expect(releases.single.notes, ['First.', 'Second.']);
+    });
+
+    test('keeps an Unreleased heading as written', () {
+      final releases = parseChangelog('## Unreleased\n\n- In flight.\n');
+      expect(releases.single.version, 'Unreleased');
+    });
+
+    test('empty or note-less input yields no crash', () {
+      expect(parseChangelog(''), isEmpty);
+      expect(parseChangelog('# Changelog\n\nNothing yet.\n'), isEmpty);
+      expect(parseChangelog('## 1.0.0\n').single.notes, isEmpty);
+    });
+  });
+
+  group('changelogSpans', () {
+    const bold = TextStyle(fontWeight: FontWeight.w600);
+    const code = TextStyle(fontFamily: 'monospace');
+
+    List<(String, TextStyle?)> runs(String text) => [
+          for (final span
+              in changelogSpans(text, bold: bold, code: code).cast<TextSpan>())
+            (span.text!, span.style),
+        ];
+
+    test('splits bold and code out of the surrounding text', () {
+      expect(
+        runs('Use **Optimise** in the `dart_pdf_printing` plugin.'),
+        [
+          ('Use ', null),
+          ('Optimise', bold),
+          (' in the ', null),
+          ('dart_pdf_printing', code),
+          (' plugin.', null),
+        ],
+      );
+    });
+
+    test('an unterminated marker stays literal', () {
+      expect(runs('100% **of the time'), [('100% **of the time', null)]);
+      expect(runs('a ` backtick'), [('a ` backtick', null)]);
+    });
+  });
+
+  group('the dialog', () {
+    late PdfEditingPreferences prefs;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      prefs = PdfEditingPreferences();
+      debugResetChangelogCache();
+      // rootBundle memoizes the load per key, and a future completed inside a
+      // finished test's fake-async zone never resolves for the next one's
+      // listeners. Evicting the key gives each test its own cold read.
+      rootBundle.evict(appChangelogAsset);
+    });
+    tearDown(() => prefs.dispose());
+
+    Future<void> pumpDialog(WidgetTester tester, String changelog) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () =>
+                  showWhatsNew(context, bundle: _FakeBundle(changelog)),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('lists every release and badges the running one',
+        (tester) async {
+      final installed = AppInfo.version;
+      await pumpDialog(tester, '''
+# Changelog
+
+## $installed
+
+- Something new.
+
+## 0.0.1
+
+- The first cut.
+''');
+
+      expect(find.byKey(const ValueKey('whats-new-dialog')), findsOneWidget);
+      expect(find.text(installed), findsOneWidget);
+      expect(find.text('0.0.1'), findsOneWidget);
+      expect(find.text('Something new.'), findsOneWidget);
+      // Only the running build's section carries the badge.
+      expect(find.byKey(const ValueKey('whats-new-installed')), findsOneWidget);
+      expect(find.text('Installed'), findsOneWidget);
+    });
+
+    testWidgets('says so rather than showing an empty sheet', (tester) async {
+      await pumpDialog(tester, '# Changelog\n');
+
+      expect(
+          find.byKey(const ValueKey('whats-new-unavailable')), findsOneWidget);
+    });
+
+    testWidgets('the command palette runs it', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      try {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+        await tester.pump();
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.keyK);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+        await tester.pumpAndSettle();
+        await tester.enterText(
+            find.byKey(const ValueKey('command-palette-field')), "what's new");
+        await tester.pumpAndSettle();
+
+        final result = find.byKey(const ValueKey('palette-result-whats-new'));
+        expect(result, findsOneWidget);
+        await tester.tap(result);
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const ValueKey('whats-new-dialog')), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('settings opens it from the About block', (tester) async {
+      await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      await tester.pump();
+      await tester.tap(find.byTooltip('DartPDF menu'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Settings'));
+      await tester.pumpAndSettle();
+
+      final tile = find.byKey(const ValueKey('settings-whats-new'));
+      await tester.ensureVisible(tile);
+      await tester.pumpAndSettle();
+      await tester.tap(tile);
+      await tester.pumpAndSettle();
+
+      // No fake bundle here: this reads the CHANGELOG.md the app really
+      // ships, so a missing asset declaration surfaces as a failure. The
+      // versions themselves move every release, so the assertion is that the
+      // file arrived and parsed into at least one section - not which one.
+      expect(find.byKey(const ValueKey('whats-new-dialog')), findsOneWidget);
+      expect(find.byKey(const ValueKey('whats-new-unavailable')), findsNothing);
+    });
+  });
+}

--- a/app/test/whats_new_test.dart
+++ b/app/test/whats_new_test.dart
@@ -180,6 +180,16 @@ void main() {
       expect(find.text('Installed'), findsOneWidget);
     });
 
+    testWidgets('Close dismisses it', (tester) async {
+      await pumpDialog(tester, '## 1.0.0\n\n- Something.\n');
+      expect(find.byKey(const ValueKey('whats-new-dialog')), findsOneWidget);
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('whats-new-dialog')), findsNothing);
+    });
+
     testWidgets('says so rather than showing an empty sheet', (tester) async {
       await pumpDialog(tester, '# Changelog\n');
 

--- a/doc/dev-log/2026-09-09-ship-changelog-in-app.md
+++ b/doc/dev-log/2026-09-09-ship-changelog-in-app.md
@@ -1,0 +1,60 @@
+# Ship the changelog with the app
+
+The release notes existed in three places a user could not reach from the
+running program: `app/CHANGELOG.md` in the repo, the GitHub release body, and
+the per-locale Play Store changelogs under `app/fastlane/`. This bundles the
+first one into the build.
+
+## What landed
+
+- `app/pubspec.yaml` declares `CHANGELOG.md` as a Flutter asset. The file the
+  release is cut from travels inside the binary, so the notes and the build
+  cannot drift, and reading them needs no network call (the web build included).
+- `app/lib/whats_new.dart`: `parseChangelog` (markdown → `ChangelogRelease`
+  sections), `changelogSpans` (inline `**bold**` / `` `code` ``),
+  `loadAppChangelog` (memoized `rootBundle` read) and `showWhatsNew` (the
+  dialog, newest release first, the running version's section badged from
+  `AppInfo.version`).
+- Entry points: a **What's new** tile in Settings > About, above View licenses,
+  and a command-palette entry (`whats-new`).
+
+## Why a hand-rolled parser
+
+The changelog is written to exactly one shape - `## <version>` over `- `
+bullets that hard-wrap at 80 columns, with `**bold**` and `` `code` `` inline,
+no nesting and no links. That is four rules; a markdown package would be a new
+dependency and a second renderer to theme. The parser rejoins wrapped lines
+(indented continuation), treats a blank line as the end of a bullet, and keeps
+the heading text verbatim - so a build cut before the release rolls
+`## Unreleased` into `## X.Y.Z` shows "Unreleased" rather than inventing a
+version.
+
+## Where it is *not*
+
+Not in the app menu. The App section deliberately holds one row (Settings), and
+`_appMenuItems` only draws a section header over two rows or more - a second
+row would turn the bare divider into an `APP` header for a feature that belongs
+under About anyway. So the palette command is registered by hand in
+`_paletteCommands()` rather than falling out of `_appActions()`, and its source
+column reads "Settings", which is where it actually lives.
+
+There is no automatic pop-up after an update. Everything here is one call
+(`showWhatsNew`) away from becoming one - store the last-seen version in
+`PdfEditingPreferences` and compare on launch - but an unrequested modal on
+first launch is a product decision, not a plumbing one.
+
+## Test gotcha
+
+`rootBundle` memoizes the load per asset key, and a future that completed
+inside a finished widget test's fake-async zone never resolves for the *next*
+test's listeners: the completion microtask is scheduled in the dead zone, the
+dialog's spinner never stops, and `pumpAndSettle` times out. Both the parsed
+memo (`debugResetChangelogCache`) and the bundle's own cache
+(`rootBundle.evict`) have to be cleared in `setUp` so each test gets a cold
+read. Note the symptom is order-dependent: the test passed on its own and hung
+only when a previous test in the same file had already read the asset.
+
+`app/test/whats_new_test.dart` covers the parser, the span splitter, both
+dialog entry points, and - deliberately without a fake bundle - one read of the
+real bundled asset, so deleting the pubspec asset line fails a test instead of
+shipping an empty dialog.


### PR DESCRIPTION
## Summary

The release notes lived in three places a running build could not reach: `app/CHANGELOG.md` in the repo, the GitHub release body, and the per-locale store listings under `app/fastlane/`. This bundles the first one into the app.

`app/pubspec.yaml` declares `CHANGELOG.md` as a Flutter asset, so the file the release was cut from travels inside the binary — the notes cannot drift from the build, and reading them needs no network call (the web build included).

`app/lib/whats_new.dart` carries the feature:

- `parseChangelog` — the one markdown shape the changelog is written in: `## <version>` headings over hard-wrapped `- ` bullets. Continuation lines rejoin into one paragraph, a blank line ends a bullet, and the heading is kept verbatim, so a build cut before the release rolls `## Unreleased` into `## X.Y.Z` says "Unreleased" rather than inventing a version. No markdown dependency for four rules.
- `changelogSpans` — inline `**bold**` and `` `code` ``; an unterminated marker stays literal instead of swallowing the rest of the line.
- `loadAppChangelog` / `showWhatsNew` — a memoized `rootBundle` read and the dialog: newest release first, the running version's section badged from `AppInfo.version` so a reader can place themselves in the list.

Two entry points: a **What's new** tile in Settings > About (above View licenses) and a command-palette command. Deliberately **not** the app menu — its App section holds one row on purpose, and `_appMenuItems` only draws a section header over two rows or more, so a second row would turn that bare divider into an `APP` header for a feature that belongs under About. The palette command is therefore registered by hand in `_paletteCommands()` and names Settings as its source.

Three new l10n keys (`whatsNew`, `whatsNewInstalled`, `whatsNewUnavailable`), translated across all 22 app bundles. The notes themselves stay in the language they were written in, like the release page.

Background: [doc/dev-log/2026-09-09-ship-changelog-in-app.md](https://github.com/ben-milanko/dart-pdf/blob/claude/gracious-franklin-bpkubr/doc/dev-log/2026-09-09-ship-changelog-in-app.md).

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] DartPDF app (`app/`) — the only package touched

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (whole workspace, clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Also run: `cd app && fvm flutter test` — 585 tests pass, including the 11 new ones. `dart run tool/check_arb_coverage.dart` and `dart run tool/sync_english_locales.dart` both clean.

The engine package suites, the corpora and the example app were not run: nothing outside `app/lib` and `app/test` changed, and no parsing or rendering path is touched.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered — a spinner while the asset loads, and a "Release notes aren't available in this build." line (rather than an empty sheet) if the changelog is missing or empty.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked — the dialog goes through `showPdfDialog` with `PdfDialogSubmit` on Close, so Enter and Escape behave like every other app dialog, and it is reachable by keyboard alone through ⌘K/Ctrl+K.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable — read-only feature, no document state involved.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out — one ~25 KB asset read, memoized after the first open, off the render path entirely.

## PDF fixtures and screenshots

None — no PDF behavior changes.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor` — the new code is in the app.
- [x] No `dart:io` imports in any `lib/` directory — the changelog is read through `rootBundle`, so the web build works unchanged.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output — the changelog parser follows the same posture: unknown lines are skipped, an unterminated marker stays literal, and no input shape throws.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **No automatic pop-up after an update.** Everything is one `showWhatsNew` call away from becoming one — store the last-seen version in `PdfEditingPreferences` and compare on launch — but an unrequested modal on first launch is a product decision, so it is left to you.
- **Test gotcha worth knowing.** `rootBundle` memoizes per asset key, and a future completed inside a finished widget test's fake-async zone never resolves for the *next* test's listeners: the dialog's spinner never stops and `pumpAndSettle` times out. `setUp` clears both the parsed memo and `rootBundle.evict(appChangelogAsset)`. The symptom was order-dependent — the test passed alone and hung only after another test in the file had read the asset.
- The `## Unreleased` entry this PR adds to `app/CHANGELOG.md` is itself the first thing the new dialog shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hu9SDB14xbzqZZEwWmMDHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu9SDB14xbzqZZEwWmMDHJ)_