### PR TITLE
Make the view modes a mode picker, not two loose checkmarks

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -3547,10 +3547,24 @@ class _EditorScreenState extends State<EditorScreen>
         view,
         _prefs.showAnnotations,
         (v) => _prefs.showAnnotations = v);
-    toggle('view-reflow', Icons.article_outlined, pdf.shellReflowText, view,
-        _prefs.showReflowView, (v) => _prefs.showReflowView = v);
-    toggle('view-page-grid', Icons.grid_view_outlined, pdf.shellPageGrid, view,
-        _prefs.showThumbnailView, (v) => _prefs.showThumbnailView = v);
+    // Reflow and the page grid each replace the page viewer, so they go
+    // through PdfEditingPreferences.viewMode rather than their own bools:
+    // turning one on has to clear the other, and turning one off has to land
+    // somewhere - plain pages.
+    toggle(
+        'view-reflow',
+        Icons.article_outlined,
+        pdf.shellReflowText,
+        view,
+        _prefs.viewMode == PdfViewMode.reflow,
+        (v) => _prefs.viewMode = v ? PdfViewMode.reflow : PdfViewMode.pages);
+    toggle(
+        'view-page-grid',
+        Icons.grid_view_outlined,
+        pdf.shellPageGrid,
+        view,
+        _prefs.viewMode == PdfViewMode.pageGrid,
+        (v) => _prefs.viewMode = v ? PdfViewMode.pageGrid : PdfViewMode.pages);
     toggle(
         'view-form-fields',
         Icons.ballot_outlined,

--- a/doc/dev-log/2026-09-10-view-modes-out-of-the-toggle-list.md
+++ b/doc/dev-log/2026-09-10-view-modes-out-of-the-toggle-list.md
@@ -1,0 +1,77 @@
+# View modes stop pretending to be display toggles (2026-09-10)
+
+The trigger was one line of feedback: "the Page grid option is in an awkward
+spot". It is, and the reason is worth writing down, because the placement was a
+symptom.
+
+## What was wrong
+
+`PdfShellViewOptionsButton`'s popup held nine rows of four different kinds:
+overlay toggles (annotations, scrollbar chapters, form-field highlight), two
+view modes (Reflow text, Page grid), two settings with values (paper colour,
+guides), and two dialog openers (author, shortcuts). No dividers, no grouping.
+
+The modes were the real problem. Both REPLACE the page viewer, so only one can
+be on, and the old handler expressed that by having each clear the other:
+
+```dart
+case _ViewOption.reflow:
+  preferences.showThumbnailView = false;
+  preferences.showReflowView = !preferences.showReflowView;
+```
+
+Drawn as checkmarks, that reads as three unrelated switches where ticking one
+silently unticks another. And there was no "Pages" member: plain pages existed
+only as the absence of the other two, so leaving a mode meant unticking the one
+you ticked rather than choosing where to go.
+
+The invariant was also re-implemented per caller, and one caller had it wrong -
+the app's command palette set `showReflowView` / `showThumbnailView`
+independently, so it could put the document in both modes at once.
+
+## What landed
+
+**The invariant moved to the state object.** `PdfEditingPreferences.viewMode`
+(`PdfViewMode.pages | reflow | pageGrid`) reads and writes the pair coherently
+and notifies once. The two bools stay - they are persisted keys and hosts use
+them - but nothing in our own code sets them individually any more. The
+`_ViewOption` enum lost its `reflow` and `pageGrid` cases entirely.
+
+**Desktop: a `SegmentedButton` above the display toggles.** It is a custom
+`PopupMenuEntry`, following `_KeyboardShortcutMenuItem`, which was already the
+precedent for a non-item row in this menu. Picking a mode closes the popup,
+matching the checked items it replaced.
+
+**Compact: the modes went UP, not down.** They are tiles in the Controls
+sheet's existing View section (`pdfShellViewModeControls`), not in the Settings
+sheet - on a phone Controls is the parent surface and Settings a child of it.
+This closed a real gap: `pdf_editor_view.dart` had already given Reflow a
+one-tap tile there, on the reasoning that phone readers reach for it often, and
+the page grid had never got one - it was Controls -> Settings -> scroll -> tick.
+`showPdfShellViewOptionsSheet` dropped its `reflow` / `pageGrid` parameters, and
+the Settings tile moved to the sheet's action row with the other dialog openers.
+
+## Two traps
+
+**Flutter caps a popup menu at 280pt.** `_kMenuMaxWidth` is `5 * 56`, which is
+why the menu has always been ~275 wide. Three labelled segments do not fit, and
+nothing warns you - the labels just squeeze. `PopupMenuButton.constraints` now
+raises the cap to `6 * 56` when the modes are present, and only then.
+
+**A `SegmentedButton` fills the width it is offered**, so that constant is not
+a ceiling the content stops short of - it IS the menu's width whenever the
+modes show. Confirmed by measuring: every locale reported the same width,
+because the cap, not the labels, was setting it. 336 was chosen from real
+Roboto metrics ("Reflow text" is the widest English label at ~79pt of 14pt
+type, plus segment padding, times three) - NOT from a widget test, whose test
+font makes any text measurement meaningless.
+
+Segment labels ellipsize with the full text in a tooltip. They have to:
+segments are all as wide as the widest, and Ukrainian's "Переформатувати
+текст" alone runs 21 characters - a set that fits no sane menu.
+`pdf_shell_test.dart` pins both the width and the Ukrainian no-overflow case.
+
+One consequence to remember: the popup and its compact twin
+(`showPdfShellViewOptionsSheet`) no longer hold the same things. That is
+deliberate - only compact has a parent surface to promote the modes into - but
+the two are easy to edit as if they mirrored each other.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- Group the view-options menu around what its rows actually do. Reflow text
+  and the page grid each REPLACE the page viewer, but they were drawn as two
+  independent checkmarks among the display overlays, and each silently cleared
+  the other - so leaving a mode meant unticking the one you ticked, and plain
+  pages existed only as the absence of both. They are now one `SegmentedButton`
+  at the top of the menu, with `Pages` as a real destination, over a
+  `PdfEditingPreferences.viewMode` (`PdfViewMode`) that owns the exclusivity
+  the callers kept re-implementing - including the command palette, which
+  toggled the two bools independently and could show both at once. On compact
+  layouts the modes move up into the Controls sheet's View section, one tap
+  from the document: Reflow already had a tile there, and the page grid needed
+  Controls -> Settings -> scroll -> tick. The Settings sheet keeps only
+  settings, and `showPdfShellViewOptionsSheet` no longer takes `reflow` /
+  `pageGrid`.
+
 - Draw unembedded standard-14 text in the metric-compatible TeX Gyre faces
   bundled by `dart_pdf_editor_assets` - Heros for Helvetica/Arial, Termes for
   Times, Cursor for Courier - ahead of any host font. Substituting a face with

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "غير معيّن",
   "shellPageColor": "لون الصفحة…",
   "shellPageGrid": "شبكة الصفحات",
+  "shellViewPages": "الصفحات",
   "shellPanelAnnotations": "التعليقات التوضيحية",
   "shellPanelBookmarks": "الإشارات المرجعية",
   "shellPanelPages": "الصفحات",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Nicht festgelegt",
   "shellPageColor": "Seitenfarbe…",
   "shellPageGrid": "Seitenraster",
+  "shellViewPages": "Seiten",
   "shellPanelAnnotations": "Anmerkungen",
   "shellPanelBookmarks": "Lesezeichen",
   "shellPanelPages": "Seiten",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -1272,6 +1272,10 @@
   "@shellPageGrid": {
     "description": "Toggle label for the full-area page thumbnail grid view."
   },
+  "shellViewPages": "Pages",
+  "@shellViewPages": {
+    "description": "View-mode label for ordinary fixed-layout pages, the alternative to the reflow view and the page grid. Distinct from shellPanelPages, which names the page thumbnail sidebar."
+  },
   "shellPanelAnnotations": "Annotations",
   "@shellPanelAnnotations": {
     "description": "Name of the annotations list panel (toggle tooltip and sheet title)."

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en_AU.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en_AU.arb
@@ -290,6 +290,7 @@
   "shellNotSet": "Not set",
   "shellPageColor": "Page colour…",
   "shellPageGrid": "Page grid",
+  "shellViewPages": "Pages",
   "shellPanelAnnotations": "Annotations",
   "shellPanelBookmarks": "Bookmarks",
   "shellPanelPages": "Pages",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en_GB.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en_GB.arb
@@ -290,6 +290,7 @@
   "shellNotSet": "Not set",
   "shellPageColor": "Page colour…",
   "shellPageGrid": "Page grid",
+  "shellViewPages": "Pages",
   "shellPanelAnnotations": "Annotations",
   "shellPanelBookmarks": "Bookmarks",
   "shellPanelPages": "Pages",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Sin establecer",
   "shellPageColor": "Color de página…",
   "shellPageGrid": "Cuadrícula de páginas",
+  "shellViewPages": "Páginas",
   "shellPanelAnnotations": "Anotaciones",
   "shellPanelBookmarks": "Marcadores",
   "shellPanelPages": "Páginas",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Non défini",
   "shellPageColor": "Couleur de page…",
   "shellPageGrid": "Grille de pages",
+  "shellViewPages": "Pages",
   "shellPanelAnnotations": "Annotations",
   "shellPanelBookmarks": "Signets",
   "shellPanelPages": "Pages",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "सेट नहीं",
   "shellPageColor": "पृष्ठ रंग…",
   "shellPageGrid": "पृष्ठ ग्रिड",
+  "shellViewPages": "पृष्ठ",
   "shellPanelAnnotations": "एनोटेशन",
   "shellPanelBookmarks": "बुकमार्क",
   "shellPanelPages": "पृष्ठ",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Tidak diatur",
   "shellPageColor": "Warna halaman…",
   "shellPageGrid": "Kisi halaman",
+  "shellViewPages": "Halaman",
   "shellPanelAnnotations": "Anotasi",
   "shellPanelBookmarks": "Markah",
   "shellPanelPages": "Halaman",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Non impostato",
   "shellPageColor": "Colore pagina…",
   "shellPageGrid": "Griglia pagine",
+  "shellViewPages": "Pagine",
   "shellPanelAnnotations": "Annotazioni",
   "shellPanelBookmarks": "Segnalibri",
   "shellPanelPages": "Pagine",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "未設定",
   "shellPageColor": "ページの色…",
   "shellPageGrid": "ページグリッド",
+  "shellViewPages": "ページ",
   "shellPanelAnnotations": "注釈",
   "shellPanelBookmarks": "ブックマーク",
   "shellPanelPages": "ページ",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "설정되지 않음",
   "shellPageColor": "페이지 색상…",
   "shellPageGrid": "페이지 그리드",
+  "shellViewPages": "페이지",
   "shellPanelAnnotations": "주석",
   "shellPanelBookmarks": "책갈피",
   "shellPanelPages": "페이지",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1876,6 +1876,12 @@ abstract class DartPdfEditorLocalizations {
   /// **'Page grid'**
   String get shellPageGrid;
 
+  /// View-mode label for ordinary fixed-layout pages, the alternative to the reflow view and the page grid. Distinct from shellPanelPages, which names the page thumbnail sidebar.
+  ///
+  /// In en, this message translates to:
+  /// **'Pages'**
+  String get shellViewPages;
+
   /// Name of the annotations list panel (toggle tooltip and sheet title).
   ///
   /// In en, this message translates to:

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -994,6 +994,9 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'شبكة الصفحات';
 
   @override
+  String get shellViewPages => 'الصفحات';
+
+  @override
   String get shellPanelAnnotations => 'التعليقات التوضيحية';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -977,6 +977,9 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Seitenraster';
 
   @override
+  String get shellViewPages => 'Seiten';
+
+  @override
   String get shellPanelAnnotations => 'Anmerkungen';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -974,6 +974,9 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Page grid';
 
   @override
+  String get shellViewPages => 'Pages';
+
+  @override
   String get shellPanelAnnotations => 'Annotations';
 
   @override
@@ -3114,6 +3117,9 @@ class DartPdfEditorLocalizationsEnAu extends DartPdfEditorLocalizationsEn {
   String get shellPageGrid => 'Page grid';
 
   @override
+  String get shellViewPages => 'Pages';
+
+  @override
   String get shellPanelAnnotations => 'Annotations';
 
   @override
@@ -5252,6 +5258,9 @@ class DartPdfEditorLocalizationsEnGb extends DartPdfEditorLocalizationsEn {
 
   @override
   String get shellPageGrid => 'Page grid';
+
+  @override
+  String get shellViewPages => 'Pages';
 
   @override
   String get shellPanelAnnotations => 'Annotations';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -978,6 +978,9 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Cuadrícula de páginas';
 
   @override
+  String get shellViewPages => 'Páginas';
+
+  @override
   String get shellPanelAnnotations => 'Anotaciones';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -979,6 +979,9 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Grille de pages';
 
   @override
+  String get shellViewPages => 'Pages';
+
+  @override
   String get shellPanelAnnotations => 'Annotations';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -974,6 +974,9 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'पृष्ठ ग्रिड';
 
   @override
+  String get shellViewPages => 'पृष्ठ';
+
+  @override
   String get shellPanelAnnotations => 'एनोटेशन';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -977,6 +977,9 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Kisi halaman';
 
   @override
+  String get shellViewPages => 'Halaman';
+
+  @override
   String get shellPanelAnnotations => 'Anotasi';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -978,6 +978,9 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Griglia pagine';
 
   @override
+  String get shellViewPages => 'Pagine';
+
+  @override
   String get shellPanelAnnotations => 'Annotazioni';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -972,6 +972,9 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'ページグリッド';
 
   @override
+  String get shellViewPages => 'ページ';
+
+  @override
   String get shellPanelAnnotations => '注釈';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -972,6 +972,9 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get shellPageGrid => '페이지 그리드';
 
   @override
+  String get shellViewPages => '페이지';
+
+  @override
   String get shellPanelAnnotations => '주석';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -977,6 +977,9 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Paginaraster';
 
   @override
+  String get shellViewPages => 'Pagina\'s';
+
+  @override
   String get shellPanelAnnotations => 'Annotaties';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -991,6 +991,9 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Siatka stron';
 
   @override
+  String get shellViewPages => 'Strony';
+
+  @override
   String get shellPanelAnnotations => 'Adnotacje';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -978,6 +978,9 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Grade de páginas';
 
   @override
+  String get shellViewPages => 'Páginas';
+
+  @override
   String get shellPanelAnnotations => 'Anotações';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -991,6 +991,9 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Сетка страниц';
 
   @override
+  String get shellViewPages => 'Страницы';
+
+  @override
   String get shellPanelAnnotations => 'Аннотации';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -975,6 +975,9 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'ตารางหน้า';
 
   @override
+  String get shellViewPages => 'หน้า';
+
+  @override
   String get shellPanelAnnotations => 'คำอธิบายประกอบ';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -975,6 +975,9 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Sayfa ızgarası';
 
   @override
+  String get shellViewPages => 'Sayfalar';
+
+  @override
   String get shellPanelAnnotations => 'Ek açıklamalar';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -990,6 +990,9 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Сітка сторінок';
 
   @override
+  String get shellViewPages => 'Сторінки';
+
+  @override
   String get shellPanelAnnotations => 'Анотації';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -977,6 +977,9 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get shellPageGrid => 'Lưới trang';
 
   @override
+  String get shellViewPages => 'Trang';
+
+  @override
   String get shellPanelAnnotations => 'Chú thích';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -970,6 +970,9 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get shellPageGrid => '页面网格';
 
   @override
+  String get shellViewPages => '页面';
+
+  @override
   String get shellPanelAnnotations => '注释';
 
   @override
@@ -3080,6 +3083,9 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get shellPageGrid => '頁面網格';
+
+  @override
+  String get shellViewPages => '頁面';
 
   @override
   String get shellPanelAnnotations => '註解';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Niet ingesteld",
   "shellPageColor": "Paginakleur…",
   "shellPageGrid": "Paginaraster",
+  "shellViewPages": "Pagina's",
   "shellPanelAnnotations": "Annotaties",
   "shellPanelBookmarks": "Bladwijzers",
   "shellPanelPages": "Pagina's",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Nie ustawiono",
   "shellPageColor": "Kolor strony…",
   "shellPageGrid": "Siatka stron",
+  "shellViewPages": "Strony",
   "shellPanelAnnotations": "Adnotacje",
   "shellPanelBookmarks": "Zakładki",
   "shellPanelPages": "Strony",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Não definido",
   "shellPageColor": "Cor da página…",
   "shellPageGrid": "Grade de páginas",
+  "shellViewPages": "Páginas",
   "shellPanelAnnotations": "Anotações",
   "shellPanelBookmarks": "Marcadores",
   "shellPanelPages": "Páginas",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Не задано",
   "shellPageColor": "Цвет страницы…",
   "shellPageGrid": "Сетка страниц",
+  "shellViewPages": "Страницы",
   "shellPanelAnnotations": "Аннотации",
   "shellPanelBookmarks": "Закладки",
   "shellPanelPages": "Страницы",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "ไม่ได้ตั้งค่า",
   "shellPageColor": "สีหน้า…",
   "shellPageGrid": "ตารางหน้า",
+  "shellViewPages": "หน้า",
   "shellPanelAnnotations": "คำอธิบายประกอบ",
   "shellPanelBookmarks": "บุ๊กมาร์ก",
   "shellPanelPages": "หน้า",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Ayarlanmadı",
   "shellPageColor": "Sayfa rengi…",
   "shellPageGrid": "Sayfa ızgarası",
+  "shellViewPages": "Sayfalar",
   "shellPanelAnnotations": "Ek açıklamalar",
   "shellPanelBookmarks": "Yer imleri",
   "shellPanelPages": "Sayfalar",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Не встановлено",
   "shellPageColor": "Колір сторінки…",
   "shellPageGrid": "Сітка сторінок",
+  "shellViewPages": "Сторінки",
   "shellPanelAnnotations": "Анотації",
   "shellPanelBookmarks": "Закладки",
   "shellPanelPages": "Сторінки",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "Chưa đặt",
   "shellPageColor": "Màu trang…",
   "shellPageGrid": "Lưới trang",
+  "shellViewPages": "Trang",
   "shellPanelAnnotations": "Chú thích",
   "shellPanelBookmarks": "Dấu trang",
   "shellPanelPages": "Trang",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "未设置",
   "shellPageColor": "页面颜色…",
   "shellPageGrid": "页面网格",
+  "shellViewPages": "页面",
   "shellPanelAnnotations": "注释",
   "shellPanelBookmarks": "书签",
   "shellPanelPages": "页面",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -310,6 +310,7 @@
   "shellNotSet": "未設定",
   "shellPageColor": "頁面顏色…",
   "shellPageGrid": "頁面網格",
+  "shellViewPages": "頁面",
   "shellPanelAnnotations": "註解",
   "shellPanelBookmarks": "書籤",
   "shellPanelPages": "頁面",

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -17,6 +17,11 @@ import 'saved_annotation.dart';
 import 'editing_signature.dart';
 import 'editing_stamps.dart';
 
+/// Which surface owns the document area: fixed-layout pages, the inferred
+/// text reflow view, or the full-area page grid. Exactly one at a time -
+/// see [PdfEditingPreferences.viewMode].
+enum PdfViewMode { pages, reflow, pageGrid }
+
 /// Editing-UI preferences, persisted on the local device.
 ///
 /// Every [PdfEditingController] creates one by default, so tool styles
@@ -1285,6 +1290,37 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _showThumbnailView) return;
     _showThumbnailView = value;
     _write((s) => s.setBool('${_prefix}showThumbnailView', value));
+    notifyListeners();
+  }
+
+  /// The surface that currently owns the document area.
+  ///
+  /// [showReflowView] and [showThumbnailView] each REPLACE the page viewer,
+  /// so at most one of them can be true. Setting the two bools individually
+  /// leaves that invariant to the caller, and every caller that forgot it
+  /// produced the same bug: view options that silently untick each other,
+  /// with no way back to plain pages except unticking the one you ticked.
+  /// This pair is the single place the modes are kept coherent - prefer it,
+  /// and it notifies once for the whole change.
+  PdfViewMode get viewMode => _showReflowView
+      ? PdfViewMode.reflow
+      : _showThumbnailView
+          ? PdfViewMode.pageGrid
+          : PdfViewMode.pages;
+
+  set viewMode(PdfViewMode value) {
+    final reflow = value == PdfViewMode.reflow;
+    final grid = value == PdfViewMode.pageGrid;
+    if (reflow == _showReflowView && grid == _showThumbnailView) return;
+    _showReflowView = reflow;
+    _showThumbnailView = grid;
+    // Both keys before yielding, for the reason in _writeSignatureLibrary:
+    // awaiting one would let a later mode change resume in between and
+    // persist a pair that was never live.
+    _write((s) => Future.wait<Object?>([
+          s.setBool('${_prefix}showReflowView', reflow),
+          s.setBool('${_prefix}showThumbnailView', grid),
+        ]));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1350,14 +1350,13 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   );
           final viewOptionsControl = PdfShellControlItem(
             key: const ValueKey('pdf-shell-view-options'),
+            group: PdfShellControlGroup.actions,
             icon: Icons.display_settings_outlined,
             label: pdfL10n(context).shellSettings,
             onPressed: () {
               showPdfShellViewOptionsSheet(
                 context,
                 preferences: prefs,
-                reflow: features.reflowView,
-                pageGrid: features.thumbnails,
                 pageColor: features.pageColorEditable,
                 editingGuides: true,
                 author: features.author,
@@ -1370,19 +1369,15 @@ class _PdfEditorViewState extends State<PdfEditorView> {
               );
             },
           );
-          // A one-tap Reflow toggle for the compact Controls sheet - reading
-          // reflow is something phone users reach for often, so it earns a
-          // direct tile instead of living only inside Settings. Mirrors the
-          // Settings toggle: turning reflow on clears the page grid.
-          final reflowControl = PdfShellControlItem(
-            key: const ValueKey('pdf-shell-reflow-toggle'),
-            icon: Icons.article_outlined,
-            label: pdfL10n(context).shellReflow,
-            selected: reflowActive,
-            onPressed: () {
-              prefs.showThumbnailView = false;
-              prefs.showReflowView = !prefs.showReflowView;
-            },
+          // Every view mode gets a one-tap tile in the compact Controls
+          // sheet. Reflow had one already - phone readers reach for it often -
+          // and Page grid, which is just as much a mode, was reachable only by
+          // opening Settings from here and scrolling to a checkbox.
+          final viewModeControls = pdfShellViewModeControls(
+            context,
+            preferences: prefs,
+            reflow: features.reflowView,
+            pageGrid: features.thumbnails,
           );
           final panelItems = [
             if (features.searchResultsPanel)
@@ -1514,8 +1509,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   if (!altView) PdfShellZoomControl(controller: _viewer),
                 ],
                 compactControls: [
+                  ...viewModeControls,
                   if (features.viewOptions) viewOptionsControl,
-                  if (features.reflowView) reflowControl,
                   for (final item in panelItems)
                     PdfShellControlItem(
                       group: PdfShellControlGroup.panels,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -506,30 +506,24 @@ class _PdfReaderState extends State<PdfReader> {
                     PdfShellZoomControl(controller: _viewer),
                 ],
                 compactControls: [
+                  // Pages / Reflow as one exclusive choice, at one tap. The
+                  // reader offers no page grid, so the set is a pair.
+                  ...pdfShellViewModeControls(context,
+                      preferences: prefs, reflow: true),
                   if (features.viewOptions)
                     PdfShellControlItem(
                       key: const ValueKey('pdf-shell-view-options'),
+                      group: PdfShellControlGroup.actions,
                       icon: Icons.display_settings_outlined,
                       label: pdfL10n(context).shellSettings,
                       onPressed: () {
                         showPdfShellViewOptionsSheet(
                           context,
                           preferences: prefs,
-                          reflow: true,
                           pageColor: features.pageColorEditable,
                         );
                       },
                     ),
-                  // A direct Reflow toggle for phone readers, who reach for the
-                  // reading view most - no need to dig into Settings.
-                  PdfShellControlItem(
-                    key: const ValueKey('pdf-shell-reflow-toggle'),
-                    icon: Icons.article_outlined,
-                    label: pdfL10n(context).shellReflow,
-                    selected: prefs.showReflowView,
-                    onPressed: () =>
-                        prefs.showReflowView = !prefs.showReflowView,
-                  ),
                   if (features.thumbnails)
                     PdfShellControlItem(
                       group: PdfShellControlGroup.panels,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1416,8 +1416,6 @@ enum _ViewOption {
   annotations,
   scrollbarChapters,
   formHighlight,
-  reflow,
-  pageGrid,
   pageColor,
   editingGuides,
   author,
@@ -1441,14 +1439,6 @@ Future<void> _selectViewOption(
       preferences.showScrollbarChapters = !preferences.showScrollbarChapters;
     case _ViewOption.formHighlight:
       preferences.highlightFormFields = !preferences.highlightFormFields;
-    case _ViewOption.reflow:
-      // reflow and the page grid both replace the page viewer - only one
-      // can claim the area, so each clears the other
-      preferences.showThumbnailView = false;
-      preferences.showReflowView = !preferences.showReflowView;
-    case _ViewOption.pageGrid:
-      preferences.showReflowView = false;
-      preferences.showThumbnailView = !preferences.showThumbnailView;
     case _ViewOption.pageColor:
       if (!pageColor) return;
       final color = await showPdfColorPicker(
@@ -1724,11 +1714,15 @@ String _shortcutGroupLabel(BuildContext context, PdfEditToolGroup group) {
   }
 }
 
+/// The compact twin of [PdfShellViewOptionsButton]'s popup.
+///
+/// It deliberately holds LESS than the popup does: the view modes live in the
+/// Controls sheet one level up (see [pdfShellViewModeControls]), because on a
+/// compact layout Controls is the parent surface and this sheet is a child of
+/// it - putting a mode here would bury it two taps deep.
 Future<void> showPdfShellViewOptionsSheet(
   BuildContext context, {
   required PdfEditingPreferences preferences,
-  bool reflow = false,
-  bool pageGrid = false,
   bool pageColor = true,
   bool editingGuides = false,
   bool author = false,
@@ -1822,40 +1816,6 @@ Future<void> showPdfShellViewOptionsSheet(
                   setSheetState(() {});
                 },
               ),
-              if (reflow)
-                SwitchListTile(
-                  key: const ValueKey('pdf-shell-reflow-view'),
-                  secondary: const Icon(Icons.article_outlined),
-                  title: Text(pdfL10n(context).shellReflowText),
-                  value: preferences.showReflowView,
-                  onChanged: (_) async {
-                    await _selectViewOption(
-                      context,
-                      _ViewOption.reflow,
-                      preferences: preferences,
-                      pageColor: pageColor,
-                      onAuthorPressed: onAuthorPressed,
-                    );
-                    setSheetState(() {});
-                  },
-                ),
-              if (pageGrid)
-                SwitchListTile(
-                  key: const ValueKey('pdf-shell-page-grid'),
-                  secondary: const Icon(Icons.view_module_outlined),
-                  title: Text(pdfL10n(context).shellPageGrid),
-                  value: preferences.showThumbnailView,
-                  onChanged: (_) async {
-                    await _selectViewOption(
-                      context,
-                      _ViewOption.pageGrid,
-                      preferences: preferences,
-                      pageColor: pageColor,
-                      onAuthorPressed: onAuthorPressed,
-                    );
-                    setSheetState(() {});
-                  },
-                ),
               if (pageColor)
                 ListTile(
                   key: const ValueKey('pdf-shell-page-color'),
@@ -1937,10 +1897,153 @@ Future<void> showPdfShellViewOptionsSheet(
   );
 }
 
-/// The "view options" popup both shells offer: display-only settings
-/// (annotation visibility, form-field highlight, paper color, and optional
-/// editing guides) that live in [PdfEditingPreferences] and never touch the
-/// document.
+/// How wide the view-options popup grows when it carries the view-mode
+/// segmented control: 6 of Flutter's 56pt menu steps.
+///
+/// Not a ceiling the content stops short of - a [SegmentedButton] fills the
+/// width it is offered, so this IS the menu's width whenever the modes are
+/// shown. 336 fits the English labels ("Reflow text" is the widest at ~79pt
+/// of 14pt Roboto, plus segment padding, times three); a verbose locale
+/// ellipsizes into the same frame rather than pushing the menu wider than a
+/// menu should be.
+const double _viewModeMenuMaxWidth = 6 * 56;
+
+/// The [PdfViewMode] to show as selected when the host does not offer every
+/// mode. A shell can turn reflow or the page grid off ([PdfEditorFeatures]),
+/// and a segmented control asserts if its selected value has no segment.
+PdfViewMode _effectiveViewMode(PdfViewMode mode,
+    {required bool reflow, required bool pageGrid}) {
+  if (mode == PdfViewMode.reflow && !reflow) return PdfViewMode.pages;
+  if (mode == PdfViewMode.pageGrid && !pageGrid) return PdfViewMode.pages;
+  return mode;
+}
+
+/// The view-mode tiles for the compact Controls sheet's "View" section.
+///
+/// Compact keeps the modes here rather than in the Settings sheet: Controls is
+/// the parent surface on a phone, so a mode reached through Settings would sit
+/// two taps deep. Reflow already had a tile of its own on that reasoning; this
+/// puts all three on the same footing, as one exclusive choice.
+///
+/// Returns nothing when the host offers no mode but plain pages - a one-member
+/// radio set is just chrome.
+List<PdfShellControlItem> pdfShellViewModeControls(
+  BuildContext context, {
+  required PdfEditingPreferences preferences,
+  bool reflow = false,
+  bool pageGrid = false,
+}) {
+  if (!reflow && !pageGrid) return const [];
+  final l10n = pdfL10n(context);
+  final mode = _effectiveViewMode(preferences.viewMode,
+      reflow: reflow, pageGrid: pageGrid);
+  return [
+    PdfShellControlItem(
+      key: const ValueKey('pdf-shell-view-mode-pages'),
+      icon: Icons.description_outlined,
+      label: l10n.shellViewPages,
+      selected: mode == PdfViewMode.pages,
+      onPressed: () => preferences.viewMode = PdfViewMode.pages,
+    ),
+    if (reflow)
+      PdfShellControlItem(
+        key: const ValueKey('pdf-shell-reflow-toggle'),
+        icon: Icons.article_outlined,
+        label: l10n.shellReflow,
+        selected: mode == PdfViewMode.reflow,
+        onPressed: () => preferences.viewMode = PdfViewMode.reflow,
+      ),
+    if (pageGrid)
+      PdfShellControlItem(
+        key: const ValueKey('pdf-shell-page-grid-toggle'),
+        icon: Icons.grid_view_outlined,
+        label: l10n.shellPageGrid,
+        selected: mode == PdfViewMode.pageGrid,
+        onPressed: () => preferences.viewMode = PdfViewMode.pageGrid,
+      ),
+  ];
+}
+
+/// The view-mode segmented control that opens the view-options popup.
+///
+/// A [PopupMenuEntry] rather than a [PopupMenuItem] because the modes are one
+/// exclusive choice, not independent commands - the same reason
+/// [_KeyboardShortcutMenuItem] is one. Drawn as checkmarks in a run of display
+/// toggles they read as three unrelated switches, and clearing one meant
+/// unticking it, since "pages" was only ever the absence of the other two.
+///
+/// Picking a mode closes the menu, matching the checked items it replaces (and
+/// there is nothing to see behind an open menu that covers the view anyway).
+class _ViewModeMenuItem extends PopupMenuEntry<_ViewOption> {
+  const _ViewModeMenuItem({
+    required this.preferences,
+    required this.reflow,
+    required this.pageGrid,
+  });
+
+  final PdfEditingPreferences preferences;
+  final bool reflow;
+  final bool pageGrid;
+
+  @override
+  double get height => kMinInteractiveDimension;
+
+  // it stands for no single _ViewOption - it handles its own taps and never
+  // travels through the menu's onSelected
+  @override
+  bool represents(_ViewOption? value) => false;
+
+  @override
+  State<_ViewModeMenuItem> createState() => _ViewModeMenuItemState();
+}
+
+class _ViewModeMenuItemState extends State<_ViewModeMenuItem> {
+  // Every segment is as wide as the widest one, so a verbose locale can ask
+  // for more than any menu should be - Ukrainian's "Переформатувати текст"
+  // alone runs to 21 characters. The label ellipsizes and keeps its full text
+  // in a tooltip rather than overflowing or forcing a menu wider than
+  // [_viewModeMenuMaxWidth].
+  ButtonSegment<PdfViewMode> _segment(PdfViewMode value, String label) =>
+      ButtonSegment(
+        value: value,
+        tooltip: label,
+        label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = pdfL10n(context);
+    final mode = _effectiveViewMode(widget.preferences.viewMode,
+        reflow: widget.reflow, pageGrid: widget.pageGrid);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+      child: SegmentedButton<PdfViewMode>(
+        key: const ValueKey('pdf-shell-view-mode'),
+        // The filled segment already says which mode is on, and a checkmark
+        // here would be the same glyph the display toggles below use for a
+        // different question - plus it costs a whole 56pt menu step.
+        showSelectedIcon: false,
+        style: const ButtonStyle(visualDensity: VisualDensity.compact),
+        segments: [
+          _segment(PdfViewMode.pages, l10n.shellViewPages),
+          if (widget.reflow) _segment(PdfViewMode.reflow, l10n.shellReflowText),
+          if (widget.pageGrid)
+            _segment(PdfViewMode.pageGrid, l10n.shellPageGrid),
+        ],
+        selected: {mode},
+        onSelectionChanged: (selection) {
+          widget.preferences.viewMode = selection.first;
+          Navigator.of(context).maybePop();
+        },
+      ),
+    );
+  }
+}
+
+/// The "view options" popup both shells offer: the view mode, then
+/// display-only settings (annotation visibility, form-field highlight, paper
+/// color, and optional editing guides) that live in [PdfEditingPreferences]
+/// and never touch the document.
 class PdfShellViewOptionsButton extends StatelessWidget {
   const PdfShellViewOptionsButton({
     super.key,
@@ -1997,6 +2100,13 @@ class PdfShellViewOptionsButton extends StatelessWidget {
     return PopupMenuButton<_ViewOption>(
       key: const ValueKey('pdf-shell-view-options'),
       tooltip: pdfL10n(context).shellSettings,
+      // A popup stops at 5 menu steps (280pt) by default, which is fine for a
+      // column of rows but squeezes three labelled segments. Raise the cap
+      // only when the modes are actually offered - IntrinsicWidth still sizes
+      // the menu to its content, in 56pt steps.
+      constraints: reflow || pageGrid
+          ? const BoxConstraints(minWidth: 112, maxWidth: _viewModeMenuMaxWidth)
+          : null,
       icon: const Icon(Icons.display_settings_outlined),
       // match the bar's IconButtons; a PopupMenuButton icon otherwise
       // defaults to black87 instead of onSurfaceVariant
@@ -2015,6 +2125,14 @@ class PdfShellViewOptionsButton extends StatelessWidget {
         );
       },
       itemBuilder: (context) => [
+        if (reflow || pageGrid) ...[
+          _ViewModeMenuItem(
+            preferences: preferences,
+            reflow: reflow,
+            pageGrid: pageGrid,
+          ),
+          const PopupMenuDivider(),
+        ],
         CheckedPopupMenuItem(
           key: const ValueKey('pdf-shell-show-annotations'),
           value: _ViewOption.annotations,
@@ -2033,20 +2151,6 @@ class PdfShellViewOptionsButton extends StatelessWidget {
           checked: preferences.highlightFormFields,
           child: Text(pdfL10n(context).shellHighlightFormFields),
         ),
-        if (reflow)
-          CheckedPopupMenuItem(
-            key: const ValueKey('pdf-shell-reflow-view'),
-            value: _ViewOption.reflow,
-            checked: preferences.showReflowView,
-            child: Text(pdfL10n(context).shellReflowText),
-          ),
-        if (pageGrid)
-          CheckedPopupMenuItem(
-            key: const ValueKey('pdf-shell-page-grid'),
-            value: _ViewOption.pageGrid,
-            checked: preferences.showThumbnailView,
-            child: Text(pdfL10n(context).shellPageGrid),
-          ),
         if (pageColor)
           PopupMenuItem(
             key: const ValueKey('pdf-shell-page-color'),

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -162,6 +162,61 @@ void main() {
       expect(prefs.stampTimeFormat, PdfStampTimeFormat.twentyFourHour);
     });
 
+    test('viewMode keeps the two view-replacing flags exclusive', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PdfEditingPreferences();
+      await prefs.ready;
+      expect(prefs.viewMode, PdfViewMode.pages);
+
+      var notifications = 0;
+      prefs.addListener(() => notifications++);
+
+      prefs.viewMode = PdfViewMode.reflow;
+      expect(prefs.showReflowView, isTrue);
+      expect(prefs.showThumbnailView, isFalse);
+      expect(notifications, 1, reason: 'one notification for the whole change');
+
+      // the bug this pair exists to prevent: picking the other mode used to
+      // leave both flags to the caller, so one silently untucked the other
+      prefs.viewMode = PdfViewMode.pageGrid;
+      expect(prefs.showReflowView, isFalse);
+      expect(prefs.showThumbnailView, isTrue);
+      expect(prefs.viewMode, PdfViewMode.pageGrid);
+      expect(notifications, 2);
+
+      // and there is a way back to plain pages that is not "untick the one
+      // you ticked"
+      prefs.viewMode = PdfViewMode.pages;
+      expect(prefs.showReflowView, isFalse);
+      expect(prefs.showThumbnailView, isFalse);
+      expect(notifications, 3);
+
+      prefs.viewMode = PdfViewMode.pages;
+      expect(notifications, 3, reason: 'no notification for a no-op');
+
+      await pumpEventQueue();
+      final restored = PdfEditingPreferences();
+      await restored.ready;
+      expect(restored.viewMode, PdfViewMode.pages);
+      prefs.dispose();
+      restored.dispose();
+    });
+
+    test('viewMode reads a legacy pair that set both flags', () async {
+      SharedPreferences.setMockInitialValues({
+        'dart_pdf_editor.editing.showReflowView': true,
+        'dart_pdf_editor.editing.showThumbnailView': true,
+      });
+      final prefs = PdfEditingPreferences();
+      await prefs.ready;
+      // reflow wins the read, and setting any mode writes the pair back clean
+      expect(prefs.viewMode, PdfViewMode.reflow);
+      prefs.viewMode = PdfViewMode.pages;
+      expect(prefs.showReflowView, isFalse);
+      expect(prefs.showThumbnailView, isFalse);
+      prefs.dispose();
+    });
+
     test('textAlign resets to null (follow text direction)', () async {
       SharedPreferences.setMockInitialValues({});
       final a = PdfEditingPreferences();

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -40,6 +40,22 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  // The view modes are one SegmentedButton in the view-options popup, so a
+  // mode is addressed by its label rather than by a per-item key. Each segment
+  // repeats its label as a tooltip (for the locales where it ellipsizes), so
+  // match the drawn label - the single-line one - not the tooltip's copy.
+  Finder viewModeSegment(String label) => find.descendant(
+      of: find.byKey(const ValueKey('pdf-shell-view-mode')),
+      matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Text && widget.data == label && widget.maxLines == 1,
+          description: 'segment labelled "$label"'));
+
+  Future<void> tapViewMode(WidgetTester tester, String label) async {
+    await tester.tap(viewModeSegment(label), kind: PointerDeviceKind.mouse);
+    await tester.pumpAndSettle();
+  }
+
   Visibility actionVisibility(WidgetTester tester, Finder action) =>
       tester.widget<Visibility>(
         find.ancestor(of: action, matching: find.byType(Visibility)).first,
@@ -291,9 +307,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('pdf-shell-reflow-view')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pumpAndSettle();
+      await tapViewMode(tester, 'Reflow text');
 
       expect(prefs.showReflowView, isTrue);
       expect(find.byType(PdfViewer), findsNothing);
@@ -354,8 +368,7 @@ void main() {
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('pdf-shell-author')), findsOneWidget);
-      expect(
-          find.byKey(const ValueKey('pdf-shell-reflow-view')), findsOneWidget);
+      expect(viewModeSegment('Reflow text'), findsOneWidget);
     });
 
     testWidgets('forwards page preview and raster cache policies',
@@ -595,9 +608,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('pdf-shell-reflow-view')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pumpAndSettle();
+      await tapViewMode(tester, 'Reflow text');
 
       expect(prefs.showReflowView, isTrue);
       expect(find.byType(PdfViewer), findsNothing);
@@ -606,6 +617,51 @@ void main() {
       expect(find.byKey(const ValueKey('pdf-search-field')), findsNothing);
       expect(find.byKey(const ValueKey('pdf-page-number-field')), findsNothing);
       expect(find.text('Hello, world!'), findsOneWidget);
+    });
+
+    testWidgets('the view-mode control clears Flutter\'s 280pt menu cap',
+        (tester) async {
+      await pump(tester,
+          PdfEditorView(bytes: buildMultiPagePdf(2), preferences: null));
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      // a popup stops at 5 * 56 by default, which squeezes three labelled
+      // segments; PdfShellViewOptionsButton raises the cap when it carries
+      // them, so all three labels stay readable
+      final width = tester
+          .getSize(find.byKey(const ValueKey('pdf-shell-view-mode')))
+          .width;
+      expect(width, greaterThan(280 - 24));
+      expect(viewModeSegment('Pages'), findsOneWidget);
+      expect(viewModeSegment('Reflow text'), findsOneWidget);
+      expect(viewModeSegment('Page grid'), findsOneWidget);
+    });
+
+    testWidgets(
+        'a verbose locale ellipsizes the segments instead of'
+        ' overflowing', (tester) async {
+      // Ukrainian has the longest set of the shipped locales; every segment is
+      // as wide as the widest, so this is the case that would overflow.
+      await tester.pumpWidget(MaterialApp(
+        locale: const Locale('uk'),
+        localizationsDelegates:
+            DartPdfEditorLocalizations.localizationsDelegates,
+        supportedLocales: DartPdfEditorLocalizations.supportedLocales,
+        home: Scaffold(body: PdfEditorView(bytes: buildMultiPagePdf(2))),
+      ));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      // reaching here without a RenderFlex overflow is the assertion
+      expect(find.byKey(const ValueKey('pdf-shell-view-mode')), findsOneWidget);
+      expect(
+          tester
+              .getSize(find.byKey(const ValueKey('pdf-shell-view-mode')))
+              .width,
+          lessThanOrEqualTo(6 * 56));
     });
 
     testWidgets('View options can swap in the full-area page grid',
@@ -621,9 +677,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pumpAndSettle();
+      await tapViewMode(tester, 'Page grid');
 
       expect(prefs.showThumbnailView, isTrue);
       expect(find.byType(PdfThumbnailView), findsOneWidget);
@@ -657,9 +711,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pumpAndSettle();
+      await tapViewMode(tester, 'Page grid');
 
       expect(prefs.showReflowView, isFalse);
       expect(prefs.showThumbnailView, isTrue);
@@ -678,7 +730,10 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      expect(find.byKey(const ValueKey('pdf-shell-page-grid')), findsNothing);
+      expect(viewModeSegment('Page grid'), findsNothing);
+      // reflow is still offered, so the control stays - as a pair
+      expect(viewModeSegment('Pages'), findsOneWidget);
+      expect(viewModeSegment('Reflow text'), findsOneWidget);
     });
 
     testWidgets('reflowView: false hides editor reflow option', (tester) async {
@@ -695,7 +750,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('pdf-shell-show-annotations')),
           findsOneWidget);
-      expect(find.byKey(const ValueKey('pdf-shell-reflow-view')), findsNothing);
+      expect(viewModeSegment('Reflow text'), findsNothing);
     });
 
     testWidgets('compact layout honors an explicit thumbnail preference',
@@ -1742,6 +1797,59 @@ void main() {
           findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-shell-properties-toggle')),
           findsOneWidget);
+    });
+
+    testWidgets('compact: the Controls sheet owns the view modes, one tap deep',
+        (tester) async {
+      compactScreen(tester);
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      await pump(tester,
+          PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs));
+      await openShellControls(tester);
+
+      // all three modes are tiles in the sheet's View section. Page grid used
+      // to be reachable only by opening Settings from here and scrolling to a
+      // checkbox, while Reflow already had a tile of its own.
+      expect(find.byKey(const ValueKey('pdf-shell-view-mode-pages')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-reflow-toggle')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-page-grid-toggle')),
+          findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(prefs.viewMode, PdfViewMode.pageGrid);
+      expect(find.byType(PdfThumbnailView), findsOneWidget);
+
+      // and picking another mode leaves the first one behind
+      await openShellControls(tester);
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-reflow-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(prefs.viewMode, PdfViewMode.reflow);
+      expect(prefs.showThumbnailView, isFalse);
+      expect(find.byType(PdfThumbnailView), findsNothing);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('compact: the Settings sheet no longer holds the view modes',
+        (tester) async {
+      compactScreen(tester);
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      await openShellControls(tester);
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-show-annotations')),
+          findsOneWidget);
+      // they live one level up, in Controls
+      expect(find.text('Reflow text'), findsNothing);
+      expect(find.text('Page grid'), findsNothing);
     });
 
     testWidgets('compact: a toggled panel floats up as a bottom sheet',


### PR DESCRIPTION
## Summary

The trigger was feedback that "Page grid" sits in an awkward spot in the view-options menu. It does, and the placement was a symptom.

Reflow text and Page grid each **replace the page viewer**, but the menu drew them as two independent checkmarks in a run of display overlays, and the handler expressed their exclusivity by having each silently clear the other:

```dart
case _ViewOption.reflow:
  preferences.showThumbnailView = false;
  preferences.showReflowView = !preferences.showReflowView;
```

Read as checkmarks, that is three unrelated switches where ticking one unticks another with no explanation. And there was no "Pages" member — plain pages existed only as the absence of the other two, so leaving a mode meant unticking the one you ticked rather than choosing where to go.

**The invariant moved to the state object.** `PdfEditingPreferences.viewMode` (`PdfViewMode.pages | reflow | pageGrid`) reads and writes the pair coherently and notifies once. The two bools stay — they are persisted keys and hosts use them — but nothing of ours sets them individually now. That caught a second bug: the app's command palette toggled them independently, so it could put a document in both modes at once.

**Desktop:** a `SegmentedButton` above the display toggles, as a custom `PopupMenuEntry` following the `_KeyboardShortcutMenuItem` already in the file. Picking a mode closes the menu, matching the checked items it replaces.

**Compact: the modes went up, not down.** They are tiles in the Controls sheet's existing View section, not in the Settings sheet — on a phone Controls is the parent surface and Settings a child of it. This closes a real gap: `pdf_editor_view.dart` had already given Reflow a one-tap tile there ("reading reflow is something phone users reach for often") and the page grid never got one, so it was Controls → Settings → scroll → tick.

### API impact

`shell_chrome.dart` is package-private (imported, never exported), so none of this is a public break:

- `showPdfShellViewOptionsSheet` drops its `reflow` / `pageGrid` parameters — the sheet no longer holds the modes.
- New package-internal `pdfShellViewModeControls(...)` builds the compact tiles for both shells.
- `PdfEditingPreferences.viewMode` and `PdfViewMode` are new **public** additions. Nothing is removed.

One deliberate asymmetry worth knowing: the popup and its compact twin no longer hold the same things, because only compact has a parent surface to promote the modes into.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Example app <!-- app/ — command palette -->

## Change type

- [x] Bug fix
- [x] Editing behavior change
- [x] Refactor / cleanup

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

If any relevant check was not run, explain why:

The engine packages are untouched (UI chrome and preferences only), so their suites, the Ghent corpus and the PDF corpus sweeps were not run — nothing in this change reaches the parser, the renderer or the writer. `app`'s own suite passes (586 tests) alongside the editor's 2758. `tool/check_arb_coverage.dart` and `tool/sync_english_locales.dart` are both clean.

**The example app smoke test is the honest gap.** I built and launched the macOS debug app to look at the menu, but screen-control access was declined, so I have not seen the control with my own eyes — the 336pt figure below is arithmetic plus tests, not observation. Worth a glance before merge.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered.
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

On the unchecked box: a `SegmentedButton` is **one focus stop containing three buttons**, so arrow-key traversal of the menu steps over it as a unit and the internal choice takes its own key handling, and a screen reader announces a button group rather than three menu items each carrying selected state. That is the cost of this shape and it is real. The alternative that avoids it — a "View as" radio group of ordinary menu rows — was drawn and set aside in favour of this one; it remains the fallback if the keyboard behaviour bites in use.

Mode selection is display-only, so there is no undo/save interaction; the mode persists and reopens as before, through the same two keys.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

**Two Flutter traps, both now pinned by tests** and written up in `doc/dev-log/2026-09-10-view-modes-out-of-the-toggle-list.md`:

1. **A popup menu caps at 280pt.** `_kMenuMaxWidth` is `5 * 56`, which is why this menu has always been ~275 wide. Three labelled segments do not fit, and nothing warns you — the labels just squeeze. `PopupMenuButton.constraints` raises the cap to `6 * 56`, and only when the modes are present.
2. **A `SegmentedButton` fills the width it is offered**, so that constant is not a ceiling the content stops short of — it *is* the menu's width whenever the modes show. This surfaced from measuring: every locale reported the same width, because the cap and not the labels was setting it. 336 comes from real Roboto metrics ("Reflow text" is the widest English label), **not** from a widget test — the test font makes any text measurement there meaningless.

Segment labels ellipsize with the full text in a tooltip. They have to: every segment is as wide as the widest, and Ukrainian's "Переформатувати текст" alone runs 21 characters, a set that fits no sane menu. There is a regression test for that locale.

**On the new string.** `shellViewPages` ("Pages", the view mode) is deliberately separate from `shellPanelPages` ("Pages", the thumbnail sidebar) so the two can diverge. Every locale was seeded from **that locale's own reviewed translation** of the identical English word rather than machine-translated — worth a translator's eye if any language distinguishes the two senses.

The design exploration behind this, including the two directions that were set aside and why: https://claude.ai/code/artifact/c4cd5943-8940-4159-914a-79f6a7782a25
