### PR TITLE
Fix page-grid double-click landing on page 1

### DIFF
--- a/doc/dev-log/2026-09-10-page-grid-double-click-page-1.md
+++ b/doc/dev-log/2026-09-10-page-grid-double-click-page-1.md
@@ -1,0 +1,48 @@
+# Double-clicking a page in the grid landed on page 1
+
+A double-click on a tile in the full-area page grid (`PdfThumbnailView`,
+View options → page grid) closed the grid but showed page 1 instead of the
+page that was clicked.
+
+The grid's own wiring was fine. `_PageTile._onTap` detects the second click,
+`_openPage` calls `viewerController.jumpToPage(index)` and then fires
+`onOpenPage`, which the shell wires to `prefs.showThumbnailView = false`. The
+jump really did happen - instrumenting `_scroll` showed the viewer sitting on
+the right page while the grid was still up, and no later `jumpTo` at all. The
+scroll offset was simply 0 again on the first frame after the grid closed.
+
+The cause was one frame further out, in `PdfShellPanelLayout.build`. It
+wrapped its result in `PdfPanelDragScope` / `PdfToolbarDragScope` only when
+the host had wired `onPanelDock` / `onToolbarDock`:
+
+```dart
+if (widget.onToolbarDock != null) {
+  result = PdfToolbarDragScope(..., child: result);
+}
+```
+
+Opening the grid sets `altView`, which hides the editing toolbar, which makes
+`PdfEditorView` pass `onToolbarDock: null`. So the wrapper vanished on open
+and came back on close. A wrapper that comes and goes changes the depth of
+everything below it, so Flutter cannot match the old elements to the new
+ones: `_PdfViewerState` was discarded and rebuilt from scratch each time (a
+`print` in `initState` fired three times for one open/close round trip), and
+its `ScrollController` re-attached to a fresh `ScrollPosition` at
+`initialScrollOffset` - page 1. The viewer *was* still mounted the whole
+time, as the existing test asserts, just not the same State.
+
+Fix: both scopes now always sit in the tree and carry an `enabled` flag
+instead. `maybeOf` returns null when disabled, so `PdfToolbarMoveHandle` and
+a panel's move handle still hide exactly as before (that null check is the
+whole public contract of these scopes), and `updateShouldNotify` now fires on
+an `enabled` flip so a handle appears or disappears when docking is turned on
+or off. The tree shape no longer depends on whether the toolbar is showing.
+
+The same wrapper churn would have rewound the viewer for any other reason the
+toolbar came and went, so this is not only a grid bug - it was just most
+visible there, because the grid is the one place where a click is *supposed*
+to move the viewer before the toolbar returns.
+
+Regression test: `pdf_shell_test.dart`, "a page grid double-click lands the
+viewer on that page" - double-click Page 6 of an 8-page document in the grid
+and assert `viewerController.currentPage == 5` after it closes.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -83,13 +83,15 @@ bool pdfPanelControlsRevealOnHover() => switch (defaultTargetPlatform) {
 
 /// Ambient wiring that lets a docked panel's move handle drive the shell's
 /// drag-to-redock affordance. [PdfShellPanelLayout] provides it around the
-/// panels; a panel's [PdfSidebarPanelGeometry.moveHandle] reads it. Absent
-/// when a shell wires no redocking - then panels render no move handle.
+/// panels; a panel's [PdfSidebarPanelGeometry.moveHandle] reads it. Reads as
+/// absent ([maybeOf] returns null) when a shell wires no redocking - then
+/// panels render no move handle.
 class PdfPanelDragScope extends InheritedWidget {
   const PdfPanelDragScope({
     super.key,
     required this.onDragStarted,
     required this.onDragEnded,
+    this.enabled = true,
     required super.child,
   });
 
@@ -100,11 +102,22 @@ class PdfPanelDragScope extends InheritedWidget {
   /// The drag ended (dropped or cancelled) - the shell hides its drop zones.
   final VoidCallback onDragEnded;
 
-  static PdfPanelDragScope? maybeOf(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<PdfPanelDragScope>();
+  /// Whether the host actually accepts a redock right now. A disabled scope
+  /// reads as absent ([maybeOf] returns null, so no move handle is drawn) yet
+  /// still sits in the tree: dropping the widget entirely would change the
+  /// depth of everything below it - the viewer included - and rebuild it from
+  /// scratch, losing its scroll position (see [PdfShellPanelLayout]).
+  final bool enabled;
+
+  static PdfPanelDragScope? maybeOf(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<PdfPanelDragScope>();
+    return scope != null && scope.enabled ? scope : null;
+  }
 
   @override
-  bool updateShouldNotify(PdfPanelDragScope oldWidget) => false;
+  bool updateShouldNotify(PdfPanelDragScope oldWidget) =>
+      oldWidget.enabled != enabled;
 }
 
 /// A compact close (×) button for a docked sidebar panel's header - the

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -202,23 +202,29 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
       Expanded(child: content),
       if (widget.dockedToolbar != null) widget.dockedToolbar!,
     ]);
-    if (widget.onPanelDock != null) {
-      // the panels below read this to drive the drag: their move handles
-      // toggle the drop zones on and off.
-      result = PdfPanelDragScope(
-        onDragStarted: () => _setPanelDragging(true),
-        onDragEnded: () => _setPanelDragging(false),
-        child: result,
-      );
-    }
-    if (widget.onToolbarDock != null) {
-      result = PdfToolbarDragScope(
-        onDragStarted: () => _setToolbarDragging(true),
-        onDragEnded: () => _setToolbarDragging(false),
-        child: result,
-      );
-    }
-    return result;
+    // Both scopes are always in the tree, switched on and off through
+    // [enabled] rather than by being wrapped conditionally. A wrapper that
+    // comes and goes changes the depth of everything below it, so Flutter
+    // cannot match the old elements to the new ones: the viewer's State is
+    // rebuilt from scratch and its ScrollController re-attaches at offset 0.
+    // Hiding the toolbar (opening the full-area page grid does exactly that,
+    // which drops `onToolbarDock`) would then rewind the reader to page 1 the
+    // moment the grid closed - the double-clicked page included.
+    //
+    // the panels below read this to drive the drag: their move handles
+    // toggle the drop zones on and off.
+    result = PdfPanelDragScope(
+      enabled: widget.onPanelDock != null,
+      onDragStarted: () => _setPanelDragging(true),
+      onDragEnded: () => _setPanelDragging(false),
+      child: result,
+    );
+    return PdfToolbarDragScope(
+      enabled: widget.onToolbarDock != null,
+      onDragStarted: () => _setToolbarDragging(true),
+      onDragEnded: () => _setToolbarDragging(false),
+      child: result,
+    );
   }
 }
 
