### PR TITLE
Open exported pages after saving them

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2510,9 +2510,6 @@ class _EditorScreenState extends State<EditorScreen>
   Future<void> _save(DocumentTab tab, {bool saveAs = false}) async {
     final bytes = tab.session?.bytes;
     if (bytes == null) return;
-    final saveAsDocument = widget.saveDocumentAs ??
-        (ctx, bytes, name) =>
-            saveBytesAs(ctx, bytes, name, pdfLabel: appL10n(ctx).fileTypePdf);
     final saveToPath = widget.saveDocumentToPath ?? saveBytesToPath;
     final inPlace = !saveAs && tab.originPath != null && supportsInPlaceSave;
     var result = inPlace
@@ -2521,11 +2518,11 @@ class _EditorScreenState extends State<EditorScreen>
             tab.originPath!,
             bookmark: tab.originBookmark,
           )
-        : await saveAsDocument(context, bytes, tab.title);
+        : await _saveAsDocument(context, bytes, tab.title);
     if (!mounted) return;
     if (inPlace && !result.succeeded) {
       // The origin couldn't be written (moved, read-only) - offer save-as.
-      result = await saveAsDocument(context, bytes, tab.title);
+      result = await _saveAsDocument(context, bytes, tab.title);
       if (!mounted) return;
     }
     if (result.succeeded) {
@@ -2558,6 +2555,48 @@ class _EditorScreenState extends State<EditorScreen>
         unawaited(_persistSession());
       }
     }
+    if (result.message != null) _toast(result.message!);
+  }
+
+  /// The Save As backend: the host/test seam when one is injected, otherwise
+  /// the platform's own save dialog, browser download, or share sheet.
+  Future<SaveResult> _saveAsDocument(
+      BuildContext context, Uint8List bytes, String suggestedName) {
+    final saveAs = widget.saveDocumentAs;
+    if (saveAs != null) return saveAs(context, bytes, suggestedName);
+    return saveBytesAs(context, bytes, suggestedName,
+        pdfLabel: appL10n(context).fileTypePdf);
+  }
+
+  /// Saves the pages exported out of [tab] (the thumbnail panels' Export
+  /// actions) and then opens what was written in a new tab, so the pages the
+  /// user just pulled out are in front of them rather than only on disk. The
+  /// source document is untouched - an export reads it, it never edits it.
+  ///
+  /// The new tab adopts the save destination as its origin when the platform
+  /// gives us one (a desktop save dialog), so Save writes straight back to the
+  /// file that was just created. A browser download or a share sheet has no
+  /// path to adopt, so the tab opens over the exported bytes alone and its
+  /// first Save asks where they should go.
+  Future<void> _exportPages(DocumentTab tab, Uint8List bytes) async {
+    final result = await _saveAsDocument(context, bytes, tab.title);
+    if (!mounted) return;
+    if (result.succeeded) {
+      final path = result.path;
+      final bookmark =
+          path == null ? null : await securityBookmarkForPath(path);
+      if (!mounted) return;
+      _openBytes(
+        bytes,
+        path == null
+            ? ensurePdfName(tab.title)
+            : path.split(RegExp(r'[/\\]')).last,
+        originPath: path,
+        originBookmark: bookmark,
+      );
+    }
+    // Up to here the export said nothing at all, so a write that failed
+    // (a full disk, a folder gone read-only) passed in silence.
     if (result.message != null) _toast(result.message!);
   }
 
@@ -2612,9 +2651,7 @@ class _EditorScreenState extends State<EditorScreen>
       title: tab.title,
       hasSignatures: PdfSignature.of(session.document).isNotEmpty,
       runner: widget.compressDocument,
-      saveCopy: widget.saveDocumentAs ??
-          (ctx, bytes, name) =>
-              saveBytesAs(ctx, bytes, name, pdfLabel: appL10n(ctx).fileTypePdf),
+      saveCopy: _saveAsDocument,
     );
   }
 
@@ -3900,8 +3937,7 @@ class _EditorScreenState extends State<EditorScreen>
       // a PDF dragged in from the desktop can be dropped between two page
       // thumbnails; the drop lands its pages exactly there
       thumbnailDropController: _thumbnailDrop,
-      onExportPages: (bytes) => unawaited(saveBytesAs(context, bytes, tab.title,
-          pdfLabel: appL10n(context).fileTypePdf)),
+      onExportPages: (bytes) => unawaited(_exportPages(tab, bytes)),
       onAction: _onAction,
       annotationMenuBuilder: _annotationMenuActions,
       formImagePicker: (context, field) => pickImageBytesFromSource(context),

