### PR TITLE
fix(viewer): keep multi-run text selections continuous

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -10,6 +10,7 @@ import 'package:pdf_document/pdf_document.dart';
 
 import '../page_geometry.dart';
 import '../renderer.dart';
+import '../text_selection_geometry.dart';
 import 'digital_signature.dart';
 import 'editing_annotation_clipboard.dart';
 import 'editing_measure.dart';
@@ -2371,11 +2372,15 @@ class PdfEditingController extends ChangeNotifier {
   /// Adds a text markup of [kind] over [quadsByPage] (page index → quad
   /// rects, e.g. from [PdfViewerController.selectionRectsOn]).
   void addMarkup(PdfMarkupKind kind, Map<int, List<PdfRect>> quadsByPage) {
-    if (quadsByPage.values.every((quads) => quads.isEmpty)) return;
+    final linesByPage = <int, List<PdfRect>>{};
+    quadsByPage.forEach((page, quads) {
+      final lines = normalizeTextSelectionRects(quads);
+      if (lines.isNotEmpty) linesByPage[page] = lines;
+    });
+    if (linesByPage.isEmpty) return;
     apply(
       (editor) {
-        quadsByPage.forEach((page, quads) {
-          if (quads.isEmpty) return;
+        linesByPage.forEach((page, quads) {
           switch (kind) {
             case PdfMarkupKind.highlight:
               editor.addHighlight(

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -52,6 +52,7 @@ import 'theme.dart';
 import 'tile_raster_backend.dart';
 import 'tile_store.dart';
 import 'toast.dart';
+import 'text_selection_geometry.dart';
 import 'viewport.dart';
 
 export 'viewport.dart' show PdfViewport, pdfDocumentKey;
@@ -7923,9 +7924,10 @@ class _PdfViewerState extends State<PdfViewer>
     // handles and chip appear when the finger lifts
     if (_touchSelecting) return null;
     final quads = _selectionQuadsOn(index);
-    if (quads.isEmpty) return null;
-    final first = quads.first;
-    final last = quads.last;
+    final rawQuads = _rawSelectionQuadsOn(index);
+    if (quads.isEmpty || rawQuads.isEmpty) return null;
+    final first = rawQuads.first;
+    final last = rawQuads.last;
     return _PageTextSelection(
       startRect: isStart ? first.bounds : null,
       startRightToLeft: isStart && first.isRightToLeft,
@@ -8082,6 +8084,7 @@ class _PdfViewerState extends State<PdfViewer>
     _wordAnchor = null;
     _selectionQuadCacheRange = null;
     _selectionQuadCache.clear();
+    _rawSelectionQuadCache.clear();
     if (_selAnchor != null || _selFocus != null || _touchSelecting) {
       setState(() {
         _selAnchor = null;
@@ -8129,25 +8132,40 @@ class _PdfViewerState extends State<PdfViewer>
   // the range changes (an active-selection drag).
   ((int, int), (int, int))? _selectionQuadCacheRange;
   final Map<int, List<PdfTextQuad>> _selectionQuadCache = {};
+  final Map<int, List<PdfTextQuad>> _rawSelectionQuadCache = {};
 
   List<PdfTextQuad> _selectionQuadsOn(int pageIndex) {
+    _ensureSelectionQuadCacheRange();
+    final cached = _selectionQuadCache[pageIndex];
+    if (cached != null) return cached;
+    return _selectionQuadCache[pageIndex] =
+        normalizeTextSelectionQuads(_rawSelectionQuadsOn(pageIndex));
+  }
+
+  void _ensureSelectionQuadCacheRange() {
     final range = _selRange;
-    if (range == null) return const [];
     if (range != _selectionQuadCacheRange) {
       _selectionQuadCacheRange = range;
       _selectionQuadCache.clear();
+      _rawSelectionQuadCache.clear();
     }
-    final cached = _selectionQuadCache[pageIndex];
+  }
+
+  List<PdfTextQuad> _rawSelectionQuadsOn(int pageIndex) {
+    _ensureSelectionQuadCacheRange();
+    final range = _selRange;
+    if (range == null) return const [];
+    final cached = _rawSelectionQuadCache[pageIndex];
     if (cached != null) return cached;
     final (start, end) = range;
     if (pageIndex < start.$1 || pageIndex > end.$1) {
-      return _selectionQuadCache[pageIndex] = const [];
+      return _rawSelectionQuadCache[pageIndex] = const [];
     }
     final text = _pageText(pageIndex);
     final from = pageIndex == start.$1 ? start.$2 : 0;
     final to = pageIndex == end.$1 ? end.$2 : text.text.length;
-    if (from >= to) return _selectionQuadCache[pageIndex] = const [];
-    return _selectionQuadCache[pageIndex] = text.quadsFor(from, to);
+    if (from >= to) return _rawSelectionQuadCache[pageIndex] = const [];
+    return _rawSelectionQuadCache[pageIndex] = text.quadsFor(from, to);
   }
 
   void _showMatch(PdfTextMatch match) {

--- a/packages/dart_pdf_editor/lib/src/text_selection_geometry.dart
+++ b/packages/dart_pdf_editor/lib/src/text_selection_geometry.dart
@@ -1,0 +1,119 @@
+import 'dart:math' as math;
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+typedef _IndexedRect<T> = ({int index, PdfRect rect, T value});
+
+class _LineBand<T> {
+  _LineBand(_IndexedRect<T> first) : members = [first];
+
+  final List<_IndexedRect<T>> members;
+}
+
+bool _validRect(PdfRect rect) =>
+    rect.left.isFinite &&
+    rect.bottom.isFinite &&
+    rect.right.isFinite &&
+    rect.top.isFinite &&
+    rect.width > 0 &&
+    rect.height > 0;
+
+bool _sameLine(PdfRect a, PdfRect b) {
+  final smaller = math.min(a.height, b.height);
+  final larger = math.max(a.height, b.height);
+  final overlap = math.max(
+    0.0,
+    math.min(a.top, b.top) - math.max(a.bottom, b.bottom),
+  );
+  final centerDelta = ((a.top + a.bottom) / 2 - (b.top + b.bottom) / 2).abs();
+  return overlap >= smaller * 0.5 &&
+      centerDelta <= smaller * 0.35 &&
+      larger <= smaller * 2;
+}
+
+int _physicalOrder<T>(_IndexedRect<T> a, _IndexedRect<T> b) {
+  final aCenter = (a.rect.top + a.rect.bottom) / 2;
+  final bCenter = (b.rect.top + b.rect.bottom) / 2;
+  var result = bCenter.compareTo(aCenter);
+  if (result != 0) return result;
+  result = a.rect.left.compareTo(b.rect.left);
+  if (result != 0) return result;
+  result = a.rect.right.compareTo(b.rect.right);
+  if (result != 0) return result;
+  result = a.rect.bottom.compareTo(b.rect.bottom);
+  if (result != 0) return result;
+  return a.index.compareTo(b.index);
+}
+
+List<_LineBand<T>> _lineBands<T>(
+  List<T> input,
+  PdfRect Function(T value) bounds,
+) {
+  final valid = <_IndexedRect<T>>[
+    for (var i = 0; i < input.length; i++)
+      if (_validRect(bounds(input[i])))
+        (index: i, rect: bounds(input[i]), value: input[i]),
+  ]..sort(_physicalOrder);
+  final bands = <_LineBand<T>>[];
+  for (final candidate in valid) {
+    _LineBand<T>? eligible;
+    for (final band in bands) {
+      if (band.members.every(
+        (member) => _sameLine(member.rect, candidate.rect),
+      )) {
+        eligible = band;
+        break;
+      }
+    }
+    if (eligible == null) {
+      bands.add(_LineBand<T>(candidate));
+    } else {
+      eligible.members.add(candidate);
+    }
+  }
+  bands.sort((a, b) => _earliest(a).compareTo(_earliest(b)));
+  return bands;
+}
+
+int _earliest<T>(_LineBand<T> band) =>
+    band.members.map((member) => member.index).reduce(math.min);
+
+PdfRect _union<T>(_LineBand<T> band) {
+  var left = band.members.first.rect.left;
+  var bottom = band.members.first.rect.bottom;
+  var right = band.members.first.rect.right;
+  var top = band.members.first.rect.top;
+  for (final member in band.members.skip(1)) {
+    left = math.min(left, member.rect.left);
+    bottom = math.min(bottom, member.rect.bottom);
+    right = math.max(right, member.rect.right);
+    top = math.max(top, member.rect.top);
+  }
+  return PdfRect(left, bottom, right, top);
+}
+
+/// Merges every fragment of one continuous selection into one rectangle per
+/// near-horizontal visual line, including all horizontal space between runs.
+List<PdfRect> normalizeTextSelectionRects(List<PdfRect> rects) =>
+    [for (final band in _lineBands(rects, (rect) => rect)) _union(band)];
+
+/// The live-selection counterpart of [normalizeTextSelectionRects]. A lone
+/// quad stays byte-for-byte geometric, preserving rotated and vertical text.
+List<PdfTextQuad> normalizeTextSelectionQuads(List<PdfTextQuad> quads) {
+  final result = <PdfTextQuad>[];
+  for (final band in _lineBands(quads, (quad) => quad.bounds)) {
+    if (band.members.length == 1) {
+      result.add(band.members.single.value);
+      continue;
+    }
+    final rect = _union(band);
+    result.add(PdfTextQuad([
+      (rect.left, rect.bottom),
+      (rect.right, rect.bottom),
+      (rect.right, rect.top),
+      (rect.left, rect.top),
+    ]));
+  }
+  return result;
+}

--- a/packages/dart_pdf_editor/test/editing_chrome_test.dart
+++ b/packages/dart_pdf_editor/test/editing_chrome_test.dart
@@ -402,15 +402,15 @@ void main() {
     /// text-markup annotation. Returns the editing controller plus the
     /// page geometry the overlay mounted with.
     Future<(PdfEditingController, PdfPageGeometry)> pumpMarkupOverlay(
-        WidgetTester tester) async {
+      WidgetTester tester, {
+      List<PdfRect> quads = const [
+        PdfRect(100, 700, 300, 712),
+        PdfRect(100, 685, 200, 697),
+      ],
+    }) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addMarkup(PdfMarkupKind.highlight, {
-          0: const [
-            // two quads on different vertical bands → /Rect spans
-            // the gap, exercising the per-quad chrome path
-            PdfRect(100, 700, 300, 712),
-            PdfRect(100, 685, 200, 697),
-          ],
+          0: quads,
         })
         ..tool = PdfEditTool.select
         ..selectAnnotation(0, 0);
@@ -461,6 +461,29 @@ void main() {
       expect(painter.extraSelectionRects, hasLength(1));
       final expected = geometry.toViewRect(const PdfRect(100, 685, 200, 697));
       expect(painter.extraSelectionRects.single, expected);
+    });
+
+    testWidgets('fragmented selected text has one chrome box per visual line',
+        (tester) async {
+      final (_, geometry) = await pumpMarkupOverlay(
+        tester,
+        quads: const [
+          PdfRect(100, 700, 170, 712),
+          PdfRect(210, 700, 300, 712),
+          PdfRect(100, 680, 160, 692),
+          PdfRect(190, 680, 260, 692),
+        ],
+      );
+      final painter = overlayPainter(tester);
+      expect(
+        painter.selectionRect,
+        geometry.toViewRect(const PdfRect(100, 700, 300, 712)),
+      );
+      expect(painter.extraSelectionRects, hasLength(1));
+      expect(
+        painter.extraSelectionRects.single,
+        geometry.toViewRect(const PdfRect(100, 680, 260, 692)),
+      );
     });
   });
 }

--- a/packages/dart_pdf_editor/test/editing_markup_geometry_test.dart
+++ b/packages/dart_pdf_editor/test/editing_markup_geometry_test.dart
@@ -1,0 +1,178 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+List<PdfRect> _markupQuads(
+  List<PdfRect> input, {
+  PdfMarkupKind kind = PdfMarkupKind.highlight,
+}) {
+  final editing = PdfEditingController(buildMultiPagePdf(1));
+  addTearDown(editing.dispose);
+  editing.addMarkup(kind, {0: input});
+  return editing.document.page(0).annotations.single.behavior.markupQuads!;
+}
+
+Set<String> _grouping(List<PdfRect> quads) => {
+      for (final q in quads) '${q.left},${q.bottom},${q.right},${q.top}',
+    };
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('selected English words become one continuous line highlight', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(100, 700, 170, 724),
+        PdfRect(210, 700, 280, 724),
+      ]),
+      const [PdfRect(100, 700, 280, 724)],
+    );
+  });
+
+  test('selected Chinese runs become one continuous line highlight', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(40, 650, 64, 674),
+        PdfRect(64, 650, 88, 674),
+        PdfRect(88, 650, 136, 674),
+      ]),
+      const [PdfRect(40, 650, 136, 674)],
+    );
+  });
+
+  test('horizontal gap size does not split one selected line', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(40, 650, 80, 674),
+        PdfRect(300, 650, 360, 674),
+      ]),
+      const [PdfRect(40, 650, 360, 674)],
+    );
+  });
+
+  test('separate visual lines remain separate', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(100, 700, 160, 712),
+        PdfRect(180, 700, 240, 712),
+        PdfRect(100, 680, 170, 692),
+        PdfRect(190, 680, 260, 692),
+      ]),
+      const [
+        PdfRect(100, 700, 240, 712),
+        PdfRect(100, 680, 260, 692),
+      ],
+    );
+  });
+
+  test('mixed heights sharing a line merge', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(100, 700, 150, 712),
+        PdfRect(160, 697, 230, 715),
+      ]),
+      const [PdfRect(100, 697, 230, 715)],
+    );
+  });
+
+  test('a tall bridge cannot transitively merge distinct lines', () {
+    final quads = _markupQuads(const [
+      PdfRect(100, 700, 150, 712),
+      PdfRect(155, 694, 205, 718),
+      PdfRect(210, 686, 260, 698),
+    ]);
+    expect(quads, const [
+      PdfRect(100, 694, 205, 718),
+      PdfRect(210, 686, 260, 698),
+    ]);
+  });
+
+  test('forward reversed and shuffled input keep the same line grouping', () {
+    const forward = [
+      PdfRect(10, 700, 30, 712),
+      PdfRect(40, 700, 60, 712),
+      PdfRect(10, 680, 30, 692),
+      PdfRect(40, 680, 60, 692),
+    ];
+    final expected = _grouping(_markupQuads(forward));
+    expect(_grouping(_markupQuads(forward.reversed.toList())), expected);
+    expect(
+      _grouping(_markupQuads([forward[2], forward[0], forward[3], forward[1]])),
+      expected,
+    );
+  });
+
+  test('line output order follows the earliest original member', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(10, 680, 30, 692),
+        PdfRect(10, 700, 30, 712),
+        PdfRect(40, 680, 60, 692),
+        PdfRect(40, 700, 60, 712),
+      ]),
+      const [
+        PdfRect(10, 680, 60, 692),
+        PdfRect(10, 700, 60, 712),
+      ],
+    );
+  });
+
+  test('diagonal and vertical arrangements remain unmerged', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(100, 700, 112, 712),
+        PdfRect(114, 694, 126, 706),
+        PdfRect(128, 688, 140, 700),
+      ]),
+      hasLength(3),
+    );
+  });
+
+  test('invalid rectangles are ignored', () {
+    expect(
+      _markupQuads(const [
+        PdfRect(double.nan, 0, 10, 10),
+        PdfRect(0, 0, double.infinity, 10),
+        PdfRect(10, 10, 10, 20),
+        PdfRect(20, 20, 10, 30),
+        PdfRect(100, 700, 180, 712),
+      ]),
+      const [PdfRect(100, 700, 180, 712)],
+    );
+  });
+
+  test('an all-invalid request is a true no-op', () {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    final document = editing.document;
+    final revision = editing.revisionId;
+
+    editing.addMarkup(PdfMarkupKind.highlight, const {
+      0: [
+        PdfRect(double.nan, 0, 10, 10),
+        PdfRect(0, 0, 0, 10),
+      ],
+    });
+
+    expect(editing.revisionId, revision);
+    expect(identical(editing.document, document), isTrue);
+    expect(editing.document.page(0).annotations, isEmpty);
+  });
+
+  for (final kind in PdfMarkupKind.values) {
+    test('$kind shares continuous selected-line geometry', () {
+      expect(
+        _markupQuads(
+          const [
+            PdfRect(100, 700, 150, 712),
+            PdfRect(200, 700, 260, 712),
+          ],
+          kind: kind,
+        ),
+        const [PdfRect(100, 700, 260, 712)],
+      );
+    });
+  }
+}