@@ -368,17 +374,28 @@ class PdfToolbarDragScope extends InheritedWidget {
     super.key,
     required this.onDragStarted,
     required this.onDragEnded,
+    this.enabled = true,
     required super.child,
   });
 
   final VoidCallback onDragStarted;
   final VoidCallback onDragEnded;
 
-  static PdfToolbarDragScope? maybeOf(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<PdfToolbarDragScope>();
+  /// Whether the shell accepts a toolbar redock right now. A disabled scope
+  /// reads as absent ([maybeOf] returns null, so no move handle is drawn) yet
+  /// still sits in the tree - see [PdfShellPanelLayout.build] for why it may
+  /// not come and go.
+  final bool enabled;
+
+  static PdfToolbarDragScope? maybeOf(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<PdfToolbarDragScope>();
+    return scope != null && scope.enabled ? scope : null;
+  }
 
   @override
-  bool updateShouldNotify(PdfToolbarDragScope oldWidget) => false;
+  bool updateShouldNotify(PdfToolbarDragScope oldWidget) =>
+      oldWidget.enabled != enabled;
 }
 
 /// Compact grab handle injected into the stock floating editing toolbar.

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -646,6 +646,44 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
     });
 
+    testWidgets('a page grid double-click lands the viewer on that page',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      await pump(
+          tester,
+          PdfEditorView(
+              bytes: buildMultiPagePdf(8),
+              preferences: prefs,
+              viewerController: viewer));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Page 6'));
+      await tester.pump();
+      await tester.tap(find.text('Page 6'));
+      await tester.pumpAndSettle();
+
+      // the grid closes onto the page that was double-clicked. Regression:
+      // hiding the editing toolbar used to drop PdfToolbarDragScope out of
+      // the tree, which rebuilt the viewer's State (and so its scroll
+      // position) from scratch - the reader landed back on page 1.
+      expect(prefs.showThumbnailView, isFalse);
+      expect(viewer.currentPage, 5);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
     testWidgets('opening the page grid clears reflow', (tester) async {
       final prefs = PdfEditingPreferences();
       addTearDown(prefs.dispose);


### PR DESCRIPTION
## Summary

Double-clicking a page in the full-area page grid (View options → page grid) closed the grid onto **page 1** instead of the page that was clicked.

The grid's own wiring was correct all along. `_PageTile._onTap` detects the second click, `_openPage` calls `viewerController.jumpToPage(index)` and fires `onOpenPage`, which the shell wires to `prefs.showThumbnailView = false`. Instrumenting `_scroll` showed the jump landing correctly while the grid was still up, and no later `jumpTo` at all — the offset was simply back at 0 on the first frame after the grid closed.

The cause was one level out, in `PdfShellPanelLayout.build`, which wrapped its result in `PdfPanelDragScope` / `PdfToolbarDragScope` only when the host had wired `onPanelDock` / `onToolbarDock`:

```dart
if (widget.onToolbarDock != null) {
  result = PdfToolbarDragScope(..., child: result);
}
```

Opening the grid sets `altView`, which hides the editing toolbar, which makes `PdfEditorView` pass `onToolbarDock: null`. So the wrapper dropped out of the tree on open and came back on close. A wrapper that comes and goes changes the depth of everything below it, so Flutter cannot match the old elements to the new ones: `_PdfViewerState` was discarded and rebuilt from scratch (a `print` in `initState` fired three times for one open/close round trip) and its `ScrollController` re-attached to a fresh `ScrollPosition` at `initialScrollOffset` — page 1. The viewer *was* still mounted throughout, as the existing test asserts; it just wasn't the same State.

Fix: both scopes now sit in the tree permanently and carry an `enabled` flag instead. `maybeOf` returns null when disabled, so `PdfToolbarMoveHandle` and a panel's move handle still hide exactly as before (that null check is the whole public contract of these scopes), and `updateShouldNotify` now fires on an `enabled` flip so a handle appears or disappears when docking is toggled. The tree shape no longer depends on whether the toolbar is showing.

The same wrapper churn would have rewound the viewer any other time the toolbar came and went; the grid is just where it was most visible, because that is the one place a click is *supposed* to move the viewer before the toolbar returns.

Background note: `doc/dev-log/2026-09-10-page-grid-double-click-page-1.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2747 passing)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to Flutter widget-tree structure in `dart_pdf_editor`; it touches no parsing, rendering, or COS code, so the pure-Dart package suites and the render corpora have nothing to exercise here.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered. The `enabled: false` path is exactly the old "scope absent" behaviour: no move handle on the floating toolbar or on a docked panel.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked. The grid's single-click/shift/⌘ selection behaviour is untouched; only the second click's destination changes.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable — not applicable, no document state is involved.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out. Strictly less work than before: the viewer is no longer torn down and re-created (with a fresh page list, preview cache binding, and render worker sync) on every grid or toolbar toggle.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Regression test lives in `packages/dart_pdf_editor/test/pdf_shell_test.dart` — "a page grid double-click lands the viewer on that page": double-click Page 6 of an 8-page document in the grid, assert `viewerController.currentPage == 5` once it closes. It fails on `main` with `currentPage == 0`.

`PdfToolbarDragScope` and `PdfPanelDragScope` gained an optional `enabled` parameter that defaults to `true`, so any external construction of either is source-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWkdUBx5zFiPjtYy1ismH3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWkdUBx5zFiPjtYy1ismH3)_