--- a/app/test/export_pages_test.dart
+++ b/app/test/export_pages_test.dart
@@ -1,0 +1,134 @@
+// Exporting pages out of a document (the thumbnail panels' Export actions)
+// saves them and then opens what was written, so the extracted pages land in
+// front of the user instead of only on disk (editor_screen.dart `_exportPages`).
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
+
+import 'test_finders.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+
+  tearDown(() {
+    prefs.dispose();
+  });
+
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: findMiddleEllipsisText(name),
+      );
+
+  /// The editor view of whichever tab is active.
+  PdfEditorView activeView(WidgetTester tester) =>
+      tester.widget<PdfEditorView>(find.byType(PdfEditorView));
+
+  /// Pumps the screen over a 4-page document and returns the saves the export
+  /// backend was handed, newest last.
+  Future<List<({Uint8List bytes, String name})>> pumpEditor(
+    WidgetTester tester, {
+    required SaveResult Function(String name) onSave,
+  }) async {
+    final saves = <({Uint8List bytes, String name})>[];
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildMultiPagePdf(4), title: 'Report.pdf'),
+        saveDocumentAs: (context, bytes, suggestedName) async {
+          saves.add((bytes: bytes, name: suggestedName));
+          return onSave(suggestedName);
+        },
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return saves;
+  }
+
+  /// Exports pages [pages] (0-based) of the active document through the host
+  /// callback the thumbnail panels' Export actions use.
+  Future<void> exportPages(WidgetTester tester, List<int> pages) async {
+    final view = activeView(tester);
+    await tester.runAsync(
+      () async => view.onExportPages!(view.controller!.exportPages(pages)),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('exported pages open as a new tab pointed at the saved file',
+      (tester) async {
+    final saves = await pumpEditor(tester,
+        onSave: (_) => SaveResult.saved('/docs/Report-pages.pdf'));
+    final source = activeView(tester).controller!;
+    final sourceBytes = Uint8List.fromList(source.bytes);
+
+    await exportPages(tester, [1, 3]);
+
+    // The save was offered the extracted pages under the document's name.
+    expect(saves, hasLength(1));
+    expect(saves.single.name, 'Report.pdf');
+
+    // The saved file is open, named after where it landed, and it is the
+    // export rather than the whole document.
+    expect(tabTitle('Report-pages.pdf'), findsOneWidget);
+    expect(tabTitle('Report.pdf'), findsOneWidget);
+    final exported = activeView(tester).controller!;
+    expect(exported.document.pageCount, 2);
+    expect(PdfTextExtractor.extract(exported.document, 0).text, 'Page 2');
+    expect(PdfTextExtractor.extract(exported.document, 1).text, 'Page 4');
+    expect(exported.bytes, saves.single.bytes);
+
+    // An export reads the document; it must not edit it.
+    expect(source.bytes, sourceBytes);
+    await tester.pump();
+    expect(find.text('Saved to /docs/Report-pages.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('a cancelled export opens nothing and says nothing',
+      (tester) async {
+    final saves = await pumpEditor(tester, onSave: (_) => SaveResult.cancelled);
+
+    await exportPages(tester, [0]);
+
+    expect(saves, hasLength(1));
+    // Still the one document, and no toast for a save the user called off.
+    expect(find.byType(PdfEditorView), findsOneWidget);
+    expect(activeView(tester).controller!.document.pageCount, 4);
+    expect(tabTitle('Report.pdf'), findsOneWidget);
+    expect(find.textContaining('Saved to'), findsNothing);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('a download with no path still opens the exported pages',
+      (tester) async {
+    await pumpEditor(tester, onSave: (name) => SaveResult.downloaded(name));
+
+    await exportPages(tester, [2]);
+
+    final exported = activeView(tester).controller!;
+    expect(exported.document.pageCount, 1);
+    expect(PdfTextExtractor.extract(exported.document, 0).text, 'Page 3');
+    expect(find.text('Downloaded Report.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('a failed export reports the failure and opens nothing',
+      (tester) async {
+    await pumpEditor(tester, onSave: (_) => SaveResult.failed('disk full'));
+
+    await exportPages(tester, [0]);
+
+    expect(find.byType(PdfEditorView), findsOneWidget);
+    expect(activeView(tester).controller!.document.pageCount, 4);
+    expect(find.textContaining('disk full'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+}

--- a/doc/dev-log/2026-09-11-open-exported-pages.md
+++ b/doc/dev-log/2026-09-11-open-exported-pages.md
@@ -1,0 +1,59 @@
+# Exported pages now open after they are saved
+
+"Export pages…" (and the thumbnail selection toolbar's export button, and
+the page tile context menu's Export entry) wrote a standalone PDF of the
+chosen pages and then said nothing at all. The user had pulled pages out of
+a document, and the only evidence was a file somewhere in the save dialog's
+folder. Now the export opens in a new tab as soon as it is written.
+
+One host callback carries all three entry points. `PdfEditorView`'s
+`onExportPages` receives the finished bytes -
+`controller.exportSelectedPages()` / `exportPageRange()` /
+`exportPages(targets)`, all of which come out of
+`PdfPageExtraction.extractPages` - so the change is entirely in the app's
+handler (`app/lib/editor_screen.dart`). It was:
+
+```dart
+onExportPages: (bytes) => unawaited(saveBytesAs(context, bytes, tab.title,
+    pdfLabel: appL10n(context).fileTypePdf)),
+```
+
+and is now `_exportPages(tab, bytes)`, which saves and then hands the same
+bytes to `_openBytes` - the path the OCR result and the initial document
+already take, so the new tab records a Recent and persists into the session
+like any other open document.
+
+Notes on the details:
+
+- The new tab adopts the save destination as its origin when there is one
+  (`result.path`, i.e. a desktop save dialog), with a fresh
+  `securityBookmarkForPath` so a sandboxed macOS folder stays writable.
+  Save then writes straight back to the file that was just created instead
+  of asking again. A web download or a mobile share sheet reports success
+  with no path, so that tab opens over the exported bytes alone and its
+  first Save asks for a location - which is the same deal any new document
+  gets there.
+- The tab's title is the basename of where it landed, matching what Save As
+  does to the tab it saved (`path.split(RegExp(r'[/\\]')).last`); with no
+  path it keeps the suggested name through `ensurePdfName`.
+- The export path had no toast either, so a write that failed (full disk,
+  a folder gone read-only) passed in complete silence - `SaveResult.failed`
+  carries a message and nothing was reading it. `_exportPages` toasts
+  `result.message` exactly like `_save` does, which also means a cancelled
+  save stays quiet (its message is null).
+- The source document is untouched: an export reads the document, and the
+  test pins `session.bytes` across the round trip to keep it that way.
+- Save As went through a lambda over `widget.saveDocumentAs` that was
+  copied out three times (`_save`, `_reduceFileSize`, and now the export).
+  That is one getter now, `_saveAsDocument`, so the export uses the same
+  injectable seam the other two do - which is also what makes it testable
+  without the platform save dialog.
+
+`app/test/export_pages_test.dart` drives the four outcomes (saved to a path,
+cancelled, downloaded without a path, failed) through that seam, asserting
+the extracted pages themselves - `PdfTextExtractor` over the new tab's
+document - rather than just the tab count.
+
+Still not wired: `PdfEditorView.onSplitPages` ("Split PDF…", one document
+per range) has no host handler in the app at all, so that action never
+appears. Whatever opens its outputs will want the same treatment.

--- a/doc/dev-log/2026-09-11-open-exported-pages.md
+++ b/doc/dev-log/2026-09-11-open-exported-pages.md
@@ -57,3 +57,25 @@ document - rather than just the tab count.
 Still not wired: `PdfEditorView.onSplitPages` ("Split PDF…", one document
 per range) has no host handler in the app at all, so that action never
 appears. Whatever opens its outputs will want the same treatment.
+
+## Ported: the page-grid shell test that main left stale
+
+CI's `test` job came back red on this branch with one failure,
+`pdf_shell_test.dart: PdfEditorView a page grid double-click lands the viewer
+on that page` — nothing to do with this change (it is all under `app/`), and
+the same single failure is red on the base commit (12f5b49) too, so every PR
+off main was red.
+
+#908 turned the loose view-mode checkmarks into one `SegmentedButton` keyed
+`pdf-shell-view-mode`, and the file grew a `tapViewMode(tester, label)` helper
+because a segment is addressed by its label, not a per-item key. Every other
+test in the file was converted; this one still tapped
+`ValueKey('pdf-shell-page-grid')` — a key that now belongs to the *grid widget
+itself* (`pdf_editor_view.dart`), which isn't in the tree until the mode is
+already on, so the finder matched nothing. (`pdf-shell-page-grid-toggle` is
+not it either: that key is on the compact Controls sheet's tile, absent from
+the desktop popup.) One line, now `await tapViewMode(tester, 'Page grid');`.
+
+Ported here rather than left for a separate PR so this branch can reach green;
+`cd packages/dart_pdf_editor && fvm flutter test` is 2753 passed / 33 skipped,
+which is CI's own count with the one failure flipped.

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -720,9 +720,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pumpAndSettle();
+      await tapViewMode(tester, 'Page grid');
 
       await tester.tap(find.text('Page 6'));
       await tester.pump();


### PR DESCRIPTION
## Summary

Exporting pages out of a document - the thumbnail selection toolbar's export button, the page tile context menu's Export entry, and the page-range "Export pages…" dialog - wrote a standalone PDF and then said nothing at all. The user had just pulled pages out of a document and the only evidence was a file somewhere in the save dialog's folder. The app's `onExportPages` handler now opens what it wrote in a new tab.

All three entry points funnel through one host callback (`PdfEditorView.onExportPages`, fed by `exportSelectedPages()` / `exportPageRange()` / `exportPages(targets)`), so the change is entirely in `app/lib/editor_screen.dart`:

- `_exportPages` saves, then hands the same bytes to `_openBytes` - the path the OCR result and the initial document already take, so the new tab records a Recent and persists into the session like any other open document.
- The new tab adopts the save destination as its origin when the platform gives one (a desktop save dialog), with a fresh `securityBookmarkForPath`, so Save writes straight back to the file just created. A browser download or a mobile share sheet reports success with no path, so that tab opens over the exported bytes alone and its first Save asks for a location. Its title is the basename of where it landed, matching what Save As does to the tab it saved.
- The export path had no toast either, so a write that failed (full disk, folder gone read-only) passed in silence - `SaveResult.failed` carried a message nobody read. It now toasts `result.message` exactly like `_save`, which keeps a cancelled save quiet (null message).
- The source document is untouched: an export reads it, it never edits it.
- Cleanup: the `widget.saveDocumentAs ?? saveBytesAs(...)` lambda was copied out three times (`_save`, Reduce file size, and now the export). It is one `_saveAsDocument` helper, which is also what makes the export testable without the platform save dialog.

`PdfEditorView.onSplitPages` ("Split PDF…") still has no host handler in the app at all, so that action never appears - noted in the dev log as follow-up.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [x] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean at the repo root)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to the app's host handler, so the app suite is the relevant one - `cd app && fvm flutter test` passes in full (590 tests), including the new `app/test/export_pages_test.dart`. Nothing under `packages/` or in the render path is touched, so the package suites and the corpus/Ghent sweeps have nothing to say about it.

## User experience

- [x] The affected user journey and expected outcome are described above.
- [x] Completion, cancellation, disabled, loading, and error states were considered - the new test covers all four save outcomes: saved to a path (opens, toasts), cancelled (opens nothing, stays quiet), downloaded with no path (opens, toasts), failed (opens nothing, reports the failure).
- [ ] Relevant keyboard, mouse, trackpad, touch, stylus, focus, and accessibility paths were checked - no new surface; the existing export controls are unchanged.
- [x] Preview, commit, undo/redo, save, and reopen behavior agree where applicable - the exported tab opens clean (its bytes *are* its saved baseline), and with a path it saves in place rather than re-prompting.
- [x] Any journey-level latency, frame-time, or memory impact was measured or ruled out - an export already held the extracted bytes; opening them is the same work any `_openBytes` does, and nothing in the render or interpreter path changed.

## PDF fixtures and screenshots

Programmatic only: the test builds a 4-page fixture (`buildMultiPagePdf(4)`) and asserts the extracted pages with `PdfTextExtractor` over the new tab's document, rather than just counting tabs.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

One judgement call worth confirming: "open" here means open in a new DartPDF tab, not hand the file to the OS viewer. That is the reading that matches the app (it is a PDF editor, and `_openBytes` already exists for the OCR result), and it works identically on desktop, web and mobile where a reveal-in-file-manager would only work on desktop. Say the word if you wanted the system handler instead.

No new localized strings: the toast reuses the existing `SaveResult` messages.

Follow-up noted in `doc/dev-log/2026-09-11-open-exported-pages.md`: Split PDF… is unreachable in the app because `onSplitPages` is unwired; whatever opens its outputs will want this same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAaQn8chm858rb6ohFkVk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfAaQn8chm858rb6ohFkVk)_