--- a/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
+++ b/packages/dart_pdf_editor/test/highlight_appearance_split_test.dart
@@ -52,7 +52,7 @@ void _disposeAll(Iterable<ui.Picture> pictures) {
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  test('a wrapped Highlight records one clipped picture per markup quad',
+  test('fragmented selected lines keep one #875 clipped picture per line',
       () async {
     final editing = PdfEditingController(
       buildTextLinesPdf(
@@ -61,20 +61,21 @@ void main() {
       ),
     );
     addTearDown(editing.dispose);
-    editing.apply(
-      (editor) => editor.addHighlight(
-        0,
-        const [
-          PdfRect(36, 716, 180, 732),
-          PdfRect(36, 692, 205, 708),
-        ],
-        color: 0xFFFF00,
-        opacity: 1,
-      ),
-    );
+    editing.addMarkup(PdfMarkupKind.highlight, const {
+      0: [
+        PdfRect(36, 716, 90, 732),
+        PdfRect(120, 716, 180, 732),
+        PdfRect(36, 692, 100, 708),
+        PdfRect(130, 692, 205, 708),
+      ],
+    });
 
     final page = editing.document.page(0);
     final annotation = page.annotations.single;
+    expect(annotation.behavior.markupQuads, const [
+      PdfRect(36, 716, 180, 732),
+      PdfRect(36, 692, 205, 708),
+    ]);
     final pictures = await PdfPageRenderer.renderAnnotationPictures(
       page,
       annotation,

--- a/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
@@ -11,6 +11,32 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+Uint8List _buildSplitRunTextPdf() {
+  const content = 'BT /F1 24 Tf 72 720 Td (signs) Tj ET '
+      'BT /F1 24 Tf 150 720 Td (and) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xref = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n$xref\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -120,6 +146,26 @@ void main() {
       expect(
           find.byKey(const ValueKey('pdf-text-selection-chip')), findsNothing);
     });
+  });
+
+  testWidgets('touch word-drag wash is continuous across split text runs',
+      (tester) async {
+    final controller = await pumpViewer(
+      tester,
+      pages: 1,
+      bytes: _buildSplitRunTextPdf(),
+    );
+    final gesture = await tester.startGesture(view(90, 720));
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveTo(view(170, 720));
+    await tester.pump();
+
+    expect(controller.selectedText, contains('signs'));
+    expect(controller.selectedText, contains('and'));
+    expect(controller.selectionRectsOn(0), hasLength(1));
+
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 400));
   });
 
   group('armed text markup', () {

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -77,6 +77,32 @@ Uint8List buildPlainAnnotationPdf() {
   return editor.save();
 }
 
+Uint8List buildSplitRunTextPdf() {
+  const content = 'BT /F1 24 Tf 72 720 Td (signs) Tj ET '
+      'BT /F1 24 Tf 150 720 Td (and) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xref = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n$xref\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
 Uint8List buildDisjointHighlightPdf({bool rotated = false}) {
   final document = PdfDocument.open(buildClassicPdf());
   final editor = PdfEditor(document)
@@ -534,6 +560,27 @@ void main() {
     expect(bounds.bottom, lessThan(721));
     expect(bounds.top, greaterThan(720));
     expect(controller.selectionRectsOn(1), isEmpty);
+  });
+
+  testWidgets('mouse selection wash is continuous across split text runs',
+      (tester) async {
+    final controller =
+        await pumpViewer(tester, bytes: buildSplitRunTextPdf(), pages: 1);
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+    final gesture = await tester.startGesture(view(195, 720),
+        kind: PointerDeviceKind.mouse);
+    await gesture.moveBy(const Offset(-20, 0));
+    await tester.pump();
+    await gesture.moveTo(view(74, 720));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(controller.selectedText, contains('signs'));
+    expect(controller.selectedText, contains('and'));
+    expect(controller.selectionRectsOn(0), hasLength(1));
   });
 
   testWidgets('hovering text shows the text cursor', (tester) async {

--- a/packages/dart_pdf_editor/test/text_selection_geometry_test.dart
+++ b/packages/dart_pdf_editor/test/text_selection_geometry_test.dart
@@ -1,0 +1,61 @@
+import 'package:dart_pdf_editor/src/text_selection_geometry.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  test('live selection unions every selected fragment on one line', () {
+    final quads = normalizeTextSelectionQuads(const [
+      PdfTextQuad([(10, 10), (40, 10), (40, 22), (10, 22)]),
+      PdfTextQuad([(80, 10), (120, 10), (120, 22), (80, 22)]),
+    ]);
+    expect(quads, hasLength(1));
+    expect(quads.single.bounds, const PdfRect(10, 10, 120, 22));
+  });
+
+  test('live selection keeps separate lines separate', () {
+    final quads = normalizeTextSelectionQuads(const [
+      PdfTextQuad([(10, 30), (40, 30), (40, 42), (10, 42)]),
+      PdfTextQuad([(80, 30), (120, 30), (120, 42), (80, 42)]),
+      PdfTextQuad([(10, 10), (40, 10), (40, 22), (10, 22)]),
+      PdfTextQuad([(80, 10), (120, 10), (120, 22), (80, 22)]),
+    ]);
+    expect(quads.map((quad) => quad.bounds), const [
+      PdfRect(10, 30, 120, 42),
+      PdfRect(10, 10, 120, 22),
+    ]);
+  });
+
+  test('a rotated singleton keeps its exact corners and direction', () {
+    const rotated = PdfTextQuad(
+      [(10, 10), (30, 20), (25, 30), (5, 20)],
+      isRightToLeft: true,
+    );
+    final result = normalizeTextSelectionQuads(const [rotated]);
+    expect(identical(result.single, rotated), isTrue);
+    expect(result.single.corners, rotated.corners);
+    expect(result.single.isRightToLeft, isTrue);
+  });
+
+  test('rectangle and live-quad normalization use identical line unions', () {
+    const rects = [
+      PdfRect(10, 30, 40, 42),
+      PdfRect(80, 30, 120, 42),
+      PdfRect(10, 10, 40, 22),
+      PdfRect(80, 10, 120, 22),
+    ];
+    final quads = [
+      for (final rect in rects)
+        PdfTextQuad([
+          (rect.left, rect.bottom),
+          (rect.right, rect.bottom),
+          (rect.right, rect.top),
+          (rect.left, rect.top),
+        ]),
+    ];
+    expect(
+      normalizeTextSelectionQuads(quads).map((quad) => quad.bounds),
+      normalizeTextSelectionRects(rects),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fix fragmented text selection and markup rendering when selected text is split
across multiple PDF text runs on the same visual line.

Previously, each text run produced an independent selection/highlight rectangle,
which left visible gaps between selected words on Android and Windows.

## Changes

- Group selected text fragments by visual line.
- Merge every selected fragment on the same line into one continuous region,
  including whitespace and larger gaps between separate PDF text runs.
- Apply the same normalization to:
  - live mouse text selection
  - touch long-press and drag selection
  - highlight, underline, strikeout, and squiggly markup creation
- Keep different visual lines as separate regions.
- Preserve raw endpoint quads for touch selection handles and RTL direction.
- Preserve rotated singleton quads instead of converting them to axis-aligned
  rectangles.
- Leave search-match geometry unchanged.

## Before
<img width="210" height="78" alt="Codex 图像 2026年9月11日 11_58_18" src="https://github.com/user-attachments/assets/73deb264-c474-4bde-87fa-29ea0886aa1c" />
<img width="393" height="111" alt="image" src="https://github.com/user-attachments/assets/f914296c-cd11-4df9-a1d4-d0cb06e83267" />
<img width="375" height="87" alt="Codex 图像 2026年9月11日 11_58_48" src="https://github.com/user-attachments/assets/4355f069-02ba-451b-b190-97d5561af6e8" />
<img width="477" height="78" alt="Codex 图像 2026年9月11日 11_58_59" src="https://github.com/user-attachments/assets/18275052-c28f-44e6-8237-b6178b45d4af" />

## After
<img width="321" height="114" alt="ScreenShot_2026-09-11_115916_550" src="https://github.com/user-attachments/assets/02a998e5-c4de-4722-bc61-167835b09add" />
<img width="306" height="114" alt="ScreenShot_2026-09-11_115933_706" src="https://github.com/user-attachments/assets/491de098-9180-4637-b376-4ce3e0f8d63b" />
<img width="180" height="54" alt="image" src="https://github.com/user-attachments/assets/0cef207e-406b-413a-9043-aa18627e7ab5" />


<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [ ] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

## User experience

<!-- For user-facing changes. Leave unchecked when not applicable and explain material omissions. -->

- [x] The affected user journey and expected outcome are described above.
- [ ] Completion, cancellation, disabled, loading, and error states were considered.
- [x] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable.
- [ ] Any journey-level latency, frame-time, or memory impact was measured or ruled out.

